### PR TITLE
Display queued version in v2 release dialog

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -24,6 +24,7 @@ describe('Release Dialog', () => {
         props: ReleaseDialogProps;
         rels: Release[];
         expect_message: boolean;
+        expect_queues: number;
         data_length: number;
     }
     const data: dataT[] = [
@@ -62,6 +63,7 @@ describe('Release Dialog', () => {
             rels: [],
 
             expect_message: true,
+            expect_queues: 0,
             data_length: 1,
         },
         {
@@ -102,7 +104,7 @@ describe('Release Dialog', () => {
                                 name: 'test1',
                                 version: 3,
                                 locks: { applock: { message: 'appLock', lockId: 'ui-applock' } },
-                                queuedVersion: 0,
+                                queuedVersion: 666,
                                 undeployVersion: false,
                             },
                         },
@@ -114,6 +116,7 @@ describe('Release Dialog', () => {
             rels: [],
 
             expect_message: true,
+            expect_queues: 1,
             data_length: 2,
         },
         {
@@ -126,6 +129,7 @@ describe('Release Dialog', () => {
             },
             rels: [],
             expect_message: false,
+            expect_queues: 0,
             data_length: 0,
         },
     ];
@@ -199,6 +203,26 @@ describe('Release Dialog', () => {
             testcase.props.envs.forEach((env) => {
                 expect(document.querySelector('.env-locks')?.children).toHaveLength(Object.values(env.locks).length);
             });
+        });
+    });
+
+    describe.each(data)(`Renders the queuedVersion`, (testcase) => {
+        it(testcase.name, () => {
+            // when
+            UpdateOverview.set({
+                applications: { [testcase.props.app as string]: { releases: testcase.rels } },
+                environments: testcase.props.envs,
+                environmentGroups: [
+                    {
+                        environmentGroupName: 'dev',
+                        environments: testcase.props.envs,
+                        distanceToUpstream: 2,
+                    },
+                ],
+            } as any);
+            updateReleaseDialog(testcase.props.app, testcase.props.version);
+            render(<ReleaseDialog {...testcase.props} />);
+            expect(document.querySelectorAll('.env-card-data-queue')).toHaveLength(testcase.expect_queues);
         });
     });
 });

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -110,7 +110,7 @@ export const EnvironmentListItem: React.FC<{
     const queueInfo =
         queuedVersion === 0 ? null : (
             <div
-                className={classNames('env-card-data', className)}
+                className={classNames('env-card-data-queue', className)}
                 title={
                     'An attempt was made to deploy version ' +
                     queuedVersion +

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -613,6 +613,14 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                 dev is deployed to version 3
               </div>
               <div
+                class="env-card-data-queue"
+                title="An attempt was made to deploy version 666 either by a release train, or when a new version was created. However, there was a lock present at the time, so kuberpult did not deploy this version. "
+              >
+                Version 
+                666
+                 was not deployed, because of a lock.
+              </div>
+              <div
                 class="env-card-buttons"
               >
                 <button


### PR DESCRIPTION
When a version is queued, we display this in the UI.

Note that queues are for informational purposes only. They don't effect how something is deployed.
A version can be queued when a deployment fails, either because the release train ran into an application lock, or the /release endpoint ran into (any) lock.

SRX-2DXE9T
