### PR TITLE
MSD-I2FA2Q - Make ingress creation optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ As of now, while we are still on version `0.*`,
 we do not use [Semantic Versioning](https://semver.org/).
 Specifically this means, that minor upgrades can contain **breaking changes**.
 
+# Unreleased yet
+* Make Ingress optional [#400](https://github.com/freiheit-com/kuberpult/pull/400)
 
 # Change Log
 

--- a/charts/kuberpult/templates/ingress.yaml
+++ b/charts/kuberpult/templates/ingress.yaml
@@ -13,7 +13,7 @@
 #You should have received a copy of the GNU General Public License
 #along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
 
-#Copyright 2021 freiheit.com
+#Copyright 2022 freiheit.com
 
 {{- if .Values.ingress.create }}
 apiVersion: networking.k8s.io/v1

--- a/charts/kuberpult/templates/ingress.yaml
+++ b/charts/kuberpult/templates/ingress.yaml
@@ -14,6 +14,8 @@
 #along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
 
 #Copyright 2021 freiheit.com
+
+{{- if .Values.ingress.create }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -59,4 +61,5 @@ spec:
     enabled: true
     oauthclientCredentials:
       secretName: {{ required ".ingress.iap.secretName is required" .Values.ingress.iap.secretName }}
+{{- end }}
 {{- end }}

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -37,6 +37,7 @@ frontend:
       cpu: 500m
       memory: 250Mi
 ingress:
+  create: true
   annotations: {}
   domainName: null
   exposeReleaseEndpoint: false


### PR DESCRIPTION
* teams can decide on their own whether or not to make kuberpult public
* introduces `ingress.create` helm template variable