### PR TITLE
infrastructure/docker: Update buf from 1.0.0 to 1.4.0 and ensure we do not run malware

### DIFF
--- a/infrastructure/docker/backend/Dockerfile
+++ b/infrastructure/docker/backend/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.15
 
 RUN apk --update add --no-cache make go git libgit2-dev pkgconfig
-RUN wget https://github.com/bufbuild/buf/releases/download/v1.0.0/buf-Linux-x86_64 -O /usr/local/bin/buf && chmod +x /usr/local/bin/buf
+RUN wget https://github.com/bufbuild/buf/releases/download/v1.4.0/buf-Linux-x86_64 -O /usr/local/bin/buf && chmod +x /usr/local/bin/buf
+RUN echo '9d38f8d504c01dd19ac9062285ac287f44788f643180545077c192eca9053a2c  /usr/local/bin/buf' | sha256sum -c
 
 EXPOSE 8080
 EXPOSE 8443

--- a/infrastructure/docker/frontend/Dockerfile
+++ b/infrastructure/docker/frontend/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.15
 
 RUN apk --update add --no-cache go make
-RUN wget https://github.com/bufbuild/buf/releases/download/v1.0.0/buf-Linux-x86_64 -O /usr/local/bin/buf && chmod +x /usr/local/bin/buf
+RUN wget https://github.com/bufbuild/buf/releases/download/v1.4.0/buf-Linux-x86_64 -O /usr/local/bin/buf && chmod +x /usr/local/bin/buf
+RUN echo '9d38f8d504c01dd19ac9062285ac287f44788f643180545077c192eca9053a2c  /usr/local/bin/buf' | sha256sum -c
 
 EXPOSE 8081
 

--- a/infrastructure/docker/install-dependencies/Dockerfile
+++ b/infrastructure/docker/install-dependencies/Dockerfile
@@ -2,7 +2,8 @@ FROM alpine:3.15
 
 RUN apk --update add --no-cache libgit2 libgit2-dev go protoc make pkgconfig git cmake yarn gettext
 RUN tar --version
-RUN wget https://github.com/bufbuild/buf/releases/download/v1.0.0/buf-Linux-x86_64 -O /usr/local/bin/buf && chmod +x /usr/local/bin/buf
+RUN wget https://github.com/bufbuild/buf/releases/download/v1.4.0/buf-Linux-x86_64 -O /usr/local/bin/buf && chmod +x /usr/local/bin/buf
+RUN echo '9d38f8d504c01dd19ac9062285ac287f44788f643180545077c192eca9053a2c  /usr/local/bin/buf' | sha256sum -c
 
 RUN wget https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
 RUN tar -zxvf helm-v3.8.0-linux-amd64.tar.gz

--- a/infrastructure/docker/ui/Dockerfile
+++ b/infrastructure/docker/ui/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.15
 
 RUN apk --update add --no-cache yarn make
-RUN wget https://github.com/bufbuild/buf/releases/download/v1.0.0/buf-Linux-x86_64 -O /usr/local/bin/buf && chmod +x /usr/local/bin/buf
+RUN wget https://github.com/bufbuild/buf/releases/download/v1.4.0/buf-Linux-x86_64 -O /usr/local/bin/buf && chmod +x /usr/local/bin/buf
+RUN echo '9d38f8d504c01dd19ac9062285ac287f44788f643180545077c192eca9053a2c  /usr/local/bin/buf' | sha256sum -c
 
 EXPOSE 3000
 


### PR DESCRIPTION
When we download something from the net (instead of installing it via our
Linux distribution, whose tools already include checksum verification), we
need to check that the file is what we expect it to be, so that no one can
smuggle malware into our images.

Story: SRX-Y9BRXK
Story: https://revolution.dev/app/-JqFGExX46gs9mH7vxR5/-M37cZx7XYoOvQ5Mmcir/STORY/-Mwb00UWgoLeu2OucGwW/
