### PR TITLE
Fix missing entry for github.com/ghodss/yaml in go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=


### PR DESCRIPTION
`pkg/api` needs `protoc-gen-grpc-gateway`.  Otherwise it complains about:
```
$ make -C pkg/api 
buf generate
Failure: plugin grpc-gateway: could not find protoc plugin for name grpc-gateway
make: *** [Makefile:19: api_grpc.pb.go] Error 1
```

Quick research shows that the `grpc-gateway` plugin for `protoc` is
`github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway`.

Installing the same then complains about:
```
$ go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
[...]
../../../../../go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway/v2@v2.4.0/internal/descriptor/grpc_api_configuration.go:8:2: missing go.sum entry for module providing package github.com/ghodss/yaml (imported by github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor); to add:
        go get github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor@v2.4.0
```
