### PR TITLE
Show Application and Team on Release Dialog

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -14,9 +14,9 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 import { EnvironmentListItem, ReleaseDialog, ReleaseDialogProps } from './ReleaseDialog';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { UpdateOverview, updateReleaseDialog, UpdateSidebar } from '../../utils/store';
-import { Priority, Release } from '../../../api/api';
+import { Environment, Priority, Release } from '../../../api/api';
 import { Spy } from 'spy4js';
 import { SideBar } from '../SideBar/SideBar';
 
@@ -27,6 +27,7 @@ describe('Release Dialog', () => {
         name: string;
         props: ReleaseDialogProps;
         rels: Release[];
+        envs: Environment[];
         expect_message: boolean;
         expect_queues: number;
         data_length: number;
@@ -46,26 +47,25 @@ describe('Release Dialog', () => {
                     undeployVersion: false,
                     prNumber: '#1337',
                 },
-                envs: [
-                    {
-                        name: 'prod',
-                        locks: { envLock: { message: 'envLock', lockId: 'ui-envlock' } },
-                        applications: {
-                            test1: {
-                                name: 'test1',
-                                version: 2,
-                                locks: { applock: { message: 'appLock', lockId: 'ui-applock' } },
-                                queuedVersion: 0,
-                                undeployVersion: false,
-                            },
-                        },
-                        distanceToUpstream: 0,
-                        priority: Priority.UPSTREAM,
-                    },
-                ],
             },
             rels: [],
-
+            envs: [
+                {
+                    name: 'prod',
+                    locks: { envLock: { message: 'envLock', lockId: 'ui-envlock' } },
+                    applications: {
+                        test1: {
+                            name: 'test1',
+                            version: 2,
+                            locks: { applock: { message: 'appLock', lockId: 'ui-applock' } },
+                            queuedVersion: 0,
+                            undeployVersion: false,
+                        },
+                    },
+                    distanceToUpstream: 0,
+                    priority: Priority.UPSTREAM,
+                },
+            ],
             expect_message: true,
             expect_queues: 0,
             data_length: 1,
@@ -84,39 +84,39 @@ describe('Release Dialog', () => {
                     undeployVersion: false,
                     prNumber: '#1337',
                 },
-                envs: [
-                    {
-                        name: 'prod',
-                        locks: { envLock: { message: 'envLock', lockId: 'ui-envlock' } },
-                        applications: {
-                            test1: {
-                                name: 'test1',
-                                version: 2,
-                                locks: { applock: { message: 'appLock', lockId: 'ui-applock' } },
-                                queuedVersion: 0,
-                                undeployVersion: false,
-                            },
-                        },
-                        distanceToUpstream: 0,
-                        priority: Priority.UPSTREAM,
-                    },
-                    {
-                        name: 'dev',
-                        locks: { envLock: { message: 'envLock', lockId: 'ui-envlock' } },
-                        applications: {
-                            test1: {
-                                name: 'test1',
-                                version: 3,
-                                locks: { applock: { message: 'appLock', lockId: 'ui-applock' } },
-                                queuedVersion: 666,
-                                undeployVersion: false,
-                            },
-                        },
-                        distanceToUpstream: 0,
-                        priority: Priority.UPSTREAM,
-                    },
-                ],
             },
+            envs: [
+                {
+                    name: 'prod',
+                    locks: { envLock: { message: 'envLock', lockId: 'ui-envlock' } },
+                    applications: {
+                        test1: {
+                            name: 'test1',
+                            version: 2,
+                            locks: { applock: { message: 'appLock', lockId: 'ui-applock' } },
+                            queuedVersion: 0,
+                            undeployVersion: false,
+                        },
+                    },
+                    distanceToUpstream: 0,
+                    priority: Priority.UPSTREAM,
+                },
+                {
+                    name: 'dev',
+                    locks: { envLock: { message: 'envLock', lockId: 'ui-envlock' } },
+                    applications: {
+                        test1: {
+                            name: 'test1',
+                            version: 3,
+                            locks: { applock: { message: 'appLock', lockId: 'ui-applock' } },
+                            queuedVersion: 666,
+                            undeployVersion: false,
+                        },
+                    },
+                    distanceToUpstream: 0,
+                    priority: Priority.UPSTREAM,
+                },
+            ],
             rels: [
                 {
                     sourceCommitId: 'cafe',
@@ -146,9 +146,9 @@ describe('Release Dialog', () => {
                 app: 'test1',
                 version: -1,
                 release: {} as Release,
-                envs: [],
             },
             rels: [],
+            envs: [],
             expect_message: false,
             expect_queues: 0,
             data_length: 0,
@@ -160,11 +160,11 @@ describe('Release Dialog', () => {
             // when
             UpdateOverview.set({
                 applications: { [testcase.props.app as string]: { releases: testcase.rels } },
-                environments: testcase.props.envs,
+                environments: testcase.envs,
                 environmentGroups: [
                     {
                         environmentGroupName: 'dev',
-                        environments: testcase.props.envs,
+                        environments: testcase.envs,
                         distanceToUpstream: 2,
                     },
                 ],
@@ -188,18 +188,18 @@ describe('Release Dialog', () => {
             // when
             UpdateOverview.set({
                 applications: { [testcase.props.app as string]: { releases: testcase.rels } },
-                environments: testcase.props.envs,
+                environments: testcase.envs,
                 environmentGroups: [
                     {
                         environmentGroupName: 'dev',
-                        environments: testcase.props.envs,
+                        environments: testcase.envs,
                         distanceToUpstream: 2,
                     },
                 ],
             } as any);
             updateReleaseDialog(testcase.props.app, testcase.props.version);
             render(<ReleaseDialog {...testcase.props} />);
-            expect(document.querySelector('.release-env-list')?.children).toHaveLength(testcase.props.envs.length);
+            expect(document.querySelector('.release-env-list')?.children).toHaveLength(testcase.envs.length);
         });
     });
 
@@ -210,11 +210,11 @@ describe('Release Dialog', () => {
             // when
             UpdateOverview.set({
                 applications: { [testcase.props.app as string]: { releases: testcase.rels } },
-                environments: testcase.props.envs,
+                environments: testcase.envs,
                 environmentGroups: [
                     {
                         environmentGroupName: 'dev',
-                        environments: testcase.props.envs,
+                        environments: testcase.envs,
                         distanceToUpstream: 2,
                     },
                 ],
@@ -224,7 +224,7 @@ describe('Release Dialog', () => {
             expect(document.body).toMatchSnapshot();
             expect(document.querySelectorAll('.release-env-group-list')).toHaveLength(1);
 
-            testcase.props.envs.forEach((env) => {
+            testcase.envs.forEach((env) => {
                 expect(document.querySelector('.env-locks')?.children).toHaveLength(Object.values(env.locks).length);
             });
         });
@@ -235,11 +235,11 @@ describe('Release Dialog', () => {
             // when
             UpdateOverview.set({
                 applications: { [testcase.props.app as string]: { releases: testcase.rels } },
-                environments: testcase.props.envs,
+                environments: testcase.envs,
                 environmentGroups: [
                     {
                         environmentGroupName: 'dev',
-                        environments: testcase.props.envs,
+                        environments: testcase.envs,
                         distanceToUpstream: 2,
                     },
                 ],
@@ -253,23 +253,19 @@ describe('Release Dialog', () => {
     describe(`Test automatic cart opening`, () => {
         const testcase = data[0];
         it('Test using direct call to open function', () => {
-            if (UpdateSidebar.get().shown === true) {
-                UpdateSidebar.set({ shown: false });
-            }
+            UpdateSidebar.set({ shown: false });
             UpdateSidebar.set({ shown: true });
             expect(UpdateSidebar.get().shown).toBeTruthy();
         });
         it('Test using deploy button click simulation', () => {
-            if (UpdateSidebar.get().shown === true) {
-                UpdateSidebar.set({ shown: false });
-            }
+            UpdateSidebar.set({ shown: false });
             UpdateOverview.set({
                 applications: { [testcase.props.app as string]: { releases: testcase.rels } },
-                environments: testcase.props.envs,
+                environments: testcase.envs,
                 environmentGroups: [
                     {
                         environmentGroupName: 'dev',
-                        environments: testcase.props.envs,
+                        environments: testcase.envs,
                         distanceToUpstream: 2,
                     },
                 ],
@@ -278,28 +274,26 @@ describe('Release Dialog', () => {
             render(<ReleaseDialog {...testcase.props} />);
             render(
                 <EnvironmentListItem
-                    env={testcase.props.envs[0]}
+                    env={testcase.envs[0]}
                     app={testcase.props.app}
                     queuedVersion={0}
                     release={testcase.props.release}
                 />
             );
-            render(<SideBar />);
-            const result = document.querySelector('.env-card-deploy-btn');
-            result?.click();
+            render(<SideBar toggleSidebar={Spy()} />);
+            const result = document.querySelector('.env-card-deploy-btn')!;
+            fireEvent.click(result);
             expect(UpdateSidebar.get().shown).toBeTruthy();
         });
         it('Test using add lock button click simulation', () => {
-            if (UpdateSidebar.get().shown === true) {
-                UpdateSidebar.set({ shown: false });
-            }
+            UpdateSidebar.set({ shown: false });
             UpdateOverview.set({
                 applications: { [testcase.props.app as string]: { releases: testcase.rels } },
-                environments: testcase.props.envs,
+                environments: testcase.envs,
                 environmentGroups: [
                     {
                         environmentGroupName: 'dev',
-                        environments: testcase.props.envs,
+                        environments: testcase.envs,
                         distanceToUpstream: 2,
                     },
                 ],
@@ -308,15 +302,15 @@ describe('Release Dialog', () => {
             render(<ReleaseDialog {...testcase.props} />);
             render(
                 <EnvironmentListItem
-                    env={testcase.props.envs[0]}
+                    env={testcase.envs[0]}
                     app={testcase.props.app}
                     queuedVersion={0}
                     release={testcase.props.release}
                 />
             );
-            render(<SideBar />);
-            const result = document.querySelector('.env-card-add-lock-btn');
-            result?.click();
+            render(<SideBar toggleSidebar={Spy()} />);
+            const result = document.querySelector('.env-card-add-lock-btn')!;
+            fireEvent.click(result);
             expect(UpdateSidebar.get().shown).toBeTruthy();
         });
     });

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -31,6 +31,7 @@ describe('Release Dialog', () => {
         expect_message: boolean;
         expect_queues: number;
         data_length: number;
+        teamName: string;
     }
     const data: dataT[] = [
         {
@@ -69,6 +70,7 @@ describe('Release Dialog', () => {
             expect_message: true,
             expect_queues: 0,
             data_length: 1,
+            teamName: '',
         },
         {
             name: 'two envs release',
@@ -139,6 +141,7 @@ describe('Release Dialog', () => {
             expect_message: true,
             expect_queues: 1,
             data_length: 3,
+            teamName: 'test me team',
         },
         {
             name: 'no release',
@@ -152,23 +155,27 @@ describe('Release Dialog', () => {
             expect_message: false,
             expect_queues: 0,
             data_length: 0,
+            teamName: '',
         },
     ];
+
+    const setTheStore = (testcase: dataT) =>
+        UpdateOverview.set({
+            applications: { [testcase.props.app]: { releases: testcase.rels, team: testcase.teamName } },
+            environments: testcase.envs,
+            environmentGroups: [
+                {
+                    environmentGroupName: 'dev',
+                    environments: testcase.envs,
+                    distanceToUpstream: 2,
+                },
+            ],
+        } as any);
 
     describe.each(data)(`Renders a Release Dialog`, (testcase) => {
         it(testcase.name, () => {
             // when
-            UpdateOverview.set({
-                applications: { [testcase.props.app as string]: { releases: testcase.rels } },
-                environments: testcase.envs,
-                environmentGroups: [
-                    {
-                        environmentGroupName: 'dev',
-                        environments: testcase.envs,
-                        distanceToUpstream: 2,
-                    },
-                ],
-            } as any);
+            setTheStore(testcase);
             updateReleaseDialog(testcase.props.app, testcase.props.version);
             render(<ReleaseDialog {...testcase.props} />);
             if (testcase.expect_message) {
@@ -186,17 +193,7 @@ describe('Release Dialog', () => {
     describe.each(data)(`Renders the environment cards`, (testcase) => {
         it(testcase.name, () => {
             // when
-            UpdateOverview.set({
-                applications: { [testcase.props.app as string]: { releases: testcase.rels } },
-                environments: testcase.envs,
-                environmentGroups: [
-                    {
-                        environmentGroupName: 'dev',
-                        environments: testcase.envs,
-                        distanceToUpstream: 2,
-                    },
-                ],
-            } as any);
+            setTheStore(testcase);
             updateReleaseDialog(testcase.props.app, testcase.props.version);
             render(<ReleaseDialog {...testcase.props} />);
             expect(document.querySelector('.release-env-list')?.children).toHaveLength(testcase.envs.length);
@@ -208,17 +205,7 @@ describe('Release Dialog', () => {
             // given
             mock_getFormattedReleaseDate.getFormattedReleaseDate.returns(<div>some formatted date</div>);
             // when
-            UpdateOverview.set({
-                applications: { [testcase.props.app as string]: { releases: testcase.rels } },
-                environments: testcase.envs,
-                environmentGroups: [
-                    {
-                        environmentGroupName: 'dev',
-                        environments: testcase.envs,
-                        distanceToUpstream: 2,
-                    },
-                ],
-            } as any);
+            setTheStore(testcase);
             updateReleaseDialog(testcase.props.app, testcase.props.version);
             render(<ReleaseDialog {...testcase.props} />);
             expect(document.body).toMatchSnapshot();
@@ -233,17 +220,7 @@ describe('Release Dialog', () => {
     describe.each(data)(`Renders the queuedVersion`, (testcase) => {
         it(testcase.name, () => {
             // when
-            UpdateOverview.set({
-                applications: { [testcase.props.app as string]: { releases: testcase.rels } },
-                environments: testcase.envs,
-                environmentGroups: [
-                    {
-                        environmentGroupName: 'dev',
-                        environments: testcase.envs,
-                        distanceToUpstream: 2,
-                    },
-                ],
-            } as any);
+            setTheStore(testcase);
             updateReleaseDialog(testcase.props.app, testcase.props.version);
             render(<ReleaseDialog {...testcase.props} />);
             expect(document.querySelectorAll('.env-card-data-queue')).toHaveLength(testcase.expect_queues);
@@ -259,17 +236,7 @@ describe('Release Dialog', () => {
         });
         it('Test using deploy button click simulation', () => {
             UpdateSidebar.set({ shown: false });
-            UpdateOverview.set({
-                applications: { [testcase.props.app as string]: { releases: testcase.rels } },
-                environments: testcase.envs,
-                environmentGroups: [
-                    {
-                        environmentGroupName: 'dev',
-                        environments: testcase.envs,
-                        distanceToUpstream: 2,
-                    },
-                ],
-            } as any);
+            setTheStore(testcase);
 
             render(<ReleaseDialog {...testcase.props} />);
             render(
@@ -287,17 +254,7 @@ describe('Release Dialog', () => {
         });
         it('Test using add lock button click simulation', () => {
             UpdateSidebar.set({ shown: false });
-            UpdateOverview.set({
-                applications: { [testcase.props.app as string]: { releases: testcase.rels } },
-                environments: testcase.envs,
-                environmentGroups: [
-                    {
-                        environmentGroupName: 'dev',
-                        environments: testcase.envs,
-                        distanceToUpstream: 2,
-                    },
-                ],
-            } as any);
+            setTheStore(testcase);
 
             render(<ReleaseDialog {...testcase.props} />);
             render(

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -17,7 +17,13 @@ import { Dialog, Tooltip } from '@material-ui/core';
 import classNames from 'classnames';
 import React, { useCallback } from 'react';
 import { Environment, EnvironmentGroup, Lock, LockBehavior, Release } from '../../../api/api';
-import { addAction, updateReleaseDialog, useOverview, useReleaseOptional } from '../../utils/store';
+import {
+    addAction,
+    updateReleaseDialog,
+    useOverview,
+    useReleaseOptional,
+    useTeamFromApplication,
+} from '../../utils/store';
 import { Button } from '../button';
 import { Close, Locks } from '../../../images';
 import { EnvironmentChip } from '../chip/EnvironmentGroupChip';
@@ -207,6 +213,7 @@ export const EnvironmentList: React.FC<{
 
 export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
     const { app, className, release, version } = props;
+    const team = useTeamFromApplication(app);
     const dialog =
         app !== '' ? (
             <div>
@@ -229,6 +236,11 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                             <div className={classNames('release-dialog-author', className)}>
                                 {release?.sourceAuthor ? 'Author: ' + release?.sourceAuthor : ''}
                             </div>
+                            <div
+                                className={classNames(
+                                    'release-dialog-app',
+                                    className
+                                )}>{`Service: ${app} | Team: ${team}`}</div>
                         </div>
                         <span className={classNames('release-dialog-commitId', className)}>
                             {release.undeployVersion ? 'undeploy version' : release?.sourceCommitId}

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -267,11 +267,9 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                             <div className={classNames('release-dialog-author', className)}>
                                 {release?.sourceAuthor ? 'Author: ' + release?.sourceAuthor : ''}
                             </div>
-                            <div
-                                className={classNames(
-                                    'release-dialog-app',
-                                    className
-                                )}>{`Service: ${app} | Team: ${team}`}</div>
+                            <div className={classNames('release-dialog-app', className)}>
+                                {`App: ${app} ` + (team ? ` | Team: ${team}` : '')}
+                            </div>
                         </div>
                         <span className={classNames('release-dialog-commitId', className)} title={undeployVersionTitle}>
                             {release.undeployVersion ? 'Undeploy Version' : release?.sourceCommitId}

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -387,7 +387,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
             <div
               class="release-dialog-app"
             >
-              App: test1 
+              App: test1  | Team: test me team
             </div>
           </div>
           <span

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -53,6 +53,11 @@ exports[`Release Dialog Renders the environment locks no release 1`] = `
             <div
               class="release-dialog-author"
             />
+            <div
+              class="release-dialog-app"
+            >
+              Service: test1 | Team: &lt;No Team&gt;
+            </div>
           </div>
           <span
             class="release-dialog-commitId"
@@ -146,6 +151,11 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
               class="release-dialog-author"
             >
               Author: test
+            </div>
+            <div
+              class="release-dialog-app"
+            >
+              Service: test1 | Team: &lt;No Team&gt;
             </div>
           </div>
           <span
@@ -371,6 +381,11 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
               class="release-dialog-author"
             >
               Author: test
+            </div>
+            <div
+              class="release-dialog-app"
+            >
+              Service: test1 | Team: &lt;No Team&gt;
             </div>
           </div>
           <span

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Release Dialog Renders the environment locks no release 1`] = `
             <div
               class="release-dialog-app"
             >
-              Service: test1 | Team: &lt;No Team&gt;
+              App: test1 
             </div>
           </div>
           <span
@@ -156,7 +156,7 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
             <div
               class="release-dialog-app"
             >
-              Service: test1 | Team: &lt;No Team&gt;
+              App: test1 
             </div>
           </div>
           <span
@@ -387,7 +387,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
             <div
               class="release-dialog-app"
             >
-              Service: test1 | Team: &lt;No Team&gt;
+              App: test1 
             </div>
           </div>
           <span

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -205,7 +205,7 @@ export const SideBarList = (): JSX.Element => {
     );
 };
 
-export const SideBar: React.FC<{ className: string; toggleSidebar: () => void }> = (props) => {
+export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }> = (props) => {
     const { className, toggleSidebar } = props;
     const actions = useActions();
     const [lockMessage, setLockMessage] = useState('');

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -200,6 +200,9 @@ export const useTeamNames = (): string[] =>
         ),
     ]);
 
+export const useTeamFromApplication = (app: string): string =>
+    useOverview(({ applications }) => applications[app]?.team?.trim() || '<No Team>');
+
 // returns applications filtered by dropdown and sorted by team name and then by app name
 export const useFilteredApps = (teams: string[]): Application[] =>
     useOverview(({ applications }) =>

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -201,7 +201,7 @@ export const useTeamNames = (): string[] =>
     ]);
 
 export const useTeamFromApplication = (app: string): string =>
-    useOverview(({ applications }) => applications[app]?.team?.trim() || '<No Team>');
+    useOverview(({ applications }) => applications[app]?.team?.trim() || '');
 
 // returns applications filtered by dropdown and sorted by team name and then by app name
 export const useFilteredApps = (teams: string[]): Application[] =>


### PR DESCRIPTION
* move the `envs[]` from release dialog props type into testdata type. in release dialog test
* show the app name on release dialog
* show team name also when it's available
* refactor a little in release dialog test (fix the red squiggles)

[SRX-HLVCYS](https://revolution.dev/app/-JqFGExX46gs9mH7vxR5/-M37cZx7XYoOvQ5Mmcir/STORY/-NOAP23nj5zjMg-U0fo4/)