### PR TITLE
Fix tests

### DIFF
--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -231,7 +231,7 @@ func TestNew(t *testing.T) {
 					t.Fatal(err)
 				}
 				state := repo.State()
-				localRev := state.Rev.String()
+				localRev := state.Commit.Id().String()
 				if localRev != strings.TrimSpace(string(out)) {
 					t.Errorf("mismatched revision. expected %q but got %q", localRev, strings.TrimSpace(string(out)))
 				}

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -92,10 +92,12 @@ func (o *OverviewServiceServer) getOverview(
 							app.Version = *version
 						}
 					}
-					if commit, err := s.GetEnvironmentApplicationVersionCommit(name, appName); err != nil {
-						return nil, err
-					} else {
-						app.VersionCommit = transformCommit(commit)
+					if app.Version != 0 {
+						if commit, err := s.GetEnvironmentApplicationVersionCommit(name, appName); err != nil {
+							return nil, err
+						} else {
+							app.VersionCommit = transformCommit(commit)
+						}
 					}
 					if queuedVersion, err := s.GetQueuedVersion(name, appName); err != nil && !errors.Is(err, os.ErrNotExist) {
 						return nil, err
@@ -143,7 +145,7 @@ func (o *OverviewServiceServer) getOverview(
 							SourceCommitId: rel.SourceCommitId,
 							SourceMessage:  rel.SourceMessage,
 						}
-						if commit, err := s.GetApplicationReleaseCommit(appName,id) ; err != nil {
+						if commit, err := s.GetApplicationReleaseCommit(appName, id); err != nil {
 							return nil, err
 						} else {
 							release.Commit = transformCommit(commit)
@@ -241,12 +243,12 @@ func transformUpstream(upstream *config.EnvironmentConfigUpstream) *api.Environm
 }
 
 func transformCommit(commit *git.Commit) *api.Commit {
-	if( commit == nil ) {
+	if commit == nil {
 		return nil
 	}
 	author := commit.Author()
 	return &api.Commit{
-		AuthorName: author.Name,
+		AuthorName:  author.Name,
 		AuthorEmail: author.Email,
 		AuthorTime:  timestamppb.New(author.When),
 	}

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -140,6 +140,9 @@ func TestOverviewService(t *testing.T) {
 					if len(app.Locks) != 0 {
 						t.Errorf("test application has locks in development: %#v", app.Locks)
 					}
+					if app.VersionCommit == nil {
+						t.Errorf("test application in dev has no version commit")
+					}
 				}
 
 				// Check staging
@@ -199,6 +202,9 @@ func TestOverviewService(t *testing.T) {
 					}
 					if len(app.Locks) != 1 {
 						t.Errorf("test application has locks in production: %#v", app.Locks)
+					}
+					if app.VersionCommit != nil {
+						t.Errorf("version commit in production is not nil")
 					}
 				}
 


### PR DESCRIPTION
- The overview test failed because we tried to fetch the version commit even when no version was deployed.
- The repository test failed because it was referencing an invalid field.