### PR TITLE
SRX-ZP4P4F  Fix wrong tags in LocksTable

### DIFF
--- a/services/frontend-service/src/ui/components/LocksTable/LocksTable.tsx
+++ b/services/frontend-service/src/ui/components/LocksTable/LocksTable.tsx
@@ -80,9 +80,13 @@ export const LocksTable: React.FC<{
                         </tr>
                     </thead>
                     <tbody className="mdc-data-table__content">
-                        {locks.map((lock) => (
-                            <LockDisplay key={lock.lockId} lock={lock} />
-                        ))}
+                        <tr>
+                            <td>
+                                {locks.map((lock) => (
+                                    <LockDisplay key={lock.lockId} lock={lock} />
+                                ))}
+                            </td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
this change fixes the `<div> cannot appear as a child of <tbody>` errors that show up in the locks page