### PR TITLE
Bugfix: Do not require authentication in frontend-service health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Specifically this means, that minor upgrades can contain **breaking changes**.
 
 # Change Log
 
+## 0.4.53
+* Bugfix: Do not require authentication in frontend-service health check [#467](https://github.com/freiheit-com/kuberpult/pull/467)
+
+
 ## 0.4.52
 * Publish the docker images additionally to the ghcr.io registry [#459](https://github.com/freiheit-com/kuberpult/pull/459)
 

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -224,7 +224,7 @@ func RunServer() {
 				*/
 				resp.Header().Set("strict-Transport-Security", "max-age=31536000; includeSubDomains;")
 				if c.AzureEnableAuth {
-					if err := auth.HttpAuthMiddleWare(resp, req, jwks, c.AzureClientId, c.AzureTenantId, []string{"/", "/release", "/manifest.json", "/favicon.png"}, []string{"/static/js", "/static/css"}); err != nil {
+					if err := auth.HttpAuthMiddleWare(resp, req, jwks, c.AzureClientId, c.AzureTenantId, []string{"/", "/release", "/health", "/manifest.json", "/favicon.png"}, []string{"/static/js", "/static/css"}); err != nil {
 						return
 					}
 				}


### PR DESCRIPTION
Before this change, when AzureAuth was enabled, the frontend services's health check did not work, as it responds with `Invalid authorization header provided`.
With this change, the health endpoint does not requires authentication anymore. It does not matter anymore if AzureAuth is enabled or not.