### PR TITLE
Fix issue with deleting locks

### DIFF
--- a/services/frontend-service/src/ui/components/SideBar/SideBar.test.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.test.tsx
@@ -25,6 +25,7 @@ import {
     deleteAllActions,
     UpdateOverview,
     appendAction,
+    DisplayLock,
 } from '../../utils/store';
 import { ActionDetails, ActionTypes, getActionDetails, SideBar } from './SideBar';
 
@@ -389,8 +390,8 @@ describe('Action details', () => {
     interface dataT {
         name: string;
         action: BatchAction;
-        envLocks?: string[];
-        appLocks?: string[];
+        envLocks?: DisplayLock[];
+        appLocks?: DisplayLock[];
         expectedDetails: ActionDetails;
     }
     const data: dataT[] = [
@@ -418,7 +419,13 @@ describe('Action details', () => {
                     deleteEnvironmentLock: { environment: 'foo', lockId: 'ui-v2-1337' },
                 },
             },
-            envLocks: ['ui-v2-1337'],
+            envLocks: [
+                {
+                    lockId: 'ui-v2-1337',
+                    environment: 'foo',
+                    message: 'bar',
+                },
+            ],
             expectedDetails: {
                 type: ActionTypes.DeleteEnvironmentLock,
                 name: 'Delete Env Lock',
@@ -459,7 +466,14 @@ describe('Action details', () => {
                     deleteEnvironmentApplicationLock: { environment: 'foo', application: 'bar', lockId: 'ui-v2-1337' },
                 },
             },
-            appLocks: ['ui-v2-1337'],
+            appLocks: [
+                {
+                    lockId: 'ui-v2-1337',
+                    environment: 'foo',
+                    message: 'bar',
+                    application: 'bar',
+                },
+            ],
             expectedDetails: {
                 type: ActionTypes.DeleteApplicationLock,
                 name: 'Delete App Lock',

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -20,12 +20,11 @@ import {
     deleteAction,
     useActions,
     deleteAllActions,
-    useApplicationLockIDs,
-    useEnvironmentLockIDs,
-    useApplicationLock,
     useNumberOfActions,
     showSnackbarSuccess,
     showSnackbarError,
+    useAllLocks,
+    DisplayLock,
 } from '../../utils/store';
 import { ChangeEvent, useCallback, useMemo, useState } from 'react';
 import { useApi } from '../../utils/GrpcApi';
@@ -60,11 +59,9 @@ export type ActionDetails = {
 
 export const getActionDetails = (
     { action }: BatchAction,
-    appLockIDs: string[],
-    envLockIDs: string[]
+    appLocks: DisplayLock[],
+    envLocks: DisplayLock[]
 ): ActionDetails => {
-    const appLocks = appLockIDs.map((lockId) => useApplicationLock(lockId));
-    const envLocks = envLockIDs.map((lockId) => useApplicationLock(lockId));
     switch (action?.$case) {
         case 'createEnvironmentLock':
             return {
@@ -173,9 +170,8 @@ type SideBarListItemProps = {
 };
 
 export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children: action }: SideBarListItemProps) => {
-    const appLocks = useApplicationLockIDs();
-    const envLocks = useEnvironmentLockIDs();
-    const actionDetails = getActionDetails(action, appLocks, envLocks);
+    const { environmentLocks, appLocks } = useAllLocks();
+    const actionDetails = getActionDetails(action, appLocks, environmentLocks);
 
     const handleDelete = useCallback(() => deleteAction(action), [action]);
     return (

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -28,13 +28,13 @@ import { useMemo } from 'react';
 import { Empty } from '../../google/protobuf/empty';
 
 export interface DisplayLock {
-    date: Date;
+    date?: Date;
     environment: string;
     application?: string;
     message: string;
     lockId: string;
-    authorName: string;
-    authorEmail: string;
+    authorName?: string;
+    authorEmail?: string;
 }
 
 const emptyOverview: GetOverviewResponse = { applications: {}, environments: {}, environmentGroups: [] };
@@ -274,15 +274,6 @@ export const useEnvironmentLocks = (): DisplayLock[] =>
         return sortLocks(locksFiltered.flat(), 'oldestToNewest');
     });
 
-// return all env lock IDs
-export const useEnvironmentLockIDs = (): string[] =>
-    useOverview(({ environments }) =>
-        Object.values(environments)
-            .map((env) => Object.values(env.locks))
-            .flat()
-            .map((lock) => lock.lockId)
-    );
-
 // return env lock IDs from given env
 export const useFilteredEnvironmentLockIDs = (envName: string): string[] =>
     useOverview(({ environments }) =>
@@ -344,16 +335,50 @@ export const searchCustomFilter = (queryContent: string | null, val: string | un
     }
 };
 
-// return app lock IDs
-export const useApplicationLockIDs = (): string[] =>
-    useOverview(({ environments }) =>
-        Object.values(environments)
-            .map((env) => Object.values(env.applications))
-            .flat()
-            .map((app) => Object.values(app.locks))
-            .flat()
-            .map((lock) => lock.lockId)
-    );
+export type AllLocks = {
+    environmentLocks: DisplayLock[];
+    appLocks: DisplayLock[];
+};
+
+export const useAllLocks = (): AllLocks => {
+    const envs = useEnvironments();
+    const environmentLocks: DisplayLock[] = [];
+    const appLocks: DisplayLock[] = [];
+    envs.forEach((env: Environment) => {
+        for (const locksKey in env.locks) {
+            const lock = env.locks[locksKey];
+            const displayLock: DisplayLock = {
+                lockId: lock.lockId,
+                date: lock.createdAt,
+                environment: env.name,
+                message: lock.message,
+                authorName: lock.createdBy?.name,
+                authorEmail: lock.createdBy?.email,
+            };
+            environmentLocks.push(displayLock);
+        }
+        for (const applicationsKey in env.applications) {
+            const app = env.applications[applicationsKey];
+            for (const locksKey in app.locks) {
+                const lock = app.locks[locksKey];
+                const displayLock: DisplayLock = {
+                    lockId: lock.lockId,
+                    application: app.name,
+                    date: lock.createdAt,
+                    environment: env.name,
+                    message: lock.message,
+                    authorName: lock.createdBy?.name,
+                    authorEmail: lock.createdBy?.email,
+                };
+                appLocks.push(displayLock);
+            }
+        }
+    });
+    return {
+        environmentLocks,
+        appLocks,
+    };
+};
 
 export const useApplicationLock = (lockId: string): DisplayLock =>
     ({


### PR DESCRIPTION
There was a loop over react hooks, which is not allowed and sometimes caused crashes when deleting locks.

This loop was removed. We now have one hook useAllLocks that returns everything neceessary, instead of first getting all IDs and then later getting the lock by id.