### PR TITLE
Verify releasetrain requests with pgp

### DIFF
--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -88,6 +88,10 @@ spec:
         - name: KUBERPULT_ENABLE_TRACING
           value: "{{ .Values.datadogTracing.enabled }}"
 {{- end }}
+{{- if .Values.pgp.keyRing }}
+        - name: KUBERPULT_PGP_KEY_RING
+          value: /keyring/keyring.gpg
+{{- end }}
         - name: KUBERPULT_AZURE_ENABLE_AUTH
           value: "{{ .Values.auth.azureAuth.enabled }}"
 {{- if .Values.auth.azureAuth.enabled }}

--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -104,6 +104,17 @@ spec:
         - name: KUBERPULT_AZURE_REDIRECT_URL
           value: "https://{{ .Values.ingress.domainName }}"
 {{- end }}
+        volumeMounts:
+{{ - if .Values.pgp.keyRing }}
+        - name: keyring
+          mountPath: /keyring
+{{ - end }}
+      volumes:
+{{- if .Values.pgp.keyRing }}
+      - name: keyring
+        configMap:
+          name: kuberpult-keyring
+{{- end }}
 
 ---
 apiVersion: v1

--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -105,10 +105,10 @@ spec:
           value: "https://{{ .Values.ingress.domainName }}"
 {{- end }}
         volumeMounts:
-{{ - if .Values.pgp.keyRing }}
+{{- if .Values.pgp.keyRing }}
         - name: keyring
           mountPath: /keyring
-{{ - end }}
+{{- end }}
       volumes:
 {{- if .Values.pgp.keyRing }}
       - name: keyring

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -159,6 +160,12 @@ func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfu
 		if strings.HasPrefix(req.URL.Path, allowedPrefix) {
 			return nil
 		}
+	}
+	// Skip authentication with ID for `/release` and `/releasetrain` endpoints. The requests will be validated with pgp signature
+	// usage in requests made by GitHub Actions and the Publish.sh script.
+	releaseTrainRx := regexp.MustCompile("/environments/[a-z]*/releasetrain")
+	if releaseTrainRx.MatchString(req.URL.Path) {
+		return nil
 	}
 
 	claims, err := ValidateToken(token, jwks, clientId, tenantId)

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -161,7 +161,7 @@ func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfu
 			return nil
 		}
 	}
-	// Skip authentication with ID for `/release` and `/releasetrain` endpoints. The requests will be validated with pgp signature
+	// Skip azure authentication with ID for `/release` and `/releasetrain` endpoints. The requests will be validated with pgp signature
 	// usage in requests from outside the cluster (e.g. by GitHub Actions and the publish.sh script).
 	releaseTrainRx := regexp.MustCompile("/environments/[^/]*/releasetrain")
 	if releaseTrainRx.MatchString(req.URL.Path) {

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -163,7 +163,7 @@ func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfu
 	}
 	// Skip authentication with ID for `/release` and `/releasetrain` endpoints. The requests will be validated with pgp signature
 	// usage in requests made by GitHub Actions and the Publish.sh script.
-	releaseTrainRx := regexp.MustCompile("/environments/[a-z]*/releasetrain")
+	releaseTrainRx := regexp.MustCompile("/environments/[^/]*/releasetrain")
 	if releaseTrainRx.MatchString(req.URL.Path) {
 		return nil
 	}

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -162,7 +162,7 @@ func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfu
 		}
 	}
 	// Skip authentication with ID for `/release` and `/releasetrain` endpoints. The requests will be validated with pgp signature
