### PR TITLE
Use fixed alpine base images instead of edge/latest

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:edge
+FROM alpine:3.14
 RUN apk add --no-cache libgit2 libgit2-dev go protoc make pkgconfig git
 RUN wget https://github.com/argoproj/argo-cd/releases/download/v2.1.2/argocd-linux-amd64 -O /usr/local/bin/argocd && chmod +x /usr/local/bin/argocd

--- a/services/cd-service/Dockerfile
+++ b/services/cd-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.14
 RUN apk --update add ca-certificates tzdata libgit2 git
 RUN wget https://github.com/argoproj/argo-cd/releases/download/v2.1.2/argocd-linux-amd64 -O /usr/local/bin/argocd && chmod +x /usr/local/bin/argocd
 ENV TZ=Europe/Berlin

--- a/services/frontend-service/Dockerfile
+++ b/services/frontend-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest AS builder
+FROM alpine:3.14 AS builder
 RUN apk --update add ca-certificates tzdata
 
 FROM scratch


### PR DESCRIPTION
Using a mix of edge + latest causes a desync of some shared libraries