### PR TITLE
Refactoring: Require return types in new ui

### DIFF
--- a/services/frontend-service/.eslintrc
+++ b/services/frontend-service/.eslintrc
@@ -12,6 +12,7 @@
     "no-console": 2,
     "eqeqeq": ["error", "always"],
     "@typescript-eslint/no-unused-vars": 2,
+    "@typescript-eslint/explicit-function-return-type": ["error"],
     "no-duplicate-imports": 0,
     "import/no-duplicates": 2,
     "prefer-const": ["error"]

--- a/services/frontend-service/.eslintrc
+++ b/services/frontend-service/.eslintrc
@@ -16,5 +16,13 @@
     "no-duplicate-imports": 0,
     "import/no-duplicates": 2,
     "prefer-const": ["error"]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/*.test.tsx"],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": ["off"]
+      }
+    }
+  ]
 }

--- a/services/frontend-service/src/legacy-ui/.eslintrc
+++ b/services/frontend-service/src/legacy-ui/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/explicit-function-return-type": "off"
+  }
+}

--- a/services/frontend-service/src/legacy-ui/Releases.tsx
+++ b/services/frontend-service/src/legacy-ui/Releases.tsx
@@ -152,7 +152,12 @@ const getFreshnessColor = (authorTime?: Date): string => {
     return 'version-history';
 };
 
-const ReleaseBox = (props: { name: string; release: Release; envs: Array<Environment>; sortOrder: EnvSortOrder }) => {
+const ReleaseBox = (props: {
+    name: string;
+    release: Release;
+    envs: Array<Environment>;
+    sortOrder: EnvSortOrder;
+}): JSX.Element => {
     const { name, release, envs, sortOrder } = props;
     const openReleaseBox = useOpen(name, release.version);
     const sortedEnvs = sortEnvironmentsByUpstream(envs, sortOrder);
@@ -178,7 +183,7 @@ const UndeployButton = (props: {
     addToCart?: () => void; //
     inCart?: boolean; //
     applicationName: string; //
-}) => {
+}): JSX.Element => {
     const buttonMsg = 'Prepare to Undeploy';
     const tooltipMsg =
         'This will create a new version that is empty. Use this only for services that are not needed anymore.';
@@ -252,7 +257,7 @@ const ApplicationBox: React.FC<any> = (props: {
     );
 };
 
-const EnvAvatar = (props: { env: Environment; application: string }) => {
+const EnvAvatar = (props: { env: Environment; application: string }): JSX.Element => {
     const { env, application } = props;
     const locked = Object.keys(env.locks).length > 0 || Object.keys(env.applications[application]?.locks).length > 0;
     const ava = <Avatar variant="rounded">{env.name.substring(0, 1).toUpperCase()}</Avatar>;

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -53,7 +53,7 @@ export const App: React.FC = () => {
                     },
                     (error) => PanicOverview.set({ error: JSON.stringify({ msg: 'error in streamoverview', error }) })
                 );
-            return () => subscription.unsubscribe();
+            return (): void => subscription.unsubscribe();
         }
     }, [api, authHeader, authReady]);
 

--- a/services/frontend-service/src/ui/components/EnvironmentCard/EnvironmentCard.tsx
+++ b/services/frontend-service/src/ui/components/EnvironmentCard/EnvironmentCard.tsx
@@ -24,8 +24,8 @@ export const EnvironmentCard: React.FC<{ environment: string }> = (props) => {
     const locks = useFilteredEnvironmentLockIDs(environment);
 
     const addLock = React.useCallback(() => {
-        const randBase36 = () => Math.random().toString(36).substring(7);
-        const randomLockId = () => 'ui-v2-' + randBase36();
+        const randBase36 = (): string => Math.random().toString(36).substring(7);
+        const randomLockId = (): string => 'ui-v2-' + randBase36();
         addAction({
             action: {
                 $case: 'createEnvironmentLock',

--- a/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.tsx
+++ b/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.tsx
@@ -18,7 +18,7 @@ import { Delete } from '../../../images';
 import { DisplayLock } from '../../utils/store';
 import classNames from 'classnames';
 
-export const daysToString = (days: number) => {
+export const daysToString = (days: number): string => {
     if (days === -1) return '';
     if (days === 0) return '< 1 day ago';
     if (days === 1) return '1 day ago';

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -39,7 +39,7 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
         if (control.current) {
             MDComponent.current = new MDCRipple(control.current);
         }
-        return () => MDComponent.current?.destroy();
+        return (): void => MDComponent.current?.destroy();
     }, []);
 
     return (

--- a/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.tsx
@@ -24,7 +24,7 @@ export type ReleaseCardMiniProps = {
     app: string;
 };
 
-const getDays = (date: Date) => {
+const getDays = (date: Date): number => {
     const current = new Date(Date.now());
     const diff = current.getTime() - date.getTime();
 

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -29,7 +29,7 @@ export type ReleaseDialogProps = {
     release: Release;
 };
 
-const setClosed = () => {
+const setClosed = (): void => {
     updateReleaseDialog('', 0);
 };
 
@@ -93,8 +93,8 @@ export const EnvironmentListItem: React.FC<{
             });
     }, [app, env.name, release.version]);
     const createAppLock = useCallback(() => {
-        const randBase36 = () => Math.random().toString(36).substring(7);
-        const randomLockId = () => 'ui-v2-' + randBase36();
+        const randBase36 = (): string => Math.random().toString(36).substring(7);
+        const randomLockId = (): string => 'ui-v2-' + randBase36();
         addAction({
             action: {
                 $case: 'createEnvironmentApplicationLock',

--- a/services/frontend-service/src/ui/components/Releases/Releases.tsx
+++ b/services/frontend-service/src/ui/components/Releases/Releases.tsx
@@ -24,12 +24,12 @@ export type ReleasesProps = {
     app: string;
 };
 
-const dateFormat = (date: Date) => {
+const dateFormat = (date: Date): string => {
     const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
     return `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
 };
 
-const getReleasesForAppGroupByDate = (releases: Array<Release>) => {
+const getReleasesForAppGroupByDate = (releases: Array<Release>): Release[][] => {
     if (releases === undefined) {
         return [];
     }

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -22,7 +22,7 @@ import { Tooltip } from '@material-ui/core';
 import { useNavigate } from 'react-router-dom';
 import * as React from 'react';
 
-function getNumberOfReleasesBetween(releases: Array<Release>, lowerVersion: number, higherVersion: number) {
+function getNumberOfReleasesBetween(releases: Array<Release>, lowerVersion: number, higherVersion: number): number {
     let diff = 0;
     let count = false;
     if (!releases) {

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -188,7 +188,7 @@ export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children:
     );
 };
 
-export const SideBarList = () => {
+export const SideBarList = (): JSX.Element => {
     const actions = useActions();
 
     return (
@@ -210,7 +210,7 @@ export const SideBar: React.FC<{ className: string; toggleSidebar: () => void }>
     const [open, setOpen] = useState(false);
 
     const handleClose = useCallback(() => setOpen(false), []);
-    const handleOpen = () => setOpen(true);
+    const handleOpen = (): void => setOpen(true);
 
     const lockCreationList = actions.filter(
         (action) =>

--- a/services/frontend-service/src/ui/components/TopAppBar/TopAppBar.tsx
+++ b/services/frontend-service/src/ui/components/TopAppBar/TopAppBar.tsx
@@ -38,7 +38,7 @@ export const TopAppBar: React.FC = () => {
         if (control.current) {
             MDComponent.current = new MDCTopAppBar(control.current);
         }
-        return () => MDComponent.current?.destroy();
+        return (): void => MDComponent.current?.destroy();
     }, []);
 
     return (

--- a/services/frontend-service/src/ui/components/button/button.tsx
+++ b/services/frontend-service/src/ui/components/button/button.tsx
@@ -23,7 +23,7 @@ export const Button = (props: {
     label?: string;
     icon?: JSX.Element;
     onClick?: () => void;
-}) => {
+}): JSX.Element => {
     const MDComponent = useRef<MDCRipple>();
     const control = useRef<HTMLButtonElement>(null);
     const { disabled, className, label, icon, onClick } = props;
@@ -32,7 +32,7 @@ export const Button = (props: {
         if (control.current) {
             MDComponent.current = new MDCRipple(control.current);
         }
-        return () => MDComponent.current?.destroy();
+        return (): void => MDComponent.current?.destroy();
     }, []);
 
     return (

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
@@ -29,7 +29,7 @@ export const EnvironmentChip = (props: {
     numberEnvsDeployed?: number;
     numberEnvsInGroup?: number;
     withEnvLocks: boolean;
-}) => {
+}): JSX.Element => {
     const { className, env } = props;
     const priority = env.priority;
     const priorityClassName = className + '-' + String(EnvPrio[priority]).toLowerCase();
@@ -68,7 +68,7 @@ export const EnvironmentChip = (props: {
     );
 };
 
-export const EnvironmentGroupChip = (props: { className: string; envGroup: EnvironmentGroupExtended }) => {
+export const EnvironmentGroupChip = (props: { className: string; envGroup: EnvironmentGroupExtended }): JSX.Element => {
     const { className, envGroup } = props;
 
     // we display it different if there's only one env in this group:

--- a/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
+++ b/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
@@ -69,7 +69,7 @@ export const DropdownSelect: React.FC<{
     );
 };
 
-export const Dropdown = (props: DropdownProps) => {
+export const Dropdown = (props: DropdownProps): JSX.Element => {
     const { className, floatingLabel, leadingIcon } = props;
     const control = useRef<HTMLDivElement>(null);
     const teams = useTeamNames();

--- a/services/frontend-service/src/ui/components/navigation/navList.tsx
+++ b/services/frontend-service/src/ui/components/navigation/navList.tsx
@@ -27,7 +27,7 @@ export const NavList: React.FC<{ children?: ReactNode; className?: string }> = (
             MDComponent.current = new MDCList(control.current);
             MDComponent.current.wrapFocus = true;
         }
-        return () => MDComponent.current?.destroy();
+        return (): void => MDComponent.current?.destroy();
     }, []);
 
     return (

--- a/services/frontend-service/src/ui/components/navigation/navListItem.tsx
+++ b/services/frontend-service/src/ui/components/navigation/navListItem.tsx
@@ -18,7 +18,7 @@ import { cloneElement, useEffect, useRef } from 'react';
 import { MDCRipple } from '@material/ripple';
 import { Link, useLocation } from 'react-router-dom';
 
-export const NavbarIndicator = (props: { pathname: string; to: string }) => {
+export const NavbarIndicator = (props: { pathname: string; to: string }): JSX.Element => {
     const { pathname, to } = props;
     return (
         <div
@@ -28,7 +28,12 @@ export const NavbarIndicator = (props: { pathname: string; to: string }) => {
     );
 };
 
-export const NavListItem = (props: { className?: string; to: string; queryParams?: string; icon?: JSX.Element }) => {
+export const NavListItem = (props: {
+    className?: string;
+    to: string;
+    queryParams?: string;
+    icon?: JSX.Element;
+}): JSX.Element => {
     const MDComponent = useRef<MDCRipple>();
     const control = useRef<HTMLAnchorElement>(null);
     const { className, to, queryParams, icon } = props;
@@ -38,7 +43,7 @@ export const NavListItem = (props: { className?: string; to: string; queryParams
         if (control.current) {
             MDComponent.current = new MDCRipple(control.current);
         }
-        return () => MDComponent.current?.destroy();
+        return (): void => MDComponent.current?.destroy();
     }, []);
 
     const allClassNames = classNames(

--- a/services/frontend-service/src/ui/components/textfield/textfield.tsx
+++ b/services/frontend-service/src/ui/components/textfield/textfield.tsx
@@ -25,7 +25,7 @@ export type TextfieldProps = {
     leadingIcon?: string;
 };
 
-export const Textfield = (props: TextfieldProps) => {
+export const Textfield = (props: TextfieldProps): JSX.Element => {
     const { className, floatingLabel, leadingIcon, value } = props;
     const control = useRef<HTMLDivElement>(null);
     const input = useRef<HTMLInputElement>(null);
@@ -35,7 +35,7 @@ export const Textfield = (props: TextfieldProps) => {
         if (control.current) {
             MDComponent.current = new MDCTextField(control.current);
         }
-        return () => MDComponent.current?.destroy();
+        return (): void => MDComponent.current?.destroy();
     }, []);
 
     useEffect(() => {

--- a/services/frontend-service/src/ui/utils/AzureAuthProvider.tsx
+++ b/services/frontend-service/src/ui/utils/AzureAuthProvider.tsx
@@ -92,7 +92,7 @@ export const AcquireToken: React.FC<{ children: React.ReactNode }> = ({ children
     return <>{children}</>;
 };
 
-export const AzureAutoSignIn = () => {
+export const AzureAutoSignIn = (): JSX.Element => {
     const isAuthenticated = useIsAuthenticated();
     const { instance } = useMsal();
     React.useEffect(() => {

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -307,14 +307,14 @@ export const useEnvironmentLock = (lockId: string): DisplayLock =>
         )?.name,
     } as DisplayLock);
 
-export const searchCustomFilter = (queryContent: string | null, val: string | undefined): string | undefined | null => {
+export const searchCustomFilter = (queryContent: string | null, val: string | undefined): string => {
     if (!!val && !!queryContent) {
         if (val.includes(queryContent)) {
             return val;
         }
-        return null;
+        return '';
     } else {
-        return val;
+        return val || '';
     }
 };
 

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -364,9 +364,6 @@ export const useApplicationLock = (lockId: string): DisplayLock =>
         )?.name,
     } as DisplayLock);
 
-export const useLock = (lockId: string): DisplayLock | undefined =>
-    [useApplicationLock(lockId), useEnvironmentLock(lockId)].find((lock) => lock.lockId === lockId);
-
 export const sortLocks = (displayLocks: DisplayLock[], sorting: 'oldestToNewest' | 'newestToOldest'): DisplayLock[] => {
     const sortMethod = sorting === 'newestToOldest' ? -1 : 1;
     displayLocks.sort((a: DisplayLock, b: DisplayLock) => {


### PR DESCRIPTION
Added rule '@typescript-eslint/explicit-function-return-type' which requires all functions to have an explicit return type.
    
Also added a specific .eslintrc for the old ui, which disables this rule, because we do not want to spend much time with the old ui anymore.
    
Adapted all functions that didn't have a return type.
    
This is a refactoring, it does not change any behavior.

SRX-2DXE9T