### PR TITLE
Allow direct links/reloads of releases page of an application

### DIFF
--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -231,7 +231,7 @@ func RunServer() {
 						return
 					}
 				}
-				if strings.HasSuffix(req.URL.Path, "/home") || strings.HasSuffix(req.URL.Path, "/environments") || strings.HasSuffix(req.URL.Path, "/locks") {
+				if strings.HasPrefix(req.URL.Path, "/home") || strings.HasSuffix(req.URL.Path, "/environments") || strings.HasSuffix(req.URL.Path, "/locks") {
 					http.ServeFile(resp, req, "build/index.html")
 				} else {
 					mux.ServeHTTP(resp, req)


### PR DESCRIPTION
Allow url paths starting with home to be served
this is a fix for #635 