### PR TITLE
Add EnvironmentGroup to getOverview endpoint

### DIFF
--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -219,6 +219,7 @@ func (o *OverviewServiceServer) getOverview(
 				Name: envName,
 				Config: &api.Environment_Config{
 					Upstream: transformUpstream(config.Upstream),
+					EnvironmentGroup: config.EnvironmentGroup,
 				},
 				Locks:        map[string]*api.Lock{},
 				Applications: map[string]*api.Environment_Application{},


### PR DESCRIPTION
This endpoint is still being used, also in the new ui, so we have to supply it with the group as well