### PR TITLE
Bugfix: Allow full page reload in UI

### DIFF
--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -231,7 +231,7 @@ func RunServer() {
 						return
 					}
 				}
-				if strings.HasPrefix(req.URL.Path, "/home") {
+				if strings.HasSuffix(req.URL.Path, "/home") || strings.HasSuffix(req.URL.Path, "/environments") || strings.HasSuffix(req.URL.Path, "/locks") {
 					http.ServeFile(resp, req, "build/index.html")
 				} else {
 					mux.ServeHTTP(resp, req)


### PR DESCRIPTION
Before this change, a full page reload in the browser on the pages "/locks" and "/environments" lead to a "not found" or similar message