### PR TITLE
Render commit message nicer in ReleaseCards

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
@@ -1,5 +1,10 @@
 @use '@material/card/mdc-card';
 
+.mdc-tooltip__title.release__details {
+    white-space: pre-wrap;
+    font-height: 7px;
+}
+
 .release-card__container {
     display: flex;
     flex-direction: column;

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -95,7 +95,7 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
             {!!createdAt && <div className="release__metadata">{getFormattedReleaseDate(createdAt)}</div>}
         </h2>
     );
-
+    const firstLine = sourceMessage.split('\n')[0];
     return (
         <Tooltip id={app + version} content={tooltipContents}>
             <div className="release-card__container">
@@ -109,7 +109,7 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
                         tabIndex={0}
                         onClick={openReleaseDialog}>
                         <div className="release-card__header">
-                            <div className="release__title">{undeployVersion ? 'Undeploy Version' : sourceMessage}</div>
+                            <div className="release__title">{undeployVersion ? 'Undeploy Version' : firstLine}</div>
                             {!!sourceCommitId && <Button className="release__hash" label={sourceCommitId} />}
                         </div>
                         <div className="mdc-card__ripple" />


### PR DESCRIPTION
Render only first line in the release cards, but render all of the lines with proper newlines in the tooltip