### PR TITLE
refactoring: rename config to RepositoryConfig

### DIFF
--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -119,7 +119,7 @@ func RunServer() {
 		// If the tracer is not started, calling this function is a no-op.
 		span, ctx := tracer.StartSpanFromContext(ctx, "Start server")
 
-		repo, err := repository.New(ctx, repository.Config{
+		repo, err := repository.New(ctx, repository.RepositoryConfig{
 			URL:            c.GitUrl,
 			Path:           "./repository",
 			CommitterEmail: c.GitCommitterEmail,

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -70,7 +70,7 @@ type repository struct {
 	writesDone   uint
 	queue        queue
 	remote       *git.Remote
-	config       *Config
+	config       *RepositoryConfig
 	credentials  *credentialsStore
 	certificates *certificateStore
 
@@ -82,7 +82,7 @@ type repository struct {
 	notify notify.Notify
 }
 
-type Config struct {
+type RepositoryConfig struct {
 	// Mandatory Config
 	URL  string
 	Path string
@@ -124,7 +124,7 @@ func openOrCreate(path string) (*git.Repository, error) {
 }
 
 // Opens a repository. The repository is initialized and updated in the background.
-func New(ctx context.Context, cfg Config) (Repository, error) {
+func New(ctx context.Context, cfg RepositoryConfig) (Repository, error) {
 	logger := logger.FromContext(ctx)
 
 	ddMetricsFromCtx := ctx.Value("ddMetrics")

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -49,7 +49,7 @@ func TestNew(t *testing.T) {
 				// run the initialization code once
 				_, err := New(
 					context.Background(),
-					Config{
+					RepositoryConfig{
 						URL:  "file://" + remoteDir,
 						Path: localDir,
 					},
@@ -75,7 +75,7 @@ func TestNew(t *testing.T) {
 				// run the initialization code once
 				repo, err := New(
 					context.Background(),
-					Config{
+					RepositoryConfig{
 						URL:  remoteDir,
 						Path: localDir,
 					},
@@ -110,7 +110,7 @@ func TestNew(t *testing.T) {
 				// run the initialization code once
 				repo, err := New(
 					context.Background(),
-					Config{
+					RepositoryConfig{
 						URL:  remoteDir,
 						Path: t.TempDir(),
 					},
@@ -265,7 +265,7 @@ func TestNew(t *testing.T) {
 			tc.Setup(t, remoteDir, localDir)
 			repo, err := New(
 				context.Background(),
-				Config{
+				RepositoryConfig{
 					URL:    "file://" + remoteDir,
 					Path:   localDir,
 					Branch: tc.Branch,
@@ -311,7 +311,7 @@ func TestBootstrapModeNew(t *testing.T) {
 			if tc.PreInitialize {
 				_, err := New(
 					context.Background(),
-					Config{
+					RepositoryConfig{
 						URL:  "file://" + remoteDir,
 						Path: localDir,
 					},
@@ -325,7 +325,7 @@ func TestBootstrapModeNew(t *testing.T) {
 
 			repo, err := New(
 				context.Background(),
-				Config{
+				RepositoryConfig{
 					URL:                    "file://" + remoteDir,
 					Path:                   localDir,
 					BootstrapMode:          true,
@@ -372,7 +372,7 @@ func TestBootstrapModeReadConfig(t *testing.T) {
 
 			repo, err := New(
 				context.Background(),
-				Config{
+				RepositoryConfig{
 					URL:                    "file://" + remoteDir,
 					Path:                   localDir,
 					BootstrapMode:          true,
@@ -431,7 +431,7 @@ func TestBootstrapError(t *testing.T) {
 
 			_, err := New(
 				context.Background(),
-				Config{
+				RepositoryConfig{
 					URL:                    "file://" + remoteDir,
 					Path:                   localDir,
 					BootstrapMode:          true,
@@ -539,7 +539,7 @@ func TestConfigReload(t *testing.T) {
 
 		repo, err := New(
 			context.Background(),
-			Config{
+			RepositoryConfig{
 				URL:  remoteDir,
 				Path: t.TempDir(),
 			},
@@ -663,7 +663,7 @@ func TestConfigValidity(t *testing.T) {
 
 			_, err = New(
 				context.Background(),
-				Config{
+				RepositoryConfig{
 					URL:  remoteDir,
 					Path: t.TempDir(),
 				},
@@ -752,7 +752,7 @@ func TestGc(t *testing.T) {
 				cmd.Wait()
 				repo, err := New(
 					context.Background(),
-					Config{
+					RepositoryConfig{
 						URL:         "file://" + remoteDir,
 						Path:        localDir,
 						GcFrequency: gcFrequency,
@@ -948,7 +948,7 @@ func TestApplyQueuePanic(t *testing.T) {
 			cmd.Wait()
 			repo, err := New(
 				context.Background(),
-				Config{
+				RepositoryConfig{
 					URL:  "file://" + remoteDir,
 					Path: localDir,
 				},
@@ -1173,7 +1173,7 @@ func TestApplyQueue(t *testing.T) {
 			cmd.Wait()
 			repo, err := New(
 				context.Background(),
-				Config{
+				RepositoryConfig{
 					URL:  "file://" + remoteDir,
 					Path: localDir,
 				},
@@ -1305,7 +1305,7 @@ func BenchmarkApplyQueue(t *testing.B) {
 
 	repo, err := New(
 		context.Background(),
-		Config{
+		RepositoryConfig{
 			URL:  "file://" + remoteDir,
 			Path: localDir,
 		},

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1928,7 +1928,7 @@ spec:
 			cmd.Wait()
 			repo, err := New(
 				context.Background(),
-				Config{
+				RepositoryConfig{
 					URL:            remoteDir,
 					Path:           localDir,
 					CommitterEmail: "kuberpult@freiheit.com",
@@ -2115,7 +2115,7 @@ func setupRepositoryTest(t *testing.T) Repository {
 	cmd.Wait()
 	repo, err := New(
 		context.Background(),
-		Config{
+		RepositoryConfig{
 			URL:            remoteDir,
 			Path:           localDir,
 			CommitterEmail: "kuberpult@freiheit.com",

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -313,7 +313,7 @@ func setupRepositoryTest(t *testing.T) (repository.Repository, error) {
 	cmd.Wait()
 	repo, err := repository.New(
 		context.Background(),
-		repository.Config{
+		repository.RepositoryConfig{
 			URL:            remoteDir,
 			Path:           localDir,
 			CommitterEmail: "kuberpult@freiheit.com",

--- a/services/cd-service/pkg/service/service_test.go
+++ b/services/cd-service/pkg/service/service_test.go
@@ -291,7 +291,7 @@ func TestServeHttp(t *testing.T) {
 			cmd.Wait()
 			repo, err := repository.New(
 				context.Background(),
-				repository.Config{
+				repository.RepositoryConfig{
 					URL:            remoteDir,
 					Path:           localDir,
 					CommitterEmail: "kuberpult@freiheit.com",
@@ -437,7 +437,7 @@ func TestServeHttpEmptyBody(t *testing.T) {
 			cmd.Wait()
 			repo, err := repository.New(
 				context.Background(),
-				repository.Config{
+				repository.RepositoryConfig{
 					URL:            remoteDir,
 					Path:           localDir,
 					CommitterEmail: "kuberpult@freiheit.com",


### PR DESCRIPTION
we have 3 structs called "config", which is unnecessarily confusing. This PR is renaming one of them.