### PR TITLE
Fix ReleaseDialog if not all envs deployed

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -17,7 +17,7 @@ import { Dialog, Tooltip } from '@material-ui/core';
 import classNames from 'classnames';
 import React, { useCallback } from 'react';
 import { Environment, EnvironmentGroup, Lock, LockBehavior, Release } from '../../../api/api';
-import { addAction, updateReleaseDialog, useOverview, useRelease } from '../../utils/store';
+import { addAction, updateReleaseDialog, useOverview, useReleaseOptional } from '../../utils/store';
 import { Button } from '../button';
 import { Locks } from '../../../images';
 import { EnvironmentChip } from '../chip/EnvironmentGroupChip';
@@ -121,7 +121,7 @@ export const EnvironmentListItem: React.FC<{
                 Version {queuedVersion} was not deployed, because of a lock.
             </div>
         );
-    const otherRelease = useRelease(app, env.applications[app].version);
+    const otherRelease = useReleaseOptional(app, env);
     return (
         <li key={env.name} className={classNames('env-card', className)}>
             <div className="env-card-header">
@@ -152,7 +152,7 @@ export const EnvironmentListItem: React.FC<{
                         {env.applications[app]
                             ? release.version === env.applications[app].version
                                 ? release.sourceCommitId + ': ' + release.sourceMessage
-                                : otherRelease.sourceCommitId + ': ' + otherRelease.sourceMessage
+                                : otherRelease?.sourceCommitId + ': ' + otherRelease?.sourceMessage
                             : `"${app}" has no version deployed on "${env.name}"`}
                     </div>
                     {queueInfo}

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -409,6 +409,20 @@ export const useRelease = (application: string, version: number): Release =>
             )!
     );
 
+export const useReleaseOptional = (application: string, env: Environment): Release | undefined => {
+    const x = env.applications[application];
+    return useOverview(({ applications }) => {
+        const version = x ? x.version : 0;
+        const res = applications[application].releases.find((r) =>
+            version === -1 ? r.undeployVersion : r.version === version
+        )!;
+        if (!x) {
+            return undefined;
+        }
+        return res;
+    });
+};
+
 // returns the release versions that are currently deployed to at least one environment
 export const useDeployedReleases = (application: string): number[] =>
     useOverview(({ environments }) =>


### PR DESCRIPTION
Some releases do not exist. When a new app is created, it will not be deployed everywhere instantly. This fixes a crashing ReleaseDialog in this situation