### PR TITLE
Allow team based train via rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ we do not use [Semantic Versioning](https://semver.org/).
 Specifically this means, that minor upgrades can contain **breaking changes**.
 
 # Unreleased yet
-
+* Add teams filter to releasetrain endpoint over rest [#417](https://github.com/freiheit-com/kuberpult/pull/417)
 
 # Change Log
 

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -939,5 +939,9 @@ func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, err
 		numServices += 1
 		completeMessage = completeMessage + transform + "\n"
 	}
-	return fmt.Sprintf("The release train deployed %d services from '%s' to '%s'\n%s\n", numServices, source, targetEnvName, completeMessage), nil
+	teamInfo := ""
+	if c.Team != "" {
+		teamInfo = "for team '" + c.Team + "'"
+	}
+	return fmt.Sprintf("The release train deployed %s %d services from '%s' to '%s'\n%s\n", teamInfo, numServices, source, targetEnvName, completeMessage), nil
 }

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -941,7 +941,7 @@ func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, err
 	}
 	teamInfo := ""
 	if c.Team != "" {
-		teamInfo = "for team '" + c.Team + "'"
+		teamInfo = " for team '" + c.Team + "'"
 	}
-	return fmt.Sprintf("The release train deployed %s %d services from '%s' to '%s'\n%s\n", teamInfo, numServices, source, targetEnvName, completeMessage), nil
+	return fmt.Sprintf("The release train deployed %d services from '%s' to '%s'%s\n%s\n", numServices, source, targetEnvName, teamInfo, completeMessage), nil
 }

--- a/services/cd-service/pkg/service/deploy_test.go
+++ b/services/cd-service/pkg/service/deploy_test.go
@@ -181,7 +181,7 @@ func TestReleaseTrainErrors(t *testing.T) {
 				},
 			},
 			expectedError:     "",
-			expectedCommitMsg: "The release train deployed 1 services from 'acceptance' to 'production'",
+			expectedCommitMsg: "The release train deployed 1 services from 'acceptance' to 'production' for team 'team1'",
 			shouldSucceed:     true,
 		},
 		{
@@ -193,7 +193,7 @@ func TestReleaseTrainErrors(t *testing.T) {
 				},
 			},
 			expectedError:     "",
-			expectedCommitMsg: "The release train deployed 1 services from 'acceptance' to 'production'",
+			expectedCommitMsg: "The release train deployed 1 services from 'acceptance' to 'production' for team 'team2'",
 			shouldSucceed:     true,
 		},
 		{
@@ -205,7 +205,7 @@ func TestReleaseTrainErrors(t *testing.T) {
 				},
 			},
 			expectedError:     "",
-			expectedCommitMsg: "The release train deployed 0 services from 'acceptance' to 'production'",
+			expectedCommitMsg: "The release train deployed 0 services from 'acceptance' to 'production' for team 'team3'",
 			shouldSucceed:     true,
 		},
 	}

--- a/services/frontend-service/pkg/handler/environments.go
+++ b/services/frontend-service/pkg/handler/environments.go
@@ -18,6 +18,8 @@ package handler
 
 import (
 	"fmt"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
+	"go.uber.org/zap"
 	"net/http"
 
 	xpath "github.com/freiheit-com/kuberpult/pkg/path"
@@ -30,7 +32,9 @@ func (s Server) HandleEnvironments(w http.ResponseWriter, req *http.Request, tai
 		return
 	}
 
+
 	function, tail := xpath.Shift(tail)
+	logger.FromContext(req.Context()).Warn("AHA 1", zap.String("function:", function))
 	switch function {
 	case "applications":
 		s.handleApplications(w, req, environment, tail)

--- a/services/frontend-service/pkg/handler/environments.go
+++ b/services/frontend-service/pkg/handler/environments.go
@@ -18,8 +18,6 @@ package handler
 
 import (
 	"fmt"
-	"github.com/freiheit-com/kuberpult/pkg/logger"
-	"go.uber.org/zap"
 	"net/http"
 
 	xpath "github.com/freiheit-com/kuberpult/pkg/path"
@@ -34,7 +32,6 @@ func (s Server) HandleEnvironments(w http.ResponseWriter, req *http.Request, tai
 
 
 	function, tail := xpath.Shift(tail)
-	logger.FromContext(req.Context()).Warn("AHA 1", zap.String("function:", function))
 	switch function {
 	case "applications":
 		s.handleApplications(w, req, environment, tail)

--- a/services/frontend-service/pkg/handler/environments.go
+++ b/services/frontend-service/pkg/handler/environments.go
@@ -30,7 +30,6 @@ func (s Server) HandleEnvironments(w http.ResponseWriter, req *http.Request, tai
 		return
 	}
 
-
 	function, tail := xpath.Shift(tail)
 	switch function {
 	case "applications":

--- a/services/frontend-service/pkg/handler/releasetrain.go
+++ b/services/frontend-service/pkg/handler/releasetrain.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
+	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"strings"
@@ -38,6 +40,9 @@ func (s Server) handleReleaseTrain(w http.ResponseWriter, req *http.Request, env
 		http.Error(w, fmt.Sprintf("releasetrain does not accept additional path arguments, got: '%s'", tail), http.StatusNotFound)
 		return
 	}
+	queryParams := req.URL.Query()
+	teamParam := queryParams.Get("team")
+	logger.FromContext(req.Context()).Warn("AHA", zap.String("teamname:", teamParam))
 
 	if s.AzureAuth {
 		if req.Body == nil {
@@ -71,6 +76,7 @@ func (s Server) handleReleaseTrain(w http.ResponseWriter, req *http.Request, env
 	}
 	response, err := s.DeployClient.ReleaseTrain(req.Context(), &api.ReleaseTrainRequest{
 		Environment: environment,
+		Team: teamParam,
 	})
 	if err != nil {
 		handleGRPCError(req.Context(), w, err)

--- a/services/frontend-service/pkg/handler/releasetrain.go
+++ b/services/frontend-service/pkg/handler/releasetrain.go
@@ -20,8 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/pkg/logger"
-	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"strings"
@@ -42,7 +40,6 @@ func (s Server) handleReleaseTrain(w http.ResponseWriter, req *http.Request, env
 	}
 	queryParams := req.URL.Query()
 	teamParam := queryParams.Get("team")
-	logger.FromContext(req.Context()).Warn("AHA", zap.String("teamname:", teamParam))
 
 	if s.AzureAuth {
 		if req.Body == nil {


### PR DESCRIPTION
Until now, only the grpc version of the release train was able to filter for teams. Now also the rest endpoint can filter by team.
The logic has not changed.
Also added the team to the commit message for release trains, if the train runs for only one team. 