### PR TITLE
SRX-5VUIF9 Refactor execution plan workflow to be used with parameters

### DIFF
--- a/.github/workflows/execution-plan-main.yml
+++ b/.github/workflows/execution-plan-main.yml
@@ -1,5 +1,6 @@
 name: "Execution Plan"
 'on':
+  # TODO: change to main push after test
   pull_request:
     branches:
       - main
@@ -7,5 +8,5 @@ jobs:
   execution-plan-pr:
     uses: ./.github/workflows/execution-plan-snippet.yml
     with:
-      trigger: pull-request
+      trigger: main
     secrets: inherit

--- a/.github/workflows/execution-plan-main.yml
+++ b/.github/workflows/execution-plan-main.yml
@@ -1,7 +1,6 @@
 name: "Execution Plan on main"
 'on':
-  # TODO: change to main push after test
-  pull_request:
+  push:
     branches:
       - main
 jobs:

--- a/.github/workflows/execution-plan-main.yml
+++ b/.github/workflows/execution-plan-main.yml
@@ -1,4 +1,4 @@
-name: "Execution Plan"
+name: "Execution Plan on main"
 'on':
   # TODO: change to main push after test
   pull_request:

--- a/.github/workflows/execution-plan-pr.yml
+++ b/.github/workflows/execution-plan-pr.yml
@@ -1,4 +1,4 @@
-name: "Execution Plan"
+name: "Execution Plan on Pull Request"
 'on':
   pull_request:
     branches:

--- a/.github/workflows/execution-plan-pr.yml
+++ b/.github/workflows/execution-plan-pr.yml
@@ -5,6 +5,6 @@ name: "Execution Plan"
       - main
 jobs:
   execution-plan-pr:
-    uses: freiheit-com/kuberpult/.github/workflows/.yml@mn-reusable-workflow
+    uses: ./.github/workflows/execution-plan-snippet.yml
     with:
       build-command: build-pr

--- a/.github/workflows/execution-plan-pr.yml
+++ b/.github/workflows/execution-plan-pr.yml
@@ -8,3 +8,4 @@ jobs:
     uses: ./.github/workflows/execution-plan-snippet.yml
     with:
       build-command: build-pr
+    secrets: inherit

--- a/.github/workflows/execution-plan-pr.yml
+++ b/.github/workflows/execution-plan-pr.yml
@@ -1,0 +1,10 @@
+name: "Execution Plan"
+'on':
+  pull_request:
+    branches:
+      - main
+jobs:
+  execution-plan-pr:
+    uses: freiheit-com/kuberpult/.github/workflows/.yml@mn-reusable-workflow
+    with:
+      build-command: build-pr

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -27,14 +27,14 @@ jobs:
         run: |
           gcloud auth configure-docker
       - run: mkdir -p artifacts/
-      - name: Plan execution
+      - name: Plan execution pull request
         if: inputs.trigger == 'pull-request'
         run: |
           ./infrastructure/scripts/execution-plan/plan-pr.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > artifacts/execution-plan.json 
-      - name: Plan execution alternate
+      - name: Plan execution main
         if: inputs.trigger == 'main'
         run: |
-          echo "Running on main branch"
+          ./infrastructure/scripts/execution-plan/plan-main.sh > artifacts/execution-plan.json 
       - name: Execute 
         run: |
           # stub code, as of now just prints the plan

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -4,7 +4,6 @@ on:
     inputs:
       trigger:
         required: true
-        default: 'pull-request'
         type: string
         description: 'The trigger which calls the workflow, one of [pull-request, main]'
       version:
@@ -29,9 +28,13 @@ jobs:
           gcloud auth configure-docker
       - run: mkdir -p artifacts/
       - name: Plan execution
-        if: ${{ inputs.trigger }}  == "pull-request" 
+        if: ${{ inputs.trigger }} == "pull-request" 
         run: |
           ./infrastructure/scripts/execution-plan/plan-pr.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > artifacts/execution-plan.json 
+      - name: Plan execution alternate
+        if: ${{ inputs.trigger }} == "main"
+        run: |
+          echo "Running on main branch"
       - name: Execute 
         run: |
           # stub code, as of now just prints the plan

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set version automatically 
         if: inputs.version == ''
         run: |
-          echo "VERSION=$(git describe --tags || echo '0.0.1')" >> $GITHUB_ENV
+          echo "VERSION=$(git describe --always --long --tags || echo 0.0.1)" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         with:
           name: execution-plan.json

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -28,11 +28,11 @@ jobs:
           gcloud auth configure-docker
       - run: mkdir -p artifacts/
       - name: Plan execution
-        if: ${{ inputs.trigger == "pull-request" }} 
+        if: inputs.trigger == "pull-request"
         run: |
           ./infrastructure/scripts/execution-plan/plan-pr.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > artifacts/execution-plan.json 
       - name: Plan execution alternate
