### PR TITLE
Fix kuberpult release

### DIFF
--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -118,6 +118,7 @@ jobs:
           data: ${{ toJSON(matrix.data) }}
       - name: Test, Build and Publish
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           IMAGE_REGISTRY=ghcr.io/freiheit-com/kuberpult ${{ matrix.data.command }}
           IMAGE_REGISTRY=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult ${{ matrix.data.command }}
       - name: Post build actions


### PR DESCRIPTION
`git config --global --add safe.directory "$GITHUB_WORKSPACE"` is required, presumably because the `Test, Build and Publish` step is now running in parallel