### PR TITLE
Add Environment Groups to getOverview response

### DIFF
--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -172,6 +172,13 @@ message EnvironmentGroup {
   repeated Environment environments = 2;
 }
 
+enum Priority {
+  PROD = 0;
+  PRE_PROD = 1;
+  UPSTREAM = 2;
+  OTHER = 3;
+}
+
 message Environment {
   message Config {
     message Upstream {
@@ -208,6 +215,7 @@ message Environment {
   map<string, Lock> locks = 3;
   map<string, Application> applications = 4;
   int32 distanceToUpstream = 5;
+  Priority priority = 6;
 }
 
 message Release {

--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -154,12 +154,12 @@ message GetOverviewRequest {
 }
 
 message GetOverviewResponse {
-  map<string, Environment> environments = 1;
+  map<string, Environment> environments = 1 [deprecated=true]; // use environmentGroups instead!
   map<string, Application> applications = 2;
+  repeated EnvironmentGroup environmentGroups = 3;
 }
 
 message GetDeployedOverviewRequest {
-
 }
 
 message GetDeployedOverviewResponse {
@@ -167,6 +167,10 @@ message GetDeployedOverviewResponse {
   map<string, Application> applications = 2;
 }
 
+message EnvironmentGroup {
+  string environmentGroupName = 1;
+  repeated Environment environments = 2;
+}
 
 message Environment {
   message Config {
@@ -203,6 +207,7 @@ message Environment {
   Config config = 2;
   map<string, Lock> locks = 3;
   map<string, Application> applications = 4;
+  int32 distanceToUpstream = 5;
 }
 
 message Release {

--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -170,6 +170,7 @@ message GetDeployedOverviewResponse {
 message EnvironmentGroup {
   string environmentGroupName = 1;
   repeated Environment environments = 2;
+  uint32 distanceToUpstream = 3;
 }
 
 enum Priority {

--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -170,6 +170,7 @@ message GetDeployedOverviewResponse {
 message EnvironmentGroup {
   string environmentGroupName = 1;
   repeated Environment environments = 2;
+  // note that the distanceToUpstream should usually be configured to be the same for all envs in this group, but this is not enforced.
   uint32 distanceToUpstream = 3;
 }
 
@@ -215,7 +216,7 @@ message Environment {
   Config config = 2;
   map<string, Lock> locks = 3;
   map<string, Application> applications = 4;
-  int32 distanceToUpstream = 5;
+  uint32 distanceToUpstream = 5;
   Priority priority = 6;
 }
 

--- a/pkg/logger/http.go
+++ b/pkg/logger/http.go
@@ -24,18 +24,18 @@ import (
 
 type injectLogger struct {
 	logger *zap.Logger
-	inner   http.Handler
+	inner  http.Handler
 }
 
 func (i *injectLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := WithLogger(r.Context(), i.logger)
-	r2  := r.Clone(ctx)
+	r2 := r.Clone(ctx)
 	i.inner.ServeHTTP(w, r2)
 }
 
 func WithHttpLogger(logger *zap.Logger, inner http.Handler) http.Handler {
 	return &injectLogger{
 		logger: logger,
-		inner: inner,
+		inner:  inner,
 	}
 }

--- a/services/cd-service/pkg/config/config.go
+++ b/services/cd-service/pkg/config/config.go
@@ -17,9 +17,9 @@ Copyright 2021 freiheit.com*/
 package config
 
 type EnvironmentConfig struct {
-	Upstream *EnvironmentConfigUpstream `json:"upstream,omitempty"`
-	ArgoCd   *EnvironmentConfigArgoCd   `json:"argocd,omitempty"`
-	EnvironmentGroup *string            `json:"environmentGroup,omitempty"`
+	Upstream         *EnvironmentConfigUpstream `json:"upstream,omitempty"`
+	ArgoCd           *EnvironmentConfigArgoCd   `json:"argocd,omitempty"`
+	EnvironmentGroup *string                    `json:"environmentGroup,omitempty"`
 }
 
 type EnvironmentConfigUpstream struct {

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -415,6 +415,10 @@ func mapEnvironmentsToGroups(envs map[string]config.EnvironmentConfig) []*api.En
 			if environment.Config.Upstream.GetLatest() {
 				environment.DistanceToUpstream = 0
 				tmpDistancesToUpstreamByEnv[environment.Name] = 0
+			} else if environment.Config.Upstream == nil {
+				// the environment has neither an upstream, nor latest configured. We can't determine where it belongs
+				environment.DistanceToUpstream = 100 // we can just pick an arbitrary number
+				tmpDistancesToUpstreamByEnv[environment.Name] = 100
 			} else {
 				// and remember the rest:
 				rest = append(rest, environment)

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -65,7 +65,7 @@ func (o *OverviewServiceServer) getDeployedOverview(
 			env := api.Environment{
 				Name: envName,
 				Config: &api.Environment_Config{
-					Upstream: transformUpstream(config.Upstream),
+					Upstream:         transformUpstream(config.Upstream),
 					EnvironmentGroup: config.EnvironmentGroup,
 				},
 				Locks:        map[string]*api.Lock{},
@@ -209,21 +209,22 @@ func (o *OverviewServiceServer) getOverview(
 	ctx context.Context,
 	s *repository.State) (*api.GetOverviewResponse, error) {
 	result := api.GetOverviewResponse{
-		Environments: map[string]*api.Environment{},
-		Applications: map[string]*api.Application{},
+		Environments:      map[string]*api.Environment{},
+		Applications:      map[string]*api.Application{},
 		EnvironmentGroups: []*api.EnvironmentGroup{},
 	}
 	if envs, err := s.GetEnvironmentConfigs(); err != nil {
 		return nil, internalError(ctx, err)
 	} else {
 		result.EnvironmentGroups = mapEnvironmentsToGroups(envs)
-		todo("now we just need to fill the groups data additionally to the iteration here over envs / maybe we can combine both")
 		for envName, config := range envs {
+			var groupName = deriveGroupName(config, envName)
+			var envInGroup = getEnvironmentInGroup(result.EnvironmentGroups, groupName, envName)
 			env := api.Environment{
 				Name: envName,
 				Config: &api.Environment_Config{
-					Upstream: transformUpstream(config.Upstream),
-					EnvironmentGroup: config.EnvironmentGroup,
+					Upstream:         transformUpstream(config.Upstream),
+					EnvironmentGroup: &groupName,
 				},
 				Locks:        map[string]*api.Lock{},
 				Applications: map[string]*api.Environment_Application{},
@@ -242,6 +243,7 @@ func (o *OverviewServiceServer) getOverview(
 						},
 					}
 				}
+				envInGroup.Locks = env.Locks
 			}
 			if apps, err := s.GetEnvironmentApplications(envName); err != nil {
 				return nil, err
@@ -307,6 +309,8 @@ func (o *OverviewServiceServer) getOverview(
 				}
 			}
 			result.Environments[envName] = &env
+			envInGroup.Applications = env.Applications
+
 		}
 	}
 	if apps, err := s.GetApplications(); err != nil {
@@ -357,36 +361,46 @@ func (o *OverviewServiceServer) getOverview(
 	return &result, nil
 }
 
-type EnvSortOrder = map[string]int;
+func getEnvironmentInGroup(groups []*api.EnvironmentGroup, groupNameToReturn string, envNameToReturn string) *api.Environment {
+	for _, currentGroup := range groups {
+		if currentGroup.EnvironmentGroupName == groupNameToReturn {
+			for _, currentEnv := range currentGroup.Environments {
+				if currentEnv.Name == envNameToReturn {
+					return currentEnv
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type EnvSortOrder = map[string]int
 
 func mapEnvironmentsToGroups(envs map[string]config.EnvironmentConfig) []*api.EnvironmentGroup {
 	var result = []*api.EnvironmentGroup{}
 	var buckets = map[string]*api.EnvironmentGroup{}
 	// first, group all envs into buckets by groupName
 	for envName, env := range envs {
-		var groupName = env.EnvironmentGroup
-		if groupName == nil {
-			groupName = &envName
-		}
-		var groupNameCopy = *groupName + "" // without this copy, unexpected pointer things happen :/
-		var bucket, ok = buckets[*groupName]
+		var groupName = deriveGroupName(env, envName)
+		var groupNameCopy = groupName + "" // without this copy, unexpected pointer things happen :/
+		var bucket, ok = buckets[groupName]
 		if !ok {
 			bucket = &api.EnvironmentGroup{
 				EnvironmentGroupName: groupNameCopy,
-				Environments: []*api.Environment{},
+				Environments:         []*api.Environment{},
 			}
 			buckets[groupNameCopy] = bucket
 		}
-		 var newEnv = &api.Environment{
+		var newEnv = &api.Environment{
 			Name: envName,
 			Config: &api.Environment_Config{
-				Upstream: transformUpstream(env.Upstream),
+				Upstream:         transformUpstream(env.Upstream),
 				EnvironmentGroup: &groupNameCopy,
 			},
 			Locks:        map[string]*api.Lock{},
 			Applications: map[string]*api.Environment_Application{},
 		}
-		bucket.Environments= append(bucket.Environments, newEnv)
+		bucket.Environments = append(bucket.Environments, newEnv)
 	}
 	// now we have all environments grouped correctly.
 	// next step, sort envs by distance to prod.
@@ -407,30 +421,30 @@ func mapEnvironmentsToGroups(envs map[string]config.EnvironmentConfig) []*api.En
 			}
 		}
 	}
-		// now we have all envs remaining that have upstream.latest == false
-		for ; len(rest) > 0; {
-			nextRest := []*api.Environment{}
+	// now we have all envs remaining that have upstream.latest == false
+	for len(rest) > 0 {
+		nextRest := []*api.Environment{}
+		for i := 0; i < len(rest); i++ {
+			env := rest[i]
+			upstreamEnv := env.Config.Upstream.GetEnvironment()
+			_, ok := tmpDistancesToUpstreamByEnv[upstreamEnv]
+			if ok {
+				tmpDistancesToUpstreamByEnv[env.Name] = tmpDistancesToUpstreamByEnv[upstreamEnv] + 1
+				env.DistanceToUpstream = tmpDistancesToUpstreamByEnv[env.Name]
+			} else {
+				nextRest = append(nextRest, env)
+			}
+		}
+		if len(rest) == len(nextRest) {
+			// if nothing changed in the previous for-loop, we have an undefined distance.
+			// to avoid an infinite loop, we fill it with an arbitrary number:
 			for i := 0; i < len(rest); i++ {
 				env := rest[i]
-				upstreamEnv := env.Config.Upstream.GetEnvironment()
-				_, ok := tmpDistancesToUpstreamByEnv[upstreamEnv]
-				if ok {
-					tmpDistancesToUpstreamByEnv[env.Name] = tmpDistancesToUpstreamByEnv[upstreamEnv] + 1
-					env.DistanceToUpstream = tmpDistancesToUpstreamByEnv[env.Name]
-				} else {
-					nextRest = append(nextRest, env)
-				}
+				tmpDistancesToUpstreamByEnv[env.Name] = uint32(len(envs) + 1)
 			}
-			if len(rest) == len(nextRest) {
-				// if nothing changed in the previous for-loop, we have an undefined distance.
-				// to avoid an infinite loop, we fill it with an arbitrary number:
-				for i := 0; i < len(rest); i++{
-					env := rest[i]
-					tmpDistancesToUpstreamByEnv[env.Name] = uint32(len(envs) + 1)
-				}
-			}
-			rest = nextRest
 		}
+		rest = nextRest
+	}
 
 	// now each environment has a distanceToUpstream.
 	// we set the distanceToUpstream also to each group:
@@ -450,16 +464,25 @@ func mapEnvironmentsToGroups(envs map[string]config.EnvironmentConfig) []*api.En
 	sort.Sort(EnvironmentGroupsByDistance(result))
 	// now, everything is sorted, so we can add more data on top that depends on the sorting.
 	// colllect all envs:
-	tmpEnvs :=  []*api.Environment{}
+	tmpEnvs := []*api.Environment{}
 	for i := 0; i < len(result); i++ {
 		var group = result[i]
 		//calculateEnvironmentPriorities(group.Environments)
 		for j := 0; j < len(group.Environments); j++ {
-			tmpEnvs = append(tmpEnvs , group.Environments[j])
+			tmpEnvs = append(tmpEnvs, group.Environments[j])
 		}
 	}
 	calculateEnvironmentPriorities(tmpEnvs)
 	return result
+}
+
+// either the groupName is set in the config, or we use the envName as a default
+func deriveGroupName(env config.EnvironmentConfig, envName string) string {
+	var groupName = env.EnvironmentGroup
+	if groupName == nil {
+		groupName = &envName
+	}
+	return *groupName
 }
 
 func calculateEnvironmentPriorities(environments []*api.Environment) {
@@ -473,7 +496,7 @@ func calculateEnvironmentPriorities(environments []*api.Environment) {
 		var env = environments[i]
 		if env.DistanceToUpstream == maxDistance {
 			env.Priority = api.Priority_PROD
-		} else if env.DistanceToUpstream == maxDistance - 1 {
+		} else if env.DistanceToUpstream == maxDistance-1 {
 			env.Priority = api.Priority_PRE_PROD
 		} else if env.DistanceToUpstream == 0 {
 			env.Priority = api.Priority_UPSTREAM
@@ -489,7 +512,6 @@ func max(a uint32, b uint32) uint32 {
 	}
 	return b
 }
-
 
 type EnvironmentByDistance []*api.Environment
 

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -217,7 +217,7 @@ func (o *OverviewServiceServer) getOverview(
 		return nil, internalError(ctx, err)
 	} else {
 		result.EnvironmentGroups = mapEnvironmentsToGroups(envs)
-		//todo("iterate over groups")
+		todo("now we just need to fill the groups data additionally to the iteration here over envs / maybe we can combine both")
 		for envName, config := range envs {
 			env := api.Environment{
 				Name: envName,

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -218,7 +217,7 @@ func (o *OverviewServiceServer) getOverview(
 		return nil, internalError(ctx, err)
 	} else {
 		result.EnvironmentGroups = mapEnvironmentsToGroups(envs)
-		todo("iterate over groups")
+		//todo("iterate over groups")
 		for envName, config := range envs {
 			env := api.Environment{
 				Name: envName,
@@ -391,7 +390,7 @@ func mapEnvironmentsToGroups(envs map[string]config.EnvironmentConfig) []*api.En
 	// now we have all environments grouped correctly.
 	// next step, sort envs by distance to prod.
 	// to do that, we first need to calculate the distance to upstream:
-	for groupName, bucket := range buckets {
+	for _, bucket := range buckets {
 		tmpDistancesToUpstreamByEnv := map[string]int32{}
 		// first, find all envs with distance 0
 		rest := []*api.Environment{}
@@ -427,6 +426,7 @@ func mapEnvironmentsToGroups(envs map[string]config.EnvironmentConfig) []*api.En
 					tmpDistancesToUpstreamByEnv[env.Name] = int32(len(envs) + 1)
 				}
 			}
+			rest = nextRest
 		}
 	}
 
@@ -460,7 +460,7 @@ func calculateEnvironmentPriorities(environments []*api.Environment) {
 	for i := 0; i < len(environments); i++ {
 		var env = environments[i]
 		if env.DistanceToUpstream == maxDistance {
-			env.priority =
+			env.Priority = 42
 		}
 	}
 }

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -421,8 +421,52 @@ func TestOverviewService(t *testing.T) {
 	}
 }
 
+func makeUpstreamLatest() *api.Environment_Config_Upstream {
+	return &api.Environment_Config_Upstream{
+		Upstream: &api.Environment_Config_Upstream_Latest{
+			Latest: true,
+		},
+	}
+}
+
+func makeUpstreamEnvironment(env  string ) *api.Environment_Config_Upstream {
+	return &api.Environment_Config_Upstream{
+		Upstream: &api.Environment_Config_Upstream_Environment{
+			Environment: env,
+		},
+	}
+}
+
+var nameStagingDe = "staging-de"
+var nameDevDe = "dev-de"
+var nameProdDe = "prod-de"
+//var nameWhoKnowsDe = "whoknows-de"
+
+var nameStagingFr = "staging-fr"
+var nameDevFr = "dev-fr"
+var nameProdFr = "prod-fr"
+//var nameWhoKnowsFr = "whoknows-fr"
+
+var nameStaging = "staging"
+var nameDev = "dev"
+var nameProd = "prod"
+//var nameWhoKnows = "whoknows"
+
+func makeEnv(envName string, groupName string, upstream *api.Environment_Config_Upstream, distanceToUpstream uint32 , priority api.Priority  ) *api.Environment {
+	return 						&api.Environment{
+		Name: envName,
+		Config: &api.Environment_Config{
+			Upstream: 		  upstream,
+			EnvironmentGroup: &groupName,
+		},
+			Locks:              map[string]*api.Lock{},
+			Applications:       map[string]*api.Environment_Application{},
+			DistanceToUpstream: distanceToUpstream,
+			Priority:           priority, // we are 1 away from prod, hence pre-prod
+	};
+}
+
 func TestMapEnvironmentsToGroup(t *testing.T) {
-	var nameA = "groupA"
 	tcs := []struct {
 		Name  string
 		InputEnvs map[string]config.EnvironmentConfig
@@ -431,46 +475,214 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 		{
 			Name: "One Environment is one Group",
 			InputEnvs: map[string]config.EnvironmentConfig{
-				"g-one": {
+				nameDevDe: {
 					Upstream:         &config.EnvironmentConfigUpstream{
-						Environment: "g-one",
+						Environment: "",
 						Latest:      true,
 					},
 					ArgoCd:           nil,
-					EnvironmentGroup: &nameA,
+					EnvironmentGroup: &nameDevDe,
 				},
 			},
 			ExpectedResult: []*api.EnvironmentGroup{
 				{
-					EnvironmentGroupName: nameA,
+					EnvironmentGroupName: nameDevDe,
 					Environments: []*api.Environment{
-						{
-							Name: nameA,
-							Config: &api.Environment_Config{
-								Upstream:         &api.Environment_Config_Upstream{
-									Upstream: &api.Environment_Config_Upstream_Latest{
-										Latest: true,
-									},
-								},
-								EnvironmentGroup: &nameA,
-							},
-							Locks:              nil,
-							Applications:       nil,
-							DistanceToUpstream: 0,
-							Priority:           0,
-						},
+						makeEnv(nameDevDe, nameDevDe, makeUpstreamLatest(), 0, api.Priority_PROD),
 					},
 					DistanceToUpstream:   0,
 				},
 			},
 		},
+		{
+			Name: "Two Environments are two Groups",
+			InputEnvs: map[string]config.EnvironmentConfig{
+				nameDevDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Latest:      true,
+					},
+					ArgoCd:           nil,
+				},
+				nameStagingDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Environment: nameDevDe,
+					},
+					ArgoCd:           nil,
+				},
+			},
+			ExpectedResult: []*api.EnvironmentGroup{
+				{
+					EnvironmentGroupName: nameDevDe,
+					Environments: []*api.Environment{
+						makeEnv(nameDevDe, nameDevDe, makeUpstreamLatest(), 0, api.Priority_PRE_PROD),
+					},
+					DistanceToUpstream:   0,
+				},
+				{
+					EnvironmentGroupName: nameStagingDe,
+					Environments: []*api.Environment{
+						makeEnv(nameStagingDe, nameStagingDe, makeUpstreamEnvironment(nameDevDe), 1, api.Priority_PROD),
+					},
+					DistanceToUpstream:   1,
+				},
+			},
+		},
+		{
+			// note that this is not a realistic example, we just want to make sure it does not crash!
+			// some outputs may be nonsensical (like distanceToUpstream), but that's fine as long as it's stable!
+			Name: "Two Environments with a loop",
+			InputEnvs: map[string]config.EnvironmentConfig{
+				nameDevDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Environment: nameStagingDe,
+					},
+					ArgoCd:           nil,
+				},
+				nameStagingDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Environment: nameDevDe,
+					},
+					ArgoCd:           nil,
+				},
+			},
+			ExpectedResult: []*api.EnvironmentGroup{
+				{
+					EnvironmentGroupName: nameDevDe,
+					Environments: []*api.Environment{
+						makeEnv(nameDevDe, nameDevDe, makeUpstreamEnvironment(nameStagingDe), 4, api.Priority_PRE_PROD),
+					},
+					DistanceToUpstream:   4,
+				},
+				{
+					EnvironmentGroupName: nameStagingDe,
+					Environments: []*api.Environment{
+						makeEnv(nameStagingDe, nameStagingDe, makeUpstreamEnvironment(nameDevDe), 5, api.Priority_PROD),
+					},
+					DistanceToUpstream:   5,
+				},
+			},
+		},
+		{
+			Name: "Three Environments are three Groups",
+			InputEnvs: map[string]config.EnvironmentConfig{
+				nameDevDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Latest:      true,
+					},
+					ArgoCd:           nil,
+				},
+				nameStagingDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Environment: nameDevDe,
+					},
+					ArgoCd:           nil,
+				},
+				nameProdDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Environment: nameStagingDe,
+					},
+					ArgoCd:           nil,
+				},
+			},
+			ExpectedResult: []*api.EnvironmentGroup{
+				{
+					EnvironmentGroupName: nameDevDe,
+					Environments: []*api.Environment{
+						makeEnv(nameDevDe, nameDevDe, makeUpstreamLatest(), 0, api.Priority_UPSTREAM),
+					},
+					DistanceToUpstream:   0,
+				},
+				{
+					EnvironmentGroupName: nameStagingDe,
+					Environments: []*api.Environment{
+						makeEnv(nameStagingDe, nameStagingDe, makeUpstreamEnvironment(nameDevDe), 1, api.Priority_PRE_PROD),
+					},
+					DistanceToUpstream:   1,
+				},
+				{
+					EnvironmentGroupName: nameProdDe,
+					Environments: []*api.Environment{
+						makeEnv(nameProdDe, nameProdDe, makeUpstreamEnvironment(nameStagingDe), 2, api.Priority_PROD),
+					},
+					DistanceToUpstream:   2,
+				},
+			},
+		},
+		{
+			// this is a realistic example
+			Name: "Three Groups with 2 envs each",
+			InputEnvs: map[string]config.EnvironmentConfig{
+				nameDevDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Latest:      true,
+					},
+					EnvironmentGroup: &nameDev,
+				},
+				nameDevFr: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Latest:      true,
+					},
+					EnvironmentGroup: &nameDev,
+				},
+				nameStagingDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Environment: nameDevDe,
+					},
+					EnvironmentGroup: &nameStaging,
+				},
+				nameStagingFr: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Environment: nameDevFr,
+					},
+					EnvironmentGroup: &nameStaging,
+				},
+				nameProdDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Environment: nameStagingDe,
+					},
+					EnvironmentGroup: &nameProd,
+				},
+				nameProdFr: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Environment: nameStagingFr,
+					},
+					EnvironmentGroup: &nameProd,
+				},
+			},
+			ExpectedResult: []*api.EnvironmentGroup{
+				{
+					EnvironmentGroupName: nameDev,
+					Environments: []*api.Environment{
+						makeEnv(nameDevDe, nameDev, makeUpstreamLatest(), 0, api.Priority_UPSTREAM),
+						makeEnv(nameDevFr, nameDev, makeUpstreamLatest(), 0, api.Priority_UPSTREAM),
+					},
+					DistanceToUpstream:   0,
+				},
+				{
+					EnvironmentGroupName: nameStaging,
+					Environments: []*api.Environment{
+						makeEnv(nameStagingDe, nameStaging, makeUpstreamEnvironment(nameDevDe), 1, api.Priority_PRE_PROD),
+						makeEnv(nameStagingFr, nameStaging, makeUpstreamEnvironment(nameDevFr), 1, api.Priority_PRE_PROD),
+					},
+					DistanceToUpstream:   1,
+				},
+				{
+					EnvironmentGroupName: nameProd,
+					Environments: []*api.Environment{
+						makeEnv(nameProdDe,  nameProd, makeUpstreamEnvironment(nameStagingDe), 2, api.Priority_PROD),
+						makeEnv(nameProdFr,  nameProd, makeUpstreamEnvironment(nameStagingFr), 2, api.Priority_PROD),
+					},
+					DistanceToUpstream:   2,
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
-		opts := cmpopts.IgnoreUnexported(api.EnvironmentGroup{}, api.Environment{})
+		opts := cmpopts.IgnoreUnexported(api.EnvironmentGroup{}, api.Environment{}, api.Environment_Config{}, api.Environment_Config_Upstream{})
 		t.Run(tc.Name, func(t *testing.T) {
 			actualResult := mapEnvironmentsToGroups(tc.InputEnvs)
-			if !cmp.Equal(tc.ExpectedResult[0].Environments[0], actualResult[0].Environments[0], opts) {
-				t.Fatal("Output mismatch (-want +got):\n", cmp.Diff(tc.ExpectedResult[0].Environments[0], actualResult[0].Environments[0], opts))
+			if !cmp.Equal(tc.ExpectedResult, actualResult, opts) {
+				t.Fatal("Output mismatch (-want +got):\n", cmp.Diff(tc.ExpectedResult, actualResult, opts))
 			}
 		})
 	}

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -429,7 +429,7 @@ func makeUpstreamLatest() *api.Environment_Config_Upstream {
 	}
 }
 
-func makeUpstreamEnvironment(env  string ) *api.Environment_Config_Upstream {
+func makeUpstreamEnvironment(env string) *api.Environment_Config_Upstream {
 	return &api.Environment_Config_Upstream{
 		Upstream: &api.Environment_Config_Upstream_Environment{
 			Environment: env,
@@ -452,31 +452,31 @@ var nameDev = "dev"
 var nameProd = "prod"
 var nameWhoKnows = "whoknows"
 
-func makeEnv(envName string, groupName string, upstream *api.Environment_Config_Upstream, distanceToUpstream uint32 , priority api.Priority  ) *api.Environment {
-	return 						&api.Environment{
+func makeEnv(envName string, groupName string, upstream *api.Environment_Config_Upstream, distanceToUpstream uint32, priority api.Priority) *api.Environment {
+	return &api.Environment{
 		Name: envName,
 		Config: &api.Environment_Config{
-			Upstream: 		  upstream,
+			Upstream:         upstream,
 			EnvironmentGroup: &groupName,
 		},
-			Locks:              map[string]*api.Lock{},
-			Applications:       map[string]*api.Environment_Application{},
-			DistanceToUpstream: distanceToUpstream,
-			Priority:           priority, // we are 1 away from prod, hence pre-prod
-	};
+		Locks:              map[string]*api.Lock{},
+		Applications:       map[string]*api.Environment_Application{},
+		DistanceToUpstream: distanceToUpstream,
+		Priority:           priority, // we are 1 away from prod, hence pre-prod
+	}
 }
 
 func TestMapEnvironmentsToGroup(t *testing.T) {
 	tcs := []struct {
-		Name  string
-		InputEnvs map[string]config.EnvironmentConfig
+		Name           string
+		InputEnvs      map[string]config.EnvironmentConfig
 		ExpectedResult []*api.EnvironmentGroup
 	}{
 		{
 			Name: "One Environment is one Group",
 			InputEnvs: map[string]config.EnvironmentConfig{
 				nameDevDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: "",
 						Latest:      true,
 					},
@@ -490,7 +490,7 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 					Environments: []*api.Environment{
 						makeEnv(nameDevDe, nameDevDe, makeUpstreamLatest(), 0, api.Priority_PROD),
 					},
-					DistanceToUpstream:   0,
+					DistanceToUpstream: 0,
 				},
 			},
 		},
@@ -498,16 +498,16 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 			Name: "Two Environments are two Groups",
 			InputEnvs: map[string]config.EnvironmentConfig{
 				nameDevDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
-						Latest:      true,
+					Upstream: &config.EnvironmentConfigUpstream{
+						Latest: true,
 					},
-					ArgoCd:           nil,
+					ArgoCd: nil,
 				},
 				nameStagingDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: nameDevDe,
 					},
-					ArgoCd:           nil,
+					ArgoCd: nil,
 				},
 			},
 			ExpectedResult: []*api.EnvironmentGroup{
@@ -516,14 +516,14 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 					Environments: []*api.Environment{
 						makeEnv(nameDevDe, nameDevDe, makeUpstreamLatest(), 0, api.Priority_PRE_PROD),
 					},
-					DistanceToUpstream:   0,
+					DistanceToUpstream: 0,
 				},
 				{
 					EnvironmentGroupName: nameStagingDe,
 					Environments: []*api.Environment{
 						makeEnv(nameStagingDe, nameStagingDe, makeUpstreamEnvironment(nameDevDe), 1, api.Priority_PROD),
 					},
-					DistanceToUpstream:   1,
+					DistanceToUpstream: 1,
 				},
 			},
 		},
@@ -533,16 +533,16 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 			Name: "Two Environments with a loop",
 			InputEnvs: map[string]config.EnvironmentConfig{
 				nameDevDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: nameStagingDe,
 					},
-					ArgoCd:           nil,
+					ArgoCd: nil,
 				},
 				nameStagingDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: nameDevDe,
 					},
-					ArgoCd:           nil,
+					ArgoCd: nil,
 				},
 			},
 			ExpectedResult: []*api.EnvironmentGroup{
@@ -551,14 +551,14 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 					Environments: []*api.Environment{
 						makeEnv(nameDevDe, nameDevDe, makeUpstreamEnvironment(nameStagingDe), 4, api.Priority_PRE_PROD),
 					},
-					DistanceToUpstream:   4,
+					DistanceToUpstream: 4,
 				},
 				{
 					EnvironmentGroupName: nameStagingDe,
 					Environments: []*api.Environment{
 						makeEnv(nameStagingDe, nameStagingDe, makeUpstreamEnvironment(nameDevDe), 5, api.Priority_PROD),
 					},
-					DistanceToUpstream:   5,
+					DistanceToUpstream: 5,
 				},
 			},
 		},
