### PR TITLE
Remove token validation from root path

### DIFF
--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -140,10 +140,13 @@ func StreamInterceptor(
 
 func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfunc.JWKS, clientId string, tenantId string) error {
 	token := req.Header.Get("authorization")
-	err := ValidateToken(token, jwks, clientId, tenantId)
-	if err != nil {
-		resp.WriteHeader(http.StatusUnauthorized)
-		resp.Write([]byte("Invalid authorization header provided"))
+	if req.URL.Path != "/" {
+		err := ValidateToken(token, jwks, clientId, tenantId)
+		if err != nil {
+			resp.WriteHeader(http.StatusUnauthorized)
+			resp.Write([]byte("Invalid authorization header provided"))
+		}
+		return err
 	}
-	return err
+	return nil
 }

--- a/services/cd-service/Buildfile
+++ b/services/cd-service/Buildfile
@@ -9,3 +9,4 @@ metadata:
 spec:
   dependsOn:
   - ../../charts/kuberpult
+  - ../../pkg

--- a/services/frontend-service/Buildfile
+++ b/services/frontend-service/Buildfile
@@ -4,3 +4,4 @@ metadata:
 spec:
   dependsOn:
   - ../../charts/kuberpult
+  - ../../pkg


### PR DESCRIPTION
without this, when loading the url for kuberpult, the react ui would not be displayed. Instead it would throw an error that invalid auth header specified. So to get access to react ui, this path shouldn't have authorization