### PR TITLE
Add button to delete all similar locks

### DIFF
--- a/services/frontend-service/src/assets/_variables.scss
+++ b/services/frontend-service/src/assets/_variables.scss
@@ -9,7 +9,13 @@ $nav-list-item-height: 130px;
 $nav-list-item-gap: 32px;
 $nav-indicator-width: 4px;
 
-//Sidebar variables
+// Buttons
+$small-warn-button-padding-left: 10px;
+$small-warn-button-padding-right: $small-warn-button-padding-left;
+$small-warn-button-font-size: 8px;
+$small-warn-button-font-weight: 700;
+
+// Sidebar variables
 $sidebar-width: 30em;
 $sidebar-planned-actions-title-right-centering: 9em;
 $sidebar-apply-button-height: 3em;

--- a/services/frontend-service/src/setupTests.ts
+++ b/services/frontend-service/src/setupTests.ts
@@ -15,6 +15,8 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright 2023 freiheit.com*/
 import '@testing-library/jest-dom/extend-expect';
 import 'react-use-sub/test-util';
+import { Lock, Release } from './api/api';
+import { DisplayLock } from './ui/utils/store';
 
 // test utility to await all running promises
 global.nextTick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
@@ -52,3 +54,37 @@ export const getElementsByClassNameSafe = (element: HTMLElement, selectors: stri
     }
     return result;
 };
+
+export const makeRelease = (version: number): Release => ({
+    version: version,
+    sourceMessage: 'test' + version,
+    sourceAuthor: 'test',
+    sourceCommitId: 'commit' + version,
+    createdAt: new Date(2002),
+    undeployVersion: false,
+    prNumber: '666',
+});
+
+const date = new Date(2023, 6, 12);
+
+export const makeLock = (input: Partial<Lock>): Lock => ({
+    lockId: 'l1',
+    message: 'lock msg 1',
+    createdAt: date,
+    createdBy: {
+        name: 'Betty',
+        email: 'betty@example.com',
+    },
+    ...input,
+});
+
+export const makeDisplayLock = (input: Partial<DisplayLock>): DisplayLock => ({
+    lockId: 'l1',
+    message: 'lock msg 1',
+    environment: 'default-env',
+    date: date,
+    // application: 'default-app', // application should not be set here, because it cannot be overwritten with undefined
+    authorEmail: 'default@example.com',
+    authorName: 'default',
+    ...input,
+});

--- a/services/frontend-service/src/ui/components/LocksTable/LocksTable.tsx
+++ b/services/frontend-service/src/ui/components/LocksTable/LocksTable.tsx
@@ -13,7 +13,7 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-import { DisplayLock, sortLocks } from '../../utils/store';
+import { DisplayLock, displayLockUniqueId, sortLocks } from '../../utils/store';
 import { LockDisplay } from '../LockDisplay/LockDisplay';
 import * as React from 'react';
 import { Button } from '../button';
@@ -80,7 +80,7 @@ export const LocksTable: React.FC<{
                         <tr>
                             <td>
                                 {locks.map((lock) => (
-                                    <LockDisplay key={lock.lockId} lock={lock} />
+                                    <LockDisplay key={displayLockUniqueId(lock)} lock={lock} />
                                 ))}
                             </td>
                         </tr>

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.test.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.test.tsx
@@ -27,7 +27,7 @@ import {
     UndeploySummary,
 } from '../../../api/api';
 import { MemoryRouter } from 'react-router-dom';
-import { elementQuerySelectorSafe } from '../../../setupTests';
+import { elementQuerySelectorSafe, makeRelease } from '../../../setupTests';
 
 const mock_ReleaseCard = Spy.mockReactComponents('../../components/ReleaseCard/ReleaseCard', 'ReleaseCard');
 const mock_addAction = Spy.mockModule('../../utils/store', 'addAction');
@@ -72,16 +72,6 @@ describe('Service Lane', () => {
         expect(mock_ReleaseCard.ReleaseCard.getCallArgument(2, 0)).toStrictEqual({ app: sampleApp.name, version: 2 });
         mock_ReleaseCard.ReleaseCard.wasCalled(3);
     });
-});
-
-const makeRelease = (version: number): Release => ({
-    version: version,
-    sourceMessage: 'test' + version,
-    sourceAuthor: 'test',
-    sourceCommitId: 'commit' + version,
-    createdAt: new Date(2002),
-    undeployVersion: false,
-    prNumber: '666',
 });
 
 type TestData = {

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.scss
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.scss
@@ -57,6 +57,35 @@
     @extend .text-regular;
 }
 
