### PR TITLE
Bugfix: Write undeploy versions correctly into manifest repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ we do not use [Semantic Versioning](https://semver.org/).
 Specifically this means, that minor upgrades can contain **breaking changes**.
 
 # Unreleased yet
+* Bugfix: Write undeploy versions correctly into manifest repo
 
 # Change Log
 

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -372,7 +372,10 @@ func (c *CreateUndeployApplicationVersion) Transform(ctx context.Context, state 
 			return "", err
 		}
 		// note that the manifest is empty here!
-		if err := util.WriteFile(fs, fs.Join(envDir, "manifests.yaml"), []byte(""), 0666); err != nil {
+		// but actually it's not quite empty!
+		// The function we are using in DeployApplication version is `util.WriteFile`. And that does not allow overwriting files with empty content.
+		// We work around this unusual behavior by writing a space into the file
+		if err := util.WriteFile(fs, fs.Join(envDir, "manifests.yaml"), []byte(" "), 0666); err != nil {
 			return "", err
 		}
 

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os/exec"
 	"path"
 	"reflect"
@@ -51,6 +52,9 @@ func TestUndeployApplicationErrors(t *testing.T) {
 		expectedError     string
 		expectedCommitMsg string
 		shouldSucceed     bool
+		application       string
+		environment       string
+		release           int
 	}{
 		{
 			Name: "Delete non-existent application",
@@ -62,6 +66,9 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			expectedError:     "UndeployApplication: error cannot undeploy non-existing application 'app1'",
 			expectedCommitMsg: "",
 			shouldSucceed:     false,
+			application:       "app1",
+			environment:       "acceptance",
+			release:           2,
 		},
 		{
 			Name: "Success",
@@ -82,6 +89,9 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			expectedError:     "",
 			expectedCommitMsg: "application 'app1' was deleted successfully",
 			shouldSucceed:     true,
+			application:       "app1",
+			environment:       "acceptance",
+			release:           2,
 		},
 		{
 			Name: "Create un-deploy Version for un-deployed application should not work",
@@ -105,6 +115,9 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			expectedError:     "cannot undeploy non-existing application 'app1'",
 			expectedCommitMsg: "",
 			shouldSucceed:     false,
+			application:       "app1",
+			environment:       "acceptance",
+			release:           2,
 		},
 		{
 			Name: "Undeploy application where there is an application lock should not work",
@@ -135,6 +148,9 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			expectedError:     "UndeployApplication: error cannot un-deploy application 'app1' unlock the application lock in the 'acceptance' environment first",
 			expectedCommitMsg: "",
 			shouldSucceed:     false,
+			application:       "app1",
+			environment:       "acceptance",
+			release:           2,
 		},
 		{
 			Name: "Undeploy application where there is an application lock created after the un-deploy version creation shouldn't work",
@@ -165,6 +181,9 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			expectedError:     "UndeployApplication: error cannot un-deploy application 'app1' unlock the application lock in the 'acceptance' environment first",
 			expectedCommitMsg: "",
 			shouldSucceed:     false,
+			application:       "app1",
+			environment:       "acceptance",
+			release:           2,
 		},
 		{
 			Name: "Undeploy application where there current releases are not undeploy shouldn't work",
@@ -194,6 +213,9 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			expectedError:     "UndeployApplication: error cannot un-deploy application 'app1' the release 'acceptance' is not un-deployed",
 			expectedCommitMsg: "",
 			shouldSucceed:     false,
+			application:       "app1",
+			environment:       "acceptance",
+			release:           2,
 		},
 		{
 			Name: "Undeploy application where there is an environment lock should work",
@@ -223,6 +245,9 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			expectedError:     "",
 			expectedCommitMsg: "application 'app1' was deleted successfully",
 			shouldSucceed:     true,
+			application:       "app1",
+			environment:       "acceptance",
+			release:           2,
 		},
 		{
 			Name: "Undeploy application where the last release is not Undeploy shouldn't work",
@@ -250,14 +275,17 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			expectedError:     "UndeployApplication: error last release is not un-deployed application version of 'app1'",
 			expectedCommitMsg: "",
 			shouldSucceed:     false,
+			application:       "app1",
+			environment:       "acceptance",
+			release:           2,
 		},
 	}
 	for _, tc := range tcs {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err := repo.ApplyTransformersInternal(context.Background(), tc.Transformers...)
+			commitMsg, updatedRepo, err := repo.ApplyTransformersInternal(context.Background(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -266,6 +294,21 @@ func TestUndeployApplicationErrors(t *testing.T) {
 				actualMsg := commitMsg[len(commitMsg)-1]
 				if actualMsg != tc.expectedCommitMsg {
 					t.Fatalf("expected a different message.\nExpected: %q\nGot %q", tc.expectedCommitMsg, actualMsg)
+				}
+				file, err := updatedRepo.Filesystem.Open(updatedRepo.Filesystem.Join("applications/", tc.application, "/releases/", fmt.Sprint(tc.release), "/environments/", tc.environment, "/manifests.yaml"))
+				if err != nil {
+					t.Fatalf("err %v", err)
+				}
+				log.Println("test" + file.Name())
+				dirinfo, _ := updatedRepo.Filesystem.ReadDir(updatedRepo.Filesystem.Join(repo.State().Commit.Owner().Path(), "applications"))
+				for _, dir := range dirinfo {
+					log.Println(dir.Name())
+				}
+				if len(dirinfo) == 0 {
+					log.Println("empty dir")
+				}
+				if _, err := updatedRepo.Filesystem.Stat(updatedRepo.Filesystem.Join(repo.State().Commit.Owner().Path(), "applications/", tc.application, "/releases/", fmt.Sprint(tc.release), "/environments/", tc.environment, "/manifests.yaml")); err != nil {
+					t.Fatalf("error creating manifests file: %v", err)
 				}
 			} else {
 				if err == nil {
@@ -281,7 +324,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 	}
 }
 
-// Tests various error cases in the prepare-Undeploy endpoint, specifically the error messages returned.
+// Tests various error cases in the prepare-Undeploy endpoint, specifically the ;cerror messages returned.
 func TestUndeployErrors(t *testing.T) {
 	tcs := []struct {
 		Name              string


### PR DESCRIPTION
go-billys WriteFile function has a funny behavior: It does not allow overwriting an existing file with empty content. We work around this by giving the file a single space. For argoCd this should not make a difference