### PR TITLE
Fix version parameter of release endpoint

### DIFF
--- a/infrastructure/scripts/create-testdata/create-release.sh
+++ b/infrastructure/scripts/create-testdata/create-release.sh
@@ -45,6 +45,14 @@ echo ${msgs[$index]}" "$commit_id > "${commit_message_file}"
 ls ${commit_message_file}
 
 release_version=()
+case "${RELEASE_VERSION:-}" in
+	'') echo "No RELEASE_VERSION set. Using non-idempotent versioning scheme";;
+	*[!0-9]*) echo "Please set the env variable RELEASE_VERSION to a number"; exit 1;;
+	*) release_version=(--form-string "version=${RELEASE_VERSION:-}");;
+esac
+
+echo "release version:" "${release_version[@]}"
+
 configuration=()
 configuration+=("--form" "team=${applicationOwnerTeam}")
 
@@ -63,6 +71,7 @@ curl http://localhost:8081/release \
   --form-string "application=$name" \
   --form-string "source_commit_id=${commit_id}" \
   --form-string "source_author=${author}" \
+  "${release_version[@]}" \
   --form "source_message=<${commit_message_file}" \
   "${configuration[@]}" \
   "${manifests[@]}"

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -241,43 +241,7 @@ func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) 
 	if err != nil {
 		return "", err
 	}
-	if isLatest {
-		for env, man := range c.Manifests {
-			envDir := fs.Join(releaseDir, "environments", env)
-
-			config, found := configs[env]
-			hasUpstream := false
-			if found {
-				hasUpstream = config.Upstream != nil
-			}
-
-			if err = fs.MkdirAll(envDir, 0777); err != nil {
-				return "", err
-			}
-			if err := util.WriteFile(fs, fs.Join(envDir, "manifests.yaml"), []byte(man), 0666); err != nil {
-				return "", err
-			}
-
-			if hasUpstream && config.Upstream.Latest {
-				d := &DeployApplicationVersion{
-					Environment:   env,
-					Application:   c.Application,
-					Version:       version, // the train should queue deployments, instead of giving up:
-					LockBehaviour: api.LockBehavior_Record,
-				}
-				deployResult, err := d.Transform(ctx, state)
-				if err != nil {
-					_, ok := err.(*LockedError)
-					if ok {
-						continue // locked error are expected
-					} else {
-						return "", err
-					}
-				}
-				result = result + deployResult + "\n"
-			}
-		}
-	} else {
+	if !isLatest {
 		// check that we can actually backfill this version
 		oldVersions, err := findOldApplicationVersions(state, c.Application)
 		if err != nil {
@@ -288,7 +252,42 @@ func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) 
 				return "", ErrReleaseTooOld
 			}
 		}
+	}
 
+	for env, man := range c.Manifests {
+		envDir := fs.Join(releaseDir, "environments", env)
+
+		config, found := configs[env]
+		hasUpstream := false
+		if found {
+			hasUpstream = config.Upstream != nil
+		}
+
+		if err = fs.MkdirAll(envDir, 0777); err != nil {
+			return "", err
+		}
+		if err := util.WriteFile(fs, fs.Join(envDir, "manifests.yaml"), []byte(man), 0666); err != nil {
+			return "", err
+		}
+
+		if hasUpstream && config.Upstream.Latest && isLatest {
+			d := &DeployApplicationVersion{
+				Environment:   env,
+				Application:   c.Application,
+				Version:       version, // the train should queue deployments, instead of giving up:
+				LockBehaviour: api.LockBehavior_Record,
+			}
+			deployResult, err := d.Transform(ctx, state)
+			if err != nil {
+				_, ok := err.(*LockedError)
+				if ok {
+					continue // locked error are expected
+				} else {
+					return "", err
+				}
+			}
+			result = result + deployResult + "\n"
+		}
 	}
 	return fmt.Sprintf("created version %d of %q\n%s", version, c.Application, result), nil
 }

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -363,6 +363,100 @@ func TestCreateUndeployApplicationVersionErrors(t *testing.T) {
 	}
 }
 
