### PR TITLE
Make v2 publicly available (beta)

### DIFF
--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -54,6 +54,7 @@ type Config struct {
 	DogstatsdAddr     string `default:"127.0.0.1:8125" split_words:"true"`
 }
 
+// DELETE ME
 func (c *Config) readPgpKeyRing() (openpgp.KeyRing, error) {
 	if c.PgpKeyRing == "" {
 		return nil, nil

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -54,7 +54,6 @@ type Config struct {
 	DogstatsdAddr     string `default:"127.0.0.1:8125" split_words:"true"`
 }
 
-// DELETE ME
 func (c *Config) readPgpKeyRing() (openpgp.KeyRing, error) {
 	if c.PgpKeyRing == "" {
 		return nil, nil

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -19,12 +19,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"golang.org/x/crypto/openpgp"
 	"io"
 	"net/http"
 	"os"
-	"strings"
-
-	"golang.org/x/crypto/openpgp"
 
 	"github.com/MicahParks/keyfunc"
 	"github.com/freiheit-com/kuberpult/services/frontend-service/pkg/config"
@@ -228,12 +226,7 @@ func RunServer() {
 						return
 					}
 				}
-				if strings.HasPrefix(req.URL.Path, "/v2/home") {
-					mux.ServeHTTP(resp, req)
-				} else {
-					mux.ServeHTTP(resp, req)
-				}
-
+				mux.ServeHTTP(resp, req)
 			}
 		})
 		authHandler := &Auth{

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/MicahParks/keyfunc"
 	"github.com/freiheit-com/kuberpult/services/frontend-service/pkg/config"
@@ -226,7 +227,11 @@ func RunServer() {
 						return
 					}
 				}
-				mux.ServeHTTP(resp, req)
+				if strings.HasPrefix(req.URL.Path, "/v2/home") {
+					http.ServeFile(resp, req, "build/index.html")
+				} else {
+					mux.ServeHTTP(resp, req)
+				}
 			}
 		})
 		authHandler := &Auth{

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -222,7 +222,7 @@ func RunServer() {
 				*/
 				resp.Header().Set("strict-Transport-Security", "max-age=31536000; includeSubDomains;")
 				if c.AzureEnableAuth {
-					if err := auth.HttpAuthMiddleWare(resp, req, jwks, c.AzureClientId, c.AzureTenantId, []string{"/", "/release", "/health", "/manifest.json", "/favicon.png"}, []string{"/static/js", "/static/css"}); err != nil {
+					if err := auth.HttpAuthMiddleWare(resp, req, jwks, c.AzureClientId, c.AzureTenantId, []string{"/", "/v2/home", "/release", "/health", "/manifest.json", "/favicon.png"}, []string{"/static/js", "/static/css"}); err != nil {
 						return
 					}
 				}

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -229,7 +229,7 @@ func RunServer() {
 					}
 				}
 				if strings.HasPrefix(req.URL.Path, "/v2/home") {
-					http.ServeFile(resp, req, "build/index.html")
+					mux.ServeHTTP(resp, req)
 				} else {
 					mux.ServeHTTP(resp, req)
 				}


### PR DESCRIPTION
Enables the url path `/v2/home` for everyone.

Note that this url is usable, but still missing some features. In general, we recommend to keep using the old UI for now, under url path `/`.
