### PR TITLE
Remove full auth context (without dummy msal instance) test. To avoid document.cookie error

### DIFF
--- a/services/frontend-service/src/legacy-ui/App/AuthContext.test.tsx
+++ b/services/frontend-service/src/legacy-ui/App/AuthContext.test.tsx
@@ -15,8 +15,7 @@ along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
 
 Copyright 2021 freiheit.com*/
 import { act, render, screen, waitFor } from '@testing-library/react';
-import { AuthProvider, AzureAutoSignIn } from './AuthContext';
-import { ConfigsContext } from './index';
+import { AzureAutoSignIn } from './AuthContext';
 import { Crypto } from '@peculiar/webcrypto';
 import { PublicClientApplication, IPublicClientApplication, Configuration, AccountInfo } from '@azure/msal-browser';
 import { AuthenticatedTemplate, MsalProvider, UnauthenticatedTemplate } from '@azure/msal-react';
@@ -37,50 +36,10 @@ describe('AuthProvider', () => {
             clientId,
         },
     };
-    const getAuthProvider = ({ enableAzureAuth }: { enableAzureAuth: boolean }) => {
-        const configs = {
-            authConfig: {
-                azureAuth: {
-                    enabled: enableAzureAuth,
-                    clientId,
-                    cloudInstance: 'https://login.microsoftonline.com/',
-                    redirectURL: 'http://localhost:3000',
-                    tenantId,
-                },
-            },
-        };
-        const setConfigs = () => {};
-        return (
-            <ConfigsContext.Provider value={{ configs, setConfigs }}>
-                <AuthProvider>
-                    <>Content</>
-                </AuthProvider>
-            </ConfigsContext.Provider>
-        );
-    };
 
     beforeAll(() => {
         Object.defineProperty(window, 'crypto', {
             value: new Crypto(),
-        });
-    });
-
-    describe.each([
-        {
-            name: 'Shows unauthed content when not logged in',
-            enableAzureAuth: true,
-            content: 'Redirecting to login',
-        },
-        {
-            name: 'Shows normal content when not auth not enabled',
-            enableAzureAuth: false,
-            content: 'Content',
-        },
-    ])(`Use azure auth`, (testcase: any) => {
-        it(testcase.name, async () => {
-            render(getAuthProvider(testcase));
-            await act(async () => await global.nextTick());
-            expect(screen.getByText(testcase.content)).toBeInTheDocument();
         });
     });
 


### PR DESCRIPTION
Adding full instance of msal instance is uncontrollable and calls dom methods in test which break the test.

There are tests that exist with mocked msal isntance, the real one can't be used here. So removing those tests

https://github.com/freiheit-com/kuberpult/runs/7834909962?check_suite_focus=true#step:9:174