### PR TITLE
Show more older releases on home

### DIFF
--- a/services/frontend-service/src/assets/_variables.scss
+++ b/services/frontend-service/src/assets/_variables.scss
@@ -84,6 +84,9 @@ $release-card-tooltip-border-color: #BABABA;
 $release-card-tooltip-width: 285px;
 $release-card-tooltip-caret-shift-left: 55px;
 
+// Service Lane Diff Element
+$service-lane-diff-element-border-color: #BABABA;
+
 // Logo
 // 6em = 96px - Logo_width(60px) = 36px / 2 = 18px
 // top_bar_height(8em) = 128px - Logo_height(72px) = 56px / 2 = 28px

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
@@ -64,14 +64,8 @@
   @extend .text-bold;
   align-self: center;
   z-index: 2;
-
+  min-height: 42px;
   > *:not(:last-child) {
     margin-right: 8px;
-  }
-
-  &--empty {
-    // when no environment chips are displayed, take the same space with an empty div
-    // used to make release cards on the same level
-    height: 42px;
   }
 }

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
@@ -11,7 +11,7 @@
   max-height: 136px;
   min-width: 240px;
   max-width: 240px;
-  margin: -20px 16px 4px 16px;
+  margin: -20px 8px 4px 8px;
   color: var(--mdc-theme-on-surface);
   box-shadow: none;
 

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
@@ -68,4 +68,10 @@
   > *:not(:last-child) {
     margin-right: 8px;
   }
