### PR TITLE
SRX-XYKGST Don't deploy queued version when unlocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Specifically this means, that minor upgrades can contain **breaking changes**.
 
 # Change Log
 
+## unreleased
+
+### Breaking change
+
+* Stop deploying from the queue after deleting the lock directly and remove the `Delete Queue` button from the UI [#396](https://github.com/freiheit-com/kuberpult/pull/396)
+
 ## 0.4.46
 
 * Add a response body to releaseTrains endpoint [#389](https://github.com/freiheit-com/kuberpult/pull/389)
@@ -70,7 +76,7 @@ Specifically this means, that minor upgrades can contain **breaking changes**.
 * Add navigation indicator [#311](https://github.com/freiheit-com/kuberpult/pull/311)
 * Return deployed releases [#315](https://github.com/freiheit-com/kuberpult/pull/315)
 #### Breaking Changes:
-* run the migration script during downtime in deployment to avoid errors [Readme](https://github.com/freiheit-com/kuberpult/blob/main/infrastructure/scripts/metadata-migration/Migration.md) 
+* run the migration script during downtime in deployment to avoid errors [Readme](https://github.com/freiheit-com/kuberpult/blob/main/infrastructure/scripts/metadata-migration/Migration.md)
 * Remove History package and persistent cache. [#282](https://github.com/freiheit-com/kuberpult/pull/282)
 * Add scripts for metadata migration. [#307](https://github.com/freiheit-com/kuberpult/pull/307)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ kuberpult works best with [ArgoCD](https://argo-cd.readthedocs.io/en/stable/) wh
 manifests to your clusters and kuberpult helps you to manage those manifests in the repository.
 
 kuberpult allows you to lock some services or an entire environment, so automatic deployments (via a typical api call) to
-those services/environments will be queued until the last lock is removed.
+those services/environments will be queued until lock is deleted and then a new version is deployed.
 Manual deployments (via the UI or a flag in the api) are always possible.
 
 `kuberpult` does not actually `deploy`. That part is usually handled by argoCD.
@@ -27,7 +27,7 @@ Both *environments* and *microservices* can be `locked`.
 Every app has a current version on every env (including `nil` for no version).
 If a deployment starts while the app/env is locked,
 instead of changing the current version, the `queued_version` will be set.
-When the lock is deleted, the queued version will be deployed.
+When the lock is deleted and a new version is deployed after deleting the lock, the queued version will be deployed.
 
 There is currently no visualization for the queue in the ui,
 so it can only be seen in the manifest repo as "queued_version" symlink next to "version".

--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -63,7 +63,7 @@ service DeployService {
 }
 
 enum LockBehavior {
-  Queue = 0;
+  Record = 0;
   Fail = 1;
   Ignore = 2;
 }
@@ -132,7 +132,7 @@ message GetFrontendConfigResponse {
       string tenantId = 3;
       string cloudInstance = 4;
       string redirectURL = 5;
-    } 
+    }
     AzureAuthConfig azureAuth= 1;
   }
   ArgoCD argoCd = 1;

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -1071,33 +1071,3 @@ func readFile(fs billy.Filesystem, path string) ([]byte, error) {
 		return io.ReadAll(file)
 	}
 }
-
-// ProcessQueue checks if there is something in the queue
-// deploys if necessary
-// deletes the queue
-func (s *State) ProcessQueue(ctx context.Context, fs billy.Filesystem, environment string, application string) (string, error) {
-	queuedVersion, err := s.GetQueuedVersion(environment, application)
-	queueDeploymentMessage := ""
-	if err != nil {
-		// could not read queued version.
-		return "", err
-	} else {
-		if queuedVersion == nil {
-			// if there is no version queued, that's not an issue, just do nothing:
-			return "", nil
-		}
-
-		currentlyDeployedVersion, err := s.GetEnvironmentApplicationVersion(environment, application)
-		if err != nil {
-			return "", err
-		}
-
-		if currentlyDeployedVersion != nil && *queuedVersion == *currentlyDeployedVersion {
-			// delete queue, it's outdated! But if we can't, that's not really a problem, as it would be overwritten
-			// whenever the next deployment happens:
-			err = s.DeleteQueuedVersion(environment, application)
-			return fmt.Sprintf("deleted queued version %d because it was already deployed. app=%q env=%q", *queuedVersion, application, environment), err
-		}
-	}
-	return queueDeploymentMessage, nil
-}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -1071,3 +1071,33 @@ func readFile(fs billy.Filesystem, path string) ([]byte, error) {
 		return io.ReadAll(file)
 	}
 }
+
+// ProcessQueue checks if there is something in the queue
+// deploys if necessary
+// deletes the queue
+func (s *State) ProcessQueue(ctx context.Context, fs billy.Filesystem, environment string, application string) (string, error) {
+	queuedVersion, err := s.GetQueuedVersion(environment, application)
+	queueDeploymentMessage := ""
+	if err != nil {
+		// could not read queued version.
+		return "", err
+	} else {
+		if queuedVersion == nil {
+			// if there is no version queued, that's not an issue, just do nothing:
+			return "", nil
+		}
+
+		currentlyDeployedVersion, err := s.GetEnvironmentApplicationVersion(environment, application)
+		if err != nil {
+			return "", err
+		}
+
+		if currentlyDeployedVersion != nil && *queuedVersion == *currentlyDeployedVersion {
+			// delete queue, it's outdated! But if we can't, that's not really a problem, as it would be overwritten
+			// whenever the next deployment happens:
+			err = s.DeleteQueuedVersion(environment, application)
+			return fmt.Sprintf("deleted queued version %d because it was already deployed. app=%q env=%q", *queuedVersion, application, environment), err
+		}
+	}
+	return queueDeploymentMessage, nil
+}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -594,13 +594,23 @@ func (c *DeleteEnvironmentLock) Transform(ctx context.Context, state *State) (st
 		s := State{
 			Filesystem: fs,
 		}
-		_, err := s.GetEnvironmentApplications(c.Environment)
+		apps, err := s.GetEnvironmentApplications(c.Environment)
 		if err != nil {
 			return "", fmt.Errorf("environment applications for %q not found: %v", c.Environment, err.Error())
 		}
 
+		additionalMessageFromDeployment := ""
+		for _, appName := range apps {
+			queueMessage, err := s.ProcessQueue(ctx, fs, c.Environment, appName)
+			if err != nil {
+				return "", err
+			}
+			if queueMessage != "" {
+				additionalMessageFromDeployment = additionalMessageFromDeployment + "\n" + queueMessage
+			}
+		}
 		GaugeEnvLockMetric(fs, c.Environment)
-		return fmt.Sprintf("unlocked environment %q", c.Environment), nil
+		return fmt.Sprintf("unlocked environment %q%s", c.Environment, additionalMessageFromDeployment), nil
 	}
 }
 
@@ -647,8 +657,15 @@ func (c *DeleteEnvironmentApplicationLock) Transform(ctx context.Context, state 
 	if err := fs.Remove(lockDir); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf("failed to delete directory %q: %w", lockDir, err)
 	} else {
+		s := State{
+			Filesystem: fs,
+		}
+		queueMessage, err := s.ProcessQueue(ctx, fs, c.Environment, c.Application)
+		if err != nil {
+			return "", err
+		}
 		GaugeEnvAppLockMetric(fs, c.Environment, c.Application)
-		return fmt.Sprintf("unlocked application %q in environment %q", c.Application, c.Environment), nil
+		return fmt.Sprintf("unlocked application %q in environment %q%q", c.Application, c.Environment, queueMessage), nil
 	}
 }
 

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -21,13 +21,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/pkg/auth"
 	"io"
 	"io/fs"
 	"os"
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/freiheit-com/kuberpult/pkg/auth"
 
 	"github.com/freiheit-com/kuberpult/pkg/api"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/config"
@@ -261,7 +262,7 @@ func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) 
 					Environment:   env,
 					Application:   c.Application,
 					Version:       version, // the train should queue deployments, instead of giving up:
-					LockBehaviour: api.LockBehavior_Queue,
+					LockBehaviour: api.LockBehavior_Record,
 				}
 				deployResult, err := d.Transform(ctx, state)
 				if err != nil {
@@ -381,7 +382,7 @@ func (c *CreateUndeployApplicationVersion) Transform(ctx context.Context, state 
 				Application: c.Application,
 				Version:     lastRelease + 1,
 				// the train should queue deployments, instead of giving up:
-				LockBehaviour: api.LockBehavior_Queue,
+				LockBehaviour: api.LockBehavior_Record,
 			}
 			deployResult, err := d.Transform(ctx, state)
 			if err != nil {
@@ -764,7 +765,7 @@ func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) 
 		}
 		if len(envLocks) > 0 || len(appLocks) > 0 {
 			switch c.LockBehaviour {
-			case api.LockBehavior_Queue:
+			case api.LockBehavior_Record:
 				q := QueueApplicationVersion{
 					Environment: c.Environment,
 					Application: c.Application,
@@ -922,7 +923,7 @@ func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, err
 			Environment:   targetEnvName, // here we deploy to the next env
 			Application:   appName,
 			Version:       versionToDeploy,
-			LockBehaviour: api.LockBehavior_Queue,
+			LockBehaviour: api.LockBehavior_Record,
 		}
 		transform, err := d.Transform(ctx, state)
 		if err != nil {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -20,12 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/pkg/api"
-	"github.com/freiheit-com/kuberpult/pkg/ptr"
-	"github.com/freiheit-com/kuberpult/pkg/testfs"
-	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/config"
-	"github.com/go-git/go-billy/v5/util"
-	godebug "github.com/kylelemons/godebug/diff"
 	"io"
 	"os/exec"
 	"path"
@@ -33,6 +27,13 @@ import (
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/freiheit-com/kuberpult/pkg/api"
+	"github.com/freiheit-com/kuberpult/pkg/ptr"
+	"github.com/freiheit-com/kuberpult/pkg/testfs"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/config"
+	"github.com/go-git/go-billy/v5/util"
+	godebug "github.com/kylelemons/godebug/diff"
 )
 
 const (
@@ -1285,7 +1286,7 @@ func TestTransformer(t *testing.T) {
 		},
 		{
 			Name:         "Deploy version ignoring locks when environment is locked LockBehavior=Queue",
-			Transformers: makeTransformersDeployTestEnvLock(api.LockBehavior_Queue),
+			Transformers: makeTransformersDeployTestEnvLock(api.LockBehavior_Record),
 			Test: func(t *testing.T, s *State) {
 				// check that the state reads the correct versions
 				i, err := s.GetEnvironmentApplicationVersion("production", "test")
@@ -1313,7 +1314,7 @@ func TestTransformer(t *testing.T) {
 		},
 		{
 			Name:         "Deploy version when application in environment is locked and config=LockBehaviourQueue",
-			Transformers: makeTransformersDeployTestAppLock(api.LockBehavior_Queue),
+			Transformers: makeTransformersDeployTestAppLock(api.LockBehavior_Record),
 			Test: func(t *testing.T, s *State) {
 				// check that the state reads the correct versions
 				i, err := s.GetEnvironmentApplicationVersion("production", "test")
@@ -1354,7 +1355,7 @@ func TestTransformer(t *testing.T) {
 		},
 		{
 			Name:         "Deploy twice LockBehavior=Queue and LockBehavior=Queue",
-			Transformers: makeTransformersTwoDeploymentsWriteToQueue(api.LockBehavior_Queue, api.LockBehavior_Queue),
+			Transformers: makeTransformersTwoDeploymentsWriteToQueue(api.LockBehavior_Record, api.LockBehavior_Record),
 			Test: func(t *testing.T, s *State) {
 				// check that the state reads the correct versions
 				i, err := s.GetEnvironmentApplicationVersion("production", "test")
@@ -1379,7 +1380,7 @@ func TestTransformer(t *testing.T) {
 		},
 		{
 			Name:         "Deploy twice LockBehavior=Queue and LockBehavior=Ignore",
-			Transformers: makeTransformersTwoDeploymentsWriteToQueue(api.LockBehavior_Queue, api.LockBehavior_Ignore),
+			Transformers: makeTransformersTwoDeploymentsWriteToQueue(api.LockBehavior_Record, api.LockBehavior_Ignore),
 			Test: func(t *testing.T, s *State) {
 				// check that the state reads the correct versions
 				i, err := s.GetEnvironmentApplicationVersion("production", "test")
@@ -1404,7 +1405,7 @@ func TestTransformer(t *testing.T) {
 		},
 		{
 			Name:         "Deploy twice LockBehavior=Ignore and LockBehavior=Queue",
-			Transformers: makeTransformersTwoDeploymentsWriteToQueue(api.LockBehavior_Ignore, api.LockBehavior_Queue),
+			Transformers: makeTransformersTwoDeploymentsWriteToQueue(api.LockBehavior_Ignore, api.LockBehavior_Record),
 			Test: func(t *testing.T, s *State) {
 				// check that the state reads the correct versions
 				i, err := s.GetEnvironmentApplicationVersion("production", "test")
@@ -1433,7 +1434,7 @@ func TestTransformer(t *testing.T) {
 		},
 		{
 			Name:         "Lock env AND app and then Deploy and unlock one lock ",
-			Transformers: makeTransformersDoubleLock(api.LockBehavior_Queue, false),
+			Transformers: makeTransformersDoubleLock(api.LockBehavior_Record, false),
 			Test: func(t *testing.T, s *State) {
 				// check that the state reads the correct versions
 				i, err := s.GetEnvironmentApplicationVersion("production", "test")
@@ -1458,7 +1459,7 @@ func TestTransformer(t *testing.T) {
 		},
 		{
 			Name:         "Lock env AND app and then Deploy and unlock both locks",
-			Transformers: makeTransformersDoubleLock(api.LockBehavior_Queue, true),
+			Transformers: makeTransformersDoubleLock(api.LockBehavior_Record, true),
 			Test: func(t *testing.T, s *State) {
 				// check that the state reads the correct versions
 				i, err := s.GetEnvironmentApplicationVersion("production", "test")

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1466,7 +1466,7 @@ func TestTransformer(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if i == nil {
+				if *i == 1 {
 					t.Errorf("unexpected version: expected 1, actual nil")
 				} else {
 					if *i != 1 {
@@ -1477,8 +1477,8 @@ func TestTransformer(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if q != nil {
-					t.Errorf("unexpected version: expected nil, actual %d", *q)
+				if q == nil {
+					t.Errorf("unexpected version: expected %d, actual nil", *q)
 				}
 			},
 		},

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1468,10 +1468,6 @@ func TestTransformer(t *testing.T) {
 				}
 				if i != nil {
 					t.Errorf("unexpected version: unexpected nil")
-				} else {
-					if *i != 1 {
-						t.Errorf("unexpected version: expected 1, actual %d", *i)
-					}
 				}
 				q, err := s.GetQueuedVersion("production", "test")
 				if err != nil {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1467,14 +1467,14 @@ func TestTransformer(t *testing.T) {
 					t.Fatal(err)
 				}
 				if i != nil {
-					t.Errorf("unexpected version: unexpected nil")
+					t.Errorf("unexpected version %d: expected: nil", *i)
 				}
 				q, err := s.GetQueuedVersion("production", "test")
 				if err != nil {
 					t.Fatal(err)
 				}
 				if q == nil {
-					t.Errorf("unexpected version: expected %d, actual nil", *q)
+					t.Errorf("unexpected version: expected 1, actual nil")
 				}
 			},
 		},

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1466,8 +1466,8 @@ func TestTransformer(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if *i == 1 {
-					t.Errorf("unexpected version: expected 1, actual nil")
+				if i != nil {
+					t.Errorf("unexpected version: unexpected nil")
 				} else {
 					if *i != 1 {
 						t.Errorf("unexpected version: expected 1, actual %d", *i)

--- a/services/frontend-service/src/legacy-ui/ReleaseDialog.tsx
+++ b/services/frontend-service/src/legacy-ui/ReleaseDialog.tsx
@@ -220,20 +220,6 @@ const DeployButtonInner = (props: {
     }
 };
 
-const DeleteQueueButtonInner: VFC<{ addToCart?: () => void; inCart?: boolean }> = ({ addToCart, inCart }) => {
-    const queueMessage =
-        'Deletes the queue. ' +
-        'Technically, it deploys the version that is already deployed here, which as a side effect deletes the queue.';
-
-    return (
-        <Tooltip title={queueMessage}>
-            <Button variant="contained" onClick={addToCart} className={''} disabled={inCart}>
-                {'Delete Queue'}
-            </Button>
-        </Tooltip>
-    );
-};
-
 export const CreateLockButton = (props: { applicationName?: string; environmentName: string }) => {
     const { applicationName, environmentName } = props;
 
@@ -366,17 +352,6 @@ const ReleaseEnvironment: VFC<{
     );
     const currentlyDeployedVersion = overview.environments[environmentName].applications[applicationName]?.version;
 
-    const deleteQueue: CartAction = useMemo(
-        () => ({
-            deleteQueue: {
-                application: applicationName,
-                environment: environmentName,
-                currentlyDeployedVersion: currentlyDeployedVersion,
-            },
-        }),
-        [applicationName, environmentName, currentlyDeployedVersion]
-    );
-
     const queuedVersion = overview.environments[environmentName].applications[applicationName]?.queuedVersion || 0;
     const hasQueue = queuedVersion !== 0;
     const envLocks = Object.entries(overview.environments[environmentName].locks ?? {});
@@ -451,11 +426,6 @@ const ReleaseEnvironment: VFC<{
                     target={version}
                     releases={overview.applications[applicationName].releases}
                 />
-                {hasQueue ? (
-                    <ConfirmationDialogProvider action={deleteQueue}>
-                        <DeleteQueueButtonInner />
-                    </ConfirmationDialogProvider>
-                ) : null}
             </Typography>
             <Typography variant="subtitle1" component="div" className="current">
                 {currentInfo}

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -24,7 +24,6 @@ export enum ActionTypes {
     Deploy,
     PrepareUndeploy,
     Undeploy,
-    DeleteQueue,
     CreateEnvironmentLock,
     DeleteEnvironmentLock,
     CreateApplicationLock,


### PR DESCRIPTION
* rename Queue Lock Behavior to Record
* Remove "Delete Queue" button and action from UI
* Stop deploying queued version when deleting a lock