### PR TITLE
Fix 0 deployment in new UI

### DIFF
--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -447,7 +447,9 @@ export const useDeployedReleases = (application: string): number[] =>
                     env.applications[application].undeployVersion ? -1 : env.applications[application].version
                 )
         ),
-    ].sort((a, b) => (a === -1 ? -1 : b === -1 ? 1 : b - a));
+    ]
+        .sort((a, b) => (a === -1 ? -1 : b === -1 ? 1 : b - a))
+        .filter((version) => version !== 0); // 0 means "not deployed", so we filter those out
 
 export type EnvironmentGroupExtended = EnvironmentGroup & { numberOfEnvsInGroup: number };
 


### PR DESCRIPTION
When services were not deployed, the service lane crashed, because useDeployedReleases returned the 0 release.
Now it skips the 0 release, because it is not an actual release. It just means "no release".
    
SRX-M2E91H