### PR TITLE
WIP: manifest fallbacks

### DIFF
--- a/services/cd-service/pkg/config/config.go
+++ b/services/cd-service/pkg/config/config.go
@@ -17,8 +17,19 @@ Copyright 2021 freiheit.com*/
 package config
 
 type EnvironmentConfig struct {
-	Upstream *EnvironmentConfigUpstream `json:"upstream,omitempty"`
-	ArgoCd   *EnvironmentConfigArgoCd   `json:"argocd,omitempty"`
+	Upstream          *EnvironmentConfigUpstream `json:"upstream,omitempty"`
+	ArgoCd            *EnvironmentConfigArgoCd   `json:"argocd,omitempty"`
+	// A list of fallbacks to use if no manifest is defined for this environment.
+	//
+	// This can be used in two scenarios:
+	//
+	//  1. Provisioning a new environment that is mostly a copy of an existing one.
+	//  2. Renaming an existing environment.
+	//
+	// When kuberpult is picking the manifests to deploy to an environment and it 
+	// cannot find manifests for the environment name, then it will also search for 
+	// manifests with a name from this list.
+	ManifestFallbacks []string                   `json:"manifestFallbacks"`
 }
 
 type EnvironmentConfigUpstream struct {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -658,19 +658,27 @@ func (s *State) GetEnvironmentConfigs() (map[string]config.EnvironmentConfig, er
 	}
 	result := map[string]config.EnvironmentConfig{}
 	for _, env := range envs {
-		fileName := s.Filesystem.Join("environments", env.Name(), "config.json")
-		var config config.EnvironmentConfig
-		if err := decodeJsonFile(s.Filesystem, fileName, &config); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				result[env.Name()] = config
-			} else {
-				return nil, err
-			}
+		if config, err := s.GetEnvironmentConfig(env.Name()); err != nil {
+			return nil, err
 		} else {
 			result[env.Name()] = config
 		}
 	}
 	return result, nil
+}
+
+func (s *State) GetEnvironmentConfig(env string) (config.EnvironmentConfig, error) {
+	fileName := s.Filesystem.Join("environments", env, "config.json")
+	var config config.EnvironmentConfig
+	if err := decodeJsonFile(s.Filesystem, fileName, &config); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return config, nil
+		} else {
+			return config, err
+		}
+	} else {
+		return config, nil
+	}
 }
 
 func (s *State) GetEnvironmentApplications(environment string) ([]string, error) {


### PR DESCRIPTION
This adds an option to specify a list of manifests fallbacks for an environment. This should simplify adding new environment or renaming existing ones. Basically you can have a list of environment names that we will be trying if the manifests for an environment cannot be found.