-	// usage in requests made by GitHub Actions and the Publish.sh script.
+	// usage in requests from outside the cluster (e.g. by GitHub Actions and the publish.sh script).
 	releaseTrainRx := regexp.MustCompile("/environments/[^/]*/releasetrain")
 	if releaseTrainRx.MatchString(req.URL.Path) {
 		return nil

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -188,6 +188,7 @@ func RunServer() {
 			LockClient:   lockClient,
 			Config:       c,
 			KeyRing:      pgpKeyRing,
+			AzureAuth:    c.AzureEnableAuth,
 		}
 		mux := http.NewServeMux()
 		mux.Handle("/environments/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -19,8 +19,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"golang.org/x/crypto/openpgp"
 	"io"
 	"net/http"
+	"os"
 
 	"github.com/MicahParks/keyfunc"
 	"github.com/freiheit-com/kuberpult/services/frontend-service/pkg/config"
@@ -47,6 +49,18 @@ var c config.ServerConfig
 func readAllAndClose(r io.ReadCloser, maxBytes int64) {
 	_, _ = io.ReadAll(io.LimitReader(r, maxBytes))
 	_ = r.Close()
+}
+
+func readPgpKeyRing() (openpgp.KeyRing, error) {
+	if c.PgpKeyRing == "" {
+		return nil, nil
+	}
+	file, err := os.Open(c.PgpKeyRing)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return openpgp.ReadArmoredKeyRing(file)
 }
 
 func RunServer() {
@@ -119,6 +133,14 @@ func RunServer() {
 			grpcStreamInterceptors = append(grpcStreamInterceptors, AzureStreamInterceptor)
 		}
 
+		pgpKeyRing, err := readPgpKeyRing()
+		if err != nil {
+			logger.FromContext(ctx).Fatal("pgp.read.error", zap.Error(err))
+		}
+		if c.AzureEnableAuth && pgpKeyRing == nil {
+			logger.FromContext(ctx).Fatal("azure.auth.error: pgpKeyRing is required to authenticate manifests when \"KUBERPULT_AZURE_ENABLE_AUTH\" is true")
+		}
+
 		gsrv := grpc.NewServer(
 			grpc.ChainStreamInterceptor(grpcStreamInterceptors...),
 			grpc.ChainUnaryInterceptor(grpcUnaryInterceptors...),
@@ -165,6 +187,7 @@ func RunServer() {
 			DeployClient: deployClient,
 			LockClient:   lockClient,
 			Config:       c,
+			KeyRing:      pgpKeyRing,
 		}
 		mux := http.NewServeMux()
 		mux.Handle("/environments/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -194,7 +217,7 @@ func RunServer() {
 				*/
 				resp.Header().Set("strict-Transport-Security", "max-age=31536000; includeSubDomains;")
 				if c.AzureEnableAuth {
-					if err := auth.HttpAuthMiddleWare(resp, req, jwks, c.AzureClientId, c.AzureTenantId, []string{"/", "/manifest.json", "/favicon.png"}, []string{"/static/js", "/static/css"}); err != nil {
+					if err := auth.HttpAuthMiddleWare(resp, req, jwks, c.AzureClientId, c.AzureTenantId, []string{"/", "/release", "/manifest.json", "/favicon.png"}, []string{"/static/js", "/static/css"}); err != nil {
 						return
 					}
 				}

--- a/services/frontend-service/pkg/config/config.go
+++ b/services/frontend-service/pkg/config/config.go
@@ -24,6 +24,7 @@ type ServerConfig struct {
 	GKEBackendServiceID string `default:"" split_words:"true"`
 	EnableTracing       bool   `default:"false" split_words:"true"`
 	ArgocdBaseUrl       string `default:"" split_words:"true"`
+	PgpKeyRing          string `split_words:"true"`
 	AzureEnableAuth     bool   `default:"false" split_words:"true"`
 	AzureCloudInstance  string `default:"https://login.microsoftonline.com/" split_words:"true"`
 	AzureClientId       string `default:"" split_words:"true"`

--- a/services/frontend-service/pkg/handler/handle.go
+++ b/services/frontend-service/pkg/handler/handle.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"fmt"
+	"golang.org/x/crypto/openpgp"
 	"net/http"
 
 	"github.com/freiheit-com/kuberpult/pkg/api"
@@ -29,6 +30,7 @@ type Server struct {
 	DeployClient api.DeployServiceClient
 	LockClient   api.LockServiceClient
 	Config       config.ServerConfig
+	KeyRing      openpgp.KeyRing
 }
 
 func (s Server) Handle(w http.ResponseWriter, req *http.Request) {

--- a/services/frontend-service/pkg/handler/handle.go
+++ b/services/frontend-service/pkg/handler/handle.go
@@ -31,6 +31,7 @@ type Server struct {
 	LockClient   api.LockServiceClient
 	Config       config.ServerConfig
 	KeyRing      openpgp.KeyRing
+	AzureAuth    bool
 }
 
 func (s Server) Handle(w http.ResponseWriter, req *http.Request) {

--- a/services/frontend-service/pkg/handler/releasetrain.go
+++ b/services/frontend-service/pkg/handler/releasetrain.go
@@ -38,16 +38,20 @@ func (s Server) handleReleaseTrain(w http.ResponseWriter, req *http.Request, env
 	}
 
 	if s.AzureAuth {
-		defer req.Body.Close()
+		if req.Body == nil {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, "missing request body")
+			return
+		}
 		signature, err := io.ReadAll(req.Body)
 		if err != nil {
-			w.WriteHeader(http.StatusUnauthorized)
+			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(w, "Can't read request body %s", err)
 			return
 		}
 
 		if len(signature) == 0 {
-			w.WriteHeader(http.StatusUnauthorized)
+			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte("Missing signature in request body"))
 			return
 		}


### PR DESCRIPTION
Add reading the gpgkeyring to the frontend service. 
this is used to verify the signature of the release train requests. 
in the backend the API requests can't be verified easily. 

any release train curl requests will have to be modified to be signed by gpg to be accepted by the service 
