### PR TITLE
Improved error handling for release trains

### DIFF
--- a/services/cd-service/pkg/httperrors/httperrors.go
+++ b/services/cd-service/pkg/httperrors/httperrors.go
@@ -14,30 +14,24 @@ You should have received a copy of the GNU General Public License
 along with kuberpult.  If not, see <http://www.gnu.org/licenses/>.
 
 Copyright 2021 freiheit.com*/
-package service
+package httperrors
 
 import (
 	"context"
-	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/httperrors"
-
-	"github.com/freiheit-com/kuberpult/pkg/api"
-	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
-	"google.golang.org/protobuf/types/known/emptypb"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-type EnvironmentServiceServer struct {
-	Repository repository.Repository
+func InternalError(ctx context.Context, err error) error {
+	logger := logger.FromContext(ctx)
+	logger.Error("grpc.internal", zap.Error(err))
+	return status.Error(codes.Internal, "internal error")
 }
 
-func (e *EnvironmentServiceServer) CreateEnvironment(
-	ctx context.Context,
-	in *api.CreateEnvironmentRequest) (*emptypb.Empty, error) {
-
-	err := e.Repository.Apply(ctx, &repository.CreateEnvironment{
-		Environment: in.Environment,
-	})
-	if err != nil {
-		return nil, httperrors.InternalError(ctx, err)
-	}
-	return &emptypb.Empty{}, nil
+func PublicError(ctx context.Context, err error) error {
+	logger := logger.FromContext(ctx)
+	logger.Error("grpc.internal", zap.Error(err))
+	return status.Error(codes.InvalidArgument, "error: " + err.Error())
 }

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -490,7 +490,7 @@ func TestReleaseTrainErrors(t *testing.T) {
 					Environment: "doesnotexistenvironment",
 				},
 			},
-			expectedError:     "could not find environment config for 'doesnotexistenvironment'",
+			expectedError:     "rpc error: code = InvalidArgument desc = error: could not find environment config for 'doesnotexistenvironment'",
 			expectedCommitMsg: "",
 			shouldSucceed:     false,
 		},

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/freiheit-com/kuberpult/pkg/api"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/httperrors"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/valid"
 	"google.golang.org/grpc/codes"
@@ -186,7 +187,7 @@ func (d *BatchServer) ProcessBatch(
 	}
 	err := d.Repository.Apply(ctx, transformers...)
 	if err != nil {
-		return nil, internalError(ctx, fmt.Errorf("could not apply transformer: %w", err))
+		return nil, httperrors.InternalError(ctx, fmt.Errorf("could not apply transformer: %w", err))
 	}
 	return &emptypb.Empty{}, nil
 }

--- a/services/cd-service/pkg/service/deploy.go
+++ b/services/cd-service/pkg/service/deploy.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/freiheit-com/kuberpult/pkg/api"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/httperrors"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/valid"
 	"google.golang.org/grpc/codes"
@@ -72,11 +72,11 @@ func (d *DeployServiceServer) Deploy(
 			}
 			stat, sErr := status.New(codes.FailedPrecondition, "locked").WithDetails(detail)
 			if sErr != nil {
-				return nil, internalError(ctx, sErr)
+				return nil, httperrors.InternalError(ctx, sErr)
 			}
 			return nil, stat.Err()
 		}
-		return nil, internalError(ctx, err)
+		return nil, httperrors.InternalError(ctx, err)
 	}
 
 	return &emptypb.Empty{}, nil
@@ -97,7 +97,7 @@ func (d *DeployServiceServer) ReleaseTrain(
 		Team:        in.Team,
 	})
 	if err != nil {
-		return nil, internalError(ctx, err)
+		return nil, err
 	}
 	state := d.Repository.State()
 	configs, err := state.GetEnvironmentConfigs()

--- a/services/cd-service/pkg/service/lock.go
+++ b/services/cd-service/pkg/service/lock.go
@@ -19,11 +19,8 @@ package service
 import (
 	"context"
 	"github.com/freiheit-com/kuberpult/pkg/api"
-	"github.com/freiheit-com/kuberpult/pkg/logger"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/httperrors"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
-	"go.uber.org/zap"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -44,7 +41,7 @@ func (l *LockServiceServer) CreateEnvironmentLock(
 		Message:     in.Message,
 	})
 	if err != nil {
-		return nil, internalError(ctx, err)
+		return nil, httperrors.InternalError(ctx, err)
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -61,7 +58,7 @@ func (l *LockServiceServer) DeleteEnvironmentLock(
 		LockId:      in.LockId,
 	})
 	if err != nil {
-		return nil, internalError(ctx, err)
+		return nil, httperrors.InternalError(ctx, err)
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -80,7 +77,7 @@ func (l *LockServiceServer) CreateEnvironmentApplicationLock(
 		Message:     in.Message,
 	})
 	if err != nil {
-		return nil, internalError(ctx, err)
+		return nil, httperrors.InternalError(ctx, err)
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -98,15 +95,9 @@ func (l *LockServiceServer) DeleteEnvironmentApplicationLock(
 		LockId:      in.LockId,
 	})
 	if err != nil {
-		return nil, internalError(ctx, err)
+		return nil, httperrors.InternalError(ctx, err)
 	}
 	return &emptypb.Empty{}, nil
-}
-
-func internalError(ctx context.Context, err error) error {
-	logger := logger.FromContext(ctx)
-	logger.Error("grpc.internal", zap.Error(err))
-	return status.Error(codes.Internal, "internal error")
 }
 
 var _ api.LockServiceServer = (*LockServiceServer)(nil)

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/httperrors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"os"
 	"path/filepath"
@@ -59,7 +60,7 @@ func (o *OverviewServiceServer) getDeployedOverview(
 		Applications: map[string]*api.Application{},
 	}
 	if envs, err := s.GetEnvironmentConfigs(); err != nil {
-		return nil, internalError(ctx, err)
+		return nil, httperrors.InternalError(ctx, err)
 	} else {
 		for envName, config := range envs {
 			env := api.Environment{
@@ -214,7 +215,7 @@ func (o *OverviewServiceServer) getOverview(
 		EnvironmentGroups: []*api.EnvironmentGroup{},
 	}
 	if envs, err := s.GetEnvironmentConfigs(); err != nil {
-		return nil, internalError(ctx, err)
+		return nil, httperrors.InternalError(ctx, err)
 	} else {
 		result.EnvironmentGroups = mapEnvironmentsToGroups(envs)
 		for envName, config := range envs {


### PR DESCRIPTION
We now differentiate between "internal" and "public" errors. Internal errors are returned as http code 500 with no further details. Public errors are returned as http code 400 with the error message attached.

Also moved the function "internalError" into its own package "httperrors".