### PR TITLE
WIP: Allow builderless jobs

### DIFF
--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -67,14 +67,14 @@ jobs:
 
   build_and_publish:
     needs: [github_convertor, execution_plan]
+    if: needs.github_convertor.outputs.matrix != '[]'
     strategy:
       matrix: 
         data: ${{fromJSON(needs.github_convertor.outputs.matrix)}}
     name: ${{ matrix.data.directory }} - Build and Publish
-    if: needs.github_convertor.outputs.matrix != '[]' && ${{ matrix.data.image != "" }}
     runs-on: ubuntu-latest
-    container: 
-      image: ${{ matrix.data.image }}
+    container: ubuntu-latest
+      # image: ${{ matrix.data.image }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -67,11 +67,11 @@ jobs:
 
   build_and_publish:
     needs: [github_convertor, execution_plan]
-    if: needs.github_convertor.outputs.matrix != '[]'
     strategy:
       matrix: 
         data: ${{fromJSON(needs.github_convertor.outputs.matrix)}}
     name: ${{ matrix.data.directory }} - Build and Publish
+    if: needs.github_convertor.outputs.matrix != '[]' && ${{ matrix.data.image != "" }}
     runs-on: ubuntu-latest
     container: 
       image: ${{ matrix.data.image }}

--- a/infrastructure/docker/builder/Makefile
+++ b/infrastructure/docker/builder/Makefile
@@ -37,3 +37,7 @@ release:
 publish: login release
 	echo $(VERSION)
 	echo $(IMAGENAME)
+
+.PHONY: get-builder-image
+get-builder-image:
+	@echo "$(KUBERPULT_BUILDER)"

--- a/infrastructure/docker/builder/Makefile
+++ b/infrastructure/docker/builder/Makefile
@@ -37,7 +37,3 @@ release:
 publish: login release
 	echo $(VERSION)
 	echo $(IMAGENAME)
-
-.PHONY: get-builder-image
-get-builder-image:
-	@echo "$(KUBERPULT_BUILDER)"

--- a/infrastructure/docker/builder/Makefile
+++ b/infrastructure/docker/builder/Makefile
@@ -41,3 +41,4 @@ publish: login release
 .PHONY: get-builder-image
 get-builder-image:
 	@echo "$(KUBERPULT_BUILDER)"
+


### PR DESCRIPTION
When builder image is not provided, the build job should run on the base image without container.