### PR TITLE
Fix: Git GC was not enabled

### DIFF
--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -94,7 +94,8 @@ func RunServer() {
 			Certificates: repository.Certificates{
 				KnownHostsFile: c.GitSshKnownHosts,
 			},
-			Branch: c.GitBranch,
+			Branch:      c.GitBranch,
+			GcFrequency: 20,
 		})
 		if err != nil {
 			logger.FromContext(ctx).Fatal("repository.new.error", zap.Error(err), zap.String("git.url", c.GitUrl), zap.String("git.branch", c.GitBranch))


### PR DESCRIPTION
While testing the GitGC, I noticed that it was not enabled by default. This enables it by default with a frequency of 1/20 commands.