### PR TITLE
added "undeploy" endpoint

### DIFF
--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -52,6 +52,7 @@ message BatchAction {
     CreateEnvironmentApplicationLockRequest create_environment_application_lock = 3;
     DeleteEnvironmentApplicationLockRequest delete_environment_application_lock = 4;
     DeployRequest deploy = 5;
+    PrepareUndeployRequest prepare_undeploy = 6;
   }
 }
 
@@ -81,7 +82,6 @@ message DeleteEnvironmentApplicationLockRequest {
 
 service DeployService {
   rpc Deploy (DeployRequest) returns (google.protobuf.Empty) {}
-//  rpc ReleaseTrain (ReleaseTrainRequest) returns (google.protobuf.Empty) {}
   rpc ReleaseTrain (ReleaseTrainRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       put: "/environments/{environment}/releasetrain"
@@ -101,6 +101,13 @@ message DeployRequest {
   string application = 2;
   uint64 version = 3;
   bool ignoreAllLocks = 4 [deprecated = true];
+  LockBehavior lockBehavior = 5;
+}
+
+message PrepareUndeployRequest {
+  string environment = 1;
+  string application = 2;
+  uint64 version = 3;
   LockBehavior lockBehavior = 5;
 }
 
@@ -155,6 +162,7 @@ message Environment {
     map<string, Lock> locks = 3;
     uint64 queuedVersion = 4;
     Commit versionCommit = 5;
+    bool undeployVersion = 6;
   }
 
   string name = 1;
@@ -169,6 +177,7 @@ message Release {
   string source_author = 3;
   string source_message = 4;
   Commit commit = 5;
+  bool undeployVersion = 6;
 }
 
 message Application {

--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -105,10 +105,7 @@ message DeployRequest {
 }
 
 message PrepareUndeployRequest {
-  string environment = 1;
-  string application = 2;
-  uint64 version = 3;
-  LockBehavior lockBehavior = 5;
+  string application = 1;
 }
 
 message ReleaseTrainRequest {

--- a/services/cd-service/pkg/argocd/render_test.go
+++ b/services/cd-service/pkg/argocd/render_test.go
@@ -1,0 +1,101 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
+
+Copyright 2021 freiheit.com*/
+package argocd
+
+import (
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/argocd/v1alpha1"
+	godebug "github.com/kylelemons/godebug/diff"
+	"testing"
+)
+
+func TestRender(t *testing.T) {
+	tcs := []struct {
+		Name              string
+		IsUndeployVersion bool
+		ExpectedResult    string
+	}{
+		{
+			Name:              "deploy",
+			IsUndeployVersion: false,
+			ExpectedResult: `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dev-app1
+spec:
+  destination: {}
+  project: dev
+  source:
+    path: environments/dev/applications/app1/manifests
+    repoURL: example.com/github
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+`,
+		},
+		{
+			Name:              "undeploy",
+			IsUndeployVersion: true,
+			ExpectedResult: `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  name: dev-app1
+spec:
+  destination: {}
+  project: dev
+  source:
+    path: environments/dev/applications/app1/manifests
+    repoURL: example.com/github
+    targetRevision: main
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+`,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			var (
+				annotations       = map[string]string{}
+				ignoreDifferences = []v1alpha1.ResourceIgnoreDifferences{}
+				destination       = v1alpha1.ApplicationDestination{}
+				GitUrl            = "example.com/github"
+				gitBranch         = "main"
+				env               = "dev"
+				appData           = AppData{
+					AppName:           "app1",
+					IsUndeployVersion: tc.IsUndeployVersion,
+				}
+			)
+
+			actualResult, err := RenderApp(GitUrl, gitBranch, annotations, env, appData, destination, ignoreDifferences)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if actualResult != tc.ExpectedResult {
+				t.Fatalf("unexpected argocd manifest:\ndiff:\n%s\n\n", godebug.Diff(tc.ExpectedResult, actualResult))
+			}
+		})
+	}
+}

--- a/services/cd-service/pkg/argocd/v1alpha1/types.go
+++ b/services/cd-service/pkg/argocd/v1alpha1/types.go
@@ -24,6 +24,7 @@ import (
 type ObjectMeta struct {
 	Name        string            `json:"name"`
 	Annotations map[string]string `json:"annotations,omitempty"`
+	Finalizers  []string          `json:"finalizers,omitempty"`
 }
 
 // This file is a subset of https://github.com/argoproj/argo-cd/blob/v1.8.7/pkg/apis/application/v1alpha1/types.go

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -705,10 +705,15 @@ func (s *State) GetApplicationReleases(application string) ([]uint64, error) {
 }
 
 type Release struct {
-	Version        uint64
-	SourceAuthor   string
-	SourceCommitId string
-	SourceMessage  string
+	Version        	uint64
+	/**
+	 "UndeployVersion=true" means that this version is empty, and has no manifest that could be deployed.
+	 It is intended to help cleanup old services within the normal release cycle (e.g. dev->staging->production).
+	 */
+	UndeployVersion bool
+	SourceAuthor   	string
+	SourceCommitId 	string
+	SourceMessage  	string
 }
 
 func (s *State) GetApplicationRelease(application string, version uint64) (*Release, error) {
@@ -738,6 +743,14 @@ func (s *State) GetApplicationRelease(application string, version uint64) (*Rele
 		}
 	} else {
 		release.SourceMessage = string(cnt)
+	}
+	if _, err := readFile(s.Filesystem, s.Filesystem.Join(base, "undeploy")); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		release.UndeployVersion = false
+	} else {
+		release.UndeployVersion = true
 	}
 	return &release, nil
 }

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -184,10 +184,3 @@ func (d *BatchServer) ProcessBatch(
 }
 
 var _ api.BatchServiceServer = (*BatchServer)(nil)
-
-
-/*
-TODO SU
- * test 1: make sure the flag is written
- * test 2: when read, is the flag returned to UI?
- */

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -78,6 +78,15 @@ func ValidateDeployment(
 	return nil
 }
 
+func ValidatePrepareUndeploy(
+	app string,
+) error {
+	if !valid.ApplicationName(app) {
+		return status.Error(codes.InvalidArgument, fmt.Sprintf("cannot create undeploy version: invalid application: '%s'", app))
+	}
+	return nil
+}
+
 func (d *BatchServer) processAction(
 	batchAction *api.BatchAction,
 ) (repository.Transformer , error) {
@@ -121,6 +130,14 @@ func (d *BatchServer) processAction(
 			Environment: act.Environment,
 			Application: act.Application,
 			LockId:      act.LockId,
+		}, nil
+	case *api.BatchAction_PrepareUndeploy:
+		act := action.PrepareUndeploy
+		if err := ValidatePrepareUndeploy(act.Application); err != nil {
+			return nil, err
+		}
+		return &repository.CreateUndeployApplicationVersion{
+			Application:   act.Application,
 		}, nil
 	case *api.BatchAction_Deploy:
 		act := action.Deploy
@@ -167,3 +184,10 @@ func (d *BatchServer) ProcessBatch(
 }
 
 var _ api.BatchServiceServer = (*BatchServer)(nil)
+
+
+/*
+TODO SU
+ * test 1: make sure the flag is written
+ * test 2: when read, is the flag returned to UI?
+ */

--- a/services/cd-service/pkg/service/service_test.go
+++ b/services/cd-service/pkg/service/service_test.go
@@ -93,7 +93,7 @@ func TestServeHttpSuccess(t *testing.T) {
 
 				expectedMsg := "Author: kuberpult <kuberpult@freiheit.com>\n" +
 					"Committer: kuberpult <kuberpult@freiheit.com>\n" +
-					"released version 1 of \"demo\"\n\n"
+					"created version 1 of \"demo\"\n\n"
 				cmd := exec.Command("git", "--git-dir="+remoteDir, "log", "--format=Author: %an <%ae>%nCommitter: %cn <%ce>%n%B", "-n", "1", "HEAD")
 				if out, err := cmd.Output(); err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
This endpoint creates a new version that we call "undeploy":
* Creating the undeploy version is similar to createApplicationVersion: it also deploys to envs, if the config is set to upstream.
* The undeploy version works like any other version, except it deploys nothing ("the empty set").
* Trying to deploy the undeploy version if it is already deployed, is essentially a no-op, but is allowed
* This change only touches the backend, so there is no button in the UI to create the undeploy version yet.

The goal is to have a process of undeployment (e.g. removing a microservice), similar to how new services are added: first on one environment, then the next, etc.