### PR TITLE
SRX-4JC9OG allow setting the release number when creating new commits

### DIFF
--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -208,11 +208,11 @@ func New(ctx context.Context, cfg Config) (Repository, error) {
 				}
 			}
 			// check that we can build the current state
-			state, err := result.buildState();
+			state, err := result.buildState()
 			if err != nil {
 				return nil, err
 			}
-			
+
 			if _, err := state.GetEnvironmentConfigs(); err != nil {
 				return nil, err
 			}

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -416,17 +416,17 @@ func TestConfigReload(t *testing.T) {
 }
 func TestConfigValidity(t *testing.T) {
 	tcs := []struct {
-		Name            string
-		ConfigContent		string
-		ErrorExpected   bool
+		Name          string
+		ConfigContent string
+		ErrorExpected bool
 	}{
 		{
-			Name: "Initialization with valid config.json file works",
+			Name:          "Initialization with valid config.json file works",
 			ConfigContent: "{\"upstream\": {\"latest\": true }}",
 			ErrorExpected: false,
 		},
 		{
-			Name: "Initialization with invalid config.json file throws error",
+			Name:          "Initialization with invalid config.json file throws error",
 			ConfigContent: "{\"upstream\": \"latest\": true }}",
 			ErrorExpected: true,
 		},
@@ -510,8 +510,7 @@ func TestConfigValidity(t *testing.T) {
 					t.Errorf("Initialization failed with valid config.json")
 				}
 			}
-			
-	
+
 		})
 	}
 }

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -460,7 +460,7 @@ func findOldApplicationVersions(fs billy.Filesystem, name string) ([]uint64, err
 func (c *CleanupOldApplicationVersions) Transform(ctx context.Context, fs billy.Filesystem) (string, error) {
 	oldVersions, err := findOldApplicationVersions(fs, c.Application)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("cleanup: could not get application releases for app '%s': %w", c.Application, err)
 	}
 
 	msg := ""

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -920,6 +920,27 @@ func TestTransformer(t *testing.T) {
 				}
 			},
 		}, {
+			Name: "Creating a version that is much too old yields the correct error",
+			Transformers: func() []Transformer {
+				t := make([]Transformer, 0, keptVersionsOnCleanup+1)
+				t = append(t, &CreateEnvironment{Environment: "production"})
+				for i := keptVersionsOnCleanup + 1; i > 0; i-- {
+					t = append(t, &CreateApplicationVersion{
+						Version:     uint64(i),
+						Application: "test",
+						Manifests: map[string]string{
+							"production": "42",
+						},
+					})
+				}
+				return t
+			}(),
+			ErrorTest: func(t *testing.T, err error) {
+				if err != ErrReleaseTooOld {
+					t.Errorf("expected %q, got %q", ErrReleaseTooOld, err)
+				}
+			},
+		}, {
 			Name: "Auto Deploy version to second env",
 			Transformers: []Transformer{
 				&CreateEnvironment{Environment: "one", Config: c1},

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -843,6 +843,55 @@ func TestTransformer(t *testing.T) {
 				}
 			},
 		}, {
+			Name: "Create version with version number",
+			Transformers: []Transformer{
+				&CreateEnvironment{Environment: "production"},
+				&CreateApplicationVersion{
+					Version:     42,
+					Application: "test",
+					Manifests: map[string]string{
+						"production": "productionmanifest",
+					},
+				},
+			},
+			Test: func(t *testing.T, s *State) {
+				// Check that reading is possible
+				{
+					rel, err := s.GetApplicationReleases("test")
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !reflect.DeepEqual(rel, []uint64{42}) {
+						t.Errorf("expected release list to be exaclty [42], but got %q", rel)
+					}
+
+				}
+			},
+		}, {
+			Name: "Create version with version number",
+			Transformers: []Transformer{
+				&CreateEnvironment{Environment: "production"},
+				&CreateApplicationVersion{
+					Version:     42,
+					Application: "test",
+					Manifests: map[string]string{
+						"production": "productionmanifest",
+					},
+				},
+				&CreateApplicationVersion{
+					Version:     42,
+					Application: "test",
+					Manifests: map[string]string{
+						"production": "productionmanifest",
+					},
+				},
+			},
+			ErrorTest: func(t *testing.T, err error) {
+				if err != ErrReleaseAlreadyExist {
+					t.Errorf("expected %q, got %q", ErrReleaseAlreadyExist, err)
+				}
+			},
+		}, {
 			Name: "Auto Deploy version to second env",
 			Transformers: []Transformer{
 				&CreateEnvironment{Environment: "one", Config: c1},

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -323,7 +323,7 @@ func TestOverviewService(t *testing.T) {
 			}
 			svc := &OverviewServiceServer{
 				Repository: repo,
-				Shutdown: shutdown,
+				Shutdown:   shutdown,
 			}
 			tc.Test(t, svc)
 			close(shutdown)


### PR DESCRIPTION
This change allows a new parameter for the deploy endpoint `version` to make the endpoint (nearly) idempotent. The parameter is optional. If it's omitted, kuberpult will use the existing behaviour and use the latest release+1.
 
This also slightly changes the http status code. Until now, the status code 204 ("No Content") is used to indicate success. However, we have now two different success outcomes. To reflect this, kuberpult will respond with 201 ("Created") when a new release was created and 200 ("Okay") when the release already exists.