### PR TITLE
Fix bug in app deletion when there are app locks

### DIFF
--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -282,8 +282,6 @@ enum UndeploySummary {
   Undeploy = 1;
   // "mixed": undeploy is deployed in one or more, but not all environments
   Mixed = 2;
-  // "locked": there is a lock on the app, so we do not allow deletion
-  Locked = 3;
 }
 
 message Application {

--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -282,6 +282,8 @@ enum UndeploySummary {
   Undeploy = 1;
   // "mixed": undeploy is deployed in one or more, but not all environments
   Mixed = 2;
+  // "locked": there is a lock on the app, so we do not allow deletion
+  Locked = 3;
 }
 
 message Application {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -435,11 +435,13 @@ func (u *UndeployApplication) Transform(ctx context.Context, state *State) (stri
 			continue
 		}
 
-		locksDir := fs.Join(envAppDir, "locks")
+		appLocksDir := fs.Join(envAppDir, "locks")
 		undeployFile := fs.Join(envAppDir, "version", "undeploy")
 
-		if entries, _ := fs.ReadDir(locksDir); entries != nil {
-			return "", fmt.Errorf("UndeployApplication: error cannot un-deploy application '%v' unlock the application lock in the '%v' environment first", u.Application, env)
+		entries, _ = fs.ReadDir(appLocksDir)
+		if entries != nil && len(entries) > 0 {
+			return "", fmt.Errorf("UndeployApplication: error cannot un-deploy application '%v' unlock the application lock in the '%v' environment first. Path '%v'. Entries: '%v'",
+				u.Application, env, appLocksDir, entries)
 		}
 
 		if _, err := fs.Stat(undeployFile); err != nil && errors.Is(err, os.ErrNotExist) {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -120,22 +120,22 @@ func TestUndeployApplicationErrors(t *testing.T) {
 						envAcceptance: "acceptance",
 					},
 				},
+				&CreateUndeployApplicationVersion{
+					Application: "app1",
+				},
 				&CreateEnvironmentApplicationLock{
 					Environment: "acceptance",
 					Application: "app1",
 					LockId:      "22133",
 					Message:     "test",
 				},
-				&CreateUndeployApplicationVersion{
-					Application: "app1",
-				},
 				&UndeployApplication{
 					Application: "app1",
 				},
 			},
-			expectedError:     "UndeployApplication: error cannot un-deploy application 'app1' unlock the application lock in the 'acceptance' environment first",
-			expectedCommitMsg: "",
-			shouldSucceed:     false,
+			expectedError:     "",
+			expectedCommitMsg: "application 'app1' was deleted successfully",
+			shouldSucceed:     true,
 		},
 		{
 			Name: "Undeploy application where there is an application lock created after the un-deploy version creation shouldn't work",

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -138,7 +138,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			shouldSucceed:     true,
 		},
 		{
-			Name: "Undeploy application where there is an application lock created after the un-deploy version creation shouldn't work",
+			Name: "Undeploy application where there is an application lock created after the un-deploy version creation should",
 			Transformers: []Transformer{
 				&CreateEnvironment{
 					Environment: "acceptance",
@@ -163,9 +163,9 @@ func TestUndeployApplicationErrors(t *testing.T) {
 					Application: "app1",
 				},
 			},
-			expectedError:     "UndeployApplication: error cannot un-deploy application 'app1' unlock the application lock in the 'acceptance' environment first",
-			expectedCommitMsg: "",
-			shouldSucceed:     false,
+			expectedError:     "",
+			expectedCommitMsg: "application 'app1' was deleted successfully",
+			shouldSucceed:     true,
 		},
 		{
 			Name: "Undeploy application where there current releases are not undeploy shouldn't work",
@@ -192,7 +192,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 					Application: "app1",
 				},
 			},
-			expectedError:     "UndeployApplication: error cannot un-deploy application 'app1' the release 'acceptance' is not un-deployed",
+			expectedError:     "UndeployApplication: error cannot un-deploy application 'app1' the release 'acceptance' is not un-deployed: 'environments/acceptance/applications/app1/version/undeploy'",
 			expectedCommitMsg: "",
 			shouldSucceed:     false,
 		},

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -371,6 +371,10 @@ func deriveUndeploySummary(appName string, groups []*api.EnvironmentGroup) api.U
 			if !exists {
 				continue
 			}
