### PR TITLE
Add better error messages to deleting locks SRX-9TWQNN

### DIFF
--- a/pkg/testfs/testfs.go
+++ b/pkg/testfs/testfs.go
@@ -1,0 +1,254 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
+
+Copyright 2021 freiheit.com*/
+package testfs
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/go-git/go-billy/v5"
+)
+
+type Operation int
+
+const (
+	NONE Operation = iota
+	CREATE
+	OPEN
+	OPENFILE
+	STAT
+	RENAME
+	REMOVE
+	READDIR
+	SYMLINK
+	READLINK
+	MKDIRALL
+)
+
+func (o Operation) String() string {
+	switch o {
+	case CREATE:
+		return "Create"
+	case OPEN:
+		return "Open"
+	case OPENFILE:
+		return "OpenFile"
+	case STAT:
+		return "Stat"
+	case RENAME:
+		return "Rename"
+	case REMOVE:
+		return "Remove"
+	case READDIR:
+		return "ReadDir"
+	case SYMLINK:
+		return "Symlink"
+	case READLINK:
+		return "ReadLink"
+	case MKDIRALL:
+		return "MkdirAll"
+	}
+	return fmt.Sprintf("unknown(%d)", o)
+}
+
+type FileOperation struct {
+	Operation Operation
+	Filename  string
+}
+
+type value struct {
+	errored bool
+}
+
+// UsageCollector tracks which file operations have been used in a test suite and reports which were not
+// tested with an injected error.
+type UsageCollector struct {
+	mx    sync.Mutex
+	usage map[FileOperation]value
+}
+
+func (u *UsageCollector) used(op Operation, filename string) {
+	u.mx.Lock()
+	defer u.mx.Unlock()
+	if u.usage == nil {
+		u.usage = map[FileOperation]value{}
+	}
+	_, ok := u.usage[FileOperation{op, filename}]
+	if !ok {
+		u.usage[FileOperation{op, filename}] = value{}
+	}
+}
+
+func (u *UsageCollector) errored(op Operation, filename string) {
+	u.mx.Lock()
+	defer u.mx.Unlock()
+	if u.usage == nil {
+		u.usage = map[FileOperation]value{}
+	}
+	u.usage[FileOperation{op, filename}] = value{errored: true}
+}
+
+func (u *UsageCollector) UntestedOps() []FileOperation {
+	u.mx.Lock()
+	defer u.mx.Unlock()
+	result := []FileOperation{}
+	for k, v := range u.usage {
+		if !v.errored {
+			result = append(result, k)
+		}
+	}
+	return result
+}
+
+type errorInjector struct {
+	operation Operation
+	filename  string
+	err       error
+	used      bool
+	collector *UsageCollector
+}
+
+func (e *errorInjector) inject(op Operation, filename string) error {
+	if e.used {
+		return nil
+	} else if e.operation == op && e.filename == filename {
+		e.used = true
+		e.collector.errored(op, filename)
+		return e.err
+	}
+	e.collector.used(op, filename)
+	return nil
+}
+
+func (uc *UsageCollector) WithError(fs billy.Filesystem, op Operation, filename string, err error) *Filesystem {
+	return &Filesystem{
+		Inner: fs,
+		errorInjector: errorInjector{
+			operation: op,
+			filename:  filename,
+			err:       err,
+			collector: uc,
+		},
+	}
+}
+
+// A special filesystem that allows injecting errors at arbitrary operations.
+type Filesystem struct {
+	Inner         billy.Filesystem
+	errorInjector errorInjector
+}
+
+func (f *Filesystem) Create(filename string) (billy.File, error) {
+	err := f.errorInjector.inject(CREATE, filename)
+	if err != nil {
+		return nil, err
+	}
+	return f.Inner.Create(filename)
+}
+
+func (f *Filesystem) Open(filename string) (billy.File, error) {
+	err := f.errorInjector.inject(OPEN, filename)
+	if err != nil {
+		return nil, err
+	}
+	return f.Inner.Open(filename)
+}
+
+func (f *Filesystem) OpenFile(filename string, flag int, perm os.FileMode) (billy.File, error) {
+	err := f.errorInjector.inject(OPENFILE, filename)
+	if err != nil {
+		return nil, err
+	}
+	return f.Inner.OpenFile(filename, flag, perm)
+}
+
+func (f *Filesystem) Stat(filename string) (os.FileInfo, error) {
+	err := f.errorInjector.inject(STAT, filename)
+	if err != nil {
+		return nil, err
+	}
+	return f.Inner.Stat(filename)
+}
+
+func (f *Filesystem) Rename(oldpath, newpath string) error {
+	err := f.errorInjector.inject(RENAME, oldpath)
+	if err != nil {
+		return err
+	}
+	return f.Inner.Rename(oldpath, newpath)
+}
+
+func (f *Filesystem) Remove(filename string) error {
+	err := f.errorInjector.inject(REMOVE, filename)
+	if err != nil {
+		return err
+	}
+	return f.Inner.Remove(filename)
+}
+
+func (f *Filesystem) Join(elem ...string) string {
+	return f.Inner.Join(elem...)
+}
+
+func (f *Filesystem) TempFile(dir, prefix string) (billy.File, error) {
+	return f.Inner.TempFile(dir, prefix)
+}
+
+func (f *Filesystem) Lstat(filename string) (os.FileInfo, error) {
+	return f.Inner.Lstat(filename)
+}
+
+func (f *Filesystem) Symlink(target, link string) error {
+	err := f.errorInjector.inject(SYMLINK, link)
+	if err != nil {
+		return err
+	}
+	return f.Inner.Symlink(target, link)
+}
+
+func (f *Filesystem) Readlink(link string) (string, error) {
+	err := f.errorInjector.inject(READLINK, link)
+	if err != nil {
+		return "", err
+	}
+	return f.Inner.Readlink(link)
+}
+
+func (f *Filesystem) ReadDir(path string) ([]os.FileInfo, error) {
+	err := f.errorInjector.inject(READDIR, path)
+	if err != nil {
+		return nil, err
+	}
+	return f.Inner.ReadDir(path)
+}
+
+func (f *Filesystem) MkdirAll(filename string, perm os.FileMode) error {
+	err := f.errorInjector.inject(MKDIRALL, filename)
+	if err != nil {
+		return err
+	}
+	return f.Inner.MkdirAll(filename, perm)
+}
+
+func (f *Filesystem) Chroot(path string) (billy.Filesystem, error) {
+	panic("Chroot not implemented")
+}
+
+func (f *Filesystem) Root() string {
+	panic("Root not implemented")
+}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -860,11 +860,12 @@ func (s *State) readSymlink(environment string, application string, symlinkName 
 			// if the link does not exist, we return nil
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("failed reading symlink %q: %w",version,err)
 	} else {
-		if stat, err := s.Filesystem.Stat(s.Filesystem.Join("environments", environment, "applications", application, lnk)); err != nil {
+		target := s.Filesystem.Join("environments", environment, "applications", application, lnk)
+		if stat, err := s.Filesystem.Stat(target); err != nil {
 			// if the file that the link points to does not exist, that's an error
-			return nil, err
+			return nil, fmt.Errorf("failed stating %q: %w",target,err)
 		} else {
 			res, err := strconv.ParseUint(stat.Name(), 10, 64)
 			return &res, err

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -535,7 +535,7 @@ func (c *DeleteEnvironmentLock) Transform(ctx context.Context, state *State) (st
 	fs := state.Filesystem
 	file := fs.Join("environments", c.Environment, "locks", c.LockId)
 	if err := fs.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", err
+		return "", fmt.Errorf("failed to delete file %q: %w", file, err)
 	} else {
 		s := State{
 			Filesystem: fs,
@@ -601,7 +601,7 @@ func (c *DeleteEnvironmentApplicationLock) Transform(ctx context.Context, state 
 	fs := state.Filesystem
 	file := fs.Join("environments", c.Environment, "applications", c.Application, "locks", c.LockId)
 	if err := fs.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", err
+		return "", fmt.Errorf("failed to delete file %q: %w", file, err)
 	} else {
 		s := State{
 			Filesystem: fs,

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/freiheit-com/kuberpult/pkg/api"
+	"github.com/freiheit-com/kuberpult/pkg/testfs"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/config"
 	"github.com/go-git/go-billy/v5/util"
 	godebug "github.com/kylelemons/godebug/diff"
@@ -251,10 +252,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			repo, err := setupRepositoryTest(t)
-			if err != nil {
-				t.Fatal(err)
-			}
+			repo := setupRepositoryTest(t)
 
 			ctx := context.Background()
 			commitMsg, _, err := repo.ApplyTransformersInternal(ctx, tc.Transformers...)
@@ -367,10 +365,7 @@ func TestUndeployErrors(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			repo, err := setupRepositoryTest(t)
-			if err != nil {
-				t.Fatal(err)
-			}
+			repo := setupRepositoryTest(t)
 			ctx := context.Background()
 			commitMsg, _, err := repo.ApplyTransformersInternal(ctx, tc.Transformers...)
 			// note that we only check the LAST error here:
@@ -446,10 +441,7 @@ func TestReleaseTrainErrors(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			repo, err := setupRepositoryTest(t)
-			if err != nil {
-				t.Fatal(err)
-			}
+			repo := setupRepositoryTest(t)
 			ctx := context.Background()
 			commitMsg, _, err := repo.ApplyTransformersInternal(ctx, tc.Transformers...)
 			// note that we only check the LAST error here:
@@ -2029,7 +2021,7 @@ func makeTransformersForDelete(numVersions uint64) []Transformer {
 	return res
 }
 
-func setupRepositoryTest(t *testing.T) (Repository, error) {
+func setupRepositoryTest(t *testing.T) Repository {
 	dir := t.TempDir()
 	remoteDir := path.Join(dir, "remote")
 	localDir := path.Join(dir, "local")
@@ -2048,5 +2040,151 @@ func setupRepositoryTest(t *testing.T) (Repository, error) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return repo, nil
+	return repo
+}
+
+
+// Injects an error in the filesystem of the state
+type injectErr struct {
+	Transformer
+	collector *testfs.UsageCollector
+	operation testfs.Operation
+	filename  string
+	err       error
+}
+
+func (i *injectErr) Transform(ctx context.Context, state *State) (string, error) {
+	original := state.Filesystem
+	state.Filesystem = i.collector.WithError(state.Filesystem, i.operation, i.filename, i.err)
+	s, err := i.Transformer.Transform(ctx, state)
+	state.Filesystem = original
+	return s, err
+}
+
+func TestAllErrorsHandledDeleteEnvironmentLock(t *testing.T) {
+	t.Parallel()
+	collector := &testfs.UsageCollector{}
+	tcs := []struct {
+		name          string
+		operation     testfs.Operation
+		filename      string
+		expectedError string
+	}{
+		{
+			name:          "delete lock succedes",
+		},
+		{
+			name:          "delete lock fails",
+			operation:     testfs.REMOVE,
+			filename:      "environments/dev/locks/foo",
+			expectedError: "failed to delete file \"environments/dev/locks/foo\": obscure error",
+		},
+		{
+			name:          "readdir fails",
+			operation:     testfs.READDIR,
+			filename:      "environments/dev/applications",
+			expectedError: "environment applications for \"dev\" not found: obscure error",
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			repo := setupRepositoryTest(t)
+			err := repo.Apply(context.Background(), &CreateEnvironment{
+				Environment: "dev",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = repo.Apply(context.Background(), &injectErr{
+				Transformer: &DeleteEnvironmentLock{
+					Environment: "dev",
+					LockId:      "foo",
+				},
+				collector: collector,
+				operation: tc.operation,
+				filename:  tc.filename,
+				err:       fmt.Errorf("obscure error"),
+			})
+			if tc.expectedError != "" {
+			if err.Error() != tc.expectedError {
+				t.Errorf("expected error to be %q but got %q", tc.expectedError, err)
+			}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, but got %q", err)
+				}
+			}
+		})
+	}
+	untested := collector.UntestedOps()
+	for _, op := range untested {
+		t.Errorf("Untested operations %s %s", op.Operation, op.Filename)
+	}
+}
+
+func TestAllErrorsHandledDeleteEnvironmentApplicationLock(t *testing.T) {
+	t.Parallel()
+	collector := &testfs.UsageCollector{}
+	tcs := []struct {
+		name          string
+		operation     testfs.Operation
+		filename      string
+		expectedError string
+	}{
+		{
+			name:          "delete lock succedes",
+		},
+		{
+			name:          "delete lock fails",
+			operation:     testfs.REMOVE,
+			filename:      "environments/dev/applications/bar/locks/foo",
+			expectedError: "failed to delete file \"environments/dev/applications/bar/locks/foo\": obscure error",
+		},
+		{
+			name:          "stat queue failes",
+			operation:     testfs.READLINK,
+			filename:      "environments/dev/applications/bar/queued_version",
+			expectedError: "failed reading symlink \"environments/dev/applications/bar/queued_version\": obscure error",
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			repo := setupRepositoryTest(t)
+			err := repo.Apply(context.Background(), &CreateEnvironment{
+				Environment: "dev",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = repo.Apply(context.Background(), &injectErr{
+				Transformer: &DeleteEnvironmentApplicationLock{
+					Environment: "dev",
+					Application: "bar",
+					LockId:      "foo",
+				},
+				collector: collector,
+				operation: tc.operation,
+				filename:  tc.filename,
+				err:       fmt.Errorf("obscure error"),
+			})
+			if tc.expectedError != "" {
+			if err == nil {
+				t.Errorf("expected error to be %q but got <nil>", tc.expectedError)
+			} else if err.Error() != tc.expectedError {
+
+				t.Errorf("expected error to be %q but got %q", tc.expectedError, err)
+			}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, but got %q", err)
+				}
+			}
+		})
+	}
+	untested := collector.UntestedOps()
+	for _, op := range untested {
+		t.Errorf("Untested operations %s %s", op.Operation, op.Filename)
+	}
 }


### PR DESCRIPTION
Several file operations didn't have useful error messages. I've added more context to them and also made sure that we actually get good error messages by using a special testfs that injects errors at arbitrary places.