### PR TITLE
Add annotations to ArgoCD application

### DIFF
--- a/services/cd-service/pkg/argocd/render.go
+++ b/services/cd-service/pkg/argocd/render.go
@@ -131,15 +131,18 @@ func RenderV1Alpha1(gitUrl string, gitBranch string, config config.EnvironmentCo
 
 func RenderApp(gitUrl string, gitBranch string, applicationAnnotations map[string]string, env string, appData AppData, destination v1alpha1.ApplicationDestination, ignoreDifferences []v1alpha1.ResourceIgnoreDifferences, syncOptions v1alpha1.SyncOptions) (string, error) {
 	name := appData.AppName
-	annotations := map[string]string{
-		"com.freiheit.kuberpult/team": appData.TeamName,
-		"com.freiheit.kuberpult/application": name,
+	annotations := map[string]string{}
+	for k, v := range applicationAnnotations {
+		annotations[k] = v
 	}
+	annotations["com.freiheit.kuberpult/team"] = appData.TeamName
+	annotations["com.freiheit.kuberpult/application"] = name
+	annotations["com.freiheit.kuberpult/environment"] = env
 	app := v1alpha1.Application{
 		TypeMeta: v1alpha1.ApplicationTypeMeta,
 		ObjectMeta: v1alpha1.ObjectMeta{
 			Name:        fmt.Sprintf("%s-%s", env, name),
-			Annotations: applicationAnnotations,
+			Annotations: annotations,
 			Finalizers:  calculateFinalizers(appData.IsUndeployVersion),
 		},
 		Spec: v1alpha1.ApplicationSpec{

--- a/services/cd-service/pkg/argocd/render.go
+++ b/services/cd-service/pkg/argocd/render.go
@@ -33,6 +33,7 @@ const V1Alpha1 ApiVersion = "v1alpha1"
 
 type AppData struct {
 	AppName           string
+	TeamName          string
 	IsUndeployVersion bool
 }
 
@@ -130,6 +131,10 @@ func RenderV1Alpha1(gitUrl string, gitBranch string, config config.EnvironmentCo
 
 func RenderApp(gitUrl string, gitBranch string, applicationAnnotations map[string]string, env string, appData AppData, destination v1alpha1.ApplicationDestination, ignoreDifferences []v1alpha1.ResourceIgnoreDifferences, syncOptions v1alpha1.SyncOptions) (string, error) {
 	name := appData.AppName
+	annotations := map[string]string{
+		"com.freiheit.kuberpult/team": appData.TeamName,
+		"com.freiheit.kuberpult/application": name,
+	}
 	app := v1alpha1.Application{
 		TypeMeta: v1alpha1.ApplicationTypeMeta,
 		ObjectMeta: v1alpha1.ObjectMeta{

--- a/services/cd-service/pkg/argocd/render_test.go
+++ b/services/cd-service/pkg/argocd/render_test.go
@@ -40,6 +40,10 @@ func TestRender(t *testing.T) {
 			ExpectedResult: `apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    com.freiheit.kuberpult/application: app1
+    com.freiheit.kuberpult/environment: dev
+    com.freiheit.kuberpult/team: ""
   name: dev-app1
 spec:
   destination: {}
@@ -73,6 +77,10 @@ spec:
 			ExpectedResult: `apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    com.freiheit.kuberpult/application: app1
+    com.freiheit.kuberpult/environment: dev
+    com.freiheit.kuberpult/team: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   name: dev-app1
@@ -111,6 +119,10 @@ spec:
 			ExpectedResult: `apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    com.freiheit.kuberpult/application: app1
+    com.freiheit.kuberpult/environment: dev
+    com.freiheit.kuberpult/team: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   name: dev-app1
@@ -305,6 +317,10 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    com.freiheit.kuberpult/application: app1
+    com.freiheit.kuberpult/environment: test-env
+    com.freiheit.kuberpult/team: ""
   name: test-env-app1
 spec:
   destination:
@@ -351,6 +367,10 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    com.freiheit.kuberpult/application: app1
+    com.freiheit.kuberpult/environment: test-env
+    com.freiheit.kuberpult/team: ""
   name: test-env-app1
 spec:
   destination: {}
@@ -432,6 +452,55 @@ spec:
   - namespace: foo
   sourceRepos:
   - '*'
+`,
+		},
+		{
+			name: "with team name",
+			config: config.EnvironmentConfig{
+				ArgoCd: &config.EnvironmentConfigArgoCd{
+					Destination: config.ArgoCdDestination{
+						Namespace:            nil,
+						AppProjectNamespace:  ptr.FromString("bar1"),
+						ApplicationNamespace: nil,
+					},
+				},
+			},
+			appData: []AppData{
+				{
+					AppName:  "app1",
+					TeamName: "some-team",
+				},
+			},
+			want: `apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: test-env
+spec:
+  description: test-env
+  destinations:
+  - namespace: bar1
+  sourceRepos:
+  - '*'
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    com.freiheit.kuberpult/application: app1
+    com.freiheit.kuberpult/environment: test-env
+    com.freiheit.kuberpult/team: some-team
+  name: test-env-app1
+spec:
+  destination: {}
+  project: test-env
+  source:
+    path: environments/test-env/applications/app1/manifests
+    repoURL: https://git.example.com/
+    targetRevision: branch-name
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
 `,
 		},
 	}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -578,9 +578,14 @@ func (r *repository) updateArgoCdApps(ctx context.Context, state *State, name st
 			if err != nil {
 				return err
 			}
+			team, err := state.GetApplicationTeamOwner(appName)
+			if err != nil {
+				return err
+			}
 			appData = append(appData, argocd.AppData{
 				AppName:           appName,
 				IsUndeployVersion: isUndeployVersion,
+				TeamName:          team,
 			})
 		}
 		if manifests, err := argocd.Render(r.config.URL, r.config.Branch, config, name, appData); err != nil {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1936,12 +1936,14 @@ spec:
 					Manifests: map[string]string{
 						"staging": "stagingmanifest",
 					},
+					Team: "team1",
 				},
 				&CreateApplicationVersion{
 					Application: "test2",
 					Manifests: map[string]string{
 						"staging": "stagingmanifest",
 					},
+					Team: "team2",
 				},
 			},
 			Test: func(t *testing.T, s *State) {
@@ -1967,6 +1969,10 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    com.freiheit.kuberpult/application: test
+    com.freiheit.kuberpult/environment: staging
+    com.freiheit.kuberpult/team: team1
   name: staging-test
 spec:
   destination:
@@ -1985,6 +1991,10 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    com.freiheit.kuberpult/application: test2
+    com.freiheit.kuberpult/environment: staging
+    com.freiheit.kuberpult/team: team2
   name: staging-test2
 spec:
   destination:
@@ -2056,6 +2066,9 @@ metadata:
   annotations:
     a: bar
     b: foo
+    com.freiheit.kuberpult/application: test
+    com.freiheit.kuberpult/environment: staging
+    com.freiheit.kuberpult/team: ""
   name: staging-test
 spec:
   destination:
@@ -2132,6 +2145,10 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    com.freiheit.kuberpult/application: test
+    com.freiheit.kuberpult/environment: staging
+    com.freiheit.kuberpult/team: ""
   name: staging-test
 spec:
   destination:


### PR DESCRIPTION
By adding the annotations

- com.freiheit.kuberpult/team
- com.freiheit.kuberpult/application
- com.freiheit.kuberpult/environment

it's possible to connect applications in argocd directly to applications/envs/teams in kuberpult