### PR TITLE
Apply extra optional annotation to the kuberpult ingress

### DIFF
--- a/charts/kuberpult/templates/ingress.yaml
+++ b/charts/kuberpult/templates/ingress.yaml
@@ -20,6 +20,9 @@ metadata:
   annotations:
     cert-manager.io/acme-challenge-type: dns01
     cert-manager.io/cluster-issuer: letsencrypt
+{{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value }}
+{{- end }}
   name: kuberpult
 spec:
   rules:


### PR DESCRIPTION
These are needed in case we want to have a static IP for the ingress on GKE we need to add this annotation
```
kubernetes.io/ingress.global-static-ip-name: <name of global static IP in GCP>
```