-        if: ${{ inputs.trigger == "main" }} 
+        if: inputs.trigger == "main"
         run: |
           echo "Running on main branch"
       - name: Execute 
@@ -41,7 +41,7 @@ jobs:
           echo "The execution plan is printed"
           cat artifacts/execution-plan.json
       - name: Set version
-        if: ${{ inputs.trigger != "" }} 
+        if: inputs.trigger != ""
         run: echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -42,18 +42,20 @@ jobs:
           cat artifacts/execution-plan.json
       - name: Set version from tag
         if: inputs.version != ''
-        run: echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
-      - name: Add git-version
+        run: |
+          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+      - name: find git-version
         if: inputs.version == ''
+        id: version
         uses: codacy/git-version@2.2.0
         with:
           release-branch: main
       - name: Set version with git-version
         if: inputs.version == ''
         run: |
-          git-version
-          git-version > version
-          echo "VERSION=$(git-version)" >> $GITHUB_ENV
+          echo ${{ steps.version.outputs.version }}
+          echo ${{ steps.version.outputs.version }} > version
+          echo "VERSION=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         with:
           name: execution-plan.json

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set version from tag
         if: inputs.version != ''
         run: |
-          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+          echo ${{ inputs.version }} > version
       - name: find git-version
         if: inputs.version == ''
         id: version
@@ -53,9 +53,7 @@ jobs:
       - name: Set version with git-version
         if: inputs.version == ''
         run: |
-          echo ${{ steps.version.outputs.version }}
           echo ${{ steps.version.outputs.version }} > version
-          echo "VERSION=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         with:
           name: execution-plan.json

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -40,9 +40,16 @@ jobs:
           # stub code, as of now just prints the plan
           echo "The execution plan is printed"
           cat artifacts/execution-plan.json
-      - name: Set version
-        if: inputs.trigger != ''
+      - name: Set version from tag
+        if: inputs.version != ''
         run: echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+      - name: Set version with git-version
+        if: inputs.version == ''
+        uses: codacy/git-version@2.2.0
+        run: |
+          ./git-version
+          ./git-version > version
+          echo "VERSION=$(./git-version)" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         with:
           name: execution-plan.json

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -2,11 +2,11 @@ name: "Execution Plan"
 on:
   workflow_call:
     inputs:
-      build-command:
+      trigger:
         required: true
-        default: 'build-pr'
+        default: 'pull-request'
         type: string
-        description: 'Build command passed from the caller workflow'
+        description: 'The trigger which calls the workflow, one of [pull-request, main]'
       version:
         required: false
         type: string
@@ -29,7 +29,7 @@ jobs:
           gcloud auth configure-docker
       - run: mkdir -p artifacts/
       - name: Plan execution
-        if: ${{ inputs.build-command }}  == "build-pr" 
+        if: ${{ inputs.trigger }}  == "pull-request" 
         run: |
           ./infrastructure/scripts/execution-plan/plan-pr.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > artifacts/execution-plan.json 
       - name: Execute 

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -28,11 +28,11 @@ jobs:
           gcloud auth configure-docker
       - run: mkdir -p artifacts/
       - name: Plan execution
-        if: inputs.trigger == "pull-request"
+        if: inputs.trigger == 'pull-request'
         run: |
           ./infrastructure/scripts/execution-plan/plan-pr.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > artifacts/execution-plan.json 
       - name: Plan execution alternate
-        if: inputs.trigger == "main"
+        if: inputs.trigger == 'main'
         run: |
           echo "Running on main branch"
       - name: Execute 
@@ -41,7 +41,7 @@ jobs:
           echo "The execution plan is printed"
           cat artifacts/execution-plan.json
       - name: Set version
-        if: inputs.trigger != ""
+        if: inputs.trigger != ''
         run: echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -28,14 +28,12 @@ jobs:
           gcloud auth configure-docker
       - run: mkdir -p artifacts/
       - name: Plan execution
-        if: ${{ inputs.trigger }} == "pull-request" 
+        if: ${{ inputs.trigger == "pull-request" }} 
         run: |
-          echo "${{ inputs.trigger }}"
           ./infrastructure/scripts/execution-plan/plan-pr.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > artifacts/execution-plan.json 
       - name: Plan execution alternate
-        if: ${{ inputs.trigger }} == "main"
+        if: ${{ inputs.trigger == "main" }} 
         run: |
-          echo "${{ inputs.trigger }}"
           echo "Running on main branch"
       - name: Execute 
         run: |
@@ -43,7 +41,7 @@ jobs:
           echo "The execution plan is printed"
           cat artifacts/execution-plan.json
       - name: Set version
-        if: ${{ inputs.version }}  != "" 
+        if: ${{ inputs.trigger != "" }} 
         run: echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set version from tag
         if: inputs.version != ''
         run: |
