### PR TITLE
SRX-VM44MY reload config file when changed in repository

### DIFF
--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -357,29 +357,38 @@ func (r *repository) Apply(ctx context.Context, transformers ...Transformer) err
 	}
 
 	if err != nil {
-		return err
-	} else {
-
-		if err := r.Push(ctx, pushAction); err != nil {
-			gerr := err.(*git.GitError)
-			if gerr.Code == git.ErrorCodeNonFastForward {
-				err = r.FetchAndReset(ctx)
-				if err != nil {
-					return err
-				}
-				err = r.ApplyTransformers(ctx, transformers...)
-				if err != nil {
-					return err
-				}
-				if err := r.Push(ctx, pushAction); err != nil {
-					return &InternalError{inner: err}
-				}
-			} else {
+		if errors.Is(err, invalidJson) {
+			err = r.FetchAndReset(ctx)
+			if err != nil {
+				return err
+			}
+			err = r.ApplyTransformers(ctx, transformers...)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}  
+	if err := r.Push(ctx, pushAction); err != nil {
+		gerr := err.(*git.GitError)
+		if gerr.Code == git.ErrorCodeNonFastForward {
+			err = r.FetchAndReset(ctx)
+			if err != nil {
+				return err
+			}
+			err = r.ApplyTransformers(ctx, transformers...)
+			if err != nil {
+				return err
+			}
+			if err := r.Push(ctx, pushAction); err != nil {
 				return &InternalError{inner: err}
 			}
+		} else {
+			return &InternalError{inner: err}
 		}
-		r.notify.Notify()
 	}
+	r.notify.Notify()
 
 	return nil
 }
@@ -750,6 +759,8 @@ func (s *State) readSymlink(environment string, application string, symlinkName 
 	}
 }
 
+var invalidJson = errors.New("JSON file is not valid")
+
 func (s *State) GetEnvironmentConfigs() (map[string]config.EnvironmentConfig, error) {
 	envs, err := s.Filesystem.ReadDir("environments")
 	if err != nil {
@@ -763,7 +774,7 @@ func (s *State) GetEnvironmentConfigs() (map[string]config.EnvironmentConfig, er
 			if errors.Is(err, os.ErrNotExist) {
 				result[env.Name()] = config
 			} else {
-				return nil, wrapFileError(err, fileName, "JSON file is not valid")
+				return nil, fmt.Errorf("%s : %w", fileName, invalidJson)
 			}
 		} else {
 			result[env.Name()] = config

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -278,6 +278,142 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestConfigReload(t *testing.T) {
+	configFiles := []struct {
+		ConfigContent		string
+		ErrorExpected   bool
+	}{
+		{
+			ConfigContent: "{\"upstream\": {\"latest\": true }}",
+			ErrorExpected: false,
+		},
+		{
+			ConfigContent: "{\"upstream\": \"latest\": true }}",
+			ErrorExpected: true,
+		},
+		{
+			ConfigContent: "{\"upstream\": {\"latest\": true }}",
+			ErrorExpected: false,
+		},
+	}
+	t.Run("Config file reload on change", func(t *testing.T) {
+		t.Parallel()
+		// create a remote
+		workdir := t.TempDir()
+		remoteDir := path.Join(workdir, "remote")
+		cmd := exec.Command("git", "init", "--bare", remoteDir)
+		cmd.Start()
+		cmd.Wait()
+
+		workdir = t.TempDir()
+		cmd = exec.Command("git", "clone", remoteDir, workdir) // Clone git dir
+		_, err := cmd.Output()
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				t.Logf("stderr: %s\n", exitErr.Stderr)
+			}
+			t.Fatal(err)
+		}
+		cmd = exec.Command("git", "config", "pull.rebase", "false") // Add a new file to git
+		cmd.Dir = workdir
+		_, err = cmd.Output()
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				t.Logf("stderr: %s\n", exitErr.Stderr)
+			}
+			t.Fatal(err)
+		}
+
+		if err := os.MkdirAll(path.Join(workdir, "environments", "development"), 0700); err != nil {
+			t.Fatal(err)
+		}
+
+		updateConfigFile := func(configFileContent string) error {
+			configFilePath := path.Join(workdir, "environments", "development", "config.json")
+			if err := os.WriteFile(configFilePath, []byte(configFileContent), 0666); err != nil {
+				return err
+			}
+			cmd = exec.Command("git", "add", configFilePath) // Add a new file to git
+			cmd.Dir = workdir
+			_, err = cmd.Output()
+			if err != nil {
+				if exitErr, ok := err.(*exec.ExitError); ok {
+					t.Logf("stderr: %s\n", exitErr.Stderr)
+				}
+				return err
+			}
+			cmd = exec.Command("git", "commit", "-m", "valid config") // commit the new file
+			cmd.Dir = workdir
+			cmd.Env = []string{
+				"GIT_AUTHOR_NAME=kuberpult",
+				"GIT_COMMITTER_NAME=kuberpult",
+				"EMAIL=test@kuberpult.com",
+			}
+			out, err := cmd.Output()
+			fmt.Println(string(out))
+			if err != nil {
+				if exitErr, ok := err.(*exec.ExitError); ok {
+					t.Logf("stderr: %s\n", exitErr.Stderr)
+					t.Logf("stderr: %s\n", err)
+				}
+				return err
+			}
+			cmd = exec.Command("git", "push", "origin", "HEAD") // push the new commit
+			cmd.Dir = workdir
+			_, err = cmd.Output()
+			if err != nil {
+				if exitErr, ok := err.(*exec.ExitError); ok {
+					t.Logf("stderr: %s\n", exitErr.Stderr)
+				}
+				return err
+			}
+			return nil
+		}
+
+		repo, err := New(
+			context.Background(),
+			Config{
+				URL:  remoteDir,
+				Path: t.TempDir(),
+			},
+		)
+
+		if (err != nil) {
+			t.Fatal(err)
+		}
+
+		for _, configFile := range(configFiles) {
+			err = updateConfigFile(configFile.ConfigContent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err := repo.Apply(context.Background(), &CreateApplicationVersion{
+				Application: "foo",
+				Manifests: map[string]string{
+					"development": "foo",
+				},
+			})
+			if configFile.ErrorExpected {
+				if err == nil {
+					t.Errorf("Apply gave error even though config.json was incorrect")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Initialization failed with valid config.json")
+				}
+				cmd = exec.Command("git", "pull") // Add a new file to git
+				cmd.Dir = workdir
+				_, err = cmd.Output()
+				if err != nil {
+					if exitErr, ok := err.(*exec.ExitError); ok {
+						t.Logf("stderr: %s\n", exitErr.Stderr)
+					}
+					t.Fatal(err)
+				}
+			}
+		}
+	})
+}
 func TestConfigValidity(t *testing.T) {
 	tcs := []struct {
 		Name            string


### PR DESCRIPTION
When kuberpult is running and an invalid config.json file is pushed and /release is run. If a valid config.json file is then pushed and /release is called, it should not throw an error stating config file is invalid