### PR TITLE
Add sqlite backend to kuberpult

### DIFF
--- a/README_DEVELOPERS.md
+++ b/README_DEVELOPERS.md
@@ -151,6 +151,12 @@ echo "export PKG_CONFIG_PATH=/opt/local/lib/pkgconfig" >> ~/.zshrc
 source ~/.zshrc
   ```
 
+-  libsqlite3
+
+On ubuntu: install the apt package `libsqlite3-dev`
+On mac: install the macports package `sqlite3`
+
+
 - Chart Testing:
   - install `helm`, `Yamale`, `Yamllint` as prerequisites to `ct` from https://github.com/helm/chart-testing#installation
   - then follow the instructions to install `ct`

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -139,11 +139,8 @@ spec:
         - name: KUBERPULT_BOOTSTRAP_MODE
           value: "{{ .Values.environment_configs.bootstrap_mode }}"
 {{- end }}
-{{- if .Values.cd.disableSqlite }}
-        - name: KUBERPULT_DISABLE_SQLITE
-          value: "true"
-{
-{{- end }}
+        - name: KUBERPULT_ENABLE_SQLITE
+          value: "{{ .Values.cd.enableSqlite }}"
         volumeMounts:
         - name: repository
           mountPath: /repository

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -139,6 +139,11 @@ spec:
         - name: KUBERPULT_BOOTSTRAP_MODE
           value: "{{ .Values.environment_configs.bootstrap_mode }}"
 {{- end }}
+{{- if .Values.cd.disableSqlite }}
+        - name: KUBERPULT_DISABLE_SQLITE
+          value: "true"
+{
+{{- end }}
         volumeMounts:
         - name: repository
           mountPath: /repository

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -27,7 +27,7 @@ cd:
     requests:
       cpu: 2
       memory: 3Gi
-  disableSqlite: false
+  enableSqlite: true
 frontend:
   image: kuberpult-frontend-service
   resources:

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -27,6 +27,7 @@ cd:
     requests:
       cpu: 2
       memory: 3Gi
+  disableSqlite: false
 frontend:
   image: kuberpult-frontend-service
   resources:

--- a/check.sh
+++ b/check.sh
@@ -137,6 +137,15 @@ do
     fix_file_yaml_make $yaml_file
 done
 
+# Read all c/h files
+c_files=$(find . -type f -name '*.[ch]')
+echo fixing c files...
+for c_file in $c_files
+do
+    fix_file $c_file
+done
+
+
 # Read all Make files
 make_files=$(find . -type f -name "Makefile*")
 echo fixing make files...

--- a/codereviewr.yaml
+++ b/codereviewr.yaml
@@ -23,6 +23,7 @@ ignoredFiles: [
     "*.VERSION",
     "*.arb",
     "*.avro",
+    "*.c",
     "*.firebaserc",
     "*.g.dart",
     "*.gcloudignore",

--- a/infrastructure/docker/backend/Dockerfile
+++ b/infrastructure/docker/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17
 
-RUN apk --update add --no-cache curl make go git libgit2-dev pkgconfig build-base
+RUN apk --update add --no-cache curl make go git libgit2-dev sqlite sqlite-dev pkgconfig build-base
 RUN BIN="/usr/local/bin" && \
   curl -sSL \
     "https://github.com/bufbuild/buf/releases/download/v1.7.0/buf-Linux-x86_64" \

--- a/services/cd-service/Dockerfile
+++ b/services/cd-service/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17
 LABEL org.opencontainers.image.source https://github.com/freiheit-com/kuberpult
-RUN apk --update add ca-certificates tzdata libgit2 git
+RUN apk --update add ca-certificates tzdata libgit2 git sqlite
 ENV TZ=Europe/Berlin
 COPY gitconfig /etc/gitconfig
 COPY bin/main /

--- a/services/cd-service/Dockerfile
+++ b/services/cd-service/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17
 LABEL org.opencontainers.image.source https://github.com/freiheit-com/kuberpult
-RUN apk --update add ca-certificates tzdata libgit2 git sqlite
+RUN apk --update add ca-certificates tzdata libgit2 git sqlite-libs
 ENV TZ=Europe/Berlin
 COPY gitconfig /etc/gitconfig
 COPY bin/main /

--- a/services/cd-service/pkg/httperrors/httperrors.go
+++ b/services/cd-service/pkg/httperrors/httperrors.go
@@ -33,5 +33,5 @@ func InternalError(ctx context.Context, err error) error {
 func PublicError(ctx context.Context, err error) error {
 	logger := logger.FromContext(ctx)
 	logger.Error("grpc.internal", zap.Error(err))
-	return status.Error(codes.InvalidArgument, "error: " + err.Error())
+	return status.Error(codes.InvalidArgument, "error: "+err.Error())
 }

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -139,6 +139,7 @@ func openOrCreate(path string, disableSqlite bool) (*git.Repository, error) {
 		if err != nil {
 			return nil, fmt.Errorf("gettting odb: %w", err)
 		}
+                // Prioriority 99 ensures that libgit prefers this backend for writing over its buildin backends.
 		err = odb.AddBackend(be, 99)
 		if err != nil {
 			return nil, fmt.Errorf("setting odb backend: %w", err)

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -706,7 +706,7 @@ func TestGc(t *testing.T) {
 			GcFrequency:        0,
 			DisableSqlite:      true,
 			ExpectedGarbageMin: 907,
-			ExpectedGarbageMax: 908,
+			ExpectedGarbageMax: 910,
 		},
 		{
 			// we are going to perform 101 requests, that should trigger a gc

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -695,7 +695,7 @@ func TestGc(t *testing.T) {
 	tcs := []struct {
 		Name               string
 		GcFrequency        uint
-		DisableSqlite      bool
+		StorageBackend     StorageBackend
 		ExpectedGarbageMin uint64
 		ExpectedGarbageMax uint64
 	}{
@@ -704,7 +704,7 @@ func TestGc(t *testing.T) {
 			// we are reasonably expecting some additional files around
 			Name:               "gc disabled",
 			GcFrequency:        0,
-			DisableSqlite:      true,
+			StorageBackend:     GitBackend,
 			ExpectedGarbageMin: 907,
 			ExpectedGarbageMax: 910,
 		},
@@ -713,16 +713,15 @@ func TestGc(t *testing.T) {
 			// the number of additional files should be lower than in the case above
 			Name:               "gc enabled",
 			GcFrequency:        100,
-			DisableSqlite:      true,
+			StorageBackend:     GitBackend,
 			ExpectedGarbageMin: 9,
 			ExpectedGarbageMax: 10,
 		},
 		{
-			// 0 disables GC entirely
-			// enabling sqlite should bring the number of loose files down to 0 however
-			Name:               "gc disabled + sqlite",
-			GcFrequency:        0,
-			DisableSqlite:      false,
+			// enabling sqlite should bring the number of loose files down to 0
+			Name:               "sqlite",
+			GcFrequency:        0, // the actual number here doesn't matter. GC is not run when sqlite is in use
+			StorageBackend:     SqliteBackend,
 			ExpectedGarbageMin: 0,
 			ExpectedGarbageMax: 0,
 		},
@@ -743,10 +742,10 @@ func TestGc(t *testing.T) {
 			repo, err := New(
 				ctx,
 				RepositoryConfig{
-					URL:           "file://" + remoteDir,
-					Path:          localDir,
-					GcFrequency:   tc.GcFrequency,
-					DisableSqlite: tc.DisableSqlite,
+					URL:            "file://" + remoteDir,
+					Path:           localDir,
+					GcFrequency:    tc.GcFrequency,
+					StorageBackend: tc.StorageBackend,
 				},
 			)
 			if err != nil {

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -723,6 +723,7 @@ func TestGc(t *testing.T) {
 			Name:               "gc disabled + sqlite",
 			GcFrequency:        0,
 			DisableSqlite:      false,
+			ExpectedGarbageMin: 0,
 			ExpectedGarbageMax: 0,
 		},
 	}

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -693,87 +693,92 @@ func TestConfigValidity(t *testing.T) {
 
 func TestGc(t *testing.T) {
 	tcs := []struct {
-		Name          string
-		GcFrequencies []uint
-		CreateGarbage func(t *testing.T, repo *repository)
-		Test          func(t *testing.T, repos []*repository)
+		Name               string
+		GcFrequency        uint
+		DisableSqlite      bool
+		ExpectedGarbageMin uint64
+		ExpectedGarbageMax uint64
 	}{
 		{
-			Name: "simple",
-			GcFrequencies: []uint{
-				// 0 disables GC entirely
-				0,
-				// we are going to perform 101 requests, that should trigger a gc
-				101,
-			},
-			CreateGarbage: func(t *testing.T, repo *repository) {
-				ctx := context.Background()
-				err := repo.Apply(ctx, &CreateEnvironment{
-					Environment: "test",
-				})
-				if err != nil {
-					t.Fatal(err)
-				}
-				for i := 0; i < 100; i++ {
-					err := repo.Apply(ctx, &CreateApplicationVersion{
-						Application: "test",
-						Manifests: map[string]string{
-							"test": fmt.Sprintf("test%d", i),
-						},
-					})
-					if err != nil {
-						t.Fatal(err)
-					}
-				}
-			},
-			Test: func(t *testing.T, repos []*repository) {
-				ctx := context.Background()
-				stats0, err := repos[0].countObjects(ctx)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if stats0.Count == 0 {
-					t.Errorf("expected object count to not be 0, but got %d", stats0.Count)
-				}
-				stats1, err := repos[1].countObjects(ctx)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if stats1.Count != 0 {
-					t.Errorf("expected object count to be 0, but got %d", stats1.Count)
-				}
-			},
+			// 0 disables GC entirely
+			// we are reasonably expecting some additional files around
+			Name:               "gc disabled",
+			GcFrequency:        0,
+			DisableSqlite:      true,
+			ExpectedGarbageMin: 907,
+			ExpectedGarbageMax: 908,
+		},
+		{
+			// we are going to perform 101 requests, that should trigger a gc
+			// the number of additional files should be lower than in the case above
+			Name:               "gc enabled",
+			GcFrequency:        100,
+			DisableSqlite:      true,
+			ExpectedGarbageMin: 9,
+			ExpectedGarbageMax: 10,
+		},
+		{
+			// 0 disables GC entirely
+			// enabling sqlite should bring the number of loose files down to 0 however
+			Name:               "gc disabled + sqlite",
+			GcFrequency:        0,
+			DisableSqlite:      false,
+			ExpectedGarbageMax: 0,
 		},
 	}
+
 	for _, tc := range tcs {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			// create a remote
-			repos := make([]*repository, len(tc.GcFrequencies))
-			for i, gcFrequency := range tc.GcFrequencies {
-				dir := t.TempDir()
-				remoteDir := path.Join(dir, "remote")
-				localDir := path.Join(dir, "local")
-				cmd := exec.Command("git", "init", "--bare", remoteDir)
-				cmd.Start()
-				cmd.Wait()
-				repo, err := New(
-					context.Background(),
-					RepositoryConfig{
-						URL:         "file://" + remoteDir,
-						Path:        localDir,
-						GcFrequency: gcFrequency,
-					},
-				)
-				if err != nil {
-					t.Fatalf("new: expected no error, got '%e'", err)
-				}
-				repoInternal := repo.(*repository)
-				tc.CreateGarbage(t, repoInternal)
-				repos[i] = repoInternal
+			dir := t.TempDir()
+			remoteDir := path.Join(dir, "remote")
+			localDir := path.Join(dir, "local")
+			cmd := exec.Command("git", "init", "--bare", remoteDir)
+			cmd.Start()
+			cmd.Wait()
+			ctx := context.Background()
+			repo, err := New(
+				ctx,
+				RepositoryConfig{
+					URL:           "file://" + remoteDir,
+					Path:          localDir,
+					GcFrequency:   tc.GcFrequency,
+					DisableSqlite: tc.DisableSqlite,
+				},
+			)
+			if err != nil {
+				t.Fatalf("new: expected no error, got '%e'", err)
 			}
-			tc.Test(t, repos)
+
+			err = repo.Apply(ctx, &CreateEnvironment{
+				Environment: "test",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := 0; i < 100; i++ {
+				err := repo.Apply(ctx, &CreateApplicationVersion{
+					Application: "test",
+					Manifests: map[string]string{
+						"test": fmt.Sprintf("test%d", i),
+					},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			stats, err := repo.(*repository).countObjects(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stats.Count > tc.ExpectedGarbageMax {
+				t.Errorf("expected object count to be lower than %d, but got %d", tc.ExpectedGarbageMax, stats.Count)
+			}
+			if stats.Count < tc.ExpectedGarbageMin {
+				t.Errorf("expected object count to be higher than %d, but got %d", tc.ExpectedGarbageMin, stats.Count)
+			}
 		})
 	}
 }

--- a/services/cd-service/pkg/sqlitestore/README.md
+++ b/services/cd-service/pkg/sqlitestore/README.md
@@ -1,0 +1,3 @@
+# sqlitestore
+
+This is a sqlite storage backend for git2go. The file sqlite.c is a verbatim copy of https://github.com/libgit2/libgit2-backends/blob/d9dec3a83a2d74d9ff6f40734c623e45a616676e/sqlite/sqlite.c .

--- a/services/cd-service/pkg/sqlitestore/README.md
+++ b/services/cd-service/pkg/sqlitestore/README.md
@@ -1,3 +1,0 @@
-# sqlitestore
-
-This is a sqlite storage backend for git2go. The file sqlite.c is inspired by https://github.com/libgit2/libgit2-backends/blob/d9dec3a83a2d74d9ff6f40734c623e45a616676e/sqlite/sqlite.c .

--- a/services/cd-service/pkg/sqlitestore/README.md
+++ b/services/cd-service/pkg/sqlitestore/README.md
@@ -1,3 +1,3 @@
 # sqlitestore
 
-This is a sqlite storage backend for git2go. The file sqlite.c is a verbatim copy of https://github.com/libgit2/libgit2-backends/blob/d9dec3a83a2d74d9ff6f40734c623e45a616676e/sqlite/sqlite.c .
+This is a sqlite storage backend for git2go. The file sqlite.c is inspired by https://github.com/libgit2/libgit2-backends/blob/d9dec3a83a2d74d9ff6f40734c623e45a616676e/sqlite/sqlite.c .

--- a/services/cd-service/pkg/sqlitestore/sqlite.c
+++ b/services/cd-service/pkg/sqlitestore/sqlite.c
@@ -1,0 +1,212 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+#include <git2.h>
+#include <git2/sys/odb_backend.h>
+#include <sqlite3.h>
+#include <string.h>
+#include "sqlite.h"
+
+typedef struct {
+	git_odb_backend parent;
+	sqlite3 *db;
+	sqlite3_stmt *read;
+	sqlite3_stmt *write;
+	sqlite3_stmt *read_header;
+} kp_backend;
+
+int kp_backend__read_header(size_t *len_out, git_otype *type_out, git_odb_backend *_backend, const git_oid *oid)
+{
+	kp_backend *backend = (kp_backend *)_backend;
+	int error = GIT_ERROR;
+        if( sqlite3_bind_text(backend->read_header, 1, (char *)oid->id, 20, SQLITE_TRANSIENT) != SQLITE_OK) {
+
+          goto cleanup;
+        }
+	if (sqlite3_step(backend->read_header) == SQLITE_ROW) {
+	  *type_out = (git_otype)sqlite3_column_int(backend->read_header, 0);
+	  *len_out = (size_t)sqlite3_column_int(backend->read_header, 1);
+	  error = GIT_OK;
+	} else {
+	  error = GIT_ENOTFOUND;
+	}
+cleanup:
+	sqlite3_reset(backend->read_header);
+	return error;
+}
+
+int kp_backend__read(void **data_out, size_t *len_out, git_otype *type_out, git_odb_backend *_backend, const git_oid *oid)
+{
+	kp_backend *backend = (kp_backend *)_backend;
+	int error = GIT_ERROR;
+
+	if (sqlite3_bind_text(backend->read, 1, (char *)oid->id, 20, SQLITE_TRANSIENT) != SQLITE_OK) {
+          goto cleanup;
+        }
+	if (sqlite3_step(backend->read) == SQLITE_ROW) {
+		*type_out = (git_otype)sqlite3_column_int(backend->read, 0);
+		*len_out = (size_t)sqlite3_column_int(backend->read, 1);
+		*data_out = malloc(*len_out);
+
+		if (*data_out == NULL) {
+			giterr_set_oom();
+			error = GIT_ERROR;
+		} else {
+			memcpy(*data_out, sqlite3_column_blob(backend->read, 2), *len_out);
+			error = GIT_OK;
+		}
+	} else {
+		error = GIT_ENOTFOUND;
+	}
+cleanup:
+	sqlite3_reset(backend->read);
+	return error;
+}
+
+int kp_backend__read_prefix(git_oid *out_oid, void **data_p, size_t *len_p, git_otype *type_p, git_odb_backend *_backend,
+					const git_oid *short_oid, size_t len) {
+	if (len >= GIT_OID_HEXSZ) {
+		/* Just match the full identifier */
+		int error = kp_backend__read(data_p, len_p, type_p, _backend, short_oid);
+		if (error == GIT_OK)
+			git_oid_cpy(out_oid, short_oid);
+
+		return error;
+	}
+	/* not implemented (yet) */
+	return GIT_ERROR;
+}
+
+int kp_backend__exists(git_odb_backend *_backend, const git_oid *oid)
+{
+	kp_backend *backend;
+	int found;
+
+
+	backend = (kp_backend *)_backend;
+	found = 0;
+
+	if (sqlite3_bind_text(backend->read_header, 1, (char *)oid->id, 20, SQLITE_TRANSIENT) == SQLITE_OK) {
+		if (sqlite3_step(backend->read_header) == SQLITE_ROW) {
+			found = 1;
+		}
+	}
+
+	sqlite3_reset(backend->read_header);
+	return found;
+}
+
+
+int kp_backend__write(git_odb_backend *_backend, const git_oid *id, const void *data, size_t len, git_otype type)
+{
+	int error;
+	kp_backend *backend;
+
+
+	backend = (kp_backend *)_backend;
+
+	error = SQLITE_ERROR;
+
+	if (sqlite3_bind_text(backend->write, 1, (char *)id->id, 20, SQLITE_TRANSIENT) == SQLITE_OK &&
+		sqlite3_bind_int(backend->write, 2, (int)type) == SQLITE_OK &&
+		sqlite3_bind_int(backend->write, 3, len) == SQLITE_OK &&
+		sqlite3_bind_blob(backend->write, 4, data, len, SQLITE_TRANSIENT) == SQLITE_OK) {
+		error = sqlite3_step(backend->write);
+	}
+
+	sqlite3_reset(backend->write);
+	return (error == SQLITE_DONE) ? GIT_OK : GIT_ERROR;
+}
+
+
+void kp_backend__free(git_odb_backend *_backend)
+{
+	kp_backend *backend;
+	backend = (kp_backend *)_backend;
+
+	sqlite3_finalize(backend->read);
+	sqlite3_finalize(backend->read_header);
+	sqlite3_finalize(backend->write);
+	sqlite3_close(backend->db);
+
+	free(backend);
+}
+
+static int create_table_if_not_exists(sqlite3 *db)
+{
+	return sqlite3_exec(db, 
+                "CREATE TABLE IF NOT EXISTS 'odb' ("
+		"'oid' CHARACTER(20) PRIMARY KEY NOT NULL,"
+		"'type' INTEGER NOT NULL,"
+		"'size' INTEGER NOT NULL,"
+		"'data' BLOB);", NULL, NULL, NULL);
+}
+
+static int init_statements(kp_backend *backend)
+{
+        int error = SQLITE_ERROR;
+	error = sqlite3_prepare_v2(backend->db,
+			    "SELECT type, size, data FROM 'odb' WHERE oid = ?;"
+			    , -1, &backend->read, NULL);
+        if( error != SQLITE_OK ){
+		return error;
+        }
+        error = sqlite3_prepare_v2(backend->db,
+				   "SELECT type, size FROM 'odb' WHERE oid = ?;",
+				   -1, &backend->read_header, NULL);
+        if( error != SQLITE_OK ){
+		return error;
+        }
+	return sqlite3_prepare_v2(backend->db,
+			   "INSERT OR IGNORE INTO 'odb' VALUES (?, ?, ?, ?);",
+			   -1, &backend->write, NULL);
+}
+
+int kp_backend_sqlite(git_odb_backend **backend_out, const char *sqlite_db, const char **err_out)
+{
+	int error = SQLITE_ERROR;
+	kp_backend *backend = calloc(1, sizeof(kp_backend));
+	if (backend == NULL) {
+		giterr_set_oom();
+		return SQLITE_ERROR;
+	}
+
+        error = sqlite3_open(sqlite_db, &backend->db);
+	if (error != SQLITE_OK)
+		goto cleanup;
+
+	error = create_table_if_not_exists(backend->db);
+	if (error != SQLITE_OK)
+		goto cleanup;
+
+	error = init_statements(backend);
+	if (error != SQLITE_OK)
+		goto cleanup;
+
+	backend->parent.version = GIT_ODB_BACKEND_VERSION;
+	backend->parent.read = &kp_backend__read;
+	backend->parent.read_prefix = &kp_backend__read_prefix;
+	backend->parent.read_header = &kp_backend__read_header;
+	backend->parent.write = &kp_backend__write;
+	backend->parent.exists = &kp_backend__exists;
+	backend->parent.free = &kp_backend__free;
+
+	*backend_out = (git_odb_backend *)backend;
+        return SQLITE_OK;
+cleanup:
+        *err_out = sqlite3_errmsg(backend->db);
+	kp_backend__free((git_odb_backend *)backend);
+	return error;
+}

--- a/services/cd-service/pkg/sqlitestore/sqlite.h
+++ b/services/cd-service/pkg/sqlitestore/sqlite.h
@@ -13,12 +13,6 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
+#include <git2/sys/odb_backend.h>
 
-// Main file for microservice cd-service.
-package main
-
-import "github.com/freiheit-com/kuberpult/services/cd-service/pkg/cmd"
-
-func main() {
-	cmd.RunServer()
-}
+int kp_backend_sqlite(git_odb_backend **backend_out, const char *sqlite_db, const char **err_out);

--- a/services/cd-service/pkg/sqlitestore/sqlitestore.go
+++ b/services/cd-service/pkg/sqlitestore/sqlitestore.go
@@ -1,5 +1,4 @@
-/*
-This file is part of kuberpult.
+/*This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -13,8 +12,7 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright 2023 freiheit.com
-*/
+Copyright 2023 freiheit.com*/
 package sqlitestore
 
 // #cgo pkg-config: sqlite3 libgit2

--- a/services/cd-service/pkg/sqlitestore/sqlitestore.go
+++ b/services/cd-service/pkg/sqlitestore/sqlitestore.go
@@ -1,0 +1,61 @@
+/*
+This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com
+*/
+package sqlitestore
+
+// #cgo pkg-config: sqlite3 libgit2
+/*
+#include <git2.h>
+#include <sqlite3.h>
+#include "sqlite.h"
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	git "github.com/libgit2/git2go/v34"
+)
+
+func NewOdbBackend(name string) (*git.OdbBackend, error) {
+	var (
+		result  *C.git_odb_backend
+		err_out *C.char
+	)
+	err := C.kp_backend_sqlite(&result, C.CString(name), &err_out)
+	if err != C.SQLITE_OK {
+		str := C.GoString(C.sqlite3_errstr(err))
+		return nil, fmt.Errorf("sqlitestore: %d %s %s", err, str, C.GoString(err_out))
+	}
+	return git.NewOdbBackendFromC(unsafe.Pointer(result)), nil
+}
+
+func NewOdb(name string) (*git.Odb, error) {
+	odb, err := git.NewOdb()
+	if err != nil {
+		return nil, fmt.Errorf("creating odb: %w", err)
+	}
+	be, err := NewOdbBackend(name)
+	if err != nil {
+		return nil, fmt.Errorf("creating odb backend: %w", err)
+	}
+	err = odb.AddBackend(be, 0)
+	if err != nil {
+		return nil, fmt.Errorf("setting odb backend: %w", err)
+	}
+	return odb, nil
+}

--- a/services/cd-service/pkg/sqlitestore/sqlitestore.go
+++ b/services/cd-service/pkg/sqlitestore/sqlitestore.go
@@ -41,19 +41,3 @@ func NewOdbBackend(name string) (*git.OdbBackend, error) {
 	}
 	return git.NewOdbBackendFromC(unsafe.Pointer(result)), nil
 }
-
-func NewOdb(name string) (*git.Odb, error) {
-	odb, err := git.NewOdb()
-	if err != nil {
-		return nil, fmt.Errorf("creating odb: %w", err)
-	}
-	be, err := NewOdbBackend(name)
-	if err != nil {
-		return nil, fmt.Errorf("creating odb backend: %w", err)
-	}
-	err = odb.AddBackend(be, 0)
-	if err != nil {
-		return nil, fmt.Errorf("setting odb backend: %w", err)
-	}
-	return odb, nil
-}

--- a/services/cd-service/pkg/sqlitestore/sqlitestore_test.go
+++ b/services/cd-service/pkg/sqlitestore/sqlitestore_test.go
@@ -1,5 +1,4 @@
-/*
-This file is part of kuberpult.
+/*This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -13,8 +12,7 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright 2023 freiheit.com
-*/
+Copyright 2023 freiheit.com*/
 package sqlitestore
 
 import (

--- a/services/cd-service/pkg/sqlitestore/sqlitestore_test.go
+++ b/services/cd-service/pkg/sqlitestore/sqlitestore_test.go
@@ -1,0 +1,51 @@
+/*
+This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com
+*/
+package sqlitestore
+
+import (
+	"testing"
+
+	git "github.com/libgit2/git2go/v34"
+)
+
+func TestMemory(t *testing.T) {
+	be, err := NewOdbBackend(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	odb, err := git.NewOdb()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = odb.AddBackend(be, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := "foo"
+	oid, err := odb.Write([]byte(data), git.ObjectBlob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := odb.Read(oid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(result.Data()) != data {
+		t.Errorf("unexpected result, expected: %q, actual: %q", data, string(result.Data()))
+	}
+}

--- a/services/cd-service/pkg/sqlitestore/sqlitestore_test.go
+++ b/services/cd-service/pkg/sqlitestore/sqlitestore_test.go
@@ -21,7 +21,7 @@ import (
 	git "github.com/libgit2/git2go/v34"
 )
 
-func TestMemory(t *testing.T) {
+func TestWriteAndRead(t *testing.T) {
 	be, err := NewOdbBackend(":memory:")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The git storage format is a tricky thing. Git stores new files as single files on disk and compacts them occassionally into bigger files containing multiple smaller files. We need to start an external process that does this compaction. When the process works, it deletes the packed files that are still openend by libgit and so leaves deleted file descriptors hanging around. When the process doesn't work, it leaves ugly error messages.

Sqlite in contrast is a proven storage mechanism that always uses a single file to store its data regardless of the number of entries added. The good thing is that it doesn't require any external compaction runs. By leveraging the libgits storage backend interface, we get libgit to store its data in sqlite instead of git pack files. The effect can be seen in https://github.com/freiheit-com/kuberpult/pull/592/files#diff-d3c9aba18b29ecc1d2f60409e4cc414f7083ebfcf0f572e1bcf9e8117ba358b1R723 . Even though we never run any garbage collections, the number of loose files ( called garbage here ) stays at exactly zero.

Fixes #551