### PR TITLE
Fix undeploy for apps that are not in all envs

### DIFF
--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -839,10 +839,10 @@ func TestRetrySsh(t *testing.T) {
 
 			if resp == nil || tc.ExpectedResponse == nil {
 				if resp != tc.ExpectedResponse {
-					t.Fatalf("new: expected '%e',  got '%e'", tc.ExpectedResponse, resp)
+					t.Fatalf("new: expected '%v',  got '%v'", tc.ExpectedResponse, resp)
 				}
 			} else if resp.Error() != tc.ExpectedResponse.Error() {
-				t.Fatalf("new: expected '%e',  got '%e'", tc.ExpectedResponse, resp)
+				t.Fatalf("new: expected '%v',  got '%v'", tc.ExpectedResponse.Error(), resp.Error())
 			}
 			if counter != tc.ExpectedNumOfCall {
 				t.Fatalf("new: expected number of calls  '%d',  got '%d'", tc.ExpectedNumOfCall, counter)

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -21,9 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/pkg/logger"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/httperrors"
-	"go.uber.org/zap"
 	"io"
 	"io/fs"
 	"os"
@@ -429,8 +427,10 @@ func (u *UndeployApplication) Transform(ctx context.Context, state *State) (stri
 	configs, err := state.GetEnvironmentConfigs()
 	for env := range configs {
 		envAppDir := environmentApplicationDirectory(fs, env, u.Application)
-		entries, errorx := fs.ReadDir(envAppDir)
-		logger.FromContext(ctx).Warn("helloWORLD", zap.Error(errorx), zap.Bool("entries exists", entries != nil), zap.String("env", env), zap.String("appdir", envAppDir))
+		entries, err := fs.ReadDir(envAppDir)
+		if err != nil {
+			return "", wrapFileError(err, envAppDir, "UndeployApplication: Could not open application directory. Does the app exist?")
+		}
 		if entries == nil {
 			// app was never deployed on this env, so we must ignore it!
 			continue

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -432,7 +432,7 @@ func (u *UndeployApplication) Transform(ctx context.Context, state *State) (stri
 		entries, errorx := fs.ReadDir(envAppDir)
 		logger.FromContext(ctx).Warn("helloWORLD", zap.Error(errorx), zap.Bool("entries exists", entries != nil), zap.String("env", env), zap.String("appdir", envAppDir))
 		if entries == nil {
-			// app was never deployed on this env, so we can ignore it!
+			// app was never deployed on this env, so we must ignore it!
 			continue
 		}
 

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -21,7 +21,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/httperrors"
+	"go.uber.org/zap"
 	"io"
 	"io/fs"
 	"os"
@@ -427,6 +429,13 @@ func (u *UndeployApplication) Transform(ctx context.Context, state *State) (stri
 	configs, err := state.GetEnvironmentConfigs()
 	for env := range configs {
 		envAppDir := environmentApplicationDirectory(fs, env, u.Application)
+		entries, errorx := fs.ReadDir(envAppDir)
+		logger.FromContext(ctx).Warn("helloWORLD", zap.Error(errorx), zap.Bool("entries exists", entries != nil), zap.String("env", env), zap.String("appdir", envAppDir))
+		if entries == nil {
+			// app was never deployed on this env, so we can ignore it!
+			continue
+		}
+
 		locksDir := fs.Join(envAppDir, "locks")
 		undeployFile := fs.Join(envAppDir, "version", "undeploy")
 

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -201,22 +201,17 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			Transformers: []Transformer{
 				&CreateEnvironment{
 					Environment: "acceptance",
-					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: envAcceptance, Latest: true}},
+					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Latest: true}},
 				},
 				&CreateEnvironment{
 					Environment: "production",
-					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: envAcceptance, Latest: true}},
+					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: envAcceptance, Latest: false}},
 				},
 				&CreateApplicationVersion{
 					Application: "app1",
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
-				},
-				&CreateEnvironmentLock{
-					Environment: "acceptance",
-					LockId:      "22133",
-					Message:     "test",
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -225,9 +220,9 @@ func TestUndeployApplicationErrors(t *testing.T) {
 					Application: "app1",
 				},
 			},
-			expectedError:     "UndeployApplication: error cannot un-deploy application 'app1' the release 'acceptance' is not un-deployed",
-			expectedCommitMsg: "",
-			shouldSucceed:     false,
+			expectedError:     "",
+			expectedCommitMsg: "application 'app1' was deleted successfully",
+			shouldSucceed:     true,
 		},
 		{
 			Name: "Undeploy application where there is an environment lock should work",

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -197,6 +197,39 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			shouldSucceed:     false,
 		},
 		{
+			Name: "Undeploy application where the app does not have a release in all envs should work",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "acceptance",
+					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: envAcceptance, Latest: true}},
+				},
+				&CreateEnvironment{
+					Environment: "production",
+					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: envAcceptance, Latest: true}},
+				},
+				&CreateApplicationVersion{
+					Application: "app1",
+					Manifests: map[string]string{
+						envAcceptance: "acceptance",
+					},
+				},
+				&CreateEnvironmentLock{
+					Environment: "acceptance",
+					LockId:      "22133",
+					Message:     "test",
+				},
+				&CreateUndeployApplicationVersion{
+					Application: "app1",
+				},
+				&UndeployApplication{
+					Application: "app1",
+				},
+			},
+			expectedError:     "UndeployApplication: error cannot un-deploy application 'app1' the release 'acceptance' is not un-deployed",
+			expectedCommitMsg: "",
+			shouldSucceed:     false,
+		},
+		{
 			Name: "Undeploy application where there is an environment lock should work",
 			Transformers: []Transformer{
 				&CreateEnvironment{

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -197,7 +197,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			shouldSucceed:     false,
 		},
 		{
-			Name: "Undeploy application where the app does not have a release in all envs should work",
+			Name: "Undeploy application where the app does not have a release in all envs must work",
 			Transformers: []Transformer{
 				&CreateEnvironment{
 					Environment: "acceptance",


### PR DESCRIPTION
This fixes a bug in the "undeploy" request.
The issue was that kuberpult checked if the app was deployed (with version "undeploy") in all environments. This was a prerequisitve to run "undeploy".
However, some apps are not supposed to be deployed in all environments. (It's an edge case, but it can happen, especially when environments are added later on).
Now, we allow to delete apps, even if they don't exists everywhere.

This is a fix for https://github.com/freiheit-com/kuberpult/issues/451

SRX-M2E91H

