### PR TITLE
Added warning if there are no envs configured during startup

### DIFF
--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -215,8 +215,12 @@ func New(ctx context.Context, cfg RepositoryConfig) (Repository, error) {
 			}
 
 			// Check configuration for errors and abort early if any:
-			if _, err := state.GetEnvironmentConfigs(); err != nil {
+			envConfigs, err := state.GetEnvironmentConfigs()
+			if err != nil {
 				return nil, err
+			}
+			if len(envConfigs) == 0 {
+				logger.Warn("No environment configurations found. Check git settings like the branch name. Kuberpult cannot operate without environments.")
 			}
 			go result.ProcessQueue(ctx)
 			return result, nil


### PR DESCRIPTION
Kuberpult cannot work properly without at least one environments configured, so we print a warning on startup, if none are found.
    
Usually this is an error (at least when running locally). However, sometimes it is intended to start up without environments (and then add them dynamically via the "createEnvironment" endpoint).
Therefore, it's just a warning.
