### PR TITLE
Fix rendering of group labels on ReleaseCards

### DIFF
--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
@@ -123,7 +123,7 @@ export type EnvChipListProps = {
 export const EnvironmentGroupChipList: React.FC<EnvChipListProps> = (props) => {
     const deployedAt = useCurrentlyDeployedAtGroup(props.app, props.version);
     return (
-        <div className={'env-group-chip-list-test'}>
+        <div className={'env-group-chip-list env-group-chip-list-test'}>
             {' '}
             {deployedAt.map((envGroup) => (
                 <EnvironmentGroupChip

--- a/services/frontend-service/src/ui/components/chip/chip.scss
+++ b/services/frontend-service/src/ui/components/chip/chip.scss
@@ -17,3 +17,7 @@
 span.mdc-evolution-chip button.mdc-evolution-chip__action span.mdc-evolution-chip__text-label {
     @extend .text-bold;
 }
+
+.env-group-chip-list {
+    display: flex;
+}


### PR DESCRIPTION
Before they were display vertically, now they are displayed horizontally.

Old:
![2023-03-09_18-02_old](https://user-images.githubusercontent.com/3481382/224101271-e45ef133-e399-4558-9dcc-4902e6643360.png)


New:
![2023-03-09_18-02_new](https://user-images.githubusercontent.com/3481382/224101253-2bc677fb-2703-4a50-8cc7-09d9df953ed6.png)
