### PR TITLE
Fix ghcr container names

### DIFF
--- a/chart/values.yaml.tpl
+++ b/chart/values.yaml.tpl
@@ -8,17 +8,18 @@ git:
 
 hub: ghcr.io/freiheit-com
 tag: "$VERSION"
+
 log:
   # Possible values are "gcp" for a gcp-optimized format and "default" for json
   format: ""
   # Other possible values are "DEBUG", "INFO", "ERROR"
   level: "WARN"
 cd:
-  image: kuberpult/cd-service
+  image: kuberpult-cd-service
   backendConfig:
     create: false # Add backend config for health checks on GKE only
 frontend:
-  image: kuberpult/frontend-service
+  image: kuberpult-frontend-service
 ingress:
   annotations: {}
   domainName: null

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine:3.14
+LABEL org.opencontainers.image.source https://github.com/freiheit-com/kuberpult
 RUN apk add --no-cache libgit2 libgit2-dev go protoc make pkgconfig git
 RUN wget https://github.com/argoproj/argo-cd/releases/download/v2.1.2/argocd-linux-amd64 -O /usr/local/bin/argocd && chmod +x /usr/local/bin/argocd

--- a/services/cd-service/Dockerfile
+++ b/services/cd-service/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.14
+LABEL org.opencontainers.image.source https://github.com/freiheit-com/kuberpult
 RUN apk --update add ca-certificates tzdata libgit2 git
 RUN wget https://github.com/argoproj/argo-cd/releases/download/v2.1.2/argocd-linux-amd64 -O /usr/local/bin/argocd && chmod +x /usr/local/bin/argocd
 ENV TZ=Europe/Berlin

--- a/services/cd-service/Makefile
+++ b/services/cd-service/Makefile
@@ -22,7 +22,7 @@ export VERSION
 
 export CGO_ENABLED=1
 
-IMAGENAME?=ghcr.io/freiheit-com/kuberpult/cd-service:${VERSION}
+IMAGENAME?=ghcr.io/freiheit-com/kuberpult-cd-service:${VERSION}
 
 COMPILE_WITH_DOCKER := $(shell [ -z "$$WITHOUT_DOCKER" ] && v=true || v=false; echo $$v)
 

--- a/services/frontend-service/Dockerfile
+++ b/services/frontend-service/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.14 AS builder
 RUN apk --update add ca-certificates tzdata
 
 FROM scratch
+LABEL org.opencontainers.image.source https://github.com/freiheit-com/kuberpult
 ENV TZ=Europe/Berlin
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo

--- a/services/frontend-service/Makefile
+++ b/services/frontend-service/Makefile
@@ -26,7 +26,7 @@ GO := go
 GO_FILES := $(shell find . -type f -name '*.go')
 
 
-IMAGENAME?=ghcr.io/freiheit-com/kuberpult/frontend-service:${VERSION}
+IMAGENAME?=ghcr.io/freiheit-com/kuberpult-frontend-service:${VERSION}
 
 GARBAGE := *.sentinel
 


### PR DESCRIPTION
Ghcr has only one level of naming hierachy so we cannot have `ghcr.io/freiheit-com/kuberpult/xyz` but we need to use `ghcr.io/freiheit-com/kuberpult-xyz`.