### PR TITLE
Reduce Whitespace in ReleaseDialog

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -62,9 +62,9 @@
         display: flex;
         flex-direction: column;
         overflow: overlay;
-        gap: 22px;
+        gap: 12px;
         margin: 0px;
-        padding: 35px 0px;
+        padding-bottom: 20px;
         align-items: center;
         border-radius: $release-dialog-bottom-border-radius;
 
@@ -84,13 +84,14 @@
             margin-left: 20px;
             margin-right: 20px;
             border-radius: $release-dialog-inner-border-radius;
-            gap: 16px;
+            gap: 0;
 
             .env-card-header {
                 display: flex;
                 flex-direction: row;
                 justify-content: space-between;
                 .release-environment {
+                    border-radius: $border-radius-large;
                     top: $release-dialog-label-displacement;
                     left: $release-dialog-label-displacement;
                     height: 42px;


### PR DESCRIPTION

New:
![Screenshot from 2023-05-05 17-43-37](https://user-images.githubusercontent.com/3481382/236504978-61124abc-e173-4860-afa2-295e28aad36d.png)

Old: (notice the scrollbar)
![Screenshot from 2023-05-05 17-44-25](https://user-images.githubusercontent.com/3481382/236505147-0aac4ff6-84c4-49b8-becc-51333703750f.png)
