### PR TITLE
Read config from file in bootstrap mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin
 services/cd-service/repository_checkedout
 services/cd-service/repository_remote
 services/cd-service/repository
+services/cd-service/environment_configs.json
 .DS_Store
 .install
 .idea/

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -39,21 +39,21 @@ import (
 
 type Config struct {
 	// these will be mapped to "KUBERPULT_GIT_URL", etc.
-	GitUrl            string `required:"true" split_words:"true"`
-	GitBranch         string `default:"master" split_words:"true"`
-	BootstrapMode     string `default:"false" split_words:"true"`
-	ConfigPath        string `default:"/etc/kuberpult_config.json" split_words:"true"`
-	GitCommitterEmail string `default:"kuberpult@freiheit.com" split_words:"true"`
-	GitCommitterName  string `default:"kuberpult" split_words:"true"`
-	GitSshKey         string `default:"/etc/ssh/identity" split_words:"true"`
-	GitSshKnownHosts  string `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
-	PgpKeyRing        string `split_words:"true"`
-	ArgoCdHost        string `default:"localhost:8080" split_words:"true"`
-	ArgoCdUser        string `default:"admin" split_words:"true"`
-	ArgoCdPass        string `default:"" split_words:"true"`
-	EnableTracing     bool   `default:"false" split_words:"true"`
-	EnableMetrics     bool   `default:"false" split_words:"true"`
-	DogstatsdAddr     string `default:"127.0.0.1:8125" split_words:"true"`
+	GitUrl                 string `required:"true" split_words:"true"`
+	GitBranch              string `default:"master" split_words:"true"`
+	BootstrapMode          bool   `default:"false" split_words:"true"`
+	EnvironmentConfigsPath string `default:"./environment_configs.json" split_words:"true"`
+	GitCommitterEmail      string `default:"kuberpult@freiheit.com" split_words:"true"`
+	GitCommitterName       string `default:"kuberpult" split_words:"true"`
+	GitSshKey              string `default:"/etc/ssh/identity" split_words:"true"`
+	GitSshKnownHosts       string `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
+	PgpKeyRing             string `split_words:"true"`
+	ArgoCdHost             string `default:"localhost:8080" split_words:"true"`
+	ArgoCdUser             string `default:"admin" split_words:"true"`
+	ArgoCdPass             string `default:"" split_words:"true"`
+	EnableTracing          bool   `default:"false" split_words:"true"`
+	EnableMetrics          bool   `default:"false" split_words:"true"`
+	DogstatsdAddr          string `default:"127.0.0.1:8125" split_words:"true"`
 }
 
 func (c *Config) readPgpKeyRing() (openpgp.KeyRing, error) {
@@ -134,8 +134,10 @@ func RunServer() {
 			Certificates: repository.Certificates{
 				KnownHostsFile: c.GitSshKnownHosts,
 			},
-			Branch:      c.GitBranch,
-			GcFrequency: 20,
+			Branch:                 c.GitBranch,
+			GcFrequency:            20,
+			BoostrapMode:           c.BootstrapMode,
+			EnvironmentConfigsPath: c.EnvironmentConfigsPath,
 		})
 		if err != nil {
 			logger.FromContext(ctx).Fatal("repository.new.error", zap.Error(err), zap.String("git.url", c.GitUrl), zap.String("git.branch", c.GitBranch))

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -41,6 +41,8 @@ type Config struct {
 	// these will be mapped to "KUBERPULT_GIT_URL", etc.
 	GitUrl            string `required:"true" split_words:"true"`
 	GitBranch         string `default:"master" split_words:"true"`
+	BootstrapMode     string `default:"false" split_words:"true"`
+	ConfigPath        string `default:"/etc/kuberpult_config.json" split_words:"true"`
 	GitCommitterEmail string `default:"kuberpult@freiheit.com" split_words:"true"`
 	GitCommitterName  string `default:"kuberpult" split_words:"true"`
 	GitSshKey         string `default:"/etc/ssh/identity" split_words:"true"`

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -39,21 +39,21 @@ import (
 
 type Config struct {
 	// these will be mapped to "KUBERPULT_GIT_URL", etc.
-	GitUrl                 string `required:"true" split_words:"true"`
-	GitBranch              string `default:"master" split_words:"true"`
-	BootstrapMode          bool   `default:"false" split_words:"true"`
-	EnvironmentConfigsPath string `default:"./environment_configs.json" split_words:"true"`
-	GitCommitterEmail      string `default:"kuberpult@freiheit.com" split_words:"true"`
-	GitCommitterName       string `default:"kuberpult" split_words:"true"`
-	GitSshKey              string `default:"/etc/ssh/identity" split_words:"true"`
-	GitSshKnownHosts       string `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
-	PgpKeyRing             string `split_words:"true"`
-	ArgoCdHost             string `default:"localhost:8080" split_words:"true"`
-	ArgoCdUser             string `default:"admin" split_words:"true"`
-	ArgoCdPass             string `default:"" split_words:"true"`
-	EnableTracing          bool   `default:"false" split_words:"true"`
-	EnableMetrics          bool   `default:"false" split_words:"true"`
-	DogstatsdAddr          string `default:"127.0.0.1:8125" split_words:"true"`
+	GitUrl        string `required:"true" split_words:"true"`
+	GitBranch     string `default:"master" split_words:"true"`
+	BootstrapMode bool   `default:"false" split_words:"true"`
+	// EnvironmentConfigsPath string `default:"./environment_configs.json" split_words:"true"`
+	GitCommitterEmail string `default:"kuberpult@freiheit.com" split_words:"true"`
+	GitCommitterName  string `default:"kuberpult" split_words:"true"`
+	GitSshKey         string `default:"/etc/ssh/identity" split_words:"true"`
+	GitSshKnownHosts  string `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
+	PgpKeyRing        string `split_words:"true"`
+	ArgoCdHost        string `default:"localhost:8080" split_words:"true"`
+	ArgoCdUser        string `default:"admin" split_words:"true"`
+	ArgoCdPass        string `default:"" split_words:"true"`
+	EnableTracing     bool   `default:"false" split_words:"true"`
+	EnableMetrics     bool   `default:"false" split_words:"true"`
+	DogstatsdAddr     string `default:"127.0.0.1:8125" split_words:"true"`
 }
 
 func (c *Config) readPgpKeyRing() (openpgp.KeyRing, error) {
@@ -136,8 +136,9 @@ func RunServer() {
 			},
 			Branch:                 c.GitBranch,
 			GcFrequency:            20,
-			BoostrapMode:           c.BootstrapMode,
-			EnvironmentConfigsPath: c.EnvironmentConfigsPath,
+			BootstrapMode:          c.BootstrapMode,
+			EnvironmentConfigsPath: "./environment_configs.json",
+			// EnvironmentConfigsPath: c.EnvironmentConfigsPath,
 		})
 		if err != nil {
 			logger.FromContext(ctx).Fatal("repository.new.error", zap.Error(err), zap.String("git.url", c.GitUrl), zap.String("git.branch", c.GitBranch))

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -39,10 +39,9 @@ import (
 
 type Config struct {
 	// these will be mapped to "KUBERPULT_GIT_URL", etc.
-	GitUrl        string `required:"true" split_words:"true"`
-	GitBranch     string `default:"master" split_words:"true"`
-	BootstrapMode bool   `default:"false" split_words:"true"`
-	// EnvironmentConfigsPath string `default:"./environment_configs.json" split_words:"true"`
+	GitUrl            string `required:"true" split_words:"true"`
+	GitBranch         string `default:"master" split_words:"true"`
+	BootstrapMode     bool   `default:"false" split_words:"true"`
 	GitCommitterEmail string `default:"kuberpult@freiheit.com" split_words:"true"`
 	GitCommitterName  string `default:"kuberpult" split_words:"true"`
 	GitSshKey         string `default:"/etc/ssh/identity" split_words:"true"`
@@ -138,7 +137,6 @@ func RunServer() {
 			GcFrequency:            20,
 			BootstrapMode:          c.BootstrapMode,
 			EnvironmentConfigsPath: "./environment_configs.json",
-			// EnvironmentConfigsPath: c.EnvironmentConfigsPath,
 		})
 		if err != nil {
 			logger.FromContext(ctx).Fatal("repository.new.error", zap.Error(err), zap.String("git.url", c.GitUrl), zap.String("git.branch", c.GitBranch))

--- a/services/cd-service/pkg/config/config.go
+++ b/services/cd-service/pkg/config/config.go
@@ -16,8 +16,6 @@ along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
 Copyright 2021 freiheit.com*/
 package config
 
-type EnvironmentConfigs map[string]EnvironmentConfig
-
 type EnvironmentConfig struct {
 	Upstream *EnvironmentConfigUpstream `json:"upstream,omitempty"`
 	ArgoCd   *EnvironmentConfigArgoCd   `json:"argocd,omitempty"`

--- a/services/cd-service/pkg/config/config.go
+++ b/services/cd-service/pkg/config/config.go
@@ -16,7 +16,7 @@ along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
 Copyright 2021 freiheit.com*/
 package config
 
-type KuberpultConfig map[string]EnvironmentConfig
+type EnvironmentConfigs map[string]EnvironmentConfig
 
 type EnvironmentConfig struct {
 	Upstream *EnvironmentConfigUpstream `json:"upstream,omitempty"`

--- a/services/cd-service/pkg/config/config.go
+++ b/services/cd-service/pkg/config/config.go
@@ -16,6 +16,8 @@ along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
 Copyright 2021 freiheit.com*/
 package config
 
+type KuberpultConfig map[string]EnvironmentConfig
+
 type EnvironmentConfig struct {
 	Upstream *EnvironmentConfigUpstream `json:"upstream,omitempty"`
 	ArgoCd   *EnvironmentConfigArgoCd   `json:"argocd,omitempty"`

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -101,7 +101,7 @@ type Config struct {
 	//
 	GcFrequency uint
 	// Bootstrap mode controls where configurations are read from
-	// true: read from json file at KuberpultConfigPath
+	// true: read from json file at EnvironmentConfigsPath
 	// false: read from config files in manifest repo
 	BootstrapMode          bool
 	EnvironmentConfigsPath string
@@ -580,7 +580,11 @@ func (r *repository) buildState() (*State, error) {
 		var gerr *git.GitError
 		if errors.As(err, &gerr) {
 			if gerr.Code == git.ErrNotFound {
-				return &State{Filesystem: fs.NewEmptyTreeBuildFS(r.repository)}, nil
+				return &State{
+					Filesystem:             fs.NewEmptyTreeBuildFS(r.repository),
+					BootstrapMode:          r.config.BootstrapMode,
+					EnvironmentConfigsPath: r.config.EnvironmentConfigsPath,
+				}, nil
 			}
 		}
 		return nil, err

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -98,6 +98,11 @@ type Config struct {
 	Branch string
 	//
 	GcFrequency uint
+	// Bootstrap mode controls where configurations are read from
+	// true: read from json file at KuberpultConfigPath
+	// false: read from config files in manifest repo
+	BoostrapMode           bool
+	EnvironmentConfigsPath string
 }
 
 func openOrCreate(path string) (*git.Repository, error) {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"sort"
@@ -36,6 +37,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/freiheit-com/kuberpult/pkg/auth"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/yaml.v2"
 
 	"github.com/freiheit-com/kuberpult/pkg/api"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/argocd"
@@ -101,7 +103,7 @@ type Config struct {
 	// Bootstrap mode controls where configurations are read from
 	// true: read from json file at KuberpultConfigPath
 	// false: read from config files in manifest repo
-	BoostrapMode           bool
+	BootstrapMode          bool
 	EnvironmentConfigsPath string
 }
 
@@ -593,10 +595,12 @@ func (r *repository) buildState() (*State, error) {
 			return nil, err
 		}
 		return &State{
-			Filesystem:    fs.NewTreeBuildFS(r.repository, commit.TreeId()),
-			Commit:        commit,
-			History:       r.history,
-			CommitHistory: commitHistory,
+			Filesystem:             fs.NewTreeBuildFS(r.repository, commit.TreeId()),
+			Commit:                 commit,
+			History:                r.history,
+			CommitHistory:          commitHistory,
+			BootstrapMode:          r.config.BootstrapMode,
+			EnvironmentConfigsPath: r.config.EnvironmentConfigsPath,
 		}, nil
 	}
 }
@@ -691,10 +695,12 @@ func (r *repository) maybeGc(ctx context.Context) {
 }
 
 type State struct {
-	Filesystem    billy.Filesystem
-	Commit        *git.Commit
-	History       *history.History
-	CommitHistory *history.CommitHistory
+	Filesystem             billy.Filesystem
+	Commit                 *git.Commit
+	History                *history.History
+	CommitHistory          *history.CommitHistory
+	BootstrapMode          bool
+	EnvironmentConfigsPath string
 }
 
 func (s *State) Applications() ([]string, error) {
@@ -867,25 +873,42 @@ func (s *State) readSymlink(environment string, application string, symlinkName 
 var invalidJson = errors.New("JSON file is not valid")
 
 func (s *State) GetEnvironmentConfigs() (map[string]config.EnvironmentConfig, error) {
-	envs, err := s.Filesystem.ReadDir("environments")
-	if err != nil {
-		return nil, err
-	}
-	result := map[string]config.EnvironmentConfig{}
-	for _, env := range envs {
-		fileName := s.Filesystem.Join("environments", env.Name(), "config.json")
-		var config config.EnvironmentConfig
-		if err := decodeJsonFile(s.Filesystem, fileName, &config); err != nil {
+	if s.BootstrapMode {
+		result := map[string]config.EnvironmentConfig{}
+		buf, err := ioutil.ReadFile(s.EnvironmentConfigsPath)
+		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				result[env.Name()] = config
-			} else {
-				return nil, fmt.Errorf("%s : %w", fileName, invalidJson)
+				return result, nil
 			}
-		} else {
-			result[env.Name()] = config
+			return nil, err
 		}
+		err = yaml.Unmarshal(buf, &result)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Println(*(result)["development"].Upstream)
+		return result, nil
+	} else {
+		envs, err := s.Filesystem.ReadDir("environments")
+		if err != nil {
+			return nil, err
+		}
+		result := map[string]config.EnvironmentConfig{}
+		for _, env := range envs {
+			fileName := s.Filesystem.Join("environments", env.Name(), "config.json")
+			var config config.EnvironmentConfig
+			if err := decodeJsonFile(s.Filesystem, fileName, &config); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					result[env.Name()] = config
+				} else {
+					return nil, fmt.Errorf("%s : %w", fileName, invalidJson)
+				}
+			} else {
+				result[env.Name()] = config
+			}
+		}
+		return result, nil
 	}
-	return result, nil
 }
 
 func (s *State) GetEnvironmentApplications(environment string) ([]string, error) {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -885,7 +885,6 @@ func (s *State) GetEnvironmentConfigs() (map[string]config.EnvironmentConfig, er
 		if err != nil {
 			return nil, err
 		}
-		fmt.Println(*(result)["development"].Upstream)
 		return result, nil
 	} else {
 		envs, err := s.Filesystem.ReadDir("environments")

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -374,7 +374,7 @@ func TestBootstrapErrors(t *testing.T) {
 		{
 			Name:          "Read error in bootstrap configuration",
 			ConfigContent: `{"development": {"upstream": {"latest": true}}}`,
-			Permission:    0111,
+			Permission:    0000,
 		},
 	}
 

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -360,21 +360,14 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestBootstrapErrors(t *testing.T) {
+func TestBootstrapError(t *testing.T) {
 	tcs := []struct {
 		Name          string
 		ConfigContent string
-		Permission    int
 	}{
 		{
 			Name:          "Invalid json in bootstrap configuration",
 			ConfigContent: `{"development": "upstream": {"latest": true}}}`,
-			Permission:    0644,
-		},
-		{
-			Name:          "Read error in bootstrap configuration",
-			ConfigContent: `{"development": {"upstream": {"latest": true}}}`,
-			Permission:    0000,
 		},
 	}
 
@@ -391,7 +384,7 @@ func TestBootstrapErrors(t *testing.T) {
 			cmd.Wait()
 
 			environmentConfigsPath := filepath.Join(remoteDir, "..", "environment_configs.json")
-			if err := os.WriteFile(environmentConfigsPath, []byte(tc.ConfigContent), fs.FileMode(tc.Permission)); err != nil {
+			if err := os.WriteFile(environmentConfigsPath, []byte(tc.ConfigContent), fs.FileMode(0644)); err != nil {
 				t.Fatal(err)
 			}
 

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -35,11 +35,10 @@ import (
 
 func TestNew(t *testing.T) {
 	tcs := []struct {
-		Name          string
-		Branch        string
-		BootstrapMode bool
-		Setup         func(t *testing.T, remoteDir, localDir string)
-		Test          func(t *testing.T, repo Repository, remoteDir string)
+		Name   string
+		Branch string
+		Setup  func(t *testing.T, remoteDir, localDir string)
+		Test   func(t *testing.T, repo Repository, remoteDir string)
 	}{
 		{
 			Name:  "new in empty directory works",
@@ -252,81 +251,6 @@ func TestNew(t *testing.T) {
 				}
 			},
 		},
-		{
-			Name:          "new in empty directory in bootstrap mode works",
-			Setup:         func(_ *testing.T, _, _ string) {},
-			BootstrapMode: true,
-			Test: func(t *testing.T, repo Repository, remoteDir string) {
-				if !repo.State().BootstrapMode {
-					t.Fatal("BootstrapMode was not preserved")
-				}
-			},
-		},
-		{
-			Name: "new in initialized repository in bootstrap mode works",
-			Setup: func(t *testing.T, remoteDir, localDir string) {
-				// run the initialization code once
-				_, err := New(
-					context.Background(),
-					Config{
-						URL:  "file://" + remoteDir,
-						Path: localDir,
-					},
-				)
-				if err != nil {
-					t.Fatal(err)
-				}
-			},
-			BootstrapMode: true,
-			Test: func(t *testing.T, repo Repository, remoteDir string) {
-				state := repo.State()
-				entries, err := state.Filesystem.ReadDir("")
-				if err != nil {
-					t.Fatal(err)
-				}
-				if len(entries) > 0 {
-					t.Errorf("repository is not empty but contains %d entries", len(entries))
-				}
-				if !state.BootstrapMode {
-					t.Fatal("BootstrapMode was not preserved")
-				}
-			},
-		},
-		{
-			Name:          "Reading config in bootstrap mode works",
-			BootstrapMode: true,
-			Setup: func(t *testing.T, remoteDir, localDir string) {
-				EnvironmentConfigsPath := filepath.Join(remoteDir, "..", "environment_configs.json")
-				configContent := `{"uniqueEnv": {"upstream": {"latest": true }}}`
-				err := os.WriteFile(EnvironmentConfigsPath, []byte(configContent), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
-			},
-			Test: func(t *testing.T, repo Repository, remoteDir string) {
-				state := repo.State()
-				entries, err := state.Filesystem.ReadDir("")
-				if err != nil {
-					t.Fatal(err)
-				}
-				if len(entries) > 0 {
-					t.Errorf("repository is not empty but contains %d entries", len(entries))
-				}
-				if !state.BootstrapMode {
-					t.Fatal("BootstrapMode was not preserved")
-				}
-				configs, err := state.GetEnvironmentConfigs()
-				if err != nil {
-					t.Fatal(err)
-				}
-				if len(configs) != 1 {
-					t.Fatal("Configuration not read properly")
-				}
-				if configs["uniqueEnv"].Upstream.Latest != true {
-					t.Fatal("Configuration not read properly")
-				}
-			},
-		},
 	}
 	for _, tc := range tcs {
 		tc := tc
@@ -346,7 +270,6 @@ func TestNew(t *testing.T) {
 					URL:                    "file://" + remoteDir,
 					Path:                   localDir,
 					Branch:                 tc.Branch,
-					BootstrapMode:          tc.BootstrapMode,
 					EnvironmentConfigsPath: filepath.Join(remoteDir, "..", "environment_configs.json"),
 				},
 			)
@@ -355,6 +278,126 @@ func TestNew(t *testing.T) {
 			}
 			if tc.Test != nil {
 				tc.Test(t, repo, remoteDir)
+			}
+		})
+	}
+}
+
+func TestBootstrapModeNew(t *testing.T) {
+	tcs := []struct {
+		Name          string
+		PreInitialize bool
+	}{
+		{
+			Name:          "New in empty repo",
+			PreInitialize: false,
+		},
+		{
+			Name:          "New in existing repo",
+			PreInitialize: true,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			// create a remote
+			dir := t.TempDir()
+			remoteDir := path.Join(dir, "remote")
+			localDir := path.Join(dir, "local")
+
+			cmd := exec.Command("git", "init", "--bare", remoteDir)
+			cmd.Start()
+			cmd.Wait()
+
+			if tc.PreInitialize {
+				_, err := New(
+					context.Background(),
+					Config{
+						URL:  "file://" + remoteDir,
+						Path: localDir,
+					},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			environmentConfigsPath := filepath.Join(remoteDir, "..", "environment_configs.json")
+
+			repo, err := New(
+				context.Background(),
+				Config{
+					URL:                    "file://" + remoteDir,
+					Path:                   localDir,
+					BootstrapMode:          true,
+					EnvironmentConfigsPath: environmentConfigsPath,
+				},
+			)
+			if err != nil {
+				t.Fatalf("New: Expected no error, error %e was thrown", err)
+			}
+
+			state := repo.State()
+			if !state.BootstrapMode {
+				t.Fatalf("Bootstrap mode not preserved")
+			}
+		})
+	}
+}
+
+func TestBootstrapModeReadConfig(t *testing.T) {
+	tcs := []struct {
+		Name string
+	}{
+		{
+			Name: "Config read correctly",
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			// create a remote
+			dir := t.TempDir()
+			remoteDir := path.Join(dir, "remote")
+			localDir := path.Join(dir, "local")
+
+			cmd := exec.Command("git", "init", "--bare", remoteDir)
+			cmd.Start()
+			cmd.Wait()
+
+			environmentConfigsPath := filepath.Join(remoteDir, "..", "environment_configs.json")
+			if err := os.WriteFile(environmentConfigsPath, []byte(`{"uniqueEnv": {"upstream": {"latest": true}}}`), fs.FileMode(0644)); err != nil {
+				t.Fatal(err)
+			}
+
+			repo, err := New(
+				context.Background(),
+				Config{
+					URL:                    "file://" + remoteDir,
+					Path:                   localDir,
+					BootstrapMode:          true,
+					EnvironmentConfigsPath: environmentConfigsPath,
+				},
+			)
+			if err != nil {
+				t.Fatalf("New: Expected no error, error %e was thrown", err)
+			}
+
+			state := repo.State()
+			if !state.BootstrapMode {
+				t.Fatalf("Bootstrap mode not preserved")
+			}
+			configs, err := state.GetEnvironmentConfigs()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(configs) != 1 {
+				t.Fatal("Configuration not read properly")
+			}
+			if configs["uniqueEnv"].Upstream.Latest != true {
+				t.Fatal("Configuration not read properly")
 			}
 		})
 	}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -626,6 +626,11 @@ func (c *CreateEnvironment) Transform(ctx context.Context, state *State) (string
 	if err := fs.MkdirAll(envDir, 0777); err != nil {
 		return "", err
 	} else {
+		// Creaetion of environment is possible, but configuring it is not if running in bootstrap mode.
+		// Configuration needs to be done by modifying config map in source repo
+		if state.BootstrapMode && c.Config != (config.EnvironmentConfig{}) {
+			return "", fmt.Errorf("Cannot create or update configuration in bootstrap mode. Please update configuration in config map instead.")
+		}
 		configFile := fs.Join(envDir, "config.json")
 		file, err := fs.OpenFile(configFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
 		if err != nil {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -623,14 +623,14 @@ type CreateEnvironment struct {
 func (c *CreateEnvironment) Transform(ctx context.Context, state *State) (string, error) {
 	fs := state.Filesystem
 	envDir := fs.Join("environments", c.Environment)
+	// Creation of environment is possible, but configuring it is not if running in bootstrap mode.
+	// Configuration needs to be done by modifying config map in source repo
+	if state.BootstrapMode && c.Config != (config.EnvironmentConfig{}) {
+		return "", fmt.Errorf("Cannot create or update configuration in bootstrap mode. Please update configuration in config map instead.")
+	}
 	if err := fs.MkdirAll(envDir, 0777); err != nil {
 		return "", err
 	} else {
-		// Creaetion of environment is possible, but configuring it is not if running in bootstrap mode.
-		// Configuration needs to be done by modifying config map in source repo
-		if state.BootstrapMode && c.Config != (config.EnvironmentConfig{}) {
-			return "", fmt.Errorf("Cannot create or update configuration in bootstrap mode. Please update configuration in config map instead.")
-		}
 		configFile := fs.Join(envDir, "config.json")
 		file, err := fs.OpenFile(configFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
 		if err != nil {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1829,6 +1829,16 @@ spec:
 				}
 			},
 		},
+		{
+			Name:          "CreateEnvironment does not error in bootstrap mode without configuration",
+			BootstrapMode: true,
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "production",
+				},
+			},
+			Test: func(t *testing.T, s *State) {},
+		},
 	}
 	for _, tc := range tcs {
 		tc := tc

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -480,10 +480,11 @@ func TestTransformer(t *testing.T) {
 	c1 := config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Latest: true}}
 
 	tcs := []struct {
-		Name         string
-		Transformers []Transformer
-		Test         func(t *testing.T, s *State)
-		ErrorTest    func(t *testing.T, err error)
+		Name          string
+		Transformers  []Transformer
+		Test          func(t *testing.T, s *State)
+		ErrorTest     func(t *testing.T, err error)
+		BootstrapMode bool
 	}{
 		{
 			Name:         "Create Versions and do not clean up because not enough versions",
@@ -1815,6 +1816,19 @@ spec:
 				}
 			},
 		},
+		{
+			Name:          "CreateEnvironment errors in bootstrap mode",
+			BootstrapMode: true,
+			Transformers: []Transformer{
+				&CreateEnvironment{Environment: "production", Config: c1},
+			},
+			ErrorTest: func(t *testing.T, err error) {
+				expectedError := "Cannot create or update configuration in bootstrap mode. Please update configuration in config map instead."
+				if err.Error() != expectedError {
+					t.Errorf("Expected error '%s', got '%s'", expectedError, err.Error())
+				}
+			},
+		},
 	}
 	for _, tc := range tcs {
 		tc := tc
@@ -1833,6 +1847,7 @@ spec:
 					Path:           localDir,
 					CommitterEmail: "kuberpult@freiheit.com",
 					CommitterName:  "kuberpult",
+					BootstrapMode:  tc.BootstrapMode,
 				},
 			)
 			if err != nil {


### PR DESCRIPTION
If `KUBERPULT_BOOTSTRAP_MODE=true` env variable is provided, then read kuberpult configuration from `./environment_configs.json` and not from manifest repo. 

If bootstrap mode is true, then updating configurations is not allowed. But creating environment without configuration is still allowed.

This file will be created in a subsequent pr from configmap

[SRX-NXORS9](https://revolution.dev/app/-JqFGExX46gs9mH7vxR5/-M37cZx7XYoOvQ5Mmcir/STORY/-N4m28IVhuVJW1-LvRHi/)