### PR TITLE
Revert "Add build-base to avoid error gcc not found, when running make run"

### DIFF
--- a/services/cd-service/Dockerfile
+++ b/services/cd-service/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.15
 LABEL org.opencontainers.image.source https://github.com/freiheit-com/kuberpult
-RUN apk --update add ca-certificates tzdata libgit2 git build-base
+RUN apk --update add ca-certificates tzdata libgit2 git
 RUN wget https://github.com/argoproj/argo-cd/releases/download/v2.1.2/argocd-linux-amd64 -O /usr/local/bin/argocd && chmod +x /usr/local/bin/argocd
 ENV TZ=Europe/Berlin
 COPY bin/main /


### PR DESCRIPTION
`build-base` really shouldn't be in a production image. This just bloats the image. `make run` should be run in the build image.


Reverts freiheit-com/kuberpult#144
