### PR TITLE
Warn when manually deployed to production

### DIFF
--- a/services/frontend-service/src/ui/ConfirmationDialog.test.tsx
+++ b/services/frontend-service/src/ui/ConfirmationDialog.test.tsx
@@ -247,7 +247,7 @@ describe('Confirmation Dialog Provider', () => {
         {
             type: 'Deploy Action With Undeployed Upstream Warning',
             act: sampleDeployActionOtherApplication,
-            undeployedUpstream: "staging",
+            undeployedUpstream: 'staging',
             expect: {
                 conflict: new Set(),
                 title: 'Are you sure you want to deploy this version?',

--- a/services/frontend-service/src/ui/ConfirmationDialog.test.tsx
+++ b/services/frontend-service/src/ui/ConfirmationDialog.test.tsx
@@ -169,6 +169,7 @@ describe('Confirmation Dialog Provider', () => {
         type: string;
         act: BatchAction;
         fin?: () => void;
+        undeployedUpstream?: string;
         locks?: [string, Lock][];
         expect: {
             conflict: Set<BatchAction>;
@@ -240,6 +241,15 @@ describe('Confirmation Dialog Provider', () => {
             locks: [['id_1234', { lockId: 'id_1234', message: 'random lock message' }]],
             expect: {
                 conflict: new Set([sampleDeployActionOtherVersion]),
+                title: 'Are you sure you want to deploy this version?',
+            },
+        },
+        {
+            type: 'Deploy Action With Undeployed Upstream Warning',
+            act: sampleDeployActionOtherApplication,
+            undeployedUpstream: "staging",
+            expect: {
+                conflict: new Set(),
                 title: 'Are you sure you want to deploy this version?',
             },
         },

--- a/services/frontend-service/src/ui/ConfirmationDialog.tsx
+++ b/services/frontend-service/src/ui/ConfirmationDialog.tsx
@@ -143,7 +143,7 @@ export const ConfirmationDialogProvider = (props: ConfirmationDialogProviderProp
         } else {
             addAction();
         }
-    }, [setDialogOpen, addAction, locks, conflicts]);
+    }, [setDialogOpen, addAction, locks, conflicts, undeployedUpstream]);
 
     const closeIcon = (
         <IconButton size="small" aria-label="close" color="secondary" onClick={closeNotification}>
@@ -158,7 +158,7 @@ export const ConfirmationDialogProvider = (props: ConfirmationDialogProviderProp
                 <strong>This version is not yet deployed to {undeployedUpstream} environment.</strong>
             </div>
             <div style={{ display: 'flex', alignItems: 'center' }}>
-                <strong>Your changes will be overridden by the next release train</strong>
+                <strong>Your changes will be overridden by the next release train.</strong>
             </div>
         </Alert>
     ) : null;

--- a/services/frontend-service/src/ui/ConfirmationDialog.tsx
+++ b/services/frontend-service/src/ui/ConfirmationDialog.tsx
@@ -153,13 +153,16 @@ export const ConfirmationDialogProvider = (props: ConfirmationDialogProviderProp
 
     const undeployedUpstreamMessage = undeployedUpstream ? (
         <Alert variant="outlined" sx={{ m: 1 }} severity="info">
-            <AlertTitle>Warning: Not deployed to {undeployedUpstream} yet!</AlertTitle>
-            <div style={{ display: 'flex', alignItems: 'center' }}>
-                <strong>This version is not yet deployed to {undeployedUpstream} environment.</strong>
-            </div>
-            <div style={{ display: 'flex', alignItems: 'center' }}>
-                <strong>Your changes will be overridden by the next release train.</strong>
-            </div>
+            <AlertTitle>Warning: Not deployed to "{undeployedUpstream}" yet!</AlertTitle>
+            {[
+                `This version is not yet deployed to "${undeployedUpstream}" environment.`,
+                'Your changes will be overridden by the next release train.',
+                `We suggest to first deploy this version to the "${undeployedUpstream}" environment.`,
+            ].map((line, id) => (
+                <div style={{ display: 'flex', alignItems: 'center' }} key={id}>
+                    <strong>{line}</strong>
+                </div>
+            ))}
         </Alert>
     ) : null;
 

--- a/services/frontend-service/src/ui/ConfirmationDialog.tsx
+++ b/services/frontend-service/src/ui/ConfirmationDialog.tsx
@@ -93,11 +93,12 @@ export interface ConfirmationDialogProviderProps {
     children: React.ReactElement;
     action: BatchAction;
     locks?: [string, Lock][];
+    undeployedUpstream?: string;
     fin?: () => void;
 }
 
 export const ConfirmationDialogProvider = (props: ConfirmationDialogProviderProps) => {
-    const { action, locks, fin } = props;
+    const { action, locks, fin, undeployedUpstream } = props;
     const [openNotify, setOpenNotify] = React.useState(false);
     const [dialogOpen, setDialogOpen] = React.useState(false);
     const { actions, setActions } = useContext(ActionsCartContext);
@@ -137,7 +138,7 @@ export const ConfirmationDialogProvider = (props: ConfirmationDialogProviderProp
     }, [fin, closeDialog, openNotification, action, actions, setActions, conflicts]);
 
     const handleAddToCart = useCallback(() => {
-        if (conflicts.size || locks?.length) {
+        if (conflicts.size || locks?.length || undeployedUpstream) {
             setDialogOpen(true);
         } else {
             addAction();
@@ -149,6 +150,18 @@ export const ConfirmationDialogProvider = (props: ConfirmationDialogProviderProp
             <Close fontSize="small" />
         </IconButton>
     );
+
+    const undeployedUpstreamMessage = undeployedUpstream ? (
+        <Alert variant="outlined" sx={{ m: 1 }} severity="info">
+            <AlertTitle>Warning: Not deployed to {undeployedUpstream} yet!</AlertTitle>
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+                <strong>This version is not yet deployed to {undeployedUpstream} environment.</strong>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+                <strong>Your changes will be overridden by the next release train</strong>
+            </div>
+        </Alert>
+    ) : null;
 
     const deployLocks = locks?.length ? (
         <Alert variant="outlined" sx={{ m: 1 }} severity="info">
@@ -193,6 +206,7 @@ export const ConfirmationDialogProvider = (props: ConfirmationDialogProviderProp
                 </DialogTitle>
                 <div style={{ margin: '16px 24px' }}>{GetActionDetails(action).description}</div>
                 {deployLocks}
+                {undeployedUpstreamMessage}
                 {conflictMessage}
                 <span style={{ alignSelf: 'end' }}>
                     <Button onClick={closeDialog}>Cancel</Button>

--- a/services/frontend-service/src/ui/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/ReleaseDialog.tsx
@@ -37,7 +37,7 @@ import Typography from '@material-ui/core/Typography';
 
 import { useUnaryCallback } from './Api';
 
-import type { Application, BatchAction, GetOverviewResponse, Lock, Release } from '../api/api';
+import type { Application, BatchAction, GetOverviewResponse, Lock, Release, Environment } from '../api/api';
 import { LockBehavior } from '../api/api';
 import { EnvSortOrder, sortEnvironmentsByUpstream } from './Releases';
 import { ConfirmationDialogProvider } from './ConfirmationDialog';
@@ -343,6 +343,21 @@ export const ReleaseLockButton = (props: {
     );
 };
 
+const getUndeployedUpstream = (
+    environments: { [key: string]: Environment },
+    environmentName: string,
+    applicationName: string,
+    version: number
+): string => {
+    let upstreamEnv = (environments[environmentName]?.config?.upstream?.upstream as any).environment;
+    while (upstreamEnv !== undefined) {
+        const upstreamVersion = environments[upstreamEnv].applications[applicationName]?.version;
+        if (upstreamVersion < version) return upstreamEnv;
+        upstreamEnv = (environments[upstreamEnv]?.config?.upstream?.upstream as any).environment;
+    }
+    return '';
+};
+
 const ReleaseEnvironment: VFC<{
     overview: GetOverviewResponse;
     applicationName: string;
@@ -384,9 +399,13 @@ const ReleaseEnvironment: VFC<{
     const envLocks = Object.entries(overview.environments[environmentName].locks ?? {});
     const appLocks = Object.entries(overview.environments[environmentName]?.applications[applicationName]?.locks ?? {});
     const locked = envLocks.length > 0 || appLocks.length > 0;
+    const undeployedUpstream = getUndeployedUpstream(overview.environments, environmentName, applicationName, version);
 
     const button = (
-        <ConfirmationDialogProvider action={act} locks={[...envLocks, ...appLocks]}>
+        <ConfirmationDialogProvider
+            action={act}
+            locks={[...envLocks, ...appLocks]}
+            undeployedUpstream={undeployedUpstream}>
             <DeployButton
                 currentlyDeployedVersion={currentlyDeployedVersion}
                 version={version}

--- a/services/frontend-service/src/ui/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/ReleaseDialog.tsx
@@ -343,7 +343,7 @@ export const ReleaseLockButton = (props: {
     );
 };
 
-const getUndeployedUpstream = (
+export const getUndeployedUpstream = (
     environments: { [key: string]: Environment },
     environmentName: string,
     applicationName: string,
@@ -351,7 +351,7 @@ const getUndeployedUpstream = (
 ): string => {
     let upstreamEnv = (environments[environmentName]?.config?.upstream?.upstream as any)?.environment;
     while (upstreamEnv !== undefined) {
-        const upstreamVersion = environments[upstreamEnv].applications[applicationName]?.version;
+        const upstreamVersion = environments[upstreamEnv]?.applications[applicationName]?.version;
         if (upstreamVersion < version) return upstreamEnv;
         upstreamEnv = (environments[upstreamEnv]?.config?.upstream?.upstream as any)?.environment;
     }

--- a/services/frontend-service/src/ui/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/ReleaseDialog.tsx
@@ -349,11 +349,11 @@ const getUndeployedUpstream = (
     applicationName: string,
     version: number
 ): string => {
-    let upstreamEnv = (environments[environmentName]?.config?.upstream?.upstream as any).environment;
+    let upstreamEnv = (environments[environmentName]?.config?.upstream?.upstream as any)?.environment;
     while (upstreamEnv !== undefined) {
         const upstreamVersion = environments[upstreamEnv].applications[applicationName]?.version;
         if (upstreamVersion < version) return upstreamEnv;
-        upstreamEnv = (environments[upstreamEnv]?.config?.upstream?.upstream as any).environment;
+        upstreamEnv = (environments[upstreamEnv]?.config?.upstream?.upstream as any)?.environment;
     }
     return '';
 };


### PR DESCRIPTION
When application is manually deployed to production, check that all its upstream environments are already updated, if not give warning. 

<img width="576" alt="image" src="https://user-images.githubusercontent.com/104761739/173861291-825c5a3b-45c1-46ff-a519-2f7793c8712e.png">


story: [SRX-5VUIF9](https://revolution.dev/app/-JqFGExX46gs9mH7vxR5/-M37cZx7XYoOvQ5Mmcir/STORY/-N3YKNILyrB8A0ik5B41/)