@@ -566,22 +566,22 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 			Name: "Three Environments are three Groups",
 			InputEnvs: map[string]config.EnvironmentConfig{
 				nameDevDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
-						Latest:      true,
+					Upstream: &config.EnvironmentConfigUpstream{
+						Latest: true,
 					},
-					ArgoCd:           nil,
+					ArgoCd: nil,
 				},
 				nameStagingDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: nameDevDe,
 					},
-					ArgoCd:           nil,
+					ArgoCd: nil,
 				},
 				nameProdDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: nameStagingDe,
 					},
-					ArgoCd:           nil,
+					ArgoCd: nil,
 				},
 			},
 			ExpectedResult: []*api.EnvironmentGroup{
@@ -590,21 +590,21 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 					Environments: []*api.Environment{
 						makeEnv(nameDevDe, nameDevDe, makeUpstreamLatest(), 0, api.Priority_UPSTREAM),
 					},
-					DistanceToUpstream:   0,
+					DistanceToUpstream: 0,
 				},
 				{
 					EnvironmentGroupName: nameStagingDe,
 					Environments: []*api.Environment{
 						makeEnv(nameStagingDe, nameStagingDe, makeUpstreamEnvironment(nameDevDe), 1, api.Priority_PRE_PROD),
 					},
-					DistanceToUpstream:   1,
+					DistanceToUpstream: 1,
 				},
 				{
 					EnvironmentGroupName: nameProdDe,
 					Environments: []*api.Environment{
 						makeEnv(nameProdDe, nameProdDe, makeUpstreamEnvironment(nameStagingDe), 2, api.Priority_PROD),
 					},
-					DistanceToUpstream:   2,
+					DistanceToUpstream: 2,
 				},
 			},
 		},
