### PR TITLE
SRX-OMXZMI Adding colors to environments

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
@@ -69,7 +69,7 @@
   background-color: #50C241;
 }
 .release-environment.release-environment-pre_prod {
-  background-color: #F3BE00;
+  background-color: #00AFFF;
 }
 .release-environment.release-environment-upstream {
   background-color: #FF8A00;

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
@@ -57,10 +57,31 @@
 
 }
 
+.release-environment {
+  background-color: green;
+  .mdc-evolution-chip__text-label {
+  color: white;
+  font-weight: bold;
+  font-size: 1.2em;
+  }
+}
 .release__environments {
   @extend .text-bold;
 
   > *:not(:last-child) {
     margin-right: 8px;
   }
+
+//   .release-environment.order-first {
+//     color: blue;
+//   }
+//   .release-environment.order-second {
+//     color: green;
+//   }
+//   .release-environment.order-last {
+//     color: orange;
+//   }
+//   .release-environment.order-other {
+//     color: red;
+//   }
 }

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
@@ -81,17 +81,4 @@
   > *:not(:last-child) {
     margin-right: 8px;
   }
-
-//   .release-environment.order-first {
-//     color: blue;
-//   }
-//   .release-environment.order-second {
-//     color: green;
-//   }
-//   .release-environment.order-last {
-//     color: orange;
-//   }
-//   .release-environment.order-other {
-//     color: red;
-//   }
 }

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
@@ -58,13 +58,23 @@
 }
 
 .release-environment {
-  background-color: green;
+  background-color: grey;
   .mdc-evolution-chip__text-label {
-  color: white;
-  font-weight: bold;
-  font-size: 1.2em;
+    color: white;
+    font-weight: bold;
+    font-size: 1.2em;
   }
 }
+.release-environment.release-environment-prod {
+  background-color: #50C241;
+}
+.release-environment.release-environment-pre_prod {
+  background-color: #F3BE00;
+}
+.release-environment.release-environment-upstream {
+  background-color: #FF8A00;
+}
+
 .release__environments {
   @extend .text-bold;
 

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -18,8 +18,10 @@ import classNames from 'classnames';
 import { Button } from '../button';
 import React, { useEffect, useRef } from 'react';
 import { MDCRipple } from '@material/ripple';
-import { updateReleaseDialog, useCurrentlyDeployedAt, useRelease } from '../../utils/store';
+import { updateReleaseDialog, useCurrentlyDeployedAt, useOverview, useRelease } from '../../utils/store';
 import { Chip } from '../chip';
+import { Environment } from '../../../api/api';
+import { calculateEnvironmentPriorities, EnvPrioMap } from '../ReleaseDialog/ReleaseDialog';
 
 export type ReleaseCardProps = {
     className?: string;
@@ -37,6 +39,10 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
         updateReleaseDialog(app, version);
     }, [app, version]);
 
