### PR TITLE
Optimize history calculation to reuse previously computed results

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/klauspost/compress v1.11.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=

--- a/services/cd-service/pkg/history/history.go
+++ b/services/cd-service/pkg/history/history.go
@@ -26,7 +26,6 @@ import (
 type History struct {
 	repository *git.Repository
 	commits    map[git.Oid]*CommitHistory
-	useOldAlg  bool
 }
 
 type NotExists struct {
@@ -48,10 +47,6 @@ var (
 
 // Returns the first commit after a certain path was changed.
 func (h *History) Change(from *git.Commit, path []string) (*git.Commit, error) {
-	if h.useOldAlg {
-		commit, _, err := h.traverse(from, path)
-		return commit, err
-	}
 	var err error
 	ch := h.commits[*from.Id()]
 	if ch == nil {
@@ -62,86 +57,6 @@ func (h *History) Change(from *git.Commit, path []string) (*git.Commit, error) {
 		h.commits[*from.Id()] = ch
 	}
 	return ch.Change(path)
-}
-
-// Returns the first commit after a certain path was changed and the oid of the tree node after the change to aid subsequent iterations.
-func (h *History) traverse(from *git.Commit, path []string) (*git.Commit, *git.Oid, error) {
-	if len(path) == 0 {
-		treeId := from.TreeId()
-		current := from
-		for {
-			next := current.Parent(0)
-			if next == nil {
-				return current, nil, nil
-			}
-			if !treeId.Equal(next.TreeId()) {
-				return current, next.TreeId(), nil
-			}
-			current = next
-		}
-	}
-	head := path[0 : len(path)-1]
-	rest := path[len(path)-1]
-	oid, err := h.lookup(from, path)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	current := from
-	for {
-		next, tree, err := h.traverse(current, head)
-		if err != nil || next.Parent(0) == nil {
-			return next, nil, err
-		}
-		if tree == nil {
-			return next, nil, err
-		}
-		node, err := h.repository.LookupTree(tree)
-		if err != nil {
-			return nil, nil, err
-		}
-		entry := node.EntryByName(rest)
-		if entry == nil {
-			return next, nil, nil
-		} else if !oid.Equal(entry.Id) {
-			return next, entry.Id, nil
-		}
-		current = next.Parent(0)
-	}
-}
-
-func (h *History) lookup(from *git.Commit, path []string) (*git.Oid, error) {
-	current, err := from.Tree()
-	if err != nil {
-		return nil, err
-	}
-	for i, elem := range path[0 : len(path)-1] {
-		node := current.EntryByName(elem)
-		if node == nil {
-			return nil, &NotExists{
-				Path: path[0 : i+1],
-			}
-		}
-		next, err := h.repository.Lookup(node.Id)
-		if err != nil {
-			return nil, err
-		}
-		tree, err := next.AsTree()
-		if err != nil {
-			return nil, &NotExists{
-				Path:  path[0 : i+2],
-				inner: err,
-			}
-		}
-		current = tree
-	}
-	last := current.EntryByName(path[len(path)-1])
-	if last == nil {
-		return nil, &NotExists{
-			Path: path,
-		}
-	}
-	return last.Id, nil
 }
 
 func NewHistory(repo *git.Repository) *History {

--- a/services/cd-service/pkg/history/history.go
+++ b/services/cd-service/pkg/history/history.go
@@ -128,15 +128,6 @@ var (
 	_ error = (*NotExists)(nil)
 )
 
-// Returns the first commit after a certain path was changed.
-func (h *History) Change(from *git.Commit, path []string) (*git.Commit, error) {
-	ch, err := NewCommitHistory(h.repository, from, h.cache)
-	if err != nil {
-		return nil, err
-	}
-	return ch.Change(path)
-}
-
 func NewHistory(repo *git.Repository) *History {
 	if repo == nil {
 		panic("nil repository passed to NewHistory")

--- a/services/cd-service/pkg/history/history_test.go
+++ b/services/cd-service/pkg/history/history_test.go
@@ -402,7 +402,3 @@ func dumpFs(t *testing.B, fs billy.Filesystem, indent string) {
 		}
 	}
 }
-
-func dumpCosts(t *testing.B, ch *CommitHistory) {
-	t.Logf("Cost: %d", ch.root.cost)
-}

--- a/services/cd-service/pkg/history/history_test.go
+++ b/services/cd-service/pkg/history/history_test.go
@@ -298,15 +298,11 @@ func assertChangedAtNthCommit(t *testing.T, actualCommit *git.Commit, expectedPo
 	t.Errorf("wrong changed commit, expected %d, actually not any known commit", expectedPosition)
 }
 
-func BenchmarkHistoryNew(b *testing.B){
-	benchmarkHistory(b, false)
+func BenchmarkHistory(b *testing.B){
+	benchmarkHistory(b)
 }
 
-func BenchmarkHistoryOld(b *testing.B){
-	benchmarkHistory(b, true)
-}
-
-func benchmarkHistory(b *testing.B, useOldAlg bool) {
+func benchmarkHistory(b *testing.B) {
 	names := []string{"a", "b", "c", "d", "e", "f"}
 	dir := b.TempDir()
 	repo, err := git.InitRepository(dir, true)
@@ -352,7 +348,6 @@ func benchmarkHistory(b *testing.B, useOldAlg bool) {
 	// Test it!
 	for n := 0; n < b.N; n++ {
 		h := NewHistory(repo)
-		h.useOldAlg = useOldAlg
 		for i := 0; i < 100; i++ {
 			for _, name := range names {
 				_, err = h.Change(commit, []string{"applications", name,"versions", strconv.Itoa(i), "manifest"})

--- a/services/cd-service/pkg/history/history_test.go
+++ b/services/cd-service/pkg/history/history_test.go
@@ -402,19 +402,7 @@ func dumpFs(t *testing.B, fs billy.Filesystem, indent string) {
 		}
 	}
 }
+
 func dumpCosts(t *testing.B, ch *CommitHistory) {
 	t.Logf("Cost: %d", ch.root.cost)
-}
-
-func dumpCacheNode(t *testing.B, ch *cacheNode, indent string) {
-	for name, node := range ch.children {
-		t.Logf("%s%s ( c=%d, h=%d, r=%d )\n", indent, name, node.cost, node.hits, node.reads)
-		dumpCacheNode(t, node, indent+"  ")
-	}
-}
-func dumpCache(t *testing.B, ch *Cache) {
-	for id, node := range ch.roots {
-		t.Logf("%x\n", id)
-		dumpCacheNode(t, node, " ")
-	}
 }

--- a/services/cd-service/pkg/history/history_test.go
+++ b/services/cd-service/pkg/history/history_test.go
@@ -60,7 +60,11 @@ func TestHistory(t *testing.T) {
 				head := commits[len(commits)-1]
 				// Verify that we get the correct error for missing files
 				{
-					c, err := h.Change(head, []string{"non_existing"})
+					ch, err := h.Of(head)
+					if err != nil {
+						t.Fatal(err)
+					}
+					c, err := ch.Change([]string{"non_existing"})
 					if c != nil {
 						t.Errorf("commit mismatch, expected nil, but got %q", c.Id())
 					}
@@ -76,7 +80,11 @@ func TestHistory(t *testing.T) {
 				}
 				// Verify that we get the correct error for wrong file types
 				{
-					c, err := h.Change(head, []string{"foo", "non_existing"})
+					ch, err := h.Of(head)
+					if err != nil {
+						t.Fatal(err)
+					}
+					c, err := ch.Change([]string{"foo", "non_existing"})
 					if c != nil {
 						t.Errorf("commit mismatch, expected nil, but got %q", c.Id())
 					}
@@ -260,7 +268,11 @@ func TestHistory(t *testing.T) {
 				// Run all tests once without cache
 				for name, changedAt := range tc.AssertChangedAt {
 					h := NewHistory(repo)
-					c, err := h.Change(commits[len(commits)-1], strings.Split(name, "/"))
+					ch, err := h.Of(commits[len(commits)-1])
+					if err != nil {
+						t.Fatal(err)
+					}
+					c, err := ch.Change(strings.Split(name, "/"))
 					if err != nil {
 						t.Errorf("unexpected error: %q", err)
 					}
@@ -270,12 +282,20 @@ func TestHistory(t *testing.T) {
 				h := NewHistory(repo)
 				// Warm cache before doing the actual run
 				for _, commit := range commits {
+					ch, err := h.Of(commit)
+					if err != nil {
+						t.Fatal(err)
+					}
 					for name := range tc.AssertChangedAt {
-						h.Change(commit, strings.Split(name, "/"))
+						ch.Change(strings.Split(name, "/"))
 					}
 				}
 				for name, changedAt := range tc.AssertChangedAt {
-					c, err := h.Change(commits[len(commits)-1], strings.Split(name, "/"))
+					ch, err := h.Of(commits[len(commits)-1])
+					if err != nil {
+						t.Fatal(err)
+					}
+					c, err := ch.Change(strings.Split(name, "/"))
 					if err != nil {
 						t.Errorf("unexpected error: %q", err)
 					}
@@ -370,7 +390,11 @@ func benchmarkHistory(b *testing.B, cache bool) {
 		p := commit.Parent(0)
 		for i := 0; i < 99; i++ {
 			for _, name := range names {
-				_, err = warmup.Change(p, []string{"applications", name, "versions", strconv.Itoa(i), "manifest"})
+				ch, err := warmup.Of(p)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_, err = ch.Change([]string{"applications", name, "versions", strconv.Itoa(i), "manifest"})
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -390,7 +414,11 @@ func benchmarkHistory(b *testing.B, cache bool) {
 		}
 		for i := 0; i < 100; i++ {
 			for _, name := range names {
-				_, err = h.Change(commit, []string{"applications", name, "versions", strconv.Itoa(i), "manifest"})
+				ch, err := h.Of(commit)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_, err = ch.Change([]string{"applications", name, "versions", strconv.Itoa(i), "manifest"})
 				if err != nil {
 					b.Fatal(err)
 				}


### PR DESCRIPTION
The history algorithm currently recalculates the whole history for the repository on every run. However, most of the things in a repo do not change on each commit. I introduced a cache that memorizes the last ten calculation results so that we can reuse them later. This bring the history calculation in most cases down from O(N) to O(1) for N = number of commits in repo.

Benchmark:

```
/build/services/cd-service/pkg/history $ go test -benchmem -bench=.
goos: linux
goarch: amd64
pkg: github.com/freiheit-com/kuberpult/services/cd-service/pkg/history
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
BenchmarkHistoryNoCache-12             4         289058522 ns/op        36413094 B/op    2330716 allocs/op
BenchmarkHistoryCache-12             465           2560525 ns/op          596726 B/op      23879 allocs/op
PASS
ok      github.com/freiheit-com/kuberpult/services/cd-service/pkg/history       45.740s
```

> Those who do not --learn-from-- cache history are doomed to repeat it.
>
> *Lenin*