@@ -612,22 +612,22 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 			Name: "Four Environments in a row to ensure that Priority_UPSTREAM works",
 			InputEnvs: map[string]config.EnvironmentConfig{
 				nameDevDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
-						Latest:      true,
+					Upstream: &config.EnvironmentConfigUpstream{
+						Latest: true,
 					},
 				},
 				nameStagingDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: nameDevDe,
 					},
 				},
 				nameProdDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: nameStagingDe,
 					},
 				},
 				nameWhoKnowsDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: nameProdDe,
 					},
 				},
@@ -638,28 +638,28 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 					Environments: []*api.Environment{
 						makeEnv(nameDevDe, nameDevDe, makeUpstreamLatest(), 0, api.Priority_UPSTREAM),
 					},
-					DistanceToUpstream:   0,
+					DistanceToUpstream: 0,
 				},
 				{
 					EnvironmentGroupName: nameStagingDe,
 					Environments: []*api.Environment{
 						makeEnv(nameStagingDe, nameStagingDe, makeUpstreamEnvironment(nameDevDe), 1, api.Priority_OTHER),
 					},
-					DistanceToUpstream:   1,
+					DistanceToUpstream: 1,
 				},
 				{
 					EnvironmentGroupName: nameProdDe,
 					Environments: []*api.Environment{
 						makeEnv(nameProdDe, nameProdDe, makeUpstreamEnvironment(nameStagingDe), 2, api.Priority_PRE_PROD),
 					},
-					DistanceToUpstream:   2,
+					DistanceToUpstream: 2,
 				},
 				{
 					EnvironmentGroupName: nameWhoKnowsDe,
 					Environments: []*api.Environment{
 						makeEnv(nameWhoKnowsDe, nameWhoKnowsDe, makeUpstreamEnvironment(nameProdDe), 3, api.Priority_PROD),
 					},
-					DistanceToUpstream:   3,
+					DistanceToUpstream: 3,
 				},
 			},
 		},