+.mdc-drawer-sidebar-list-item-delete-all {
+    @extend .text-regular;
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    border-top: solid;
+    padding-top: 10px;
+    margin-top: 10px;
+    .no-wrap {
+        white-space: nowrap;
+    }
+    .mdc-button__label {
+        font-size: 8px;
+        font-weight: 700;
+    }
+    .mdc-button__ripple {
+        position: relative;
+    }
+    button.mdc-button {
+        color: red;
+        border-color: red;
+        border: solid;
+        border-radius: 5px;
+        padding-left: 10px;
+        padding-right: 10px;
+        height: min-content;
+    }
+}
+
 .mdc-drawer-sidebar-list-item-delete-icon {
     flex: 2;
     position: absolute;

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.scss
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.scss
@@ -69,8 +69,8 @@
         white-space: nowrap;
     }
     .mdc-button__label {
-        font-size: 8px;
-        font-weight: 700;
+        font-size: $small-warn-button-font-size;
+        font-weight: $small-warn-button-font-weight;
     }
     .mdc-button__ripple {
         position: relative;
@@ -79,9 +79,9 @@
         color: red;
         border-color: red;
         border: solid;
-        border-radius: 5px;
-        padding-left: 10px;
-        padding-right: 10px;
+        border-radius: $border-radius-medium;
+        padding-left: $small-warn-button-padding-left;
+        padding-right: $small-warn-button-padding-right;
         height: min-content;
     }
 }

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -182,13 +182,13 @@ export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children:
     const handleAddAll = useCallback(() => {
         similarLocks.appLocks.forEach((displayLock: DisplayLock) => {
             if (!displayLock.environment) {
-                throw new Error('action of type ' + ActionTypes.DeleteEnvironmentLock + ' must have environment set');
+                throw new Error('app lock must have environment set: ' + JSON.stringify(displayLock));
             }
             if (!displayLock.lockId) {
-                throw new Error('action must have lockId set');
+                throw new Error('app lock must have lock id set: ' + JSON.stringify(displayLock));
             }
             if (!displayLock.application) {
-                throw new Error('action of type ' + ActionTypes.DeleteApplicationLock + ' must have application set');
+                throw new Error('app lock must have application set: ' + JSON.stringify(displayLock));
             }
             const newAction: BatchAction = {
                 action: {
@@ -204,10 +204,10 @@ export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children:
         });
         similarLocks.environmentLocks.forEach((displayLock: DisplayLock) => {
             if (!displayLock.environment) {
-                throw new Error('action of type ' + ActionTypes.DeleteEnvironmentLock + ' must have environment set');
+                throw new Error('env lock must have environment set: ' + JSON.stringify(displayLock));
             }
             if (!displayLock.lockId) {
-                throw new Error('action must have lockId set');
+                throw new Error('env lock must have lock id set: ' + JSON.stringify(displayLock));
             }
             const newAction: BatchAction = {
                 action: {

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -26,12 +26,15 @@ import {
     useAllLocks,
     DisplayLock,
     randomLockId,
+    addAction,
+    useLocksSimilarTo,
 } from '../../utils/store';
 import { ChangeEvent, useCallback, useMemo, useState } from 'react';
 import { useApi } from '../../utils/GrpcApi';
 import { TextField, Dialog, DialogTitle, DialogActions } from '@material-ui/core';
 import classNames from 'classnames';
 import { useAzureAuthSub } from '../../utils/AzureAuthProvider';
+import * as React from 'react';
 
 export enum ActionTypes {
     Deploy,
@@ -176,11 +179,69 @@ export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children:
     const actionDetails = getActionDetails(action, appLocks, environmentLocks);
 
     const handleDelete = useCallback(() => deleteAction(action), [action]);
+    const similarLocks = useLocksSimilarTo(action);
+    const handleAddAll = useCallback(() => {
+        similarLocks.appLocks.forEach((displayLock: DisplayLock) => {
+            if (!displayLock.environment) {
+                throw new Error('action of type ' + ActionTypes.DeleteEnvironmentLock + ' must have environment set');
+            }
+            if (!displayLock.lockId) {
+                throw new Error('action must have lockId set');
+            }
+            if (!displayLock.application) {
+                throw new Error('action of type ' + ActionTypes.DeleteApplicationLock + ' must have application set');
+            }
+            const newAction: BatchAction = {
+                action: {
+                    $case: 'deleteEnvironmentApplicationLock',
+                    deleteEnvironmentApplicationLock: {
+                        environment: displayLock.environment,
+                        application: displayLock.application,
+                        lockId: displayLock.lockId,
+                    },
+                },
+            };
+            addAction(newAction);
+        });
+        similarLocks.environmentLocks.forEach((displayLock: DisplayLock) => {
+            if (!displayLock.environment) {
+                throw new Error('action of type ' + ActionTypes.DeleteEnvironmentLock + ' must have environment set');
+            }
+            if (!displayLock.lockId) {
+                throw new Error('action must have lockId set');
+            }
+            const newAction: BatchAction = {
+                action: {
+                    $case: 'deleteEnvironmentLock',
+                    deleteEnvironmentLock: {
+                        environment: displayLock.environment,
+                        lockId: displayLock.lockId,
+                    },
+                },
+            };
+            addAction(newAction);
+        });
+    }, [similarLocks]);
+    const deleteAllSection =
+        similarLocks.environmentLocks.length === 0 && similarLocks.appLocks.length === 0 ? null : (
+            <div className="mdc-drawer-sidebar-list-item-delete-all">
+                <div
+                    title={
+                        'Other locks are detected by Lock Id (' +
+                        actionDetails.lockId +
+                        '). This means these locks were created with the same "Apply" of the planned actions.'
+                    }>
+                    There are other similar locks.
+                </div>
+                <Button onClick={handleAddAll} label={' Delete them all! '} className={'button-lock'}></Button>
+            </div>
+        );
     return (
         <>
             <div className="mdc-drawer-sidebar-list-item-text">
                 <div className="mdc-drawer-sidebar-list-item-text-name">{actionDetails.name}</div>
                 <div className="mdc-drawer-sidebar-list-item-text-summary">{actionDetails.summary}</div>
+                {deleteAllSection}
             </div>
             <div onClick={handleDelete}>
                 <DeleteGray className="mdc-drawer-sidebar-list-item-delete-icon" />

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -34,7 +34,6 @@ import { useApi } from '../../utils/GrpcApi';
 import { TextField, Dialog, DialogTitle, DialogActions } from '@material-ui/core';
 import classNames from 'classnames';
 import { useAzureAuthSub } from '../../utils/AzureAuthProvider';
-import * as React from 'react';
 
 export enum ActionTypes {
     Deploy,

--- a/services/frontend-service/src/ui/utils/store.test.tsx
+++ b/services/frontend-service/src/ui/utils/store.test.tsx
@@ -1,0 +1,197 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+import { renderHook } from '@testing-library/react';
+import { AllLocks, updateActions, UpdateOverview, useLocksSimilarTo } from './store';
+import { BatchAction, EnvironmentGroup, Priority } from '../../api/api';
+import { makeDisplayLock, makeLock } from '../../setupTests';
+
+type TestDataStore = {
+    name: string;
+    inputEnvGroups: EnvironmentGroup[]; // this just defines what locks generally exist
+    inputAction: BatchAction; // the action we are rendering currently in the sidebar
+    expectedLocks: AllLocks;
+};
+
+const testdata: TestDataStore[] = [
+    {
+        name: 'empty data',
+        inputAction: {
+            action: {
+                $case: 'deleteEnvironmentLock',
+                deleteEnvironmentLock: {
+                    environment: 'dev',
+                    lockId: 'l1',
+                },
+            },
+        },
+        inputEnvGroups: [],
+        expectedLocks: {
+            appLocks: [],
+            environmentLocks: [],
+        },
+    },
+    {
+        name: 'one env lock: should not find another lock',
+        inputAction: {
+            action: {
+                $case: 'deleteEnvironmentLock',
+                deleteEnvironmentLock: {
+                    environment: 'dev',
+                    lockId: 'l1',
+                },
+            },
+        },
+        inputEnvGroups: [
+            {
+                environments: [
+                    {
+                        name: 'dev',
+                        distanceToUpstream: 0,
+                        priority: Priority.UPSTREAM,
+                        locks: {
+                            l1: makeLock({ lockId: 'l1' }),
+                        },
+                        applications: {},
+                    },
+                ],
+                environmentGroupName: 'group1',
+                distanceToUpstream: 0,
+            },
+        ],
+        expectedLocks: {
+            appLocks: [],
+            environmentLocks: [],
+        },
+    },
+    {
+        name: 'two env locks with same ID on different envs: should find the other lock',
+        inputAction: {
+            action: {
+                $case: 'deleteEnvironmentLock',
+                deleteEnvironmentLock: {
+                    environment: 'dev',
+                    lockId: 'l1',
+                },
+            },
+        },
+        inputEnvGroups: [
+            {
+                environments: [
+                    {
+                        name: 'dev',
+                        distanceToUpstream: 0,
+                        priority: Priority.UPSTREAM,
+                        locks: {
+                            l1: makeLock({ lockId: 'l1' }),
+                        },
+                        applications: {},
+                    },
+                    {
+                        name: 'staging',
+                        distanceToUpstream: 0,
+                        priority: Priority.UPSTREAM,
+                        locks: {
+                            l1: makeLock({ lockId: 'l1' }),
+                        },
+                        applications: {},
+                    },
+                ],
+                environmentGroupName: 'group1',
+                distanceToUpstream: 0,
+            },
+        ],
+        expectedLocks: {
+            appLocks: [],
+            environmentLocks: [
+                makeDisplayLock({
+                    lockId: 'l1',
+                    environment: 'staging',
+                    authorName: 'Betty',
+                    authorEmail: 'betty@example.com',
+                }),
+            ],
+        },
+    },
+    {
+        name: 'env lock and app lock with same ID: deleting the env lock should find the other lock',
+        inputAction: {
+            action: {
+                $case: 'deleteEnvironmentLock',
+                deleteEnvironmentLock: {
+                    environment: 'dev',
+                    lockId: 'l1',
+                },
+            },
+        },
+        inputEnvGroups: [
+            {
+                environments: [
+                    {
+                        name: 'dev',
+                        distanceToUpstream: 0,
+                        priority: Priority.UPSTREAM,
+                        locks: {
+                            l1: makeLock({ lockId: 'l1' }),
+                        },
+                        applications: {
+                            app1: {
+                                name: 'betty',
+                                locks: {
+                                    l1: makeLock({ lockId: 'l1' }),
+                                },
+                                version: 666,
+                                undeployVersion: false,
+                                queuedVersion: 0,
+                                argoCD: undefined,
+                            },
+                        },
+                    },
+                ],
+                environmentGroupName: 'group1',
+                distanceToUpstream: 0,
+            },
+        ],
+        expectedLocks: {
+            appLocks: [
+                makeDisplayLock({
+                    environment: 'dev',
+                    lockId: 'l1',
+                    application: 'betty',
+                    message: 'lock msg 1',
+                    authorName: 'Betty',
+                    authorEmail: 'betty@example.com',
+                }),
+            ],
+            environmentLocks: [],
+        },
+    },
+];
+
+describe.each(testdata)('Test useLocksSimilarTo', (testcase) => {
+    it(testcase.name, () => {
+        // given
+        updateActions([]);
+        UpdateOverview.set({
+            applications: {},
+            environmentGroups: testcase.inputEnvGroups,
+        });
+        // when
+        const actions = renderHook(() => useLocksSimilarTo(testcase.inputAction)).result.current;
+        // then
+        expect(actions.appLocks).toStrictEqual(testcase.expectedLocks.appLocks);
+        expect(actions.environmentLocks).toStrictEqual(testcase.expectedLocks.environmentLocks);
+    });
+});


### PR DESCRIPTION
If a user removes a lock (adds it to the planned actions), kuberpult now checks if there are "similar" locks. We assume a lock is similar, if it has the same ID. Locks can have the same ID if they are different in other fields like "app" and "env".

UI:
![Screenshot from 2023-05-04 17-30-54](https://user-images.githubusercontent.com/3481382/236256152-07e2be0e-cd57-4fd5-aba7-f34377fe6590.png)

