### PR TITLE
Add documentation for scripts and return nil when locks are not found

### DIFF
--- a/infrastructure/scripts/metadata-migration/Migration.md
+++ b/infrastructure/scripts/metadata-migration/Migration.md
@@ -5,15 +5,18 @@ We can improve this, by storing data explicitly, instead of relying on the git-h
 We do this anyway for some things like author.
 * The releases script goes over all releases for all applications, and writes the commit date
   (the date when this release was created) to a new file `created_at`
-* The locks script goes over all env and app locks, removes the lock **file** and creates a **directory** 
+* The locks script goes over all env and app locks, removes the lock **file** and creates a **directory**
   with the same name instead. Then it writes the commit date (the date when this lock was created)
   as well as the author name and email and the message into files in the new lock directory.
-  
-  
-  
+* The scripts only create the files and do not add or push to GitHub.
+
 The new kuberpult will only read the data in the new format and will ignore old data which is normally deleted by the script.
 
 ## Deployment with Downtime
 1) Shut down kuberpult: Delete StatefulSet
 2) Write data to manifest repo, this could happen locally during downtime
-3) Deploy new kuberpult version that reads new data
+   * clone the manifests repository depends on where Kuberpult is deployed.
+   * cd and run the scripts in the top dir.
+   * Add the created files. and commit the changes to the manifests
+     repo (use a different branch to get approval first).
+3) Merge and then Deploy new kuberpult version that reads new data

--- a/infrastructure/scripts/metadata-migration/Migration.md
+++ b/infrastructure/scripts/metadata-migration/Migration.md
@@ -1,0 +1,19 @@
+# Background
+Kuberpult uses git-data (like time & author of a commit) and displays this in the UI.
+This git-data requires parsing a long list of git commits, and is therefor slow and memory intensive.
+We can improve this, by storing data explicitly, instead of relying on the git-history.
+We do this anyway for some things like author.
+* The releases script goes over all releases for all applications, and writes the commit date
+  (the date when this release was created) to a new file `created_at`
+* The locks script goes over all env and app locks, removes the lock **file** and creates a **directory** 
+  with the same name instead. Then it writes the commit date (the date when this lock was created)
+  as well as the author name and email and the message into files in the new lock directory.
+  
+  
+  
+The new kuberpult will only read the data in the new format and will ignore old data which is normally deleted by the script.
+
+## Deployment with Downtime
+1) Shut down kuberpult: Delete StatefulSet
+2) Write data to manifest repo, this could happen locally during downtime
+3) Deploy new kuberpult version that reads new data

--- a/infrastructure/scripts/metadata-migration/Migration.md
+++ b/infrastructure/scripts/metadata-migration/Migration.md
@@ -19,4 +19,13 @@ The new kuberpult will only read the data in the new format and will ignore old 
    * cd and run the scripts in the top dir.
    * Add the created files. and commit the changes to the manifests
      repo (use a different branch to get approval first).
+     ```bash
+     git clone $MANIFEST_REPO
+     git checkout -b kuberpult_migrate
+     ./create-metadata-locks.sh
+     ./create-metadata-releases.sh
+     git add .
+     git commit -m "migration to new kuberpult"
+     git push
+     ```
 3) Merge and then Deploy new kuberpult version that reads new data

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -790,7 +790,7 @@ func (s *State) GetEnvironmentLocks(environment string) (map[string]Lock, error)
 		result := make(map[string]Lock, len(entries))
 		for _, e := range entries {
 			if !e.IsDir() {
-				continue
+				return nil, fmt.Errorf("error getting environment locks: found file in the locks directory. run migration script to generate correct metadata")
 			}
 			if lock, err := readLock(s.Filesystem, s.Filesystem.Join(base, e.Name())); err != nil {
 				return nil, err
@@ -810,7 +810,7 @@ func (s *State) GetEnvironmentApplicationLocks(environment, application string) 
 		result := make(map[string]Lock, len(entries))
 		for _, e := range entries {
 			if !e.IsDir() {
-				continue
+				return nil, fmt.Errorf("error getting application locks: found file in the locks directory. run migration script to generate correct metadata")
 			}
 			if lock, err := readLock(s.Filesystem, s.Filesystem.Join(base, e.Name())); err != nil {
 				return nil, err

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -741,35 +741,45 @@ type Lock struct {
 }
 
 func readLock(fs billy.Filesystem, lockDir string) (*Lock, error) {
-	msg, err := readFile(fs, fs.Join(lockDir, "message"))
-	if err != nil {
-		return nil, err
-	}
-	email, err := readFile(fs, fs.Join(lockDir, "created_by_email"))
-	if err != nil {
-		return nil, err
-	}
-	name, err := readFile(fs, fs.Join(lockDir, "created_by_name"))
-	if err != nil {
-		return nil, err
-	}
-	date, err := readFile(fs, fs.Join(lockDir, "created_at"))
-	if err != nil {
-		return nil, err
-	}
-	createdAt, err := time.Parse(time.RFC3339, strings.TrimSpace(string(date)))
-	if err != nil {
-		return nil, err
+	lock := &Lock{}
+
+	if cnt, err := readFile(fs, fs.Join(lockDir, "message")); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	} else {
+		lock.Message = string(cnt)
 	}
 
-	return &Lock{
-		Message: strings.TrimSpace(string(msg)),
-		CreatedBy: Actor{
-			Name:  strings.TrimSpace(string(name)),
-			Email: strings.TrimSpace(string(email)),
-		},
-		CreatedAt: createdAt,
-	}, nil
+	if cnt, err := readFile(fs, fs.Join(lockDir, "created_by_email")); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	} else {
+		lock.CreatedBy.Email = string(cnt)
+	}
+
+	if cnt, err := readFile(fs, fs.Join(lockDir, "created_by_name")); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	} else {
+		lock.CreatedBy.Name = string(cnt)
+	}
+
+	if cnt, err := readFile(fs, fs.Join(lockDir, "created_at")); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	} else {
+		if createdAt, err := time.Parse(time.RFC3339, strings.TrimSpace(string(cnt))); err != nil {
+			return nil, err
+		} else {
+			lock.CreatedAt = createdAt
+		}
+	}
+
+	return lock, nil
 }
 
 func (s *State) GetEnvironmentLocks(environment string) (map[string]Lock, error) {


### PR DESCRIPTION
quote from the story: 
> Do not read old data. If data is not found, just return nil/"". 
> Since we have the migration script, this should be fine.