### PR TITLE
 undeploy endpoint with tests SRX-M5GOA4

### DIFF
--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -53,6 +53,7 @@ message BatchAction {
     DeleteEnvironmentApplicationLockRequest delete_environment_application_lock = 4;
     DeployRequest deploy = 5;
     PrepareUndeployRequest prepare_undeploy = 6;
+    UndeployRequest undeploy = 7;
   }
 }
 
@@ -105,6 +106,10 @@ message DeployRequest {
 }
 
 message PrepareUndeployRequest {
+  string application = 1;
+}
+
+message UndeployRequest {
   string application = 1;
 }
 

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -167,7 +167,6 @@ func (c *CreateApplicationVersion) Transform(fs billy.Filesystem) (string, error
 			result = result + deployResult + "\n"
 		}
 	}
-
 	return fmt.Sprintf("created version %d of %q\n%s", lastRelease+1, c.Application, result), nil
 }
 
@@ -269,7 +268,7 @@ func (u *UndeployApplication) Transform(fs billy.Filesystem) (string, error) {
 		undeployFile := fs.Join(appDir, "version", "undeploy")
 
 		if entries, _ := fs.ReadDir(locksDir); entries != nil {
-			return "", fmt.Errorf("UndeployApplication: error cannot un-deploy application '%v' unlock the application lock in the '%v' release first", u.Application, env)
+			return "", fmt.Errorf("UndeployApplication: error cannot un-deploy application '%v' unlock the application lock in the '%v' environment first", u.Application, env)
 		}
 
 		if _, err := fs.Stat(undeployFile); err != nil && errors.Is(err, os.ErrNotExist) {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -46,6 +46,10 @@ func releasesDirectory(fs billy.Filesystem, application string) string {
 	return fs.Join("applications", application, "releases")
 }
 
+func environmentApplicationDirectory(fs billy.Filesystem, environment, application string) string {
+	return fs.Join("environments", environment, "applications", application)
+}
+
 func releasesDirectoryWithVersion(fs billy.Filesystem, application string, version uint64) string {
 	return fs.Join(releasesDirectory(fs, application), versionToString(version))
 }
@@ -168,7 +172,7 @@ func (c *CreateApplicationVersion) Transform(fs billy.Filesystem) (string, error
 }
 
 type CreateUndeployApplicationVersion struct {
-	Application    string
+	Application string
 }
 
 func (c *CreateUndeployApplicationVersion) Transform(fs billy.Filesystem) (string, error) {
@@ -232,6 +236,62 @@ func (c *CreateUndeployApplicationVersion) Transform(fs billy.Filesystem) (strin
 		}
 	}
 	return fmt.Sprintf("created undeploy-version %d of '%v'\n%s", lastRelease+1, c.Application, result), nil
+}
+
+type UndeployApplication struct {
+	Application string
+}
+
+func (u *UndeployApplication) Transform(fs billy.Filesystem) (string, error) {
+	lastRelease, err := GetLastRelease(fs, u.Application)
+	if err != nil {
+		return "", err
+	}
+	if lastRelease == 0 {
+		return "", fmt.Errorf("UndeployApplication: error cannot undeploy non-existing application '%v'", u.Application)
+	}
+
+	isUndeploy, err := (&State{Filesystem: fs}).IsUndeployVersion(u.Application, lastRelease)
+	if err != nil {
+		return "", err
+	}
+	if !isUndeploy {
+		return "", fmt.Errorf("UndeployApplication: error last release is not un-deployed application version of '%v'", u.Application)
+	}
+
+	releaseDir := releasesDirectoryWithVersion(fs, u.Application, lastRelease)
+
+	configs, err := (&State{Filesystem: fs}).GetEnvironmentConfigs()
+
+	for env := range configs {
+		appDir := environmentApplicationDirectory(fs, env, u.Application)
+		locksDir := fs.Join(appDir, "locks")
+		undeployFile := fs.Join(appDir, "version", "undeploy")
+
+		if entries, _ := fs.ReadDir(locksDir); entries != nil {
+			return "", fmt.Errorf("UndeployApplication: error cannot un-deploy application '%v' unlock the application lock in the '%v' release first", u.Application, env)
+		}
+
+		if _, err := fs.Stat(undeployFile); err != nil && errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("UndeployApplication: error cannot un-deploy application '%v' the release '%v' is not un-deployed", u.Application, env)
+		}
+	}
+
+	// remove application
+	if err = fs.Remove(releaseDir); err != nil {
+		return "", err
+	}
+
+	for env := range configs {
+		appDir := environmentApplicationDirectory(fs, env, u.Application)
+
+		// remove environment application
+		if err := fs.Remove(appDir); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("UndeployApplication: unexpected error application '%v' environment '%v': '%w'", u.Application, env, err)
+		}
+
+	}
+	return fmt.Sprintf("application '%v' was deleted successfully", u.Application), nil
 }
 
 type CleanupOldApplicationVersions struct {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -39,6 +39,163 @@ const (
 	additionalVersions = 7
 )
 
+func TestUndeployApplicationErrors(t *testing.T) {
+	tcs := []struct {
+		Name              string
+		Transformers      []Transformer
+		expectedError     string
+		expectedCommitMsg string
+		shouldSucceed     bool
+	}{
+		{
+			Name: "Delete non-existent application",
+			Transformers: []Transformer{
+				&UndeployApplication{
+					Application: "app1",
+				},
+			},
+			expectedError:     "UndeployApplication: error cannot undeploy non-existing application 'app1'",
+			expectedCommitMsg: "",
+			shouldSucceed:     false,
+		},
+		{
+			Name: "Success",
+			Transformers: []Transformer{
+				&CreateApplicationVersion{
+					Application: "app1",
+					Manifests: map[string]string{
+						envProduction: "productionmanifest",
+					},
+				},
+				&CreateUndeployApplicationVersion{
+					Application: "app1",
+				},
+				&UndeployApplication{
+					Application: "app1",
+				},
+			},
+			expectedError:     "",
+			expectedCommitMsg: "application 'app1' was deleted successfully",
+			shouldSucceed:     true,
+		},
+		{
+			Name: "Undeploy application where there is an application locks shouldn't work",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "dev",
+				},
+				&CreateApplicationVersion{
+					Application: "app1",
+					Manifests: map[string]string{
+						envProduction: "productionmanifest",
+					},
+				},
+				&CreateEnvironmentApplicationLock{
+					Environment: "dev",
+					Application: "app1",
+					LockId:      "22133",
+					Message:     "test",
+				},
+				&CreateUndeployApplicationVersion{
+					Application: "app1",
+				},
+				&UndeployApplication{
+					Application: "app1",
+				},
+			},
+			expectedError:     "UndeployApplication: error cannot un-deploy application 'app1' unlock the application lock in the 'dev' release first",
+			expectedCommitMsg: "",
+			shouldSucceed:     false,
+		},
+		{
+			Name: "Undeploy application where there current releases are not undeploy  shouldn't work",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "dev",
+				},
+				&CreateApplicationVersion{
+					Application: "app1",
+					Manifests: map[string]string{
+						envProduction: "productionmanifest",
+					},
+				},
+				&CreateEnvironmentLock{
+					Environment: "dev",
+					LockId:      "22133",
+					Message:     "test",
+				},
+				&CreateUndeployApplicationVersion{
+					Application: "app1",
+				},
+				&UndeployApplication{
+					Application: "app1",
+				},
+			},
+			expectedError:     "UndeployApplication: error cannot un-deploy application 'app1' the release 'dev' is not un-deployed",
+			expectedCommitMsg: "",
+			shouldSucceed:     false,
+		},
+		{
+			Name: "Undeploy application where the last release is not Undeploy shouldn't work",
+			Transformers: []Transformer{
+				&CreateApplicationVersion{
+					Application: "app1",
+					Manifests: map[string]string{
+						envProduction: "productionmanifest",
+					},
+				},
+				&CreateUndeployApplicationVersion{
+					Application: "app1",
+				},
+				&CreateApplicationVersion{
+					Application:    "app1",
+					Manifests:      nil,
+					SourceCommitId: "",
+					SourceAuthor:   "",
+					SourceMessage:  "",
+				},
+				&UndeployApplication{
+					Application: "app1",
+				},
+			},
+			expectedError:     "UndeployApplication: error last release is not un-deployed application version of 'app1'",
+			expectedCommitMsg: "",
+			shouldSucceed:     false,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			repo, err := setupRepositoryTest(t)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			commitMsg, _, err := repo.ApplyTransformersInternal(tc.Transformers...)
+			// note that we only check the LAST error here:
+			if tc.shouldSucceed {
+				if err != nil {
+					t.Fatalf("Expected no error: %v", err)
+				}
+				actualMsg := commitMsg[len(commitMsg)-1]
+				if actualMsg != tc.expectedCommitMsg {
+					t.Fatalf("expected a different message.\nExpected: %q\nGot %q", tc.expectedCommitMsg, actualMsg)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("Expected an error but got none")
+				} else {
+					actualMsg := err.Error()
+					if actualMsg != tc.expectedError {
+						t.Fatalf("expected a different error.\nExpected: %q\nGot %q", tc.expectedError, actualMsg)
+					}
+				}
+			}
+		})
+	}
+}
+
 // Tests various error cases in the Undeploy endpoint, specifically the error messages returned.
 func TestUndeployErrors(t *testing.T) {
 	tcs := []struct {


### PR DESCRIPTION
Added un-deploy endpoint to completely remove a service.

There are two checks before un-deploy an application:
1) check locks ( ignore env locks )
2) check that all releases are un-deployed