+func TestCreateApplicationVersionWithVersion(t *testing.T) {
+	tcs := []struct {
+		Name             string
+		Transformers     []Transformer
+		expectedError    string
+		expectedPath     string
+		shouldSucceed    bool
+		expectedFileData []byte
+	}{
+		{
+			Name: "successfully create app version with right order - should work",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "acceptance",
+					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: envAcceptance, Latest: true}},
+				},
+				&CreateApplicationVersion{
+					Application: "app1",
+					Manifests: map[string]string{
+						envAcceptance: "first version (100) manifest",
+					},
+					Version: 100,
+				},
+				&CreateApplicationVersion{
+					Application: "app1",
+					Manifests: map[string]string{
+						envAcceptance: "second version (101) manifest",
+					},
+					Version: 101,
+				},
+			},
+			expectedError:    "",
+			expectedPath:     "applications/app1/releases/101/environments/acceptance/manifests.yaml",
+			expectedFileData: []byte("second version (101) manifest"),
+			shouldSucceed:    true,
+		},
+		{
+			Name: "successfully create 2 app versions in wrong order - should work",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "acceptance",
+					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: envAcceptance, Latest: true}},
+				},
+				&CreateApplicationVersion{
+					Application: "app1",
+					Manifests: map[string]string{
+						envAcceptance: "first version (100) manifest",
+					},
+					Version: 100,
+				},
+				&CreateApplicationVersion{
+					Application: "app1",
+					Manifests: map[string]string{
+						envAcceptance: "second version (99) manifest",
+					},
+					Version: 99,
+				},
+			},
+			expectedError:    "",
+			expectedPath:     "applications/app1/releases/99/environments/acceptance/manifests.yaml",
+			expectedFileData: []byte("second version (99) manifest"),
+			shouldSucceed:    true,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			repo := setupRepositoryTest(t)
+			_, updatedState, _ := repo.ApplyTransformersInternal(context.Background(), tc.Transformers...)
+
+			fileData, err := util.ReadFile(updatedState.Filesystem, updatedState.Filesystem.Join(updatedState.Filesystem.Root(), tc.expectedPath))
+
+			if tc.shouldSucceed {
+				if err != nil {
+					t.Fatalf("Expected no error: %v", err)
+				}
+				if !cmp.Equal(fileData, tc.expectedFileData) {
+					t.Fatalf("Expected %v, got %v", string(tc.expectedFileData), string(fileData))
+				}
+			} else {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				} else {
+					actualMsg := err.Error()
+					if actualMsg != tc.expectedError {
+						t.Fatalf("expected a different error.\nExpected: %q\nGot %q", tc.expectedError, actualMsg)
+					}
+				}
+			}
+		})
+	}
+}
+
 // Tests various error cases in the prepare-Undeploy endpoint, specifically the error messages returned.
 func TestUndeployErrors(t *testing.T) {
 	tcs := []struct {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -367,9 +367,7 @@ func TestCreateApplicationVersionWithVersion(t *testing.T) {
 	tcs := []struct {
 		Name             string
 		Transformers     []Transformer
-		expectedError    string
 		expectedPath     string
-		shouldSucceed    bool
 		expectedFileData []byte
 	}{
 		{
@@ -394,10 +392,8 @@ func TestCreateApplicationVersionWithVersion(t *testing.T) {
 					Version: 101,
 				},
 			},
-			expectedError:    "",
 			expectedPath:     "applications/app1/releases/101/environments/acceptance/manifests.yaml",
 			expectedFileData: []byte("second version (101) manifest"),
-			shouldSucceed:    true,
 		},
 		{
 			Name: "successfully create 2 app versions in wrong order - should work",
@@ -421,10 +417,8 @@ func TestCreateApplicationVersionWithVersion(t *testing.T) {
 					Version: 99,
 				},
 			},
-			expectedError:    "",
 			expectedPath:     "applications/app1/releases/99/environments/acceptance/manifests.yaml",
 			expectedFileData: []byte("second version (99) manifest"),
-			shouldSucceed:    true,
 		},
 	}
 	for _, tc := range tcs {
@@ -436,22 +430,11 @@ func TestCreateApplicationVersionWithVersion(t *testing.T) {
 
 			fileData, err := util.ReadFile(updatedState.Filesystem, updatedState.Filesystem.Join(updatedState.Filesystem.Root(), tc.expectedPath))
 
-			if tc.shouldSucceed {
-				if err != nil {
-					t.Fatalf("Expected no error: %v", err)
-				}
-				if !cmp.Equal(fileData, tc.expectedFileData) {
-					t.Fatalf("Expected %v, got %v", string(tc.expectedFileData), string(fileData))
-				}
-			} else {
-				if err == nil {
-					t.Fatal("Expected error but got none")
-				} else {
-					actualMsg := err.Error()
-					if actualMsg != tc.expectedError {
-						t.Fatalf("expected a different error.\nExpected: %q\nGot %q", tc.expectedError, actualMsg)
-					}
-				}
+			if err != nil {
+				t.Fatalf("Expected no error: %v", err)
+			}
+			if !cmp.Equal(fileData, tc.expectedFileData) {
+				t.Fatalf("Expected %v, got %v", string(tc.expectedFileData), string(fileData))
 			}
 		})
 	}


### PR DESCRIPTION
This fixes an issue when the "release" endpoint gets a "version" parameter that is less than the newest version number.
In that case, kuberpult didn't generate any manifest files (just the basic files like "author" were written).