### PR TITLE
Add bootstrap mode in kuberpult chart

### DIFF
--- a/charts/kuberpult/ci/test-values-override.yaml
+++ b/charts/kuberpult/ci/test-values-override.yaml
@@ -17,6 +17,7 @@ frontend:
     limits:
       cpu: 250m
 environment_configs:
+  bootstrap_mode: true
   environment_configs_json: |
     {
       "production": {

--- a/charts/kuberpult/ci/test-values-override.yaml
+++ b/charts/kuberpult/ci/test-values-override.yaml
@@ -16,4 +16,14 @@ frontend:
       cpu: 250m
     limits:
       cpu: 250m
-
+environment_configs:
+  environment_configs_json: |
+    {
+      "production": {
+        "upstream": {
+            "latest": true
+         },
+         "argocd" :{}
+      }
+    }
+ 

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -130,6 +130,8 @@ spec:
               name: kuberpult-argocd
               key: KUBERPULT_ARGO_CD_PASS
 {{- end }}
+        - name: KUBERPULT_BOOTSTRAP_MODE
+          value: {{ .Values.environment_configs.bootstrap_mode }}
         volumeMounts:
         - name: repository
           mountPath: /repository

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -144,6 +144,11 @@ spec:
           mountPath: {{ .Values.dogstatsdMetrics.hostSocketPath }}
           readOnly: true
 {{- end }}
+{{- if .Values.environment_configs.bootstrap_mode }}
+        - name: environment_configs
+          mountPath: /repository/environment_configs.json
+          subPath: environment_configs.json
+{{- end }}
       volumes:
       - name: ssh
         secret:
@@ -152,6 +157,14 @@ spec:
       - name: keyring
         configMap:
           name: kuberpult-keyring
+{{- end }}
+{{- if .Values.environment_configs.bootstrap_mode }}
+      - name: environment_configs
+        configMap:
+          items: 
+          - key: environment_configs.json
+            path: environment_configs.json
+          name: environment_configs
 {{- end }}
 {{- if .Values.dogstatsdMetrics.enabled }}
       - name: dsdsocket
@@ -229,3 +242,13 @@ type: Opaque
 data:
   KUBERPULT_ARGO_CD_PASS: {{ .Values.argocd.password | b64enc }}
 {{- end }}
+{{- if .Values.environment_configs.bootstrap_mode }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: environment_configs 
+data:
+  environment_configs.json: {{ required ".Values.environment_configs.environment_configs.json is required in bootstrap mode" .Values.environment_configs.environment_configs.json | quote }}
+{{- end }}
+

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -145,8 +145,8 @@ spec:
           readOnly: true
 {{- end }}
 {{- if .Values.environment_configs.bootstrap_mode }}
-        - name: environment_configs
-          mountPath: /repository/environment_configs.json
+        - name: environment-configs
+          mountPath: /environment_configs.json
           subPath: environment_configs.json
 {{- end }}
       volumes:
@@ -159,12 +159,12 @@ spec:
           name: kuberpult-keyring
 {{- end }}
 {{- if .Values.environment_configs.bootstrap_mode }}
-      - name: environment_configs
+      - name: environment-configs
         configMap:
           items: 
           - key: environment_configs.json
             path: environment_configs.json
-          name: environment_configs
+          name: environment-configs
 {{- end }}
 {{- if .Values.dogstatsdMetrics.enabled }}
       - name: dsdsocket
@@ -247,8 +247,8 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: environment_configs 
+  name: environment-configs 
 data:
-  environment_configs.json: {{ required ".Values.environment_configs.environment_configs.json is required in bootstrap mode" .Values.environment_configs.environment_configs.json | quote }}
+  environment_configs.json: {{ required ".Values.environment_configs.environment_configs_json is required when .Values.environment_configs.bootstrap is true" .Values.environment_configs.environment_configs_json | quote }}
 {{- end }}
 

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -130,8 +130,10 @@ spec:
               name: kuberpult-argocd
               key: KUBERPULT_ARGO_CD_PASS
 {{- end }}
+{{- if .Values.environment_configs.bootstrap_mode }}
         - name: KUBERPULT_BOOTSTRAP_MODE
-          value: {{ .Values.environment_configs.bootstrap_mode }}
+          value: "{{ .Values.environment_configs.bootstrap_mode }}"
+{{- end }}
         volumeMounts:
         - name: repository
           mountPath: /repository

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -81,13 +81,13 @@ gke:
 
 environment_configs:
   bootstrap_mode: true
-  environment_configs.json: |
-    {
-      "production": {
-        "upstream": {
-            "latest": true
-         },
-         "argocd" :{}
-      }
-    }
-  # environment_configs.json: null
+  # environment_configs_json: |
+  #   {
+  #     "production": {
+  #       "upstream": {
+  #           "latest": true
+  #        },
+  #        "argocd" :{}
+  #     }
+  #   }
+  environment_configs_json: null

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -78,3 +78,16 @@ imagePullSecrets: []
 gke:
   backend_service_id: ""
   project_number: ""
+
+environment_configs:
+  bootstrap_mode: true
+  environment_configs.json: |
+    {
+      "production": {
+        "upstream": {
+            "latest": true
+         },
+         "argocd" :{}
+      }
+    }
+  # environment_configs.json: null

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -80,7 +80,7 @@ gke:
   project_number: ""
 
 environment_configs:
-  bootstrap_mode: true
+  bootstrap_mode: false
   # environment_configs_json: |
   #   {
   #     "production": {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -876,14 +876,11 @@ func (s *State) readSymlink(environment string, application string, symlinkName 
 var invalidJson = errors.New("JSON file is not valid")
 
 func (s *State) GetEnvironmentConfigs() (map[string]config.EnvironmentConfig, error) {
-	fmt.Println("In GetEnvironmentConfigs")
-	fmt.Println("bootstrap mode", s.BootstrapMode)
 	if s.BootstrapMode {
 		result := map[string]config.EnvironmentConfig{}
 		buf, err := ioutil.ReadFile(s.EnvironmentConfigsPath)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				fmt.Println("File not found", s.EnvironmentConfigsPath)
 				return result, nil
 			}
 			return nil, err
@@ -891,10 +888,6 @@ func (s *State) GetEnvironmentConfigs() (map[string]config.EnvironmentConfig, er
 		err = yaml.Unmarshal(buf, &result)
 		if err != nil {
 			return nil, err
-		}
-		fmt.Println("File found", result)
-		for k, v := range result {
-			fmt.Println(k, v.Upstream.Latest)
 		}
 		return result, nil
 	} else {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -876,11 +876,14 @@ func (s *State) readSymlink(environment string, application string, symlinkName 
 var invalidJson = errors.New("JSON file is not valid")
 
 func (s *State) GetEnvironmentConfigs() (map[string]config.EnvironmentConfig, error) {
+	fmt.Println("In GetEnvironmentConfigs")
+	fmt.Println("bootstrap mode", s.BootstrapMode)
 	if s.BootstrapMode {
 		result := map[string]config.EnvironmentConfig{}
 		buf, err := ioutil.ReadFile(s.EnvironmentConfigsPath)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
+				fmt.Println("File not found", s.EnvironmentConfigsPath)
 				return result, nil
 			}
 			return nil, err
@@ -889,6 +892,7 @@ func (s *State) GetEnvironmentConfigs() (map[string]config.EnvironmentConfig, er
 		if err != nil {
 			return nil, err
 		}
+		fmt.Println("File found", result)
 		for k, v := range result {
 			fmt.Println(k, v.Upstream.Latest)
 		}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -889,6 +889,7 @@ func (s *State) GetEnvironmentConfigs() (map[string]config.EnvironmentConfig, er
 		if err != nil {
 			return nil, err
 		}
+		fmt.Println("test print", result["production"].Upstream.Latest)
 		return result, nil
 	} else {
 		envs, err := s.Filesystem.ReadDir("environments")

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -889,7 +889,9 @@ func (s *State) GetEnvironmentConfigs() (map[string]config.EnvironmentConfig, er
 		if err != nil {
 			return nil, err
 		}
-		fmt.Println("test print", result["production"].Upstream.Latest)
+		for k, v := range result {
+			fmt.Println(k, v.Upstream.Latest)
+		}
 		return result, nil
 	} else {
 		envs, err := s.Filesystem.ReadDir("environments")

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -267,10 +267,9 @@ func TestNew(t *testing.T) {
 			repo, err := New(
 				context.Background(),
 				Config{
-					URL:                    "file://" + remoteDir,
-					Path:                   localDir,
-					Branch:                 tc.Branch,
-					EnvironmentConfigsPath: filepath.Join(remoteDir, "..", "environment_configs.json"),
+					URL:    "file://" + remoteDir,
+					Path:   localDir,
+					Branch: tc.Branch,
 				},
 			)
 			if err != nil {


### PR DESCRIPTION
Add bootstrap mode in chart.
When bootstrap mode is enabled, configuration is read from configmap in source repository and not from config files in manifest repo

[SRX-NXORS9](https://revolution.dev/app/-JqFGExX46gs9mH7vxR5/-M37cZx7XYoOvQ5Mmcir/STORY/-N4m28IVhuVJW1-LvRHi/)