### PR TITLE
Fix: Show sync window warning

### DIFF
--- a/services/frontend-service/src/ui/ConfirmationDialog.tsx
+++ b/services/frontend-service/src/ui/ConfirmationDialog.tsx
@@ -146,7 +146,7 @@ export const ConfirmationDialogProvider = (props: ConfirmationDialogProviderProp
         } else {
             addAction();
         }
-    }, [setDialogOpen, addAction, locks, conflicts, undeployedUpstream]);
+    }, [setDialogOpen, addAction, locks, conflicts, undeployedUpstream, hasSyncWindows]);
 
     const closeIcon = (
         <IconButton size="small" aria-label="close" color="secondary" onClick={closeNotification}>

--- a/services/frontend-service/src/ui/ConfirmationDialog.tsx
+++ b/services/frontend-service/src/ui/ConfirmationDialog.tsx
@@ -131,6 +131,7 @@ export const ConfirmationDialogProvider = (props: ConfirmationDialogProviderProp
     }, [fin, closeDialog, openNotification, action, actions, setActions]);
 
     const conflicts = getCartConflicts(actions, action);
+    const hasSyncWindows = syncWindows && syncWindows.length > 0;
 
     const replaceAction = useCallback(() => {
         openNotification();
@@ -140,7 +141,7 @@ export const ConfirmationDialogProvider = (props: ConfirmationDialogProviderProp
     }, [fin, closeDialog, openNotification, action, actions, setActions, conflicts]);
 
     const handleAddToCart = useCallback(() => {
-        if (conflicts.size || locks?.length || undeployedUpstream) {
+        if (conflicts.size || locks?.length || undeployedUpstream || hasSyncWindows) {
             setDialogOpen(true);
         } else {
             addAction();
@@ -184,21 +185,20 @@ export const ConfirmationDialogProvider = (props: ConfirmationDialogProviderProp
             <strong>Possible conflict with actions already in cart!</strong>
         </Alert>
     );
-    const syncWindowsMessage =
-        syncWindows && syncWindows.length > 0 ? (
-            <Alert variant="outlined" sx={{ m: 1 }} severity="warning">
-                <AlertTitle>ArgoCD sync windows are active for this application!</AlertTitle>
-                <p>Warning: This can delay deployment.</p>
-                <h3>Sync windows:</h3>
-                <ul>
-                    {syncWindows?.map((w, n) => (
-                        <li key={`${n}:${w}`}>
-                            <SyncWindow w={w} />
-                        </li>
-                    ))}
-                </ul>
-            </Alert>
-        ) : null;
+    const syncWindowsMessage = hasSyncWindows ? (
+        <Alert variant="outlined" sx={{ m: 1 }} severity="warning">
+            <AlertTitle>ArgoCD sync windows are active for this application!</AlertTitle>
+            <p>Warning: This can delay deployment.</p>
+            <h3>Sync windows:</h3>
+            <ul>
+                {syncWindows?.map((w, n) => (
+                    <li key={`${n}:${w}`}>
+                        <SyncWindow w={w} />
+                    </li>
+                ))}
+            </ul>
+        </Alert>
+    ) : null;
 
     return (
         <>


### PR DESCRIPTION
Before, if the sync window warning would have been the only warning,
the confirmation dialog would not show.  This commit fixes it.

Fixes: e4cfa8348dcb97a917daf1d97400a80d1620ed3c