@@ -668,37 +668,37 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 			Name: "Three Groups with 2 envs each",
 			InputEnvs: map[string]config.EnvironmentConfig{
 				nameDevDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
-						Latest:      true,
+					Upstream: &config.EnvironmentConfigUpstream{
+						Latest: true,
 					},
 					EnvironmentGroup: &nameDev,
 				},
 				nameDevFr: {
-					Upstream:         &config.EnvironmentConfigUpstream{
-						Latest:      true,
+					Upstream: &config.EnvironmentConfigUpstream{
+						Latest: true,
 					},
 					EnvironmentGroup: &nameDev,
 				},
 				nameStagingDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: nameDevDe,
 					},
 					EnvironmentGroup: &nameStaging,
 				},
 				nameStagingFr: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: nameDevFr,
 					},
 					EnvironmentGroup: &nameStaging,
 				},
 				nameProdDe: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: nameStagingDe,
 					},
 					EnvironmentGroup: &nameProd,
 				},
 				nameProdFr: {
-					Upstream:         &config.EnvironmentConfigUpstream{
+					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: nameStagingFr,
 					},
 					EnvironmentGroup: &nameProd,
@@ -711,7 +711,7 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 						makeEnv(nameDevDe, nameDev, makeUpstreamLatest(), 0, api.Priority_UPSTREAM),
 						makeEnv(nameDevFr, nameDev, makeUpstreamLatest(), 0, api.Priority_UPSTREAM),
 					},
