### PR TITLE
Remove whitespace in ReleaseDialog of new UI

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -5,6 +5,14 @@
     border-radius: $release-dialog-outer-border-radius;
     overflow-y: inherit;
   }
+  .content-area {
+    display: flex;
+  }
+  .content-right {
+    margin-right: 20px;
+    margin-left: auto;
+    display: flex;
+  }
 
   .release-dialog-app-bar {
     border-radius: $release-dialog-top-border-radius;
@@ -71,7 +79,6 @@
       display: flex;
       flex-direction: column;
       width: 900px;
-      height: 160px;
       padding: 0px;
       margin-top: 10px;
       margin-bottom: 0px;
@@ -125,7 +132,7 @@
 
       .env-card-buttons {
         margin-left: auto;
-        margin-right: 36px;
+        margin-right: 18px;
         margin-bottom: 17px;
         display: flex;
         flex-direction: row;

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -131,7 +131,6 @@ export const EnvironmentListItem: React.FC<{
                     groupNameOverride={undefined}
                     numberEnvsDeployed={undefined}
                     numberEnvsInGroup={undefined}
-                    withEnvLocks={true}
                 />
                 <div className={classNames('env-card-app-locks')}>
                     {Object.values(env.applications)
@@ -144,27 +143,33 @@ export const EnvironmentListItem: React.FC<{
                         )}
                 </div>
             </div>
-            <div className={classNames('env-card-data', className)}>
-                {env.applications[app]
-                    ? release.version === env.applications[app].version
-                        ? release.sourceCommitId + ':' + release.sourceMessage
-                        : env.name + ' is deployed to version ' + env.applications[app].version
-                    : `"${app}" has no version deployed on "${env.name}"`}
-            </div>
-            {queueInfo}
-            <div className="env-card-buttons">
-                <Button
-                    className="env-card-add-lock-btn"
-                    label="Add lock"
-                    onClick={createAppLock}
-                    icon={<Locks className="icon" />}
-                />
-                <Button
-                    disabled={!release.version}
-                    className={classNames('env-card-deploy-btn', { 'btn-disabled': !release.version })}
-                    onClick={deploy}
-                    label="Deploy"
-                />
+            <div className="content-area">
+                <div className="content-left">
+                    <div className={classNames('env-card-data', className)}>
+                        {env.applications[app]
+                            ? release.version === env.applications[app].version
+                                ? release.sourceCommitId + ':' + release.sourceMessage
+                                : env.name + ' is deployed to version ' + env.applications[app].version
+                            : `"${app}" has no version deployed on "${env.name}"`}
+                    </div>
+                    {queueInfo}
+                </div>
+                <div className="content-right">
+                    <div className="env-card-buttons">
+                        <Button
+                            className="env-card-add-lock-btn"
+                            label="Add lock"
+                            onClick={createAppLock}
+                            icon={<Locks className="icon" />}
+                        />
+                        <Button
+                            disabled={!release.version}
+                            className={classNames('env-card-deploy-btn', { 'btn-disabled': !release.version })}
+                            onClick={deploy}
+                            label="Deploy"
+                        />
+                    </div>
+                </div>
             </div>
         </li>
     );

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -270,44 +270,56 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                 </div>
               </div>
               <div
-                class="env-card-data"
+                class="content-area"
               >
-                commit:test1
-              </div>
-              <div
-                class="env-card-buttons"
-              >
-                <button
-                  aria-label="Add lock"
-                  class="mdc-button env-card-add-lock-btn"
+                <div
+                  class="content-left"
                 >
                   <div
-                    class="mdc-button__ripple"
-                  />
-                  <svg
-                    class="icon"
+                    class="env-card-data"
                   >
-                    Locks.svg
-                  </svg>
-                  <span
-                    class="mdc-button__label"
-                  >
-                    Add lock
-                  </span>
-                </button>
-                <button
-                  aria-label="Deploy"
-                  class="mdc-button env-card-deploy-btn"
+                    commit:test1
+                  </div>
+                </div>
+                <div
+                  class="content-right"
                 >
                   <div
-                    class="mdc-button__ripple"
-                  />
-                  <span
-                    class="mdc-button__label"
+                    class="env-card-buttons"
                   >
-                    Deploy
-                  </span>
-                </button>
+                    <button
+                      aria-label="Add lock"
+                      class="mdc-button env-card-add-lock-btn"
+                    >
+                      <div
+                        class="mdc-button__ripple"
+                      />
+                      <svg
+                        class="icon"
+                      >
+                        Locks.svg
+                      </svg>
+                      <span
+                        class="mdc-button__label"
+                      >
+                        Add lock
+                      </span>
+                    </button>
+                    <button
+                      aria-label="Deploy"
+                      class="mdc-button env-card-deploy-btn"
+                    >
+                      <div
+                        class="mdc-button__ripple"
+                      />
+                      <span
+                        class="mdc-button__label"
+                      >
+                        Deploy
+                      </span>
+                    </button>
+                  </div>
+                </div>
               </div>
             </li>
           </ul>
@@ -493,44 +505,56 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                 </div>
               </div>
               <div
-                class="env-card-data"
+                class="content-area"
               >
-                commit:test1
-              </div>
-              <div
-                class="env-card-buttons"
-              >
-                <button
-                  aria-label="Add lock"
-                  class="mdc-button env-card-add-lock-btn"
+                <div
+                  class="content-left"
                 >
                   <div
-                    class="mdc-button__ripple"
-                  />
-                  <svg
-                    class="icon"
+                    class="env-card-data"
                   >
-                    Locks.svg
-                  </svg>
-                  <span
-                    class="mdc-button__label"
-                  >
-                    Add lock
-                  </span>
-                </button>
-                <button
-                  aria-label="Deploy"
-                  class="mdc-button env-card-deploy-btn"
+                    commit:test1
+                  </div>
+                </div>
+                <div
+                  class="content-right"
                 >
                   <div
-                    class="mdc-button__ripple"
-                  />
-                  <span
-                    class="mdc-button__label"
+                    class="env-card-buttons"
                   >
-                    Deploy
-                  </span>
-                </button>
+                    <button
+                      aria-label="Add lock"
+                      class="mdc-button env-card-add-lock-btn"
+                    >
+                      <div
+                        class="mdc-button__ripple"
+                      />
+                      <svg
+                        class="icon"
+                      >
+                        Locks.svg
+                      </svg>
+                      <span
+                        class="mdc-button__label"
+                      >
+                        Add lock
+                      </span>
+                    </button>
+                    <button
+                      aria-label="Deploy"
+                      class="mdc-button env-card-deploy-btn"
+                    >
+                      <div
+                        class="mdc-button__ripple"
+                      />
+                      <span
+                        class="mdc-button__label"
+                      >
+                        Deploy
+                      </span>
+                    </button>
+                  </div>
+                </div>
               </div>
             </li>
             <li
@@ -608,52 +632,64 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                 </div>
               </div>
               <div
-                class="env-card-data"
+                class="content-area"
               >
-                dev is deployed to version 3
-              </div>
-              <div
-                class="env-card-data env-card-data-queue"
-                title="An attempt was made to deploy version 666 either by a release train, or when a new version was created. However, there was a lock present at the time, so kuberpult did not deploy this version. "
-              >
-                Version 
-                666
-                 was not deployed, because of a lock.
-              </div>
-              <div
-                class="env-card-buttons"
-              >
-                <button
-                  aria-label="Add lock"
-                  class="mdc-button env-card-add-lock-btn"
+                <div
+                  class="content-left"
                 >
                   <div
-                    class="mdc-button__ripple"
-                  />
-                  <svg
-                    class="icon"
+                    class="env-card-data"
                   >
-                    Locks.svg
-                  </svg>
-                  <span
-                    class="mdc-button__label"
+                    dev is deployed to version 3
+                  </div>
+                  <div
+                    class="env-card-data env-card-data-queue"
+                    title="An attempt was made to deploy version 666 either by a release train, or when a new version was created. However, there was a lock present at the time, so kuberpult did not deploy this version. "
                   >
-                    Add lock
-                  </span>
-                </button>
-                <button
-                  aria-label="Deploy"
-                  class="mdc-button env-card-deploy-btn"
+                    Version 
+                    666
+                     was not deployed, because of a lock.
+                  </div>
+                </div>
+                <div
+                  class="content-right"
                 >
                   <div
-                    class="mdc-button__ripple"
-                  />
-                  <span
-                    class="mdc-button__label"
+                    class="env-card-buttons"
                   >
-                    Deploy
-                  </span>
-                </button>
+                    <button
+                      aria-label="Add lock"
+                      class="mdc-button env-card-add-lock-btn"
+                    >
+                      <div
+                        class="mdc-button__ripple"
+                      />
+                      <svg
+                        class="icon"
+                      >
+                        Locks.svg
+                      </svg>
+                      <span
+                        class="mdc-button__label"
+                      >
+                        Add lock
+                      </span>
+                    </button>
+                    <button
+                      aria-label="Deploy"
+                      class="mdc-button env-card-deploy-btn"
+                    >
+                      <div
+                        class="mdc-button__ripple"
+                      />
+                      <span
+                        class="mdc-button__label"
+                      >
+                        Deploy
+                      </span>
+                    </button>
+                  </div>
+                </div>
               </div>
             </li>
           </ul>


### PR DESCRIPTION
This makes the Release dialog more compact in height. It also fixes an issue where the "deploy" button was out of bounds when there was too much text on the left.

New: ![2023-03-07_17-24_after](https://user-images.githubusercontent.com/3481382/223484907-1abbce14-699b-4b8c-b483-54ce3f7c1ccd.png)


Old: ![2023-03-07_17-24_before](https://user-images.githubusercontent.com/3481382/223484910-6f9ddca6-a6b4-4f8b-add4-74fefd6792e4.png)
