### PR TITLE
Temporarily going back to use a persistant volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## 0.4.33
 
 **released 2022-08-11**
+
 ### Fixed
-* Fixed issue with cache being ineffective [#266](https://github.com/freiheit-com/kuberpult/pull/266)
+* Temporarily going back to use a persistant volume [#290](https://github.com/freiheit-com/kuberpult/pull/290)
 
 ## 0.4.32
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.4.33
+
+**released 2022-08-11**
+### Fixed
+* Fixed issue with cache being ineffective [#266](https://github.com/freiheit-com/kuberpult/pull/266)
+
 ## 0.4.32
 
 **released 2022-07-27**

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -143,12 +143,6 @@ spec:
           subPath: environment_configs.json
 {{- end }}
       volumes:
-      - name: repository
-        # We use emptyDir, because none of our data needs to survive for long (it's all in the github repo).
-        # EmptyDir has the nice advantage, that it triggers a restart of the pod and creates a new volume when the current one is full
-        # Because of an issue in gitlib2, this actually happens.
-        emptyDir:
-          sizeLimit: 10G
       - name: ssh
         secret:
           secretName: kuberpult-ssh
@@ -170,6 +164,14 @@ spec:
         hostPath:
           path: {{ .Values.dogstatsdMetrics.hostSocketPath }}
 {{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: repository
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: "15Gi"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Currently we still have a cache, and that cache only works when the data is stored beyond pod restarts.
In the future we will remove the cache and go back to emptydir, but for now, we need the cache working.
This does not fix the high memory usage, but it will improve startup times after the cache is filled once.

This is almost an exact revert of commit fc057869dc4656cc59e5db195f1cb4879c720add.