-					DistanceToUpstream:   0,
+					DistanceToUpstream: 0,
 				},
 				{
 					EnvironmentGroupName: nameStaging,
@@ -719,15 +719,15 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 						makeEnv(nameStagingDe, nameStaging, makeUpstreamEnvironment(nameDevDe), 1, api.Priority_PRE_PROD),
 						makeEnv(nameStagingFr, nameStaging, makeUpstreamEnvironment(nameDevFr), 1, api.Priority_PRE_PROD),
 					},
-					DistanceToUpstream:   1,
+					DistanceToUpstream: 1,
 				},
 				{
 					EnvironmentGroupName: nameProd,
 					Environments: []*api.Environment{
-						makeEnv(nameProdDe,  nameProd, makeUpstreamEnvironment(nameStagingDe), 2, api.Priority_PROD),
-						makeEnv(nameProdFr,  nameProd, makeUpstreamEnvironment(nameStagingFr), 2, api.Priority_PROD),
+						makeEnv(nameProdDe, nameProd, makeUpstreamEnvironment(nameStagingDe), 2, api.Priority_PROD),
+						makeEnv(nameProdFr, nameProd, makeUpstreamEnvironment(nameStagingFr), 2, api.Priority_PROD),
 					},
-					DistanceToUpstream:   2,
+					DistanceToUpstream: 2,
 				},
 			},
 		},

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -440,17 +440,17 @@ func makeUpstreamEnvironment(env  string ) *api.Environment_Config_Upstream {
 var nameStagingDe = "staging-de"
 var nameDevDe = "dev-de"
 var nameProdDe = "prod-de"
-//var nameWhoKnowsDe = "whoknows-de"
+var nameWhoKnowsDe = "whoknows-de"
 
 var nameStagingFr = "staging-fr"
 var nameDevFr = "dev-fr"
 var nameProdFr = "prod-fr"
-//var nameWhoKnowsFr = "whoknows-fr"
+var nameWhoKnowsFr = "whoknows-fr"
 
 var nameStaging = "staging"
 var nameDev = "dev"
 var nameProd = "prod"
-//var nameWhoKnows = "whoknows"
+var nameWhoKnows = "whoknows"
 
 func makeEnv(envName string, groupName string, upstream *api.Environment_Config_Upstream, distanceToUpstream uint32 , priority api.Priority  ) *api.Environment {
 	return 						&api.Environment{
@@ -605,6 +605,61 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 						makeEnv(nameProdDe, nameProdDe, makeUpstreamEnvironment(nameStagingDe), 2, api.Priority_PROD),
 					},
 					DistanceToUpstream:   2,
+				},
+			},
+		},
+		{
+			Name: "Four Environments in a row to ensure that Priority_UPSTREAM works",
+			InputEnvs: map[string]config.EnvironmentConfig{
+				nameDevDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Latest:      true,
+					},
+				},
+				nameStagingDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Environment: nameDevDe,
+					},
+				},
+				nameProdDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Environment: nameStagingDe,
+					},
+				},
+				nameWhoKnowsDe: {
+					Upstream:         &config.EnvironmentConfigUpstream{
+						Environment: nameProdDe,
+					},
+				},
+			},
+			ExpectedResult: []*api.EnvironmentGroup{
+				{
+					EnvironmentGroupName: nameDevDe,
+					Environments: []*api.Environment{
+						makeEnv(nameDevDe, nameDevDe, makeUpstreamLatest(), 0, api.Priority_UPSTREAM),
+					},
+					DistanceToUpstream:   0,
+				},
+				{
+					EnvironmentGroupName: nameStagingDe,
+					Environments: []*api.Environment{
+						makeEnv(nameStagingDe, nameStagingDe, makeUpstreamEnvironment(nameDevDe), 1, api.Priority_OTHER),
+					},
+					DistanceToUpstream:   1,
+				},
+				{
+					EnvironmentGroupName: nameProdDe,
+					Environments: []*api.Environment{
+						makeEnv(nameProdDe, nameProdDe, makeUpstreamEnvironment(nameStagingDe), 2, api.Priority_PRE_PROD),
+					},
+					DistanceToUpstream:   2,
+				},
+				{
+					EnvironmentGroupName: nameWhoKnowsDe,
+					Environments: []*api.Environment{
+						makeEnv(nameWhoKnowsDe, nameWhoKnowsDe, makeUpstreamEnvironment(nameProdDe), 3, api.Priority_PROD),
+					},
+					DistanceToUpstream:   3,
 				},
 			},
 		},

--- a/services/frontend-service/pkg/handler/releasetrain.go
+++ b/services/frontend-service/pkg/handler/releasetrain.go
@@ -73,7 +73,7 @@ func (s Server) handleReleaseTrain(w http.ResponseWriter, req *http.Request, env
 	}
 	response, err := s.DeployClient.ReleaseTrain(req.Context(), &api.ReleaseTrainRequest{
 		Environment: environment,
-		Team: teamParam,
+		Team:        teamParam,
 	})
 	if err != nil {
 		handleGRPCError(req.Context(), w, err)


### PR DESCRIPTION
This adds a new field `EnvironmentGroups` to the server response.
The old field `Environments` still exists, but is deprecated. Logically, they contain the same information, but `EnvironmentGroups` is structured better for use in the UI.

This commits moves over functions like `calculateEnvironmentPriorities` to the server, that where implemented on client side before.