### PR TITLE
make: Run `ct` in container

### DIFF
--- a/charts/kuberpult/Makefile
+++ b/charts/kuberpult/Makefile
@@ -25,7 +25,7 @@ REL_DIR := $(subst $(TOP_DIR)/,,$(CURDIR))
 
 # Run from container image, as recommended by https://github.com/helm/chart-testing#installation
 # `ct` analyses the Git history, so we need to mount the whole repository.
-CT := podman run --mount=type=bind,source=$(TOP_DIR),target=/src,readonly,relabel=shared --workdir=/src/$(REL_DIR) quay.io/helmpack/chart-testing:v3.5.0 ct
+CT := docker run --mount=type=bind,source=$(TOP_DIR),target=/src,readonly,relabel=shared --workdir=/src/$(REL_DIR) quay.io/helmpack/chart-testing:v3.5.0 ct
 # Manual / local installation
 #CT := ct
 

--- a/charts/kuberpult/Makefile
+++ b/charts/kuberpult/Makefile
@@ -45,7 +45,7 @@ ct-test:
 ifeq ($(CI),true)
 	@echo "running on CI no need to test this again! Check chart testing action."
 else
-	$(CT) lint --chart-dirs=.. --chart-yaml-schema=ci/chart_schema.yaml --lint-conf=ci/lintconf.yaml --target-branch=main --all
+	$(CT) lint --chart-yaml-schema=ci/chart_schema.yaml --lint-conf=ci/lintconf.yaml --target-branch=main --chart-dirs=. --charts=.
 endif
 
 test: ct-test kuberpult-$(VERSION).tgz

--- a/charts/kuberpult/Makefile
+++ b/charts/kuberpult/Makefile
@@ -16,10 +16,17 @@
 #Copyright 2021 freiheit.com
 MAKEFLAGS += --no-builtin-rules
 
-# Container image as recommended by https://github.com/helm/chart-testing#installation
-#CT := podman run -ti quay.io/helmpack/chart-testing:v3.5.0 ct
+top_dir = \
+	$(if $(wildcard $1/.git), \
+		$1, \
+		$(call top_dir,$(patsubst %/,%,$(dir $1))))
+TOP_DIR := $(realpath $(call top_dir,$(CURDIR)))
+REL_DIR := $(subst $(TOP_DIR)/,,$(CURDIR))
+
+# Run from container image, as recommended by https://github.com/helm/chart-testing#installation
+CT := podman run --mount=type=bind,source=$(TOP_DIR),target=/src,readonly,relabel=shared --workdir=/src/$(REL_DIR) quay.io/helmpack/chart-testing:v3.5.0 ct
 # Manual / local installation
-CT := ct
+#CT := ct
 
 VERSION=$(shell cat ../../version)
 export VERSION
@@ -37,7 +44,7 @@ ct-test:
 ifeq ($(CI),true)
 	@echo "running on CI no need to test this again! Check chart testing action."
 else
-	$(CT) lint --target-branch main --all --chart-dirs ../ --chart-yaml-schema ci/chart_schema.yaml --lint-conf ci/lintconf.yaml
+	$(CT) lint --chart-dirs=.. --chart-yaml-schema=ci/chart_schema.yaml --lint-conf=ci/lintconf.yaml --target-branch=main --all
 endif
 
 test: ct-test kuberpult-$(VERSION).tgz

--- a/charts/kuberpult/Makefile
+++ b/charts/kuberpult/Makefile
@@ -16,6 +16,11 @@
 #Copyright 2021 freiheit.com
 MAKEFLAGS += --no-builtin-rules
 
+# Container image as recommended by https://github.com/helm/chart-testing#installation
+#CT := podman run -ti quay.io/helmpack/chart-testing:v3.5.0 ct
+# Manual / local installation
+CT := ct
+
 VERSION=$(shell cat ../../version)
 export VERSION
 
@@ -32,7 +37,7 @@ ct-test:
 ifeq ($(CI),true)
 	@echo "running on CI no need to test this again! Check chart testing action."
 else
-	ct lint --target-branch main --all --chart-dirs ../ --chart-yaml-schema ci/chart_schema.yaml --lint-conf ci/lintconf.yaml
+	$(CT) lint --target-branch main --all --chart-dirs ../ --chart-yaml-schema ci/chart_schema.yaml --lint-conf ci/lintconf.yaml
 endif
 
 test: ct-test kuberpult-$(VERSION).tgz

--- a/charts/kuberpult/Makefile
+++ b/charts/kuberpult/Makefile
@@ -24,6 +24,7 @@ TOP_DIR := $(realpath $(call top_dir,$(CURDIR)))
 REL_DIR := $(subst $(TOP_DIR)/,,$(CURDIR))
 
 # Run from container image, as recommended by https://github.com/helm/chart-testing#installation
+# `ct` analyses the Git history, so we need to mount the whole repository.
 CT := podman run --mount=type=bind,source=$(TOP_DIR),target=/src,readonly,relabel=shared --workdir=/src/$(REL_DIR) quay.io/helmpack/chart-testing:v3.5.0 ct
 # Manual / local installation
 #CT := ct


### PR DESCRIPTION
Their documentation recommends to use the container image, which has all
necessary tools installed [^1] and simplifies running the tool greatly.

[^1]: https://github.com/helm/chart-testing#installation