### PR TITLE
Fix /environments/ endpoint

### DIFF
--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -95,7 +95,7 @@ func RunServer() {
 			LockClient:   lockClient,
 		}
 		mux := http.NewServeMux()
-		mux.Handle("/environments", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		mux.Handle("/environments/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			defer readAllAndClose(req.Body, 1024)
 			httpHandler.Handle(w, req)
 		}))


### PR DESCRIPTION
`http.ServerMux` only supports prefix matches when the path ends with a slash.