### PR TITLE
Return undeploy summary in cd-service

### DIFF
--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -275,11 +275,21 @@ message Release {
   string prNumber = 7;
 }
 
+enum UndeploySummary {
+  // "normal": usual case for an active app, there is no undeploy version deployed in any environment
+  Normal = 0;
+  // "undeploy": all versions are in "undeploy" or don't exist on an environment
+  Undeploy = 1;
+  // "mixed": undeploy is deployed in one or more, but not all environments
+  Mixed = 2;
+}
+
 message Application {
   string name = 1;
   repeated Release releases = 2;
   string sourceRepoUrl= 3;
   string team = 4;
+  UndeploySummary undeploySummary = 5;
 }
 
 message Actor {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -942,6 +942,9 @@ func (s *State) GetApplicationReleases(application string) ([]uint64, error) {
 				result = append(result, i)
 			}
 		}
+		sort.Slice(result, func(i, j int) bool {
+			return result[i] < result[j]
+		})
 		return result, nil
 	}
 }

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -378,9 +378,6 @@ func deriveUndeploySummary(appName string, groups []*api.EnvironmentGroup) api.U
 			}
 		}
 	}
-	if len(groups) == 0 {
-		return api.UndeploySummary_Undeploy
-	}
 	if allUndeploy {
 		return api.UndeploySummary_Undeploy
 	}

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -355,7 +355,7 @@ func (o *OverviewServiceServer) getOverview(
 			} else {
 				app.SourceRepoUrl = url
 			}
-			app.UndeploySummary = deriveUndeploySummary(appName, result.EnvironmentGroups) // TODO SU
+			app.UndeploySummary = deriveUndeploySummary(appName, result.EnvironmentGroups)
 			result.Applications[appName] = &app
 		}
 	}


### PR DESCRIPTION
We should do all complex calculations in the backend.
The undeploy summary will be used to determine which option to show the user (create undeploy version or delete completely)