+
+  &--empty {
+    // when no environment chips are displayed, take the same space with an empty div
+    // used to make release cards on the same level
+    height: 42px;
+  }
 }

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
@@ -48,6 +48,7 @@
   .mdc-evolution-chip__cell {
     @extend .sub-headline1;
     color: $environment-label-color;
+    overflow: hidden;
   }
 }
 .release-environment.release-environment-prod {

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -101,7 +101,7 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
         <Tooltip id={app + version} content={tooltipContents}>
             <div className="release-card__container">
                 <div className="release__environments">
-                    <EnvironmentGroupChipList app={props.app} version={props.version} useFirstLetter />
+                    <EnvironmentGroupChipList app={props.app} version={props.version} smallEnvChip />
                 </div>
                 <div className={classNames('mdc-card release-card', className)}>
                     <div

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -218,32 +218,32 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                     <span
                       class="mdc-evolution-chip__text-numbers"
                     />
-                  </span>
-                  <div
-                    class="release-environment env-locks"
-                  >
                     <div
-                      aria-label="Lock Message: \\"envLock\\" | ID: \\"ui-envlock\\"  | Click to unlock. "
-                      class=""
-                      data-mui-internal-clone-element="true"
+                      class="release-environment env-locks"
                     >
-                      <button
-                        aria-label=""
-                        class="mdc-button button-lock"
+                      <div
+                        aria-label="Lock Message: \\"envLock\\" | ID: \\"ui-envlock\\"  | Click to unlock. "
+                        class=""
+                        data-mui-internal-clone-element="true"
                       >
-                        <div
-                          class="mdc-button__ripple"
-                        />
-                        <svg
-                          class="env-card-env-lock-icon"
-                          height="42px"
-                          width="30px"
+                        <button
+                          aria-label=""
+                          class="mdc-button button-lock"
                         >
-                          Locks_White.svg
-                        </svg>
-                      </button>
+                          <div
+                            class="mdc-button__ripple"
+                          />
+                          <svg
+                            class="env-card-env-lock-icon"
+                            height="24px"
+                            width="24px"
+                          >
+                            Locks_White.svg
+                          </svg>
+                        </button>
+                      </div>
                     </div>
-                  </div>
+                  </span>
                 </div>
                 <div
                   class="env-card-app-locks"
@@ -441,32 +441,32 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                     <span
                       class="mdc-evolution-chip__text-numbers"
                     />
-                  </span>
-                  <div
-                    class="release-environment env-locks"
-                  >
                     <div
-                      aria-label="Lock Message: \\"envLock\\" | ID: \\"ui-envlock\\"  | Click to unlock. "
-                      class=""
-                      data-mui-internal-clone-element="true"
+                      class="release-environment env-locks"
                     >
-                      <button
-                        aria-label=""
-                        class="mdc-button button-lock"
+                      <div
+                        aria-label="Lock Message: \\"envLock\\" | ID: \\"ui-envlock\\"  | Click to unlock. "
+                        class=""
+                        data-mui-internal-clone-element="true"
                       >
-                        <div
-                          class="mdc-button__ripple"
-                        />
-                        <svg
-                          class="env-card-env-lock-icon"
-                          height="42px"
-                          width="30px"
+                        <button
+                          aria-label=""
+                          class="mdc-button button-lock"
                         >
-                          Locks_White.svg
-                        </svg>
-                      </button>
+                          <div
+                            class="mdc-button__ripple"
+                          />
+                          <svg
+                            class="env-card-env-lock-icon"
+                            height="24px"
+                            width="24px"
+                          >
+                            Locks_White.svg
+                          </svg>
+                        </button>
+                      </div>
                     </div>
-                  </div>
+                  </span>
                 </div>
                 <div
                   class="env-card-app-locks"
@@ -556,32 +556,32 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                     <span
                       class="mdc-evolution-chip__text-numbers"
                     />
-                  </span>
-                  <div
-                    class="release-environment env-locks"
-                  >
                     <div
-                      aria-label="Lock Message: \\"envLock\\" | ID: \\"ui-envlock\\"  | Click to unlock. "
-                      class=""
-                      data-mui-internal-clone-element="true"
+                      class="release-environment env-locks"
                     >
-                      <button
-                        aria-label=""
-                        class="mdc-button button-lock"
+                      <div
+                        aria-label="Lock Message: \\"envLock\\" | ID: \\"ui-envlock\\"  | Click to unlock. "
+                        class=""
+                        data-mui-internal-clone-element="true"
                       >
-                        <div
-                          class="mdc-button__ripple"
-                        />
-                        <svg
-                          class="env-card-env-lock-icon"
-                          height="42px"
-                          width="30px"
+                        <button
+                          aria-label=""
+                          class="mdc-button button-lock"
                         >
-                          Locks_White.svg
-                        </svg>
-                      </button>
+                          <div
+                            class="mdc-button__ripple"
+                          />
+                          <svg
+                            class="env-card-env-lock-icon"
+                            height="24px"
+                            width="24px"
+                          >
+                            Locks_White.svg
+                          </svg>
+                        </button>
+                      </div>
                     </div>
-                  </div>
+                  </span>
                 </div>
                 <div
                   class="env-card-app-locks"

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.scss
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.scss
@@ -35,9 +35,41 @@
   display: flex;
 }
 
