### PR TITLE
Add build-base to avoid error gcc not found, when running make run

### DIFF
--- a/services/cd-service/Dockerfile
+++ b/services/cd-service/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.15
 LABEL org.opencontainers.image.source https://github.com/freiheit-com/kuberpult
-RUN apk --update add ca-certificates tzdata libgit2 git
+RUN apk --update add ca-certificates tzdata libgit2 git build-base
 RUN wget https://github.com/argoproj/argo-cd/releases/download/v2.1.2/argocd-linux-amd64 -O /usr/local/bin/argocd && chmod +x /usr/local/bin/argocd
 ENV TZ=Europe/Berlin
 COPY bin/main /


### PR DESCRIPTION
When make run is run from within cd-service, it tries to run make from within the docker container, but fails with error gcc not found. Once pull request is merged, ghcr.io/freiheit-com/kuberpult/build:latest would need to be rebuilt

exec docker run -it --tmpfs /.cache:rw,noexec,nosuid --mount type=bind,source=/Users/nisham/go,target=/go --mount type=bind,source=/Users/nisham/workspace/kuberpult/test,target=/etc/ssh --mount type=bind, source=/Users/nisham/workspace/kuberpult,target=/build -w /build --rm -u 501 --security-opt=seccomp=default.json -e WITHOUT_DOCKER=true ghcr.io/freiheit-com/kuberpult/build:latest make -C services/cd-service bin/main

Add build-base which contains gcc to avoid the error.