### PR TITLE
Allow Release Dialog to open via query parameters

### DIFF
--- a/services/frontend-service/src/ui/App/index.test.tsx
+++ b/services/frontend-service/src/ui/App/index.test.tsx
@@ -19,6 +19,7 @@ import { Spy } from 'spy4js';
 import { AzureAuthSub } from '../utils/AzureAuthProvider';
 import { Observable } from 'rxjs';
 import { PanicOverview, UpdateOverview } from '../utils/store';
+import { MemoryRouter } from 'react-router-dom';
 
 Spy.mockModule('../components/NavigationBar/NavigationBar', 'NavigationBar');
 Spy.mockModule('../components/TopAppBar/TopAppBar', 'TopAppBar');
@@ -44,7 +45,11 @@ jest.mock('../utils/GrpcApi', () => ({
     },
 }));
 
-const getNode = (): JSX.Element => <App />;
+const getNode = (): JSX.Element => (
+    <MemoryRouter>
+        <App />
+    </MemoryRouter>
+);
 const getWrapper = () => render(getNode());
 
 describe('App uses the API', () => {

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -19,7 +19,7 @@ import { ReleaseDialog } from '../components/ReleaseDialog/ReleaseDialog';
 import { PageRoutes } from './PageRoutes';
 import '../../assets/app-v2.scss';
 import * as React from 'react';
-import { PanicOverview, showSnackbarWarn, UpdateOverview, useReleaseDialog, useReleaseInfo } from '../utils/store';
+import { PanicOverview, showSnackbarWarn, UpdateOverview, useValidReleaseDialogParams } from '../utils/store';
 import { useApi } from '../utils/GrpcApi';
 import { AzureAuthProvider, UpdateFrontendConfig, useAzureAuthSub } from '../utils/AzureAuthProvider';
 import { Snackbar } from '../components/snackbar/snackbar';
@@ -88,13 +88,12 @@ export const App: React.FC = () => {
         }
     );
 
-    const { app, version } = useReleaseDialog(({ app, version }) => ({ app, version }));
-    const releaseInfo = useReleaseInfo(app, version);
+    const [app, version] = useValidReleaseDialogParams();
 
     return (
         <AzureAuthProvider>
             <div className={'app-container--v2'}>
-                <ReleaseDialog app={app} version={version} release={releaseInfo} />
+                {app ? <ReleaseDialog app={app} version={version} /> : null}
                 <NavigationBar />
                 <div className="mdc-drawer-app-content">
                     <TopAppBar />

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -88,12 +88,12 @@ export const App: React.FC = () => {
         }
     );
 
-    const [app, version] = useValidReleaseDialogParams();
+    const { app, version } = useValidReleaseDialogParams();
 
     return (
         <AzureAuthProvider>
             <div className={'app-container--v2'}>
-                {app ? <ReleaseDialog app={app} version={version} /> : null}
+                {app && version ? <ReleaseDialog app={app} version={version} /> : null}
                 <NavigationBar />
                 <div className="mdc-drawer-app-content">
                     <TopAppBar />

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -19,7 +19,7 @@ import { ReleaseDialog } from '../components/ReleaseDialog/ReleaseDialog';
 import { PageRoutes } from './PageRoutes';
 import '../../assets/app-v2.scss';
 import * as React from 'react';
-import { PanicOverview, showSnackbarWarn, UpdateOverview, useValidReleaseDialogParams } from '../utils/store';
+import { PanicOverview, showSnackbarWarn, UpdateOverview, useReleaseDialogParams } from '../utils/store';
 import { useApi } from '../utils/GrpcApi';
 import { AzureAuthProvider, UpdateFrontendConfig, useAzureAuthSub } from '../utils/AzureAuthProvider';
 import { Snackbar } from '../components/snackbar/snackbar';
@@ -88,7 +88,7 @@ export const App: React.FC = () => {
         }
     );
 
-    const { app, version } = useValidReleaseDialogParams();
+    const { app, version } = useReleaseDialogParams();
 
     return (
         <AzureAuthProvider>

--- a/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.tsx
@@ -16,7 +16,7 @@ Copyright 2023 freiheit.com*/
 import { Releases } from '../../components/Releases/Releases';
 
 export const ReleasesPage: React.FC = () => {
-    const url = window.location.href.split('/');
+    const url = window.location.pathname.split('/');
     const app_name = url[url.length - 1];
     return (
         <main className="main-content">

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.test.tsx
@@ -16,6 +16,7 @@ Copyright 2023 freiheit.com*/
 import { getFormattedReleaseDate, ReleaseCard, ReleaseCardProps } from './ReleaseCard';
 import { render } from '@testing-library/react';
 import { UpdateOverview } from '../../utils/store';
+import { MemoryRouter } from 'react-router-dom';
 
 describe('Relative Date Calculation', () => {
     // the test release date ===  18/06/2001 is constant across this test
@@ -69,7 +70,11 @@ describe('Relative Date Calculation', () => {
 });
 
 describe('Release Card', () => {
-    const getNode = (overrides: ReleaseCardProps) => <ReleaseCard {...overrides} />;
+    const getNode = (overrides: ReleaseCardProps) => (
+        <MemoryRouter>
+            <ReleaseCard {...overrides} />
+        </MemoryRouter>
+    );
     const getWrapper = (overrides: ReleaseCardProps) => render(getNode(overrides));
 
     const data = [

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -18,7 +18,7 @@ import { Button } from '../button';
 import { Tooltip } from '../tooltip/tooltip';
 import React, { useEffect, useRef } from 'react';
 import { MDCRipple } from '@material/ripple';
-import { updateReleaseDialog, useRelease } from '../../utils/store';
+import { useRelease, useOpenReleaseDialog } from '../../utils/store';
 import { EnvironmentGroupChipList } from '../chip/EnvironmentGroupChip';
 
 const getRelativeDate = (date: Date): string => {
@@ -77,9 +77,7 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
     const control = useRef<HTMLDivElement>(null);
     const { className, app, version } = props;
     const { createdAt, sourceMessage, sourceCommitId, sourceAuthor, undeployVersion } = useRelease(app, version);
-    const clickHandler = React.useCallback(() => {
-        updateReleaseDialog(app, version);
-    }, [app, version]);
+    const openReleaseDialog = useOpenReleaseDialog(app, version);
 
     useEffect(() => {
         if (control.current) {
@@ -108,7 +106,7 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
                         className="mdc-card__primary-action release-card__description"
                         ref={control}
                         tabIndex={0}
-                        onClick={clickHandler}>
+                        onClick={openReleaseDialog}>
                         <div className="release-card__header">
                             <div className="release__title">{undeployVersion ? 'Undeploy Version' : sourceMessage}</div>
                             {!!sourceCommitId && <Button className="release__hash" label={sourceCommitId} />}

--- a/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.test.tsx
@@ -16,9 +16,14 @@ Copyright 2023 freiheit.com*/
 import { ReleaseCardMini, ReleaseCardMiniProps } from './ReleaseCardMini';
 import { render } from '@testing-library/react';
 import { UpdateOverview } from '../../utils/store';
+import { MemoryRouter } from 'react-router-dom';
 
 describe('Release Card Mini', () => {
-    const getNode = (overrides: ReleaseCardMiniProps) => <ReleaseCardMini {...overrides} />;
+    const getNode = (overrides: ReleaseCardMiniProps) => (
+        <MemoryRouter>
+            <ReleaseCardMini {...overrides} />
+        </MemoryRouter>
+    );
     const getWrapper = (overrides: ReleaseCardMiniProps) => render(getNode(overrides));
 
     const data = [

--- a/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.tsx
@@ -15,7 +15,7 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright 2023 freiheit.com*/
 import classNames from 'classnames';
 import React from 'react';
-import { updateReleaseDialog, useRelease } from '../../utils/store';
+import { useOpenReleaseDialog, useRelease } from '../../utils/store';
 import { EnvironmentGroupChipList } from '../chip/EnvironmentGroupChip';
 import { undeployTooltipExplanation } from '../ReleaseDialog/ReleaseDialog';
 
@@ -35,9 +35,7 @@ const getDays = (date: Date): number => {
 export const ReleaseCardMini: React.FC<ReleaseCardMiniProps> = (props) => {
     const { className, app, version } = props;
     const { createdAt, sourceMessage, sourceAuthor, undeployVersion } = useRelease(app, version);
-    const clickHanlder = React.useCallback(() => {
-        updateReleaseDialog(app, version);
-    }, [app, version]);
+    const openReleaseDialog = useOpenReleaseDialog(app, version);
     let msg = sourceAuthor;
     if (createdAt !== undefined) {
         const days = getDays(createdAt);
@@ -53,7 +51,7 @@ export const ReleaseCardMini: React.FC<ReleaseCardMiniProps> = (props) => {
     const displayedMessage = undeployVersion ? 'Undeploy Version' : sourceMessage;
     const displayedTitle = undeployVersion ? undeployTooltipExplanation : '';
     return (
-        <div className={classNames('release-card-mini', className)} onClick={clickHanlder}>
+        <div className={classNames('release-card-mini', className)} onClick={openReleaseDialog}>
             <div className={classNames('release__details-mini', className)}>
                 <div className="release__details-header" title={displayedTitle}>
                     {displayedMessage}

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -19,8 +19,9 @@ import React, { useCallback } from 'react';
 import { Environment, EnvironmentGroup, Lock, LockBehavior, Release } from '../../../api/api';
 import {
     addAction,
-    updateReleaseDialog,
+    useCloseReleaseDialog,
     useOverview,
+    useRelease,
     useReleaseOptional,
     useTeamFromApplication,
 } from '../../utils/store';
@@ -33,11 +34,6 @@ export type ReleaseDialogProps = {
     className?: string;
     app: string;
     version: number;
-    release: Release;
-};
-
-const setClosed = (): void => {
-    updateReleaseDialog('', 0);
 };
 
 export type EnvSortOrder = { [index: string]: number };
@@ -240,8 +236,10 @@ export const undeployTooltipExplanation =
     'This is the "undeploy" version. It is essentially an empty manifest. Deploying this means removing all kubernetes entities like deployments from the given environment. You must deploy this to all environments before kuberpult allows to delete the app entirely.';
 
 export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
-    const { app, className, release, version } = props;
+    const { app, className, version } = props;
+    const release = useRelease(app, version);
     const team = useTeamFromApplication(app);
+    const closeReleaseDialog = useCloseReleaseDialog();
     const undeployVersionTitle = release.undeployVersion
         ? undeployTooltipExplanation
         : 'Commit Hash of the source repository.';
@@ -253,7 +251,7 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                     fullWidth={true}
                     maxWidth="md"
                     open={app !== ''}
-                    onClose={setClosed}>
+                    onClose={closeReleaseDialog}>
                     <div className={classNames('release-dialog-app-bar', className)}>
                         <div className={classNames('release-dialog-app-bar-data')}>
                             <div className={classNames('release-dialog-message', className)}>
@@ -275,7 +273,7 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                             {release.undeployVersion ? 'Undeploy Version' : release?.sourceCommitId}
                         </span>
                         <Button
-                            onClick={setClosed}
+                            onClick={closeReleaseDialog}
                             className={classNames('release-dialog-close', className)}
                             icon={<Close />}
                         />

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -1,97 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Release Dialog Renders the environment locks no release 1`] = `
-<body
-  style="padding-right: 0px; overflow: hidden;"
->
-  <div
-    aria-hidden="true"
-  >
-    <div>
-      <div />
-    </div>
-  </div>
-  <div
-    class="MuiModal-root MuiDialog-root release-dialog css-zw3mfo-MuiModal-root-MuiDialog-root"
-    role="presentation"
-  >
-    <div
-      aria-hidden="true"
-      class="MuiBackdrop-root css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
-    />
-    <div
-      data-test="sentinelStart"
-      tabindex="0"
-    />
-    <div
-      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
-      role="presentation"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
-      tabindex="-1"
-    >
-      <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-142erj9-MuiPaper-root-MuiDialog-paper"
-        role="dialog"
-      >
-        <div
-          class="release-dialog-app-bar"
-        >
-          <div
-            class="release-dialog-app-bar-data"
-          >
-            <div
-              class="release-dialog-message"
-            >
-              <span
-                class="release-dialog-commitMessage"
-              />
-            </div>
-            <div
-              class="release-dialog-createdAt"
-            />
-            <div
-              class="release-dialog-author"
-            />
-            <div
-              class="release-dialog-app"
-            >
-              App: test1 
-            </div>
-          </div>
-          <span
-            class="release-dialog-commitId"
-            title="Commit Hash of the source repository."
-          />
-          <button
-            aria-label=""
-            class="mdc-button release-dialog-close"
-          >
-            <div
-              class="mdc-button__ripple"
-            />
-            <svg>
-              Close.svg
-            </svg>
-          </button>
-        </div>
-        <div
-          class="release-env-group-list"
-        >
-          <ul
-            class="release-env-list"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      data-test="sentinelEnd"
-      tabindex="0"
-    />
-  </div>
-</body>
-`;
-
 exports[`Release Dialog Renders the environment locks normal release 1`] = `
 <body
   style="padding-right: 0px; overflow: hidden;"
@@ -370,7 +278,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
               <span
                 class="release-dialog-commitMessage"
               >
-                test1
+                the other commit message 2
               </span>
             </div>
             <div
@@ -383,7 +291,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
             <div
               class="release-dialog-author"
             >
-              Author: test
+              Author: nobody
             </div>
             <div
               class="release-dialog-app"
@@ -395,7 +303,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
             class="release-dialog-commitId"
             title="Commit Hash of the source repository."
           >
-            commit
+            cafe
           </span>
           <button
             aria-label=""
@@ -499,7 +407,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                     class="env-card-data"
                     title="Shows the version that is currently deployed on prod. "
                   >
-                    commit: test1
+                    cafe: the other commit message 2
                   </div>
                 </div>
                 <div
@@ -681,6 +589,106 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
               </div>
             </li>
           </ul>
+        </div>
+      </div>
+    </div>
+    <div
+      data-test="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
+exports[`Release Dialog Renders the environment locks undeploy version release 1`] = `
+<body
+  style="padding-right: 0px; overflow: hidden;"
+>
+  <div
+    aria-hidden="true"
+  >
+    <div>
+      <div />
+    </div>
+  </div>
+  <div
+    class="MuiModal-root MuiDialog-root release-dialog css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-test="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-142erj9-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <div
+          class="release-dialog-app-bar"
+        >
+          <div
+            class="release-dialog-app-bar-data"
+          >
+            <div
+              class="release-dialog-message"
+            >
+              <span
+                class="release-dialog-commitMessage"
+              />
+            </div>
+            <div
+              class="release-dialog-createdAt"
+            >
+              <div>
+                some formatted date
+              </div>
+            </div>
+            <div
+              class="release-dialog-author"
+            >
+              Author: test1
+            </div>
+            <div
+              class="release-dialog-app"
+            >
+              App: test1 
+            </div>
+          </div>
+          <span
+            class="release-dialog-commitId"
+            title="This is the \\"undeploy\\" version. It is essentially an empty manifest. Deploying this means removing all kubernetes entities like deployments from the given environment. You must deploy this to all environments before kuberpult allows to delete the app entirely."
+          >
+            Undeploy Version
+          </span>
+          <button
+            aria-label=""
+            class="mdc-button release-dialog-close"
+          >
+            <div
+              class="mdc-button__ripple"
+            />
+            <svg>
+              Close.svg
+            </svg>
+          </button>
+        </div>
+        <div
+          class="release-env-group-list"
+        >
+          <ul
+            class="release-env-list"
+          />
         </div>
       </div>
     </div>

--- a/services/frontend-service/src/ui/components/Releases/Releases.test.tsx
+++ b/services/frontend-service/src/ui/components/Releases/Releases.test.tsx
@@ -17,6 +17,7 @@ import { Releases } from './Releases';
 import { render } from '@testing-library/react';
 import { UpdateOverview } from '../../utils/store';
 import { Release } from '../../../api/api';
+import { MemoryRouter } from 'react-router-dom';
 
 describe('Release Dialog', () => {
     const data = [
@@ -83,7 +84,11 @@ describe('Release Dialog', () => {
                 applications: { test: { releases: testcase.releases } },
                 environments: {},
             } as any);
-            render(<Releases app="test" />);
+            render(
+                <MemoryRouter>
+                    <Releases app="test" />
+                </MemoryRouter>
+            );
 
             expect(document.querySelectorAll('.release_date')).toHaveLength(testcase.dates);
             expect(document.querySelectorAll('.content')).toHaveLength(testcase.releases.length);

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -192,7 +192,7 @@ export const useCloseReleaseDialog = (): (() => void) => {
     }, [params, setParams]);
 };
 
-export const useValidReleaseDialogParams = (): { app: string | null; version: number | null } => {
+export const useReleaseDialogParams = (): { app: string | null; version: number | null } => {
     const [params] = useSearchParams();
     const app = params.get('dialog-app') ?? '';
     const version = +(params.get('dialog-version') ?? '');

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -192,14 +192,14 @@ export const useCloseReleaseDialog = (): (() => void) => {
     }, [params, setParams]);
 };
 
-export const useValidReleaseDialogParams = (): [string, number] => {
+export const useValidReleaseDialogParams = (): { app: string | null; version: number | null } => {
     const [params] = useSearchParams();
     const app = params.get('dialog-app') ?? '';
     const version = +(params.get('dialog-version') ?? '');
     const valid = useOverview(({ applications }) =>
         applications[app] ? !!applications[app].releases.find((r) => r.version === version) : false
     );
-    return valid ? [app, version] : ['', 0];
+    return valid ? { app, version } : { app: null, version: null };
 };
 
 export const deleteAllActions = (): void => {

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -24,8 +24,9 @@ import {
     Release,
 } from '../../api/api';
 import { useApi } from './GrpcApi';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Empty } from '../../google/protobuf/empty';
+import { useSearchParams } from 'react-router-dom';
 
 export interface DisplayLock {
     date?: Date;
@@ -44,8 +45,6 @@ const emptyBatch: BatchRequest = { actions: [] };
 export const [useAction, UpdateAction] = createStore(emptyBatch);
 
 export const [_, PanicOverview] = createStore({ error: '' });
-
-export const [useReleaseDialog, UpdateReleaseDialog] = createStore({ app: '', version: 0 });
 
 export const useApplyActions = (): Promise<Empty> => useApi.batchService().ProcessBatch({ actions: useActions() });
 
@@ -175,9 +174,34 @@ export const addAction = (action: BatchAction): void => {
     UpdateSidebar.set({ shown: true });
 };
 
-export const updateReleaseDialog = (app: string, version: number): void => {
-    UpdateReleaseDialog.set({ app: app, version: version });
+export const useOpenReleaseDialog = (app: string, version: number): (() => void) => {
+    const [params, setParams] = useSearchParams();
+    return useCallback(() => {
+        params.set('dialog-app', app);
+        params.set('dialog-version', version.toString());
+        setParams(params);
+    }, [app, params, setParams, version]);
 };
+
+export const useCloseReleaseDialog = (): (() => void) => {
+    const [params, setParams] = useSearchParams();
+    return useCallback(() => {
+        params.delete('dialog-app');
+        params.delete('dialog-version');
+        setParams(params);
+    }, [params, setParams]);
+};
+
+export const useValidReleaseDialogParams = (): [string, number] => {
+    const [params] = useSearchParams();
+    const app = params.get('dialog-app') ?? '';
+    const version = +(params.get('dialog-version') ?? '');
+    const valid = useOverview(({ applications }) =>
+        applications[app] ? !!applications[app].releases.find((r) => r.version === version) : false
+    );
+    return valid ? [app, version] : ['', 0];
+};
+
 export const deleteAllActions = (): void => {
     UpdateAction.set({ actions: [] });
 };
@@ -460,16 +484,6 @@ export const useCurrentlyDeployedAtGroup = (application: string, version: number
         return envGroups;
     }, [environmentGroups, application, version]);
 };
-
-// Get release information for a version
-export const useReleaseInfo = (app: string, version: number): Release =>
-    useOverview(({ applications }) => {
-        const releaseInfo = applications[app]?.releases.filter((release) => release.version === version)[0];
-        if (!releaseInfo) {
-            return {} as Release;
-        }
-        return releaseInfo;
-    });
 
 // Get all releases for an app
 export const useReleasesForApp = (app: string): Release[] =>


### PR DESCRIPTION
The two query parameters `dialog-app` and `dialog-version` open the dialog automatically. the release card would set the parameters to show a new dialog. closing the dialog will simply clear the parameters. 

* delete the `useReleaseInfo` hook from the store.
* `useOpenReleaseDialog` to add the query params for some app/version
* `useCloseReleaseDialog` to clear those params
* `useReleaseDialogParams` to get the app/version from the URL and verify that they represent an actual release. => Then open the dialog.
* remove the release dialog store