-          echo ${{ inputs.version }} > version
+          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
       - name: find git-version
         if: inputs.version == ''
         id: version
@@ -51,7 +51,7 @@ jobs:
       - name: Set version with git-version
         if: inputs.version == ''
         run: |
-          echo ${{ steps.version.outputs.version }} > version
+          echo "VERSION=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         with:
           name: execution-plan.json

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -51,9 +51,9 @@ jobs:
       - name: Set version with git-version
         if: inputs.version == ''
         run: |
-          ./git-version
-          ./git-version > version
-          echo "VERSION=$(./git-version)" >> $GITHUB_ENV
+          git-version
+          git-version > version
+          echo "VERSION=$(git-version)" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         with:
           name: execution-plan.json

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set version automatically 
         if: inputs.version == ''
         run: |
-          echo "VERSION=$(git describe --tags)" >> $GITHUB_ENV
+          echo "VERSION=$(git describe --tags || echo '0.0.1')" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         with:
           name: execution-plan.json

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -30,10 +30,12 @@ jobs:
       - name: Plan execution
         if: ${{ inputs.trigger }} == "pull-request" 
         run: |
+          echo "${{ inputs.trigger }}"
           ./infrastructure/scripts/execution-plan/plan-pr.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > artifacts/execution-plan.json 
       - name: Plan execution alternate
         if: ${{ inputs.trigger }} == "main"
         run: |
+          echo "${{ inputs.trigger }}"
           echo "Running on main branch"
       - name: Execute 
         run: |

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -42,16 +42,10 @@ jobs:
         if: inputs.version != ''
         run: |
           echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
-      - name: find git-version
-        if: inputs.version == ''
-        id: version
-        uses: codacy/git-version@2.2.0
-        with:
-          release-branch: main
-      - name: Set version with git-version
+      - name: Set version automatically 
         if: inputs.version == ''
         run: |
-          echo "VERSION=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
+          echo "VERSION=$(git describe --tags)" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         with:
           name: execution-plan.json

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -1,8 +1,17 @@
 name: "Execution Plan"
-'on':
-  pull_request:
-    branches:
-      - main
+on:
+  workflow_call:
+    inputs:
+      build-command:
+        required: true
+        default: 'build-pr'
+        type: string
+        description: 'Build command passed from the caller workflow'
+      version:
+        required: false
+        type: string
+        description: 'If provided this will override git-version of the tool'
+
 jobs:
   execution_plan:
     runs-on: ubuntu-latest
@@ -20,6 +29,7 @@ jobs:
           gcloud auth configure-docker
       - run: mkdir -p artifacts/
       - name: Plan execution
+        if: ${{ inputs.build-command }}  == "build-pr" 
         run: |
           ./infrastructure/scripts/execution-plan/plan-pr.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > artifacts/execution-plan.json 
       - name: Execute 
@@ -27,6 +37,9 @@ jobs:
           # stub code, as of now just prints the plan
           echo "The execution plan is printed"
           cat artifacts/execution-plan.json
+      - name: Set version
+        if: ${{ inputs.version }}  != "" 
+        run: echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         with:
           name: execution-plan.json

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -43,9 +43,13 @@ jobs:
       - name: Set version from tag
         if: inputs.version != ''
         run: echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
-      - name: Set version with git-version
+      - name: Add git-version
         if: inputs.version == ''
         uses: codacy/git-version@2.2.0
+        with:
+          release-branch: main
+      - name: Set version with git-version
+        if: inputs.version == ''
         run: |
           ./git-version
           ./git-version > version

--- a/infrastructure/scripts/execution-plan/plan-main.sh
+++ b/infrastructure/scripts/execution-plan/plan-main.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -ueo pipefail
-find . | grep "/Buildfile$" | docker run -i -v "$(pwd)":/repo eu.gcr.io/freiheit-core/images/execution-plan:2.0-scratch-NG-6 build-main
+find -name Buildfile | docker run -i -v "$(pwd)":/repo eu.gcr.io/freiheit-core/images/execution-plan:2.0-scratch-NG-6 build-main

--- a/infrastructure/scripts/execution-plan/plan-main.sh
+++ b/infrastructure/scripts/execution-plan/plan-main.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -ueo pipefail
+find . | grep "/Buildfile$" | docker run -i -v "$(pwd)":/repo eu.gcr.io/freiheit-core/images/execution-plan:2.0-scratch-NG-6 build-main


### PR DESCRIPTION
Refactor execution plan workflow, to be called from both pull request and main workflow, such that inputs can be provided for the minor changes required between them.

Use git-versioning to get the version number so as to avoid conflicts

On main branch, since release is common and not independant for all services, all buildfiles are passed to execution plan, in effect building everything