### PR TITLE
Added git commit parameter and field to the overview service

### DIFF
--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -144,12 +144,15 @@ service OverviewService {
 }
 
 message GetOverviewRequest {
+  // Retrieve the overview at a certain state of the repository. If it's empty, the latest commit will be used.
+  string git_revision = 1;
 }
 
 message GetOverviewResponse {
   map<string, Environment> environments = 1 [deprecated=true]; // use environmentGroups instead!
   map<string, Application> applications = 2;
   repeated EnvironmentGroup environmentGroups = 3;
+  string git_revision = 4;
 }
 
 message GetDeployedOverviewRequest {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -635,16 +635,16 @@ func (r *repository) State() *State {
 }
 
 func (r *repository) StateAt(oid *git.Oid) (*State, error) {
-    commit, err := r.repository.LookupCommit(oid)
-		if err != nil {
-			return nil, err
-		}
-      return &State{
-	      Filesystem:             fs.NewTreeBuildFS(r.repository, commit.TreeId()),
-	      Commit:                 commit,
-	      BootstrapMode:          r.config.BootstrapMode,
-	      EnvironmentConfigsPath: r.config.EnvironmentConfigsPath,
-      }, nil
+	commit, err := r.repository.LookupCommit(oid)
+	if err != nil {
+		return nil, err
+	}
+	return &State{
+		Filesystem:             fs.NewTreeBuildFS(r.repository, commit.TreeId()),
+		Commit:                 commit,
+		BootstrapMode:          r.config.BootstrapMode,
+		EnvironmentConfigsPath: r.config.EnvironmentConfigsPath,
+	}, nil
 }
 
 func (r *repository) Notify() *notify.Notify {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -249,7 +249,7 @@ func New(ctx context.Context, cfg RepositoryConfig) (Repository, error) {
 			}
 
 			// check that we can build the current state
-			state, err := result.buildState()
+			state, err := result.StateAt(nil)
 			if err != nil {
 				return nil, err
 			}
@@ -393,7 +393,7 @@ func (r *repository) ProcessQueueOnce(e element) {
 }
 
 func (r *repository) ApplyTransformersInternal(ctx context.Context, transformers ...Transformer) ([]string, *State, error) {
-	if state, err := r.buildState(); err != nil {
+	if state, err := r.StateAt(nil); err != nil {
 		return nil, nil, &InternalError{inner: err}
 	} else {
 		commitMsg := []string{}
@@ -599,35 +599,8 @@ func (r *repository) updateArgoCdApps(ctx context.Context, state *State, name st
 	return nil
 }
 
-func (r *repository) buildState() (*State, error) {
-	if obj, err := r.repository.RevparseSingle(fmt.Sprintf("refs/heads/%s", r.config.Branch)); err != nil {
-		var gerr *git.GitError
-		if errors.As(err, &gerr) {
-			if gerr.Code == git.ErrNotFound {
-				return &State{
-					Filesystem:             fs.NewEmptyTreeBuildFS(r.repository),
-					BootstrapMode:          r.config.BootstrapMode,
-					EnvironmentConfigsPath: r.config.EnvironmentConfigsPath,
-				}, nil
-			}
-		}
-		return nil, err
-	} else {
-		commit, err := obj.AsCommit()
-		if err != nil {
-			return nil, err
-		}
-		return &State{
-			Filesystem:             fs.NewTreeBuildFS(r.repository, commit.TreeId()),
-			Commit:                 commit,
-			BootstrapMode:          r.config.BootstrapMode,
-			EnvironmentConfigsPath: r.config.EnvironmentConfigsPath,
-		}, nil
-	}
-}
-
 func (r *repository) State() *State {
-	s, err := r.buildState()
+	s, err := r.StateAt(nil)
 	if err != nil {
 		panic(err)
 	}
@@ -635,9 +608,32 @@ func (r *repository) State() *State {
 }
 
 func (r *repository) StateAt(oid *git.Oid) (*State, error) {
-	commit, err := r.repository.LookupCommit(oid)
-	if err != nil {
-		return nil, err
+	var commit *git.Commit
+	if oid == nil {
+		if obj, err := r.repository.RevparseSingle(fmt.Sprintf("refs/heads/%s", r.config.Branch)); err != nil {
+			var gerr *git.GitError
+			if errors.As(err, &gerr) {
+				if gerr.Code == git.ErrNotFound {
+					return &State{
+						Filesystem:             fs.NewEmptyTreeBuildFS(r.repository),
+						BootstrapMode:          r.config.BootstrapMode,
+						EnvironmentConfigsPath: r.config.EnvironmentConfigsPath,
+					}, nil
+				}
+			}
+			return nil, err
+		} else {
+			commit, err = obj.AsCommit()
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		var err error
+		commit, err = r.repository.LookupCommit(oid)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &State{
 		Filesystem:             fs.NewTreeBuildFS(r.repository, commit.TreeId()),

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -57,6 +57,7 @@ type Repository interface {
 	Push(ctx context.Context, pushAction func() error) error
 	ApplyTransformersInternal(ctx context.Context, transformers ...Transformer) ([]string, *State, error)
 	State() *State
+	StateAt(oid *git.Oid) (*State, error)
 	Notify() *notify.Notify
 }
 
@@ -631,6 +632,19 @@ func (r *repository) State() *State {
 		panic(err)
 	}
 	return s
+}
+
+func (r *repository) StateAt(oid *git.Oid) (*State, error) {
+    commit, err := r.repository.LookupCommit(oid)
+		if err != nil {
+			return nil, err
+		}
+      return &State{
+	      Filesystem:             fs.NewTreeBuildFS(r.repository, commit.TreeId()),
+	      Commit:                 commit,
+	      BootstrapMode:          r.config.BootstrapMode,
+	      EnvironmentConfigsPath: r.config.EnvironmentConfigsPath,
+      }, nil
 }
 
 func (r *repository) Notify() *notify.Notify {

--- a/services/cd-service/pkg/repository/testrepository/testrepository.go
+++ b/services/cd-service/pkg/repository/testrepository/testrepository.go
@@ -18,8 +18,10 @@ package testrepository
 
 import (
 	"context"
+
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/notify"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
+	git "github.com/libgit2/git2go/v34"
 )
 
 func Failing(err error) repository.Repository {
@@ -45,6 +47,10 @@ func (fr *failingRepository) ApplyTransformersInternal(ctx context.Context, tran
 
 func (fr *failingRepository) State() *repository.State {
 	return &repository.State{}
+}
+
+func (fr *failingRepository) StateAt(oid *git.Oid) (*repository.State, error) {
+	return &repository.State{}, nil
 }
 
 func (fr *failingRepository) Notify() *notify.Notify {

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -429,7 +429,7 @@ func TestOverviewService(t *testing.T) {
 	}
 }
 
-func TestOverviewService2(t *testing.T) {
+func TestOverviewServiceFromCommit(t *testing.T) {
 	type step struct {
 		Transformer repository.Transformer
 	}

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -38,7 +38,12 @@ export interface DisplayLock {
     authorEmail?: string;
 }
 
-const emptyOverview: GetOverviewResponse = { applications: {}, environments: {}, environmentGroups: [], gitRevision: "" };
+const emptyOverview: GetOverviewResponse = {
+    applications: {},
+    environments: {},
+    environmentGroups: [],
+    gitRevision: '',
+};
 const [useOverview, UpdateOverview_] = createStore(emptyOverview);
 export const UpdateOverview = UpdateOverview_; // we do not want to export "useOverview". The store.tsx should act like a facade to the data.
 

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -38,7 +38,7 @@ export interface DisplayLock {
     authorEmail?: string;
 }
 
-const emptyOverview: GetOverviewResponse = { applications: {}, environments: {}, environmentGroups: [] };
+const emptyOverview: GetOverviewResponse = { applications: {}, environments: {}, environmentGroups: [], gitRevision: "" };
 const [useOverview, UpdateOverview_] = createStore(emptyOverview);
 export const UpdateOverview = UpdateOverview_; // we do not want to export "useOverview". The store.tsx should act like a facade to the data.
 


### PR DESCRIPTION
In the rollout service, I get the currently deployed commit id from argo cd. I need some way to figure out the application version of the services in each environment. The overview endpoint already contains this information and we also have a streaming endpoint for it which would make it a perfect fit to use for that usecase. The only thing that is missing is, is the git commit id and an option to retrieve older overviews.

This commit implements exactly this.