### PR TITLE
SRX-4SBVE2 Add tracing envs to frontend

### DIFF
--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -60,6 +60,26 @@ spec:
           value: "{{ .Values.gke.backend_service_id }}"
         - name: KUBERPULT_GKE_PROJECT_NUMBER
           value: "{{ .Values.gke.project_number }}"
+{{- if .Values.datadogTracing.enabled }}
+        - name: DD_AGENT_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: DD_ENV
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['tags.datadoghq.com/env']
+        - name: DD_SERVICE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['tags.datadoghq.com/service']
+        - name: DD_VERSION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['tags.datadoghq.com/version']
+        - name: KUBERPULT_ENABLE_TRACING
+          value: "{{ .Values.datadogTracing.enabled }}"
+{{- end }}
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Tracing for the frontend was enabled in #198 but the helm chart wasn't yet updated to include the necessary envs.