### PR TITLE
Use emptyDir in order to work around volume growth

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -143,6 +143,12 @@ spec:
           subPath: environment_configs.json
 {{- end }}
       volumes:
+      - name: repository
+        # We use emptyDir, because none of our data needs to survive for long (it's all in the github repo).
+        # EmptyDir has the nice advantage, that it triggers a restart of the pod and creates a new volume when the current one is full
+        # Because of an issue in gitlib2, this actually happens.
+        emptyDir:
+          sizeLimit: 10G
       - name: ssh
         secret:
           secretName: kuberpult-ssh
@@ -164,14 +170,6 @@ spec:
         hostPath:
           path: {{ .Values.dogstatsdMetrics.hostSocketPath }}
 {{- end }}
-  volumeClaimTemplates:
-  - metadata:
-      name: repository
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: "5Gi"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
With GitLib2 we have the issue that the storage slowly, but eventually runs full.
Using emptyDir works around this issue,
as it restarts the pod and creates a new volume when the original volume is full.
Plus, we never needed our volume to be persistent anyway.
All critical data is saved in the manifest repository.