-.service-lane__diff_number {
+.service-lane__diff--container {
   display: flex;
-  font-size: xx-large;
-  padding: 100px 0px 20px 10px;
-  height: 40px;
+  flex-direction: row;
+  align-self: center;
+  justify-content: space-evenly;
+  width: 80px;
+
+  .service-lane__diff--number {
+    @extend .sub-headline1;
+    display: flex;
+    align-self: center;
+    box-sizing: border-box;
+    justify-content: space-evenly;
+
+    // Copied from figma
+    width: 33px;
+    height: 33px;
+    left: calc(50% - 33px / 2 - 0.5px);
+    top: calc(50% - 33px / 2);
+
+    border: 2px solid $service-lane-diff-element-border-color;
+    border-radius: 10px;
+  }
+
+  .service-lane__diff--dot {
+    align-self: center;
+    box-sizing: border-box;
+
+
+    // Copied from figma
+    width: 4px;
+    height: 4px;
+    left: calc(50% - 4px / 2 - 23px);
+    top: calc(50% - 4px / 2);
+    background: $service-lane-diff-element-border-color;
+    border-radius: 10px;
+  }
 }

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.test.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.test.tsx
@@ -78,15 +78,18 @@ describe('Service Lane', () => {
     const getWrapper = (overrides: { application: Application }) => render(getNode(overrides));
     it('Renders a row of releases', () => {
         // when
-        UpdateOverview.set({
-            environments: sampleEnvs,
-        });
         const sampleApp = {
             name: 'test2',
-            releases: [],
+            releases: [{ version: -1 }, { version: 2 }, { version: 3 }],
             sourceRepoUrl: 'http://test2.com',
             team: 'example',
-        };
+        } as any;
+        UpdateOverview.set({
+            environments: sampleEnvs,
+            applications: {
+                test2: sampleApp,
+            },
+        });
         getWrapper({ application: sampleApp });
 
         // then releases are sorted and Release card is called with props:
@@ -288,10 +291,10 @@ describe('Service Lane Diff', () => {
             const { container } = getWrapper({ application: sampleApp });
 
             // check for the diff between versions
-            if (testcase.diff === '-1') {
-                expect(document.querySelector('.service-lane__diff_number') === undefined);
+            if (testcase.diff === '-1' || testcase.diff === '0') {
+                expect(document.querySelector('.service-lane__diff--number') === undefined);
             } else {
-                expect(container.querySelector('.service-lane__diff_number')?.textContent).toContain(testcase.diff);
+                expect(container.querySelector('.service-lane__diff--number')?.textContent).toContain(testcase.diff);
             }
         });
     });

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -41,7 +41,7 @@ const getReleasesToDisplay = (deployedReleases: number[], allReleases: number[])
 };
 
 function getNumberOfReleasesBetween(releases: number[], higherVersion: number, lowerVersion: number): number {
-    // = index of lower version (older release) - index of lower version (newer release) - 1
+    // diff = index of lower version (older release) - index of higher version (newer release) - 1
     return releases.findIndex((ver) => ver === lowerVersion) - releases.findIndex((ver) => ver === higherVersion) - 1;
 }
 

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -22,6 +22,25 @@ import { Tooltip } from '@material-ui/core';
 import { useNavigate } from 'react-router-dom';
 import * as React from 'react';
 
+// number of releases on home. based on design
+const numberOfDisplayedReleasesOnHome = 6;
+
+const getAllDisplayedReleases = (deployedReleases: number[], allReleases: number[]): number[] => {
+    // number of remaining releases to get from history
+    const numOfTrailingReleases = numberOfDisplayedReleasesOnHome - deployedReleases.length;
+    // last deployed release e.g. Prod
+    const oldestDeployedRelease = deployedReleases[deployedReleases.length - 1];
+
+    const allDisplayedReleases = deployedReleases;
+    // go over the remaining spots and fill from history
+    for (let i = 1; i <= numOfTrailingReleases; i++) {
+        const index = allReleases.indexOf(oldestDeployedRelease) + i;
+        if (index >= allReleases.length) break;
+        allDisplayedReleases.push(allReleases[index]);
+    }
+    return allDisplayedReleases;
+};
+
 function getNumberOfReleasesBetween(releases: Array<Release>, lowerVersion: number, higherVersion: number): number {
     let diff = 0;
     let count = false;
@@ -45,19 +64,24 @@ function getNumberOfReleasesBetween(releases: Array<Release>, lowerVersion: numb
 
 export const ServiceLane: React.FC<{ application: Application }> = (props) => {
     const { application } = props;
-    const releases = useDeployedReleases(application.name);
+    const deployedReleases = useDeployedReleases(application.name);
     const all_releases = useReleasesForApp(application.name);
     const navigate = useNavigate();
     const navigateToReleases = React.useCallback(() => {
         navigate('releases/' + application.name);
     }, [application.name, navigate]);
+    const releases = getAllDisplayedReleases(
+        deployedReleases,
+        all_releases.map((rel) => rel.version)
+    );
+
     const releases_lane =
         !!releases &&
         releases.map((rel, index) => {
-            if (index > 0) {
-                const diff = getNumberOfReleasesBetween(all_releases, releases[index - 1], rel);
-                return (
-                    <div key={application + '-' + rel} className="service-lane__diff">
+            const diff = index > 0 ? getNumberOfReleasesBetween(all_releases, releases[index - 1], rel) : 0;
+            return (
+                <div key={application + '-' + rel} className="service-lane__diff">
+                    {!!diff && (
                         <Tooltip
                             title={
                                 'There are ' +
@@ -69,11 +93,10 @@ export const ServiceLane: React.FC<{ application: Application }> = (props) => {
                             }>
                             <div className="service-lane__diff_number">{diff}</div>
                         </Tooltip>
-                        <ReleaseCard app={application.name} version={rel} />
-                    </div>
-                );
-            }
-            return <ReleaseCard app={application.name} version={rel} key={application + '-' + rel} />;
+                    )}
+                    <ReleaseCard app={application.name} version={rel} key={application + '-' + rel} />
+                </div>
+            );
         });
 
     return (

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -45,6 +45,18 @@ function getNumberOfReleasesBetween(releases: number[], higherVersion: number, l
     return releases.findIndex((ver) => ver === lowerVersion) - releases.findIndex((ver) => ver === higherVersion) - 1;
 }
 
+const DiffElement = (diff: number): JSX.Element => (
+    <div className="service-lane__diff--container">
+        <div className="service-lane__diff--dot" />
+        <div className="service-lane__diff--dot" />
+        <div className="service-lane__diff--dot" />
+        <div className="service-lane__diff--number">{diff}</div>
+        <div className="service-lane__diff--dot" />
+        <div className="service-lane__diff--dot" />
+        <div className="service-lane__diff--dot" />
+    </div>
+);
+
 export const ServiceLane: React.FC<{ application: Application }> = (props) => {
     const { application } = props;
     const deployedReleases = useDeployedReleases(application.name);
@@ -77,7 +89,7 @@ export const ServiceLane: React.FC<{ application: Application }> = (props) => {
                                 ' and version ' +
                                 rel
                             }>
-                            <div className="service-lane__diff_number">{diff}</div>
+                            {DiffElement(diff)}
                         </Tooltip>
                     )}
                 </div>

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -23,16 +23,17 @@ import { useNavigate } from 'react-router-dom';
 import * as React from 'react';
 
 // number of releases on home. based on design
+// we could update this dynamically based on viewport width
 const numberOfDisplayedReleasesOnHome = 6;
 
 const getReleasesToDisplay = (deployedReleases: number[], allReleases: number[]): number[] => {
     // number of remaining releases to get from history
     const numOfTrailingReleases = numberOfDisplayedReleasesOnHome - deployedReleases.length;
-    // find the index of the last deployed release e.g. Prod
+    // find the index of the last deployed release e.g. Prod (or -1 when there's no deployed releases)
     const oldestDeployedReleaseIndex = deployedReleases.length
         ? allReleases.findIndex((version) => version === deployedReleases.slice(-1)[0])
-        : 0;
-    // take the deployed releases + a slice from the oldest element with total length 6
+        : -1;
+    // take the deployed releases + a slice from the oldest element (or very first, see above) with total length 6
     return [
         ...deployedReleases,
         ...allReleases.slice(oldestDeployedReleaseIndex + 1, oldestDeployedReleaseIndex + numOfTrailingReleases + 1),

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.test.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.test.tsx
@@ -27,7 +27,7 @@ describe('EnvironmentChip', () => {
         applications: {},
     };
     const getNode = (overloads?: EnvironmentChipProps) => (
-        <EnvironmentChip className={'chip--test'} env={env} withEnvLocks={false} {...overloads} />
+        <EnvironmentChip className={'chip--test'} env={env} {...overloads} />
     );
     const getWrapper = (overloads?: EnvironmentChipProps) => render(getNode(overloads));
     it('renders a chip', () => {
@@ -50,12 +50,15 @@ describe('EnvironmentChip', () => {
                 <span
                   class="mdc-evolution-chip__text-numbers"
                 />
+                <div
+                  class="chip--test env-locks"
+                />
               </span>
             </div>
         `);
     });
     it('renders a short form tag chip', () => {
-        const { container } = getWrapper({ useFirstLetter: true } as any);
+        const { container } = getWrapper({ smallEnvChip: true } as any);
         expect(container.querySelector('.mdc-evolution-chip__text-name')?.textContent).toBe(env.name[0].toUpperCase());
     });
 });
@@ -121,7 +124,7 @@ const envGroupChipData: Array<TestDataGroups> = [
     {
         envGroup: envGroupFromPrio(Priority.PROD, 1, [envFromPrio(Priority.PROD)]),
         expectedClass: 'prod',
-        expectedNumbers: '(1/1)',
+        expectedNumbers: '(1)',
         expectedDisplayName: 'Test Me',
     },
     {

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
@@ -39,7 +39,9 @@ export const EnvironmentChip = (props: EnvironmentChipProps): JSX.Element => {
     const name = props.groupNameOverride ? props.groupNameOverride : env.name;
     const numberString =
         props.numberEnvsDeployed && props.numberEnvsInGroup
-            ? '(' + props.numberEnvsDeployed + '/' + props.numberEnvsInGroup + ')'
+            ? props.numberEnvsDeployed !== props.numberEnvsInGroup
+                ? '(' + props.numberEnvsDeployed + '/' + props.numberEnvsInGroup + ')'
+                : '(' + props.numberEnvsInGroup + ')' // when all envs are deployed, only show the total number on envs
             : '';
     const locks = props.withEnvLocks ? (
         <div className={classNames(className, 'env-locks')}>
@@ -118,11 +120,7 @@ export type EnvChipListProps = {
 export const EnvironmentGroupChipList: React.FC<EnvChipListProps> = (props) => {
     const deployedAt = useCurrentlyDeployedAtGroup(props.app, props.version);
     return (
-        <div
-            className={classNames(
-                'env-group-chip-list-test',
-                deployedAt.length === 0 ? 'release__environments--empty' : ''
-            )}>
+        <div className={'env-group-chip-list-test'}>
             {' '}
             {deployedAt.map((envGroup) => (
                 <EnvironmentGroupChip

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
@@ -118,7 +118,11 @@ export type EnvChipListProps = {
 export const EnvironmentGroupChipList: React.FC<EnvChipListProps> = (props) => {
     const deployedAt = useCurrentlyDeployedAtGroup(props.app, props.version);
     return (
-        <div className={'env-group-chip-list-test'}>
+        <div
+            className={classNames(
+                'env-group-chip-list-test',
+                deployedAt.length === 0 ? 'release__environments--empty' : ''
+            )}>
             {' '}
             {deployedAt.map((envGroup) => (
                 <EnvironmentGroupChip

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
@@ -28,12 +28,11 @@ export type EnvironmentChipProps = {
     groupNameOverride?: string;
     numberEnvsDeployed?: number;
     numberEnvsInGroup?: number;
-    withEnvLocks: boolean;
-    useFirstLetter?: boolean;
+    smallEnvChip?: boolean;
 };
 
 export const EnvironmentChip = (props: EnvironmentChipProps): JSX.Element => {
-    const { className, env, useFirstLetter } = props;
+    const { className, env, smallEnvChip } = props;
     const priority = env.priority;
     const priorityClassName = className + '-' + String(EnvPrio[priority]).toLowerCase();
     const name = props.groupNameOverride ? props.groupNameOverride : env.name;
@@ -43,7 +42,7 @@ export const EnvironmentChip = (props: EnvironmentChipProps): JSX.Element => {
                 ? '(' + props.numberEnvsDeployed + '/' + props.numberEnvsInGroup + ')'
                 : '(' + props.numberEnvsInGroup + ')' // when all envs are deployed, only show the total number on envs
             : '';
-    const locks = props.withEnvLocks ? (
+    const locks = !smallEnvChip ? (
         <div className={classNames(className, 'env-locks')}>
             {Object.values(env.locks).map((lock) => (
                 <Tooltip
@@ -52,23 +51,29 @@ export const EnvironmentChip = (props: EnvironmentChipProps): JSX.Element => {
                     title={'Lock Message: "' + lock.message + '" | ID: "' + lock.lockId + '"  | Click to unlock. '}>
                     <div>
                         <Button
-                            icon={<LocksWhite className="env-card-env-lock-icon" width="30px" height="42px" />}
+                            icon={<LocksWhite className="env-card-env-lock-icon" width="24px" height="24px" />}
                             className={'button-lock'}
                         />
                     </div>
                 </Tooltip>
             ))}
         </div>
-    ) : null;
+    ) : (
+        !!Object.entries(env.locks).length && (
+            <div className={classNames(className, 'env-locks')}>
+                <LocksWhite className="env-card-env-lock-icon" width="18px" height="18px" />
+            </div>
+        )
+    );
     return (
         <div className={classNames('mdc-evolution-chip', className, priorityClassName)} role="row">
             <span
                 className="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
                 role="gridcell">
-                <span className="mdc-evolution-chip__text-name">{useFirstLetter ? name[0].toUpperCase() : name}</span>{' '}
+                <span className="mdc-evolution-chip__text-name">{smallEnvChip ? name[0].toUpperCase() : name}</span>{' '}
                 <span className="mdc-evolution-chip__text-numbers">{numberString}</span>
+                {locks}
             </span>
-            {locks}
         </div>
     );
 };
@@ -76,9 +81,9 @@ export const EnvironmentChip = (props: EnvironmentChipProps): JSX.Element => {
 export const EnvironmentGroupChip = (props: {
     className: string;
     envGroup: EnvironmentGroupExtended;
-    useFirstLetter?: boolean;
+    smallEnvChip?: boolean;
 }): JSX.Element => {
-    const { className, envGroup, useFirstLetter } = props;
+    const { className, envGroup, smallEnvChip } = props;
 
     // we display it different if there's only one env in this group:
     const displayAsGroup = envGroup.environments.length >= 2;
@@ -91,8 +96,7 @@ export const EnvironmentGroupChip = (props: {
                     groupNameOverride={envGroup.environmentGroupName}
                     numberEnvsDeployed={envGroup.environments.length}
                     numberEnvsInGroup={envGroup.numberOfEnvsInGroup}
-                    withEnvLocks={false}
-                    useFirstLetter={useFirstLetter}
+                    smallEnvChip={smallEnvChip}
                 />
             </div>
         );
@@ -105,8 +109,7 @@ export const EnvironmentGroupChip = (props: {
             groupNameOverride={undefined}
             numberEnvsDeployed={1}
             numberEnvsInGroup={envGroup.numberOfEnvsInGroup}
-            withEnvLocks={false}
-            useFirstLetter={useFirstLetter}
+            smallEnvChip={smallEnvChip}
         />
     );
 };
@@ -114,7 +117,7 @@ export const EnvironmentGroupChip = (props: {
 export type EnvChipListProps = {
     version: number;
     app: string;
-    useFirstLetter?: boolean;
+    smallEnvChip?: boolean;
 };
 
 export const EnvironmentGroupChipList: React.FC<EnvChipListProps> = (props) => {
@@ -127,7 +130,7 @@ export const EnvironmentGroupChipList: React.FC<EnvChipListProps> = (props) => {
                     key={envGroup.environmentGroupName}
                     envGroup={envGroup}
                     className={'release-environment'}
-                    useFirstLetter={props.useFirstLetter}
+                    smallEnvChip={props.smallEnvChip}
                 />
             ))}{' '}
         </div>

--- a/services/frontend-service/src/ui/components/chip/chip.scss
+++ b/services/frontend-service/src/ui/components/chip/chip.scss
@@ -6,6 +6,12 @@
         padding-left: 7px;
         padding-right: 7px;
     }
+    .env-locks {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        padding-right: -7px;
+    }
 }
 
 span.mdc-evolution-chip button.mdc-evolution-chip__action span.mdc-evolution-chip__text-label {

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -467,3 +467,6 @@ export const useReleasesForApp = (app: string): Release[] =>
             a.version === -1 ? -1 : b.version === -1 ? 1 : b.version - a.version
         )
     );
+
+// Get all release versions for an app
+export const useVersionsForApp = (app: string): number[] => useReleasesForApp(app).map((rel) => rel.version);


### PR DESCRIPTION
* As in the figma design, show a trailing number of releases after the currently deployed ones.
* add a margin for whenever environment tags are not displayed.
* add Diff Elements and styles
* add the small lock icons on environment chips