### PR TITLE
Bugfix: Make all UI paths available with hard reload

### DIFF
--- a/README_DEVELOPERS.md
+++ b/README_DEVELOPERS.md
@@ -219,3 +219,27 @@ Verify that the release draft is correct in the GitHub UI and publish it for rel
 
 - The first version of this tool was written using go-git v5. Sadly the performance was abysmal. Adding a new manifest took > 20 seconds. Therefore, we switched to libgit2, which is much faster but less ergonomic.
 
+## Running locally with 2 images
+The normal docker-compose.yml file starts 3 containers: cd-service, frontend-service, ui.
+The file `docker-compose.tpl.yml` starts 2 containers: cd-service and frontend+ui in one.
+In the helm chart, there are also only 2 containers.
+
+Pros of running 2 containers:
+* closer to the "real world", meaning the helm chart
+* You can (manually) test things like path redirects much better
+
+Cons of running 2 containers:
+* There's no UI hot-reload
+
+To run with 2 containers (you need to run this with every change):
+```shell
+# replace "sven" with any other prefix or your choice:
+docker-compose stop
+PREFIX=sven-d
+export IMAGE_REGISTRY=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult 
+IMAGENAME="$IMAGE_REGISTRY"/kuberpult-cd-service:"$PREFIX"-0.4.66-23-g0d06019 make docker -C services/cd-service/
+IMAGENAME="$IMAGE_REGISTRY"/kuberpult-frontend-service:"$PREFIX"-0.4.66-23-g0d06019 make docker -C services/frontend-service/
+IMAGE_TAG_CD="$PREFIX"-0.4.66-23-g0d06019 IMAGE_TAG_FRONTEND="$PREFIX"-0.4.66-23-g0d06019 dc -f ./docker-compose.tpl.yml up -d --remove-orphans
+```
+Now open a browser to `http://localhost:8081/`.
+

--- a/services/frontend-service/src/ui/App/PageRoutes.tsx
+++ b/services/frontend-service/src/ui/App/PageRoutes.tsx
@@ -21,24 +21,24 @@ import { Routes as ReactRoutes, Route, Navigate } from 'react-router-dom';
 
 const routes = [
     {
-        path: `/environments/*`,
+        path: `/ui/environments/*`,
         element: <EnvironmentsPage />,
     },
     {
-        path: `/locks/*`,
+        path: `/ui/locks/*`,
         element: <LocksPage />,
     },
     {
-        path: `/home/*`,
+        path: `/ui/home/*`,
         element: <Home />,
     },
     {
-        path: `/home/releases/:appName`,
+        path: `/ui/home/releases/:appName`,
         element: <ReleasesPage />,
     },
     {
         path: `/*`,
-        element: <Navigate replace to="/home" />,
+        element: <Navigate replace to="/ui/home" />,
     },
 ];
 

--- a/services/frontend-service/src/ui/components/NavigationBar/NavigationBar.tsx
+++ b/services/frontend-service/src/ui/components/NavigationBar/NavigationBar.tsx
@@ -23,9 +23,9 @@ export const NavigationBar: React.FC = () => (
         </div>
         <div className="mdc-drawer__content">
             <NavList>
-                <NavListItem to={'home'} icon={<Home />} />
-                <NavListItem to={'environments'} icon={<Environments />} />
-                <NavListItem to={'locks'} icon={<LocksWhite />} />
+                <NavListItem to={'ui/home'} icon={<Home />} />
+                <NavListItem to={'ui/environments'} icon={<Environments />} />
+                <NavListItem to={'ui/locks'} icon={<LocksWhite />} />
             </NavList>
         </div>
     </aside>

--- a/services/frontend-service/src/ui/utils/store.test.tsx
+++ b/services/frontend-service/src/ui/utils/store.test.tsx
@@ -294,7 +294,7 @@ describe('Test useNavigateWithSearchParams', () => {
         },
         {
             name: 'url with some search parameters',
-            currentURL: '/home/test/whaat?query1=boo&query2=bar',
+            currentURL: '/ui/home/test/whaat?query1=boo&query2=bar',
             navigationTo: 'test-random-page',
             expectedURL: 'test-random-page?query1=boo&query2=bar',
         },


### PR DESCRIPTION
All ui pages have been moved from "/" to "/ui/".
There are still some exceptions, like "/" itself and the favicon.

Issues like this cannot be tested with a 3 container setup - added a section in the readme to explain how to start with 2 containers (and why).