+    const envs: Environment[] = useOverview((x) => Object.values(x));
+    // const sortedEnvs: Environment[] = sortEnvironmentsByUpstream(envs);
+    const envPrioMap: EnvPrioMap = calculateEnvironmentPriorities(envs);
+
     useEffect(() => {
         if (control.current) {
             MDComponent.current = new MDCRipple(control.current);
@@ -51,7 +57,7 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
                 {!!sourceCommitId && <Button className="release__hash" label={sourceCommitId} />}
             </div>
             <div className="mdc-card__primary-action release-card__description" ref={control} tabIndex={0}>
-                <div className="mdc-card__ripple"></div>
+                <div className="mdc-card__ripple" />
                 <div className="release__details">
                     {!!createdAt && (
                         <div className="release__metadata mdc-typography--subtitle2">
@@ -64,7 +70,12 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
                 </div>
                 <div className="release__environments">
                     {environments.map((env) => (
-                        <Chip className={'release-environment'} label={env.name} key={env.name} />
+                        <Chip
+                            className={'release-environment order-second'}
+                            label={env.name}
+                            key={env.name}
+                            priority={envPrioMap[env.name]}
+                        />
                     ))}
                 </div>
             </div>

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -21,7 +21,7 @@ import { MDCRipple } from '@material/ripple';
 import { updateReleaseDialog, useCurrentlyDeployedAt, useOverview, useRelease } from '../../utils/store';
 import { Chip } from '../chip';
 import { Environment } from '../../../api/api';
-import { calculateEnvironmentPriorities, EnvPrioMap } from '../ReleaseDialog/ReleaseDialog';
+import { calculateEnvironmentPriorities, EnvPrioMap, sortEnvironmentsByUpstream } from '../ReleaseDialog/ReleaseDialog';
 
 export type ReleaseCardProps = {
     className?: string;
@@ -34,14 +34,15 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
     const control = useRef<HTMLDivElement>(null);
     const { className, app, version } = props;
     const { createdAt, sourceMessage, sourceCommitId, sourceAuthor } = useRelease(app, version);
-    const environments = useCurrentlyDeployedAt(app, version);
+    const environmentsForApp = useCurrentlyDeployedAt(app, version);
     const clickHanlder = React.useCallback(() => {
         updateReleaseDialog(app, version);
     }, [app, version]);
 
-    const envs: Environment[] = useOverview((x) => Object.values(x));
-    // const sortedEnvs: Environment[] = sortEnvironmentsByUpstream(envs);
+    const envs: Environment[] = useOverview((x) => Object.values(x.environments));
+    const sortedEnvs: Environment[] = sortEnvironmentsByUpstream(envs);
     const envPrioMap: EnvPrioMap = calculateEnvironmentPriorities(envs);
+    const envsForAppSorted = sortedEnvs.filter((env: Environment) => environmentsForApp.includes(env));
 
     useEffect(() => {
         if (control.current) {
@@ -69,9 +70,9 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
                     <div className="release__author mdc-typography--body1">{'Author: ' + sourceAuthor}</div>
                 </div>
                 <div className="release__environments">
-                    {environments.map((env) => (
+                    {envsForAppSorted.map((env) => (
                         <Chip
-                            className={'release-environment order-second'}
+                            className={'release-environment'}
                             label={env.name}
                             key={env.name}
                             priority={envPrioMap[env.name]}

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -39,9 +39,9 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
         updateReleaseDialog(app, version);
     }, [app, version]);
 
-    const envs: Environment[] = useOverview((x) => Object.values(x.environments));
-    const sortedEnvs: Environment[] = sortEnvironmentsByUpstream(envs);
-    const envPrioMap: EnvPrioMap = calculateEnvironmentPriorities(envs);
+    const allEnvs: Environment[] = useOverview((x) => Object.values(x.environments));
+    const sortedEnvs: Environment[] = sortEnvironmentsByUpstream(allEnvs);
+    const envPrioMap: EnvPrioMap = calculateEnvironmentPriorities(allEnvs);
     const envsForAppSorted = sortedEnvs.filter((env: Environment) => environmentsForApp.includes(env));
 
     useEffect(() => {

--- a/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.tsx
@@ -16,8 +16,10 @@ along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
 Copyright 2021 freiheit.com*/
 import classNames from 'classnames';
 import React from 'react';
-import { updateReleaseDialog, useCurrentlyDeployedAt, useRelease } from '../../utils/store';
+import { updateReleaseDialog, useCurrentlyDeployedAt, useOverview, useRelease } from '../../utils/store';
 import { Chip } from '../chip';
+import { calculateEnvironmentPriorities, EnvPrioMap, sortEnvironmentsByUpstream } from '../ReleaseDialog/ReleaseDialog';
+import { Environment } from '../../../api/api';
 
 export type ReleaseCardMiniProps = {
     className?: string;
@@ -35,7 +37,7 @@ const getDays = (date: Date) => {
 export const ReleaseCardMini: React.FC<ReleaseCardMiniProps> = (props) => {
     const { className, app, version } = props;
     const { createdAt, sourceMessage, sourceAuthor } = useRelease(app, version);
-    const environments = useCurrentlyDeployedAt(app, version);
+    const environmentsForApp = useCurrentlyDeployedAt(app, version);
     const clickHanlder = React.useCallback(() => {
         updateReleaseDialog(app, version);
     }, [app, version]);
@@ -51,6 +53,10 @@ export const ReleaseCardMini: React.FC<ReleaseCardMiniProps> = (props) => {
         }
         msg += `${createdAt.getHours()}:${createdAt.getMinutes()}:${createdAt.getSeconds()}`;
     }
+    const allEnvs: Environment[] = useOverview((x) => Object.values(x.environments));
+    const sortedEnvs: Environment[] = sortEnvironmentsByUpstream(allEnvs);
+    const envPrioMap: EnvPrioMap = calculateEnvironmentPriorities(allEnvs);
+    const envsForAppSorted = sortedEnvs.filter((env: Environment) => environmentsForApp.includes(env));
 
     return (
         <div className={classNames('release-card-mini', className)} onClick={clickHanlder}>
@@ -59,8 +65,13 @@ export const ReleaseCardMini: React.FC<ReleaseCardMiniProps> = (props) => {
                 <div className="release__details-msg">{msg}</div>
             </div>
             <div className="release__environments-mini">
-                {environments.map((env) => (
-                    <Chip className={classNames('release-environment', className)} label={env.name} key={env.name} />
+                {envsForAppSorted.map((env) => (
+                    <Chip
+                        className={classNames('release-environment', className)}
+                        label={env.name}
+                        key={env.name}
+                        priority={envPrioMap[env.name]}
+                    />
                 ))}
             </div>
         </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -82,21 +82,12 @@
         display: flex;
         flex-direction: row;
         justify-content: space-between;
-
-        .env-card-label {
-          border-radius: 10px;
-          width: auto;
-          height: 42px;
-          padding: 10px;
-          background-color: #FF8A00;
-          color: var(--mdc-theme-on-primary);
-          @extend .text-bold;
-          position: relative;
+        .release-environment {
           top: -10px;
           left: -10px;
-          display: flex;
-          flex-direction: row;
-
+          height: 42px;
+        }
+        .env-card-label {
           svg.env-card-env-lock-icon {
             width: 24px;
             height: 24px;

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -15,7 +15,9 @@ along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
 
 Copyright 2021 freiheit.com*/
 import {
-    calculateDistanceToUpstream, calculateEnvironmentPriorities, EnvPrio,
+    calculateDistanceToUpstream,
+    calculateEnvironmentPriorities,
+    EnvPrio,
     ReleaseDialog,
     ReleaseDialogProps,
     sortEnvironmentsByUpstream,
@@ -244,7 +246,7 @@ const getEnvs = (testcase: string): Environment[] => {
                 getEnvironment('env3'),
             ];
         default:
-            throw new Error("bad test: " + testcase);
+            throw new Error('bad test: ' + testcase);
     }
 };
 
@@ -280,26 +282,43 @@ describe.each(sortByUpstreamData)(`Environment set`, (testcase) => {
     });
 });
 
-
 const calcEnvPrioData = [
     {
         type: 'chain',
-        expect: {'env0': EnvPrio.UPSTREAM, 'env4': EnvPrio.PROD, 'env3': EnvPrio.PRE_PROD, 'env2': EnvPrio.OTHER, 'env1': EnvPrio.OTHER },
+        expect: {
+            env0: EnvPrio.UPSTREAM,
+            env4: EnvPrio.PROD,
+            env3: EnvPrio.PRE_PROD,
+            env2: EnvPrio.OTHER,
+            env1: EnvPrio.OTHER,
+        },
     },
     {
         type: 'tree',
-        expect: {'env0': EnvPrio.PROD, 'env4': EnvPrio.UPSTREAM, 'env3': EnvPrio.UPSTREAM, 'env2': EnvPrio.PRE_PROD, 'env1': EnvPrio.PROD },
+        expect: {
+            env0: EnvPrio.PROD,
+            env4: EnvPrio.UPSTREAM,
+            env3: EnvPrio.UPSTREAM,
+            env2: EnvPrio.PRE_PROD,
+            env1: EnvPrio.PROD,
+        },
     },
     {
         // the main point here is that it doesn't crash
         // we do not fully support disconnected trees
         type: 'cycle',
-        expect: {'env0': EnvPrio.PROD, 'env4': EnvPrio.UPSTREAM, 'env3': EnvPrio.PROD, 'env2': EnvPrio.OTHER, 'env1': EnvPrio.PROD },
+        expect: {
+            env0: EnvPrio.PROD,
+            env4: EnvPrio.UPSTREAM,
+            env3: EnvPrio.PROD,
+            env2: EnvPrio.OTHER,
+            env1: EnvPrio.PROD,
+        },
     },
     {
         // the main point here is that it doesn't crash
         type: 'no-config',
-        expect: {'env0': EnvPrio.PROD, 'env4': EnvPrio.PROD, 'env3': EnvPrio.PROD, 'env2': EnvPrio.PROD, 'env1': EnvPrio.PROD },
+        expect: { env0: EnvPrio.PROD, env4: EnvPrio.PROD, env3: EnvPrio.PROD, env2: EnvPrio.PROD, env1: EnvPrio.PROD },
     },
 ];
 

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -18,9 +18,10 @@ import { Dialog, Tooltip } from '@material-ui/core';
 import classNames from 'classnames';
 import React from 'react';
 import { Environment, Release } from '../../../api/api';
-import { updateReleaseDialog } from '../../utils/store';
+import { updateReleaseDialog, useOverview } from '../../utils/store';
 import { Button } from '../button';
 import { Locks, LocksWhite } from '../../../images';
+import { Chip } from "../chip";
 
 export type ReleaseDialogProps = {
     className?: string;
@@ -131,11 +132,20 @@ export const EnvironmentList: React.FC<{ envs: Environment[]; release: Release; 
     release,
     app,
     className,
-}) => (
-    <ul className={classNames('release-env-list', className)}>
+}) => {
+    const allEnvs: Environment[] = useOverview((x) => Object.values(x.environments));
+    const envPrioMap: EnvPrioMap = calculateEnvironmentPriorities(allEnvs);
+    return (<ul className={classNames('release-env-list', className)}>
         {sortEnvironmentsByUpstream(envs).map((env) => (
             <li key={env.name} className={classNames('env-card', className)}>
                 <div className="env-card-header">
+                    <Chip
+                        className={'release-environment'}
+                        label={env.name}
+                        key={env.name}
+                        priority={envPrioMap[env.name]}
+                    />
+
                     <div className={classNames('env-card-label', className)}>
                         <div className={classNames('env-card-label-name', className)}>{env.name}</div>
                         {Object.values(env.locks).length !== 0 ? (
@@ -154,7 +164,7 @@ export const EnvironmentList: React.FC<{ envs: Environment[]; release: Release; 
                                         }>
                                         <div>
                                             <Button
-                                                icon={<LocksWhite className="env-card-env-lock-icon" />}
+                                                icon={<LocksWhite className="env-card-env-lock-icon"/>}
                                                 className={'button-lock'}
                                             />
                                         </div>
@@ -183,7 +193,7 @@ export const EnvironmentList: React.FC<{ envs: Environment[]; release: Release; 
                                         }>
                                         <div>
                                             <Button
-                                                icon={<Locks className="env-card-app-lock" />}
+                                                icon={<Locks className="env-card-app-lock"/>}
                                                 className={'button-lock'}
                                             />
                                         </div>
@@ -198,13 +208,13 @@ export const EnvironmentList: React.FC<{ envs: Environment[]; release: Release; 
                         : env.name + ' is deployed to version ' + env.applications[app].version}
                 </div>
                 <div className="env-card-buttons">
-                    <Button className="env-card-add-lock-btn" label="Add lock" icon={<Locks className="icon" />} />
-                    <Button className="env-card-deploy-btn" label="Deploy" />
+                    <Button className="env-card-add-lock-btn" label="Add lock" icon={<Locks className="icon"/>}/>
+                    <Button className="env-card-deploy-btn" label="Deploy"/>
                 </div>
             </li>
         ))}
-    </ul>
-);
+    </ul>);
+};
 
 export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
     const { app, className, release, envs } = props;

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -21,7 +21,7 @@ import { Environment, Release } from '../../../api/api';
 import { updateReleaseDialog, useOverview } from '../../utils/store';
 import { Button } from '../button';
 import { Locks, LocksWhite } from '../../../images';
-import { Chip } from "../chip";
+import { Chip } from '../chip';
 
 export type ReleaseDialogProps = {
     className?: string;
@@ -135,85 +135,85 @@ export const EnvironmentList: React.FC<{ envs: Environment[]; release: Release; 
 }) => {
     const allEnvs: Environment[] = useOverview((x) => Object.values(x.environments));
     const envPrioMap: EnvPrioMap = calculateEnvironmentPriorities(allEnvs);
-    return (<ul className={classNames('release-env-list', className)}>
-        {sortEnvironmentsByUpstream(envs).map((env) => (
-            <li key={env.name} className={classNames('env-card', className)}>
-                <div className="env-card-header">
-                    <Chip
-                        className={'release-environment'}
-                        label={env.name}
-                        key={env.name}
-                        priority={envPrioMap[env.name]}
-                    />
-
-                    <div className={classNames('env-card-label', className)}>
-                        <div className={classNames('env-card-label-name', className)}>{env.name}</div>
-                        {Object.values(env.locks).length !== 0 ? (
-                            <div className={classNames('env-card-env-locks', className)}>
-                                {Object.values(env.locks).map((lock) => (
-                                    <Tooltip
-                                        className="env-card-env-lock"
-                                        key={lock.lockId}
-                                        arrow
-                                        title={
-                                            'Lock Message: "' +
-                                            lock.message +
-                                            '" | ID: "' +
-                                            lock.lockId +
-                                            '"  | Click to unlock. '
-                                        }>
-                                        <div>
-                                            <Button
-                                                icon={<LocksWhite className="env-card-env-lock-icon"/>}
-                                                className={'button-lock'}
-                                            />
-                                        </div>
-                                    </Tooltip>
-                                ))}
-                            </div>
-                        ) : (
-                            <></>
-                        )}
-                    </div>
-                    <div className={classNames('env-card-app-locks')}>
-                        {Object.values(env.applications)
-                            .filter((application) => application.name === app)
-                            .map((app) => app.locks)
-                            .map((locks) =>
-                                Object.values(locks).map((lock) => (
-                                    <Tooltip
-                                        key={lock.lockId}
-                                        arrow
-                                        title={
-                                            'Lock Message: "' +
-                                            lock.message +
-                                            '" | ID: "' +
-                                            lock.lockId +
-                                            '"  | Click to unlock. '
-                                        }>
-                                        <div>
-                                            <Button
-                                                icon={<Locks className="env-card-app-lock"/>}
-                                                className={'button-lock'}
-                                            />
-                                        </div>
-                                    </Tooltip>
-                                ))
+    return (
+        <ul className={classNames('release-env-list', className)}>
+            {sortEnvironmentsByUpstream(envs).map((env) => (
+                <li key={env.name} className={classNames('env-card', className)}>
+                    <div className="env-card-header">
+                        <Chip
+                            className={'release-environment'}
+                            label={env.name}
+                            key={env.name}
+                            priority={envPrioMap[env.name]}
+                        />
+                        <div className={classNames('_env-card-label', className)}>
+                            {Object.values(env.locks).length !== 0 ? (
+                                <div className={classNames('env-card-env-locks', className)}>
+                                    {Object.values(env.locks).map((lock) => (
+                                        <Tooltip
+                                            className="env-card-env-lock"
+                                            key={lock.lockId}
+                                            arrow
+                                            title={
+                                                'Lock Message: "' +
+                                                lock.message +
+                                                '" | ID: "' +
+                                                lock.lockId +
+                                                '"  | Click to unlock. '
+                                            }>
+                                            <div>
+                                                <Button
+                                                    icon={<LocksWhite className="env-card-env-lock-icon" />}
+                                                    className={'button-lock'}
+                                                />
+                                            </div>
+                                        </Tooltip>
+                                    ))}
+                                </div>
+                            ) : (
+                                <></>
                             )}
+                        </div>
+                        <div className={classNames('env-card-app-locks')}>
+                            {Object.values(env.applications)
+                                .filter((application) => application.name === app)
+                                .map((app) => app.locks)
+                                .map((locks) =>
+                                    Object.values(locks).map((lock) => (
+                                        <Tooltip
+                                            key={lock.lockId}
+                                            arrow
+                                            title={
+                                                'Lock Message: "' +
+                                                lock.message +
+                                                '" | ID: "' +
+                                                lock.lockId +
+                                                '"  | Click to unlock. '
+                                            }>
+                                            <div>
+                                                <Button
+                                                    icon={<Locks className="env-card-app-lock" />}
+                                                    className={'button-lock'}
+                                                />
+                                            </div>
+                                        </Tooltip>
+                                    ))
+                                )}
+                        </div>
                     </div>
-                </div>
-                <div className={classNames('env-card-data', className)}>
-                    {release.version === env.applications[app].version
-                        ? release.sourceCommitId + ':' + release.sourceMessage
-                        : env.name + ' is deployed to version ' + env.applications[app].version}
-                </div>
-                <div className="env-card-buttons">
-                    <Button className="env-card-add-lock-btn" label="Add lock" icon={<Locks className="icon"/>}/>
-                    <Button className="env-card-deploy-btn" label="Deploy"/>
-                </div>
-            </li>
-        ))}
-    </ul>);
+                    <div className={classNames('env-card-data', className)}>
+                        {release.version === env.applications[app].version
+                            ? release.sourceCommitId + ':' + release.sourceMessage
+                            : env.name + ' is deployed to version ' + env.applications[app].version}
+                    </div>
+                    <div className="env-card-buttons">
+                        <Button className="env-card-add-lock-btn" label="Add lock" icon={<Locks className="icon" />} />
+                        <Button className="env-card-deploy-btn" label="Deploy" />
+                    </div>
+                </li>
+            ))}
+        </ul>
+    );
 };
 
 export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
@@ -247,7 +247,7 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                                 )}
                             </div>
                             <div className={classNames('release-dialog-author', className)}>
-                                {release?.sourceAuthor ? 'Author:' + release?.sourceAuthor : ''}
+                                {release?.sourceAuthor ? 'Author: ' + release?.sourceAuthor : ''}
                             </div>
                         </div>
                         <span className={classNames('release-dialog-commitId', className)}>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -36,11 +36,13 @@ const setClosed = () => {
 
 export type EnvSortOrder = { [index: string]: number };
 
+// do not rename!
+// these are mapped directly to css classes in chip.tsx
 export enum EnvPrio {
-    PROD = 0,
-    PRE_PROD = 1,
-    UPSTREAM = 2,
-    OTHER = -1,
+    PROD,
+    PRE_PROD,
+    UPSTREAM,
+    OTHER,
 }
 
 export type EnvPrioMap = { [key: string]: EnvPrio };

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -64,7 +64,7 @@ export const calculateEnvironmentPriorities = (envs: Environment[]): EnvPrioMap 
     envs.forEach((env: Environment) => {
         maxDistance = Math.max(maxDistance, distances[env.name]);
     });
-    // now that we have the maximum, we can assign prod and pre-prod:
+    // now assign each environment a prio:
     envs.forEach((env: Environment) => {
         if (distances[env.name] === maxDistance) {
             result[env.name] = EnvPrio.PROD;

--- a/services/frontend-service/src/ui/components/Releases/Releases.test.tsx
+++ b/services/frontend-service/src/ui/components/Releases/Releases.test.tsx
@@ -81,7 +81,7 @@ describe('Release Dialog', () => {
         it(testcase.name, () => {
             // when
             UpdateOverview.set({
-                applications: { ['test']: { releases: testcase.releases } },
+                applications: { test: { releases: testcase.releases } },
                 environments: {},
             } as any);
             render(<Releases app="test" />);

--- a/services/frontend-service/src/ui/components/chip/chip.test.tsx
+++ b/services/frontend-service/src/ui/components/chip/chip.test.tsx
@@ -46,19 +46,19 @@ describe('Chip', () => {
 const data = [
     {
         envPrio: EnvPrio.PROD,
-        expectedClass: "prod"
+        expectedClass: 'prod',
     },
     {
         envPrio: EnvPrio.PRE_PROD,
-        expectedClass: "pre_prod"
+        expectedClass: 'pre_prod',
     },
     {
         envPrio: EnvPrio.UPSTREAM,
-        expectedClass: "upstream"
+        expectedClass: 'upstream',
     },
     {
         envPrio: EnvPrio.OTHER,
-        expectedClass: "other"
+        expectedClass: 'other',
     },
 ];
 
@@ -67,7 +67,8 @@ describe.each(data)(`Chip with envPrio Classname`, (testcase) => {
         const getNode = () => <Chip className={'chip--hello'} label={'Test Me'} priority={testcase.envPrio} />;
         const getWrapper = () => render(getNode());
         const { container } = getWrapper();
-        expect(container.firstChild).toHaveClass("mdc-evolution-chip chip--hello chip--hello-" + testcase.expectedClass);
-
+        expect(container.firstChild).toHaveClass(
+            'mdc-evolution-chip chip--hello chip--hello-' + testcase.expectedClass
+        );
     });
 });

--- a/services/frontend-service/src/ui/components/chip/chip.test.tsx
+++ b/services/frontend-service/src/ui/components/chip/chip.test.tsx
@@ -16,24 +16,22 @@ along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
 Copyright 2021 freiheit.com*/
 import { Chip } from './chip';
 import { render } from '@testing-library/react';
+import { EnvPrio } from '../ReleaseDialog/ReleaseDialog';
 
 describe('Chip', () => {
-    const getNode = () => <Chip className={'chip--test'} label={'Test Me'} />;
+    const getNode = () => <Chip className={'chip--test'} label={'Test Me'} priority={EnvPrio.PROD} />;
     const getWrapper = () => render(getNode());
     it('renders a chip', () => {
         const { container } = getWrapper();
         expect(container.firstChild).toMatchInlineSnapshot(`
             <span
-              class="mdc-evolution-chip chip--test"
+              class="mdc-evolution-chip chip--test chip--test-prod"
               role="row"
             >
               <span
-                class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary"
+                class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
                 role="gridcell"
               >
-                <span
-                  class="mdc-evolution-chip__ripple mdc-evolution-chip__ripple--primary"
-                />
                 <span
                   class="mdc-evolution-chip__text-label"
                 >
@@ -42,5 +40,34 @@ describe('Chip', () => {
               </span>
             </span>
         `);
+    });
+});
+
+const data = [
+    {
+        envPrio: EnvPrio.PROD,
+        expectedClass: "prod"
+    },
+    {
+        envPrio: EnvPrio.PRE_PROD,
+        expectedClass: "pre_prod"
+    },
+    {
+        envPrio: EnvPrio.UPSTREAM,
+        expectedClass: "upstream"
+    },
+    {
+        envPrio: EnvPrio.OTHER,
+        expectedClass: "other"
+    },
+];
+
+describe.each(data)(`Chip with envPrio Classname`, (testcase) => {
+    it(`with envPrio=${testcase.envPrio}`, () => {
+        const getNode = () => <Chip className={'chip--hello'} label={'Test Me'} priority={testcase.envPrio} />;
+        const getWrapper = () => render(getNode());
+        const { container } = getWrapper();
+        expect(container.firstChild).toHaveClass("mdc-evolution-chip chip--hello chip--hello-" + testcase.expectedClass);
+
     });
 });

--- a/services/frontend-service/src/ui/components/chip/chip.test.tsx
+++ b/services/frontend-service/src/ui/components/chip/chip.test.tsx
@@ -31,19 +31,14 @@ describe('Chip', () => {
                 class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary"
                 role="gridcell"
               >
-                <button
-                  class="mdc-evolution-chip__action mdc-evolution-chip__action--primary"
-                  type="button"
+                <span
+                  class="mdc-evolution-chip__ripple mdc-evolution-chip__ripple--primary"
+                />
+                <span
+                  class="mdc-evolution-chip__text-label"
                 >
-                  <span
-                    class="mdc-evolution-chip__ripple mdc-evolution-chip__ripple--primary"
-                  />
-                  <span
-                    class="mdc-evolution-chip__text-label"
-                  >
-                    Test Me
-                  </span>
-                </button>
+                  Test Me
+                </span>
               </span>
             </span>
         `);

--- a/services/frontend-service/src/ui/components/chip/chip.tsx
+++ b/services/frontend-service/src/ui/components/chip/chip.tsx
@@ -17,11 +17,11 @@ Copyright 2021 freiheit.com*/
 import classNames from 'classnames';
 import { EnvPrio } from '../ReleaseDialog/ReleaseDialog';
 
-export const Chip = (props: { className?: string; label: string; priority: EnvPrio }) => {
+export const Chip = (props: { className: string; label: string; priority: EnvPrio }) => {
     const { className, label } = props;
-
+    const prioClassName = className + '-' + String(EnvPrio[props.priority]).toLowerCase();
     return (
-        <span className={classNames('mdc-evolution-chip', className)} role="row">
+        <span className={classNames('mdc-evolution-chip', className, prioClassName)} role="row">
             <span
                 className="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
                 role="gridcell">

--- a/services/frontend-service/src/ui/components/chip/chip.tsx
+++ b/services/frontend-service/src/ui/components/chip/chip.tsx
@@ -15,17 +15,17 @@ along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
 
 Copyright 2021 freiheit.com*/
 import classNames from 'classnames';
+import { EnvPrio } from '../ReleaseDialog/ReleaseDialog';
 
-export const Chip = (props: { className?: string; label?: string }) => {
+export const Chip = (props: { className?: string; label: string; priority: EnvPrio }) => {
     const { className, label } = props;
 
     return (
         <span className={classNames('mdc-evolution-chip', className)} role="row">
-            <span className="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary" role="gridcell">
-                <button className={'mdc-evolution-chip__action mdc-evolution-chip__action--primary'} type="button">
-                    <span className="mdc-evolution-chip__ripple mdc-evolution-chip__ripple--primary" />
-                    <span className="mdc-evolution-chip__text-label">{label}</span>
-                </button>
+            <span
+                className="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
+                role="gridcell">
+                <span className="mdc-evolution-chip__text-label">{label}</span>
             </span>
         </span>
     );


### PR DESCRIPTION
The colors will be set automatically, depending on the "upstream" settings in config.json.
There are 4 groups:
* prod: Green. These are all envs that are the last in the chain.
* pre-prod: Blue: All envs that come directly before prod.
* upstream=true: Orange. These are all envs that are deployed immediately (usually called "dev").
* other: Grey: All envs that are none of the above, e.g. if you have a chain of 4.