### PR TITLE
DRAFT workaround git repack issue

### DIFF
--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -670,7 +670,7 @@ func (r *repository) maybeGc(ctx context.Context) {
 	cmd.Dir = r.config.Path
 	err := cmd.Run()
 	if err != nil {
-		log.Error("git.repack", zap.Error(err))
+		log.Fatal("git.repack", zap.Error(err))
 		return
 	}
 	statsAfter, _ := r.countObjects(ctx)


### PR DESCRIPTION
The issue fixes itself with a new volume, and we get a new volume when the pod restarts. "Fatal" runs "os.Exit(1)" automatically.