### PR TITLE
Fix alignment for queue information in release dialog

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -117,7 +117,7 @@ describe('Release Dialog', () => {
 
             expect_message: true,
             expect_queues: 1,
-            data_length: 2,
+            data_length: 3,
         },
         {
             name: 'no release',
@@ -158,6 +158,7 @@ describe('Release Dialog', () => {
                 expect(document.querySelector('.release-dialog-message') === undefined);
             }
             expect(document.querySelectorAll('.env-card-data')).toHaveLength(testcase.data_length);
+            expect(document.querySelectorAll('.env-card-data-queue')).toHaveLength(testcase.expect_queues);
         });
     });
 

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -110,7 +110,7 @@ export const EnvironmentListItem: React.FC<{
     const queueInfo =
         queuedVersion === 0 ? null : (
             <div
-                className={classNames('env-card-data-queue', className)}
+                className={classNames('env-card-data env-card-data-queue', className)}
                 title={
                     'An attempt was made to deploy version ' +
                     queuedVersion +

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -613,7 +613,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                 dev is deployed to version 3
               </div>
               <div
-                class="env-card-data-queue"
+                class="env-card-data env-card-data-queue"
                 title="An attempt was made to deploy version 666 either by a release train, or when a new version was created. However, there was a lock present at the time, so kuberpult did not deploy this version. "
               >
                 Version 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/88655074/220187114-b7a96d77-79ad-4c44-beef-2b66de5d3279.png)

After:
![image](https://user-images.githubusercontent.com/88655074/220187075-455763fd-646d-4d79-903e-d0e0d885e699.png)
