### PR TITLE
 fix distance to upstream

### DIFF
--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -454,7 +454,7 @@ func mapEnvironmentsToGroups(envs map[string]config.EnvironmentConfig) []*api.En
 			// to avoid an infinite loop, we fill it with an arbitrary number:
 			for i := 0; i < len(rest); i++ {
 				env := rest[i]
-				tmpDistancesToUpstreamByEnv[env.Name] = 666
+				tmpDistancesToUpstreamByEnv[env.Config.Upstream.GetEnvironment()] = 666
 			}
 		}
 		rest = nextRest

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -430,6 +430,10 @@ func mapEnvironmentsToGroups(envs map[string]config.EnvironmentConfig) []*api.En
 				environment.DistanceToUpstream = 100 // we can just pick an arbitrary number
 				tmpDistancesToUpstreamByEnv[environment.Name] = 100
 			} else {
+				upstreamEnv := environment.Config.Upstream.GetEnvironment()
+				if _, exists := envs[upstreamEnv]; !exists { // upstreamEnv is not exists!
+					tmpDistancesToUpstreamByEnv[upstreamEnv] = 666
+				}
 				// and remember the rest:
 				rest = append(rest, environment)
 			}

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -559,6 +559,41 @@ func TestMapEnvironmentsToGroup(t *testing.T) {
 			},
 		},
 		{
+			// note that this is not a realistic example, we just want to make sure it does not crash!
+			// some outputs may be nonsensical (like distanceToUpstream), but that's fine as long as it's stable!
+			Name: "Two Environments with non exists upstream",
+			InputEnvs: map[string]config.EnvironmentConfig{
+				nameDevDe: {
+					Upstream: &config.EnvironmentConfigUpstream{
+						Latest: true,
+					},
+					ArgoCd: nil,
+				},
+				nameStagingDe: {
+					Upstream: &config.EnvironmentConfigUpstream{
+						Environment: nameWhoKnows,
+					},
+					ArgoCd: nil,
+				},
+			},
+			ExpectedResult: []*api.EnvironmentGroup{
+				{
+					EnvironmentGroupName: nameDevDe,
+					Environments: []*api.Environment{
+						makeEnv(nameDevDe, nameDevDe, makeUpstreamLatest(), 0, api.Priority_UPSTREAM),
+					},
+					DistanceToUpstream: 0,
+				},
+				{
+					EnvironmentGroupName: nameStagingDe,
+					Environments: []*api.Environment{
+						makeEnv(nameStagingDe, nameStagingDe, makeUpstreamEnvironment(nameWhoKnows), 667, api.Priority_PROD),
+					},
+					DistanceToUpstream: 667,
+				},
+			},
+		},
+		{
 			Name: "Three Environments are three Groups",
 			InputEnvs: map[string]config.EnvironmentConfig{
 				nameDevDe: {


### PR DESCRIPTION
If an environment doesn’t have an `Upstream`, calculating distance upstream stuck in infinite for loop