+			if app.Version == 0 {
+				// if the app exists but nothing is deployed, we ignore this
+				continue
+			}
 			if app.UndeployVersion {
 				allNormal = false
 			} else {

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -371,12 +371,6 @@ func deriveUndeploySummary(appName string, groups []*api.EnvironmentGroup) api.U
 			if !exists {
 				continue
 			}
-			if len(app.Locks) > 0 {
-				// if there are locks on the app, we should not allow deletion - maybe the lock is there for a good reason.
-				// note that we ignore environment locks here. Otherwise, you would essentially never be able to delete an app,
-				// because there is very often SOME lock on some environment.
-				return api.UndeploySummary_Locked
-			}
 			if app.UndeployVersion {
 				allNormal = false
 			} else {

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -371,6 +371,12 @@ func deriveUndeploySummary(appName string, groups []*api.EnvironmentGroup) api.U
 			if !exists {
 				continue
 			}
+			if len(app.Locks) > 0 {
+				// if there are locks on the app, we should not allow deletion - maybe the lock is there for a good reason.
+				// note that we ignore environment locks here. Otherwise, you would essentially never be able to delete an app,
+				// because there is very often SOME lock on some environment.
+				return api.UndeploySummary_Locked
+			}
 			if app.UndeployVersion {
 				allNormal = false
 			} else {

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -804,6 +804,7 @@ func TestDeriveUndeploySummary(t *testing.T) {
 					Applications: map[string]*api.Environment_Application{
 						"bar": { // different app
 							UndeployVersion: true,
+							Version:         666,
 						},
 					},
 				},
@@ -818,6 +819,7 @@ func TestDeriveUndeploySummary(t *testing.T) {
 					Applications: map[string]*api.Environment_Application{
 						"foo": {
 							UndeployVersion: true,
+							Version:         666,
 						},
 					},
 				},
@@ -832,6 +834,7 @@ func TestDeriveUndeploySummary(t *testing.T) {
 					Applications: map[string]*api.Environment_Application{
 						"foo": {
 							UndeployVersion: false,
+							Version:         666,
 						},
 					},
 				},
@@ -846,6 +849,7 @@ func TestDeriveUndeploySummary(t *testing.T) {
 					Applications: map[string]*api.Environment_Application{
 						"foo": {
 							UndeployVersion: true,
+							Version:         666,
 						},
 					},
 				},
@@ -853,6 +857,7 @@ func TestDeriveUndeploySummary(t *testing.T) {
 					Applications: map[string]*api.Environment_Application{
 						"foo": {
 							UndeployVersion: true,
+							Version:         666,
 						},
 					},
 				},
@@ -867,6 +872,7 @@ func TestDeriveUndeploySummary(t *testing.T) {
 					Applications: map[string]*api.Environment_Application{
 						"foo": {
 							UndeployVersion: false,
+							Version:         666,
 						},
 					},
 				},
@@ -874,6 +880,7 @@ func TestDeriveUndeploySummary(t *testing.T) {
 					Applications: map[string]*api.Environment_Application{
 						"foo": {
 							UndeployVersion: false,
+							Version:         666,
 						},
 					},
 				},
@@ -888,6 +895,7 @@ func TestDeriveUndeploySummary(t *testing.T) {
 					Applications: map[string]*api.Environment_Application{
 						"foo": {
 							UndeployVersion: true,
+							Version:         666,
 						},
 					},
 				},
@@ -895,6 +903,7 @@ func TestDeriveUndeploySummary(t *testing.T) {
 					Applications: map[string]*api.Environment_Application{
 						"foo": {
 							UndeployVersion: false,
+							Version:         666,
 						},
 					},
 				},


### PR DESCRIPTION
If there is an app lock while deleting an app, we ignore the lock (and delete it too).

Env locks are not considered or touched for deletion of apps.
