### PR TITLE
Add build-base into cd-service dockerfile

### DIFF
--- a/infrastructure/docker/backend/Dockerfile
+++ b/infrastructure/docker/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.15
 
-RUN apk --update add --no-cache make go git libgit2-dev pkgconfig
+RUN apk --update add --no-cache make go git libgit2-dev pkgconfig build-base
 RUN wget https://github.com/bufbuild/buf/releases/download/v1.4.0/buf-Linux-x86_64 -O /usr/local/bin/buf && chmod +x /usr/local/bin/buf
 RUN echo '9d38f8d504c01dd19ac9062285ac287f44788f643180545077c192eca9053a2c  /usr/local/bin/buf' | sha256sum -c
 


### PR DESCRIPTION
When running docker-compose up, cd-service errors out during make with gcc - command not found.
Adding gcc dependancy into cd-service Dockerfile