### PR TITLE
Increase frontend service memory to stop OOM-killed

### DIFF
--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -32,10 +32,10 @@ frontend:
   resources:
     limits:
       cpu: 500m
-      memory: 100Mi
+      memory: 250Mi
     requests:
       cpu: 500m
-      memory: 100Mi
+      memory: 250Mi
 ingress:
   annotations: {}
   domainName: null


### PR DESCRIPTION
the ui is taking more memory. could be because the overview response is bigger. or because V2 UI is taking memory too. 

after upgrade from 0.4.33 to 0.4.38
