### PR TITLE
Rephrase release dialog text

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -117,7 +117,24 @@ describe('Release Dialog', () => {
                     },
                 ],
             },
-            rels: [],
+            rels: [
+                {
+                    sourceCommitId: 'cafe',
+                    sourceMessage: 'the other commit message 2',
+                    version: 2,
+                    undeployVersion: false,
+                    prNumber: 'PR123',
+                    sourceAuthor: 'nobody',
+                },
+                {
+                    sourceCommitId: 'cafe',
+                    sourceMessage: 'the other commit message 3',
+                    version: 3,
+                    undeployVersion: false,
+                    prNumber: 'PR123',
+                    sourceAuthor: 'nobody',
+                },
+            ],
 
             expect_message: true,
             expect_queues: 1,

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -17,7 +17,7 @@ import { Dialog, Tooltip } from '@material-ui/core';
 import classNames from 'classnames';
 import React, { useCallback } from 'react';
 import { Environment, EnvironmentGroup, Lock, LockBehavior, Release } from '../../../api/api';
-import { addAction, updateReleaseDialog, useOverview } from '../../utils/store';
+import { addAction, updateReleaseDialog, useOverview, useRelease } from '../../utils/store';
 import { Button } from '../button';
 import { Locks } from '../../../images';
 import { EnvironmentChip } from '../chip/EnvironmentGroupChip';
@@ -121,6 +121,7 @@ export const EnvironmentListItem: React.FC<{
                 Version {queuedVersion} was not deployed, because of a lock.
             </div>
         );
+    const otherRelease = useRelease(app, env.applications[app].version);
     return (
         <li key={env.name} className={classNames('env-card', className)}>
             <div className="env-card-header">
@@ -145,11 +146,13 @@ export const EnvironmentListItem: React.FC<{
             </div>
             <div className="content-area">
                 <div className="content-left">
-                    <div className={classNames('env-card-data', className)}>
+                    <div
+                        className={classNames('env-card-data', className)}
+                        title={'Shows the version that is currently deployed on ' + env.name}>
                         {env.applications[app]
                             ? release.version === env.applications[app].version
-                                ? release.sourceCommitId + ':' + release.sourceMessage
-                                : env.name + ' is deployed to version ' + env.applications[app].version
+                                ? release.sourceCommitId + ': ' + release.sourceMessage
+                                : otherRelease.sourceCommitId + ': ' + otherRelease.sourceMessage
                             : `"${app}" has no version deployed on "${env.name}"`}
                     </div>
                     {queueInfo}

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -277,8 +277,9 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                 >
                   <div
                     class="env-card-data"
+                    title="Shows the version that is currently deployed on prod"
                   >
-                    commit:test1
+                    commit: test1
                   </div>
                 </div>
                 <div
@@ -512,8 +513,9 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                 >
                   <div
                     class="env-card-data"
+                    title="Shows the version that is currently deployed on prod"
                   >
-                    commit:test1
+                    commit: test1
                   </div>
                 </div>
                 <div
@@ -639,8 +641,9 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                 >
                   <div
                     class="env-card-data"
+                    title="Shows the version that is currently deployed on dev"
                   >
-                    dev is deployed to version 3
+                    cafe: the other commit message 3
                   </div>
                   <div
                     class="env-card-data env-card-data-queue"


### PR DESCRIPTION
Instead of "version 5" we now display the commit message of the release

Added tooltip to save some space.

New tooltip:
![2023-03-07_19-04_tooltip](https://user-images.githubusercontent.com/3481382/223510238-c0ef3798-7393-4a70-9009-a445e8b9c424.png)
