### PR TITLE
Add more secure header configurations and add tests to frontend server

### DIFF
--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -93,6 +93,8 @@ spec:
           value: "{{ .Values.gke.backend_service_id }}"
         - name: KUBERPULT_GKE_PROJECT_NUMBER
           value: "{{ .Values.gke.project_number }}"
+        - name: KUBERPULT_ALLOWED_ORIGINS
+          value: "https://{{ .Values.ingress.domainName }}"
 {{- if .Values.datadogTracing.enabled }}
         - name: DD_AGENT_HOST
           valueFrom:

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -14,11 +14,9 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 
-//
 // Setup implementation shared between all microservices.
 // If this file is changed it will affect _all_ microservices in the monorepo (and this
 // is deliberately so).
-//
 package setup
 
 import (
@@ -142,6 +140,7 @@ func (s *setup) listenToShutdownSignal(ctx context.Context, cancelFunc context.C
 	select {
 	case <-osSignalChannel:
 	case <-shutdownChannel:
+	case <-ctx.Done():
 	}
 
 	// cancel the context

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -237,9 +237,9 @@ func runServer(ctx context.Context) error {
 			- self is generally sufficient for most sources
 			- fonts.googleapis.com is used for font hosting
 			- fonts.gstatic.con is used for font hosting
-			- login.microsoft.com is used for azure login
+			- login.microsoftonline.com is used for azure login
 			*/
-			resp.Header().Set("Content-Security-Policy", "default-src 'self'; style-src-elem 'self' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' login.microsoft.com; child-src 'none'")
+			resp.Header().Set("Content-Security-Policy", "default-src 'self'; style-src-elem 'self' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' login.microsoftonline.com; child-src 'none'")
 
 			if c.AzureEnableAuth {
 				// these are the paths and prefixes that must not have azure authentication, in order to bootstrap the html, js, etc:

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -65,213 +65,219 @@ func readPgpKeyRing() (openpgp.KeyRing, error) {
 }
 
 func RunServer() {
-	logger.Wrap(context.Background(), func(ctx context.Context) error {
-		err := envconfig.Process("kuberpult", &c)
+	logger.Wrap(context.Background(), runServer)
+}
+
+func runServer(ctx context.Context) error {
+	err := envconfig.Process("kuberpult", &c)
+	if err != nil {
+		logger.FromContext(ctx).Fatal("config.parse", zap.Error(err))
+		return err
+	}
+
+	var jwks *keyfunc.JWKS = nil
+	if c.AzureEnableAuth {
+		jwks, err = auth.JWKSInitAzure(ctx)
 		if err != nil {
-			logger.FromContext(ctx).Fatal("config.parse", zap.Error(err))
+			logger.FromContext(ctx).Fatal("Unable to initialize jwks for azure auth")
+			return err
 		}
+	}
+	logger.FromContext(ctx).Info("config.gke_project_number: " + c.GKEProjectNumber + "\n")
+	logger.FromContext(ctx).Info("config.gke_backend_service_id: " + c.GKEBackendServiceID + "\n")
 
-		var jwks *keyfunc.JWKS = nil
-		if c.AzureEnableAuth {
-			jwks, err = auth.JWKSInitAzure(ctx)
-			if err != nil {
-				logger.FromContext(ctx).Fatal("Unable to initialize jwks for azure auth")
-			}
-		}
-		logger.FromContext(ctx).Info("config.gke_project_number: " + c.GKEProjectNumber + "\n")
-		logger.FromContext(ctx).Info("config.gke_backend_service_id: " + c.GKEBackendServiceID + "\n")
+	grpcServerLogger := logger.FromContext(ctx).Named("grpc_server")
 
-		grpcServerLogger := logger.FromContext(ctx).Named("grpc_server")
+	grpcStreamInterceptors := []grpc.StreamServerInterceptor{
+		grpc_zap.StreamServerInterceptor(grpcServerLogger),
+	}
+	grpcUnaryInterceptors := []grpc.UnaryServerInterceptor{
+		grpc_zap.UnaryServerInterceptor(grpcServerLogger),
+	}
 
-		grpcStreamInterceptors := []grpc.StreamServerInterceptor{
-			grpc_zap.StreamServerInterceptor(grpcServerLogger),
-		}
-		grpcUnaryInterceptors := []grpc.UnaryServerInterceptor{
-			grpc_zap.UnaryServerInterceptor(grpcServerLogger),
-		}
+	grpcClientOpts := []grpc.DialOption{
+		grpc.WithInsecure(),
+	}
 
-		grpcClientOpts := []grpc.DialOption{
-			grpc.WithInsecure(),
-		}
+	if c.EnableTracing {
+		tracer.Start()
+		defer tracer.Stop()
 
-		if c.EnableTracing {
-			tracer.Start()
-			defer tracer.Stop()
-
-			grpcStreamInterceptors = append(grpcStreamInterceptors,
-				grpctrace.StreamServerInterceptor(grpctrace.WithServiceName("frontend-service")),
-			)
-			grpcUnaryInterceptors = append(grpcUnaryInterceptors,
-				grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName("frontend-service")),
-			)
-
-			grpcClientOpts = append(grpcClientOpts,
-				grpc.WithStreamInterceptor(
-					grpctrace.StreamClientInterceptor(grpctrace.WithServiceName("frontend-service")),
-				),
-				grpc.WithUnaryInterceptor(
-					grpctrace.UnaryClientInterceptor(grpctrace.WithServiceName("frontend-service")),
-				),
-			)
-		}
-
-		if c.AzureEnableAuth {
-			var AzureUnaryInterceptor = func(ctx context.Context,
-				req interface{},
-				info *grpc.UnaryServerInfo,
-				handler grpc.UnaryHandler) (interface{}, error) {
-				return auth.UnaryInterceptor(ctx, req, info, handler, jwks, c.AzureClientId, c.AzureTenantId)
-			}
-			var AzureStreamInterceptor = func(
-				srv interface{},
-				stream grpc.ServerStream,
-				info *grpc.StreamServerInfo,
-				handler grpc.StreamHandler,
-			) error {
-				return auth.StreamInterceptor(srv, stream, info, handler, jwks, c.AzureClientId, c.AzureTenantId)
-			}
-			grpcUnaryInterceptors = append(grpcUnaryInterceptors, AzureUnaryInterceptor)
-			grpcStreamInterceptors = append(grpcStreamInterceptors, AzureStreamInterceptor)
-		}
-
-		pgpKeyRing, err := readPgpKeyRing()
-		if err != nil {
-			logger.FromContext(ctx).Fatal("pgp.read.error", zap.Error(err))
-		}
-		if c.AzureEnableAuth && pgpKeyRing == nil {
-			logger.FromContext(ctx).Fatal("azure.auth.error: pgpKeyRing is required to authenticate manifests when \"KUBERPULT_AZURE_ENABLE_AUTH\" is true")
-		}
-
-		gsrv := grpc.NewServer(
-			grpc.ChainStreamInterceptor(grpcStreamInterceptors...),
-			grpc.ChainUnaryInterceptor(grpcUnaryInterceptors...),
+		grpcStreamInterceptors = append(grpcStreamInterceptors,
+			grpctrace.StreamServerInterceptor(grpctrace.WithServiceName("frontend-service")),
 		)
-		con, err := grpc.Dial(c.CdServer, grpcClientOpts...)
-		if err != nil {
-			logger.FromContext(ctx).Fatal("grpc.dial.error", zap.Error(err), zap.String("addr", c.CdServer))
-		}
+		grpcUnaryInterceptors = append(grpcUnaryInterceptors,
+			grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName("frontend-service")),
+		)
 
-		lockClient := api.NewLockServiceClient(con)
-		deployClient := api.NewDeployServiceClient(con)
-		environmentClient := api.NewEnvironmentServiceClient(con)
-		gproxy := &GrpcProxy{
-			LockClient:        lockClient,
-			OverviewClient:    api.NewOverviewServiceClient(con),
-			DeployClient:      deployClient,
-			BatchClient:       api.NewBatchServiceClient(con),
-			EnvironmentClient: environmentClient,
-		}
-		api.RegisterLockServiceServer(gsrv, gproxy)
-		api.RegisterOverviewServiceServer(gsrv, gproxy)
-		api.RegisterDeployServiceServer(gsrv, gproxy)
-		api.RegisterBatchServiceServer(gsrv, gproxy)
-		api.RegisterEnvironmentServiceServer(gsrv, gproxy)
+		grpcClientOpts = append(grpcClientOpts,
+			grpc.WithStreamInterceptor(
+				grpctrace.StreamClientInterceptor(grpctrace.WithServiceName("frontend-service")),
+			),
+			grpc.WithUnaryInterceptor(
+				grpctrace.UnaryClientInterceptor(grpctrace.WithServiceName("frontend-service")),
+			),
+		)
+	}
 
-		frontendConfigService := &service.FrontendConfigServiceServer{
-			Config: config.FrontendConfig{
-				ArgoCd: &config.ArgoCdConfig{BaseUrl: c.ArgocdBaseUrl},
-				Auth: &config.AuthConfig{
-					AzureAuth: &config.AzureAuthConfig{
-						Enabled:       c.AzureEnableAuth,
-						ClientId:      c.AzureClientId,
-						TenantId:      c.AzureTenantId,
-						RedirectURL:   c.AzureRedirectUrl,
-						CloudInstance: c.AzureCloudInstance,
-					},
+	if c.AzureEnableAuth {
+		var AzureUnaryInterceptor = func(ctx context.Context,
+			req interface{},
+			info *grpc.UnaryServerInfo,
+			handler grpc.UnaryHandler) (interface{}, error) {
+			return auth.UnaryInterceptor(ctx, req, info, handler, jwks, c.AzureClientId, c.AzureTenantId)
+		}
+		var AzureStreamInterceptor = func(
+			srv interface{},
+			stream grpc.ServerStream,
+			info *grpc.StreamServerInfo,
+			handler grpc.StreamHandler,
+		) error {
+			return auth.StreamInterceptor(srv, stream, info, handler, jwks, c.AzureClientId, c.AzureTenantId)
+		}
+		grpcUnaryInterceptors = append(grpcUnaryInterceptors, AzureUnaryInterceptor)
+		grpcStreamInterceptors = append(grpcStreamInterceptors, AzureStreamInterceptor)
+	}
+
+	pgpKeyRing, err := readPgpKeyRing()
+	if err != nil {
+		logger.FromContext(ctx).Fatal("pgp.read.error", zap.Error(err))
+		return err
+	}
+	if c.AzureEnableAuth && pgpKeyRing == nil {
+		logger.FromContext(ctx).Fatal("azure.auth.error: pgpKeyRing is required to authenticate manifests when \"KUBERPULT_AZURE_ENABLE_AUTH\" is true")
+		return err
+	}
+
+	gsrv := grpc.NewServer(
+		grpc.ChainStreamInterceptor(grpcStreamInterceptors...),
+		grpc.ChainUnaryInterceptor(grpcUnaryInterceptors...),
+	)
+	con, err := grpc.Dial(c.CdServer, grpcClientOpts...)
+	if err != nil {
+		logger.FromContext(ctx).Fatal("grpc.dial.error", zap.Error(err), zap.String("addr", c.CdServer))
+	}
+
+	lockClient := api.NewLockServiceClient(con)
+	deployClient := api.NewDeployServiceClient(con)
+	environmentClient := api.NewEnvironmentServiceClient(con)
+	gproxy := &GrpcProxy{
+		LockClient:        lockClient,
+		OverviewClient:    api.NewOverviewServiceClient(con),
+		DeployClient:      deployClient,
+		BatchClient:       api.NewBatchServiceClient(con),
+		EnvironmentClient: environmentClient,
+	}
+	api.RegisterLockServiceServer(gsrv, gproxy)
+	api.RegisterOverviewServiceServer(gsrv, gproxy)
+	api.RegisterDeployServiceServer(gsrv, gproxy)
+	api.RegisterBatchServiceServer(gsrv, gproxy)
+	api.RegisterEnvironmentServiceServer(gsrv, gproxy)
+
+	frontendConfigService := &service.FrontendConfigServiceServer{
+		Config: config.FrontendConfig{
+			ArgoCd: &config.ArgoCdConfig{BaseUrl: c.ArgocdBaseUrl},
+			Auth: &config.AuthConfig{
+				AzureAuth: &config.AzureAuthConfig{
+					Enabled:       c.AzureEnableAuth,
+					ClientId:      c.AzureClientId,
+					TenantId:      c.AzureTenantId,
+					RedirectURL:   c.AzureRedirectUrl,
+					CloudInstance: c.AzureCloudInstance,
 				},
-				SourceRepoUrl:    c.SourceRepoUrl,
-				KuberpultVersion: c.Version,
 			},
-		}
+			SourceRepoUrl:    c.SourceRepoUrl,
+			KuberpultVersion: c.Version,
+		},
+	}
 
-		api.RegisterFrontendConfigServiceServer(gsrv, frontendConfigService)
+	api.RegisterFrontendConfigServiceServer(gsrv, frontendConfigService)
 
-		grpcWebServer := grpcweb.WrapServer(gsrv)
-		httpHandler := handler.Server{
-			DeployClient:      deployClient,
-			LockClient:        lockClient,
-			EnvironmentClient: environmentClient,
-			Config:            c,
-			KeyRing:           pgpKeyRing,
-			AzureAuth:         c.AzureEnableAuth,
-		}
-		mux := http.NewServeMux()
-		mux.Handle("/environments/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			defer readAllAndClose(req.Body, 1024)
-			httpHandler.Handle(w, req)
-		}))
-		mux.Handle("/release", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			defer readAllAndClose(req.Body, 1024)
-			httpHandler.Handle(w, req)
-		}))
-		mux.Handle("/health", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			w.WriteHeader(200)
-			fmt.Fprintf(w, "ok\n")
-		}))
-		mux.Handle("/", http.FileServer(http.Dir("build")))
-		// Split HTTP REST from gRPC Web requests, as suggested in the documentation:
-		// https://pkg.go.dev/github.com/improbable-eng/grpc-web@v0.15.0/go/grpcweb
-		splitGrpcHandler := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			if grpcWebServer.IsGrpcWebRequest(req) {
-				grpcWebServer.ServeHTTP(resp, req)
-			} else {
-				/**
-				The htst header is a security feature that tells the browser:
-				"If someone requests anything on this domain via http, do not do that request, instead make the request with https"
-				Docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
-				Wiki: https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
-				Parameter "preload" is not necessary as kuberpult is not on a publicly available domain.
-				Parameter "includeSubDomains" is not really necessary for kuberpult right now,
-				  but should be set anyway in case we ever have subdomains.
-				31536000 seconds = 1 year.
-				*/
-				resp.Header().Set("strict-Transport-Security", "max-age=31536000; includeSubDomains;")
-				if c.AzureEnableAuth {
-					// these are the paths and prefixes that must not have azure authentication, in order to bootstrap the html, js, etc:
-					var allowedPaths = []string{"/", "/release", "/health", "/manifest.json", "/favicon.png"}
-					var allowedPrefixes = []string{"/static/js", "/static/css", "/ui"}
-					if err := auth.HttpAuthMiddleWare(resp, req, jwks, c.AzureClientId, c.AzureTenantId, allowedPaths, allowedPrefixes); err != nil {
-						return
-					}
-				}
-				/**
-				When the user requests any path under "/ui", we always return the same index.html (because it's a single page application).
-				Anything else may be another valid rest request, like /health or /release.
-				*/
-				if strings.HasPrefix(req.URL.Path, "/ui") {
-					http.ServeFile(resp, req, "build/index.html")
-				} else {
-					mux.ServeHTTP(resp, req)
+	grpcWebServer := grpcweb.WrapServer(gsrv)
+	httpHandler := handler.Server{
+		DeployClient:      deployClient,
+		LockClient:        lockClient,
+		EnvironmentClient: environmentClient,
+		Config:            c,
+		KeyRing:           pgpKeyRing,
+		AzureAuth:         c.AzureEnableAuth,
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/environments/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		defer readAllAndClose(req.Body, 1024)
+		httpHandler.Handle(w, req)
+	}))
+	mux.Handle("/release", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		defer readAllAndClose(req.Body, 1024)
+		httpHandler.Handle(w, req)
+	}))
+	mux.Handle("/health", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprintf(w, "ok\n")
+	}))
+	mux.Handle("/", http.FileServer(http.Dir("build")))
+	// Split HTTP REST from gRPC Web requests, as suggested in the documentation:
+	// https://pkg.go.dev/github.com/improbable-eng/grpc-web@v0.15.0/go/grpcweb
+	splitGrpcHandler := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		if grpcWebServer.IsGrpcWebRequest(req) {
+			grpcWebServer.ServeHTTP(resp, req)
+		} else {
+			/**
+			The htst header is a security feature that tells the browser:
+			"If someone requests anything on this domain via http, do not do that request, instead make the request with https"
+			Docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+			Wiki: https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
+			Parameter "preload" is not necessary as kuberpult is not on a publicly available domain.
+			Parameter "includeSubDomains" is not really necessary for kuberpult right now,
+			  but should be set anyway in case we ever have subdomains.
+			31536000 seconds = 1 year.
+			*/
+			resp.Header().Set("strict-Transport-Security", "max-age=31536000; includeSubDomains;")
+			if c.AzureEnableAuth {
+				// these are the paths and prefixes that must not have azure authentication, in order to bootstrap the html, js, etc:
+				var allowedPaths = []string{"/", "/release", "/health", "/manifest.json", "/favicon.png"}
+				var allowedPrefixes = []string{"/static/js", "/static/css", "/ui"}
+				if err := auth.HttpAuthMiddleWare(resp, req, jwks, c.AzureClientId, c.AzureTenantId, allowedPaths, allowedPrefixes); err != nil {
+					return
 				}
 			}
-		})
-		authHandler := &Auth{
-			HttpServer: splitGrpcHandler,
+			/**
+			When the user requests any path under "/ui", we always return the same index.html (because it's a single page application).
+			Anything else may be another valid rest request, like /health or /release.
+			*/
+			if strings.HasPrefix(req.URL.Path, "/ui") {
+				http.ServeFile(resp, req, "build/index.html")
+			} else {
+				mux.ServeHTTP(resp, req)
+			}
 		}
-		corsHandler := &setup.CORSMiddleware{
-			PolicyFor: func(r *http.Request) *setup.CORSPolicy {
-				return &setup.CORSPolicy{
-					AllowMethods:     "POST",
-					AllowHeaders:     "content-type,x-grpc-web,authorization",
-					AllowOrigin:      "*",
-					AllowCredentials: true,
-				}
-			},
-			NextHandler: authHandler,
-		}
+	})
+	authHandler := &Auth{
+		HttpServer: splitGrpcHandler,
+	}
+	corsHandler := &setup.CORSMiddleware{
+		PolicyFor: func(r *http.Request) *setup.CORSPolicy {
+			return &setup.CORSPolicy{
+				AllowMethods:     "POST",
+				AllowHeaders:     "content-type,x-grpc-web,authorization",
+				AllowOrigin:      "*",
+				AllowCredentials: true,
+			}
+		},
+		NextHandler: authHandler,
+	}
 
-		setup.Run(ctx, setup.ServerConfig{
-			HTTP: []setup.HTTPConfig{
-				{
-					Port: "8081",
-					Register: func(mux *http.ServeMux) {
-						mux.Handle("/", corsHandler)
-					},
+	setup.Run(ctx, setup.ServerConfig{
+		HTTP: []setup.HTTPConfig{
+			{
+				Port: "8081",
+				Register: func(mux *http.ServeMux) {
+					mux.Handle("/", corsHandler)
 				},
 			},
-		})
-		return nil
+		},
 	})
+	return nil
 }
 
 type Auth struct {

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -233,6 +233,14 @@ func runServer(ctx context.Context) error {
 			31536000 seconds = 1 year.
 			*/
 			resp.Header().Set("strict-Transport-Security", "max-age=31536000; includeSubDomains;")
+			/**
+			- self is generally sufficient for most sources
+			- fonts.googleapis.com is used for font hosting
+			- fonts.gstatic.con is used for font hosting
+			- login.microsoft.com is used for azure login
+			*/
+			resp.Header().Set("Content-Security-Policy", "default-src 'self'; style-src-elem 'self' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' login.microsoft.com; child-src 'none'")
+
 			if c.AzureEnableAuth {
 				// these are the paths and prefixes that must not have azure authentication, in order to bootstrap the html, js, etc:
 				var allowedPaths = []string{"/", "/release", "/health", "/manifest.json", "/favicon.png"}
@@ -260,7 +268,7 @@ func runServer(ctx context.Context) error {
 			return &setup.CORSPolicy{
 				AllowMethods:     "POST",
 				AllowHeaders:     "content-type,x-grpc-web,authorization",
-				AllowOrigin:      "*",
+				AllowOrigin:      c.AllowedOrigins,
 				AllowCredentials: true,
 			}
 		},

--- a/services/frontend-service/pkg/cmd/server_test.go
+++ b/services/frontend-service/pkg/cmd/server_test.go
@@ -43,7 +43,7 @@ func TestServerHeader(t *testing.T) {
 
 			ExpectedHeaders: http.Header{
 				"Content-Type": {"text/plain; charset=utf-8"}, "Content-Security-Policy": {
-					"default-src 'self'; style-src-elem 'self' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' login.microsoft.com; child-src 'none'",
+					"default-src 'self'; style-src-elem 'self' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' login.microsoftonline.com; child-src 'none'",
 				},
 				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains;"},
 				"X-Content-Type-Options":    {"nosniff"},
@@ -64,7 +64,7 @@ func TestServerHeader(t *testing.T) {
 				"Access-Control-Allow-Credentials": {"true"},
 				"Access-Control-Allow-Origin":      {"https://kuberpult.fdc"},
 				"Allow":                            {"OPTIONS, GET, HEAD"},
-				"Content-Security-Policy":          {"default-src 'self'; style-src-elem 'self' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' login.microsoft.com; child-src 'none'"},
+				"Content-Security-Policy":          {"default-src 'self'; style-src-elem 'self' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' login.microsoftonline.com; child-src 'none'"},
 				"Strict-Transport-Security":        {"max-age=31536000; includeSubDomains;"},
 			},
 		},

--- a/services/frontend-service/pkg/cmd/server_test.go
+++ b/services/frontend-service/pkg/cmd/server_test.go
@@ -1,0 +1,88 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestServerHeader(t *testing.T) {
+	tcs := []struct {
+		Name        string
+		RequestPath string
+
+		ExpectedHeaders http.Header
+	}{
+		{
+			Name:        "simple case",
+			RequestPath: "/",
+
+			ExpectedHeaders: http.Header{
+				"Content-Type":              {"text/plain; charset=utf-8"},
+				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains;"},
+				"X-Content-Type-Options":    {"nosniff"},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			go func(t *testing.T) {
+				defer cancel()
+				for {
+					res, err := http.Get("http://localhost:8081/health")
+					if err != nil {
+						<-time.After(1 * time.Second)
+						continue
+					}
+					if res.StatusCode != 200 {
+						<-time.After(1 * time.Second)
+						continue
+					}
+					break
+				}
+				//
+				path, err := url.JoinPath("http://localhost:8081/", tc.RequestPath)
+				if err != nil {
+					panic(err)
+				}
+				res, err := http.Get(path)
+				if err != nil {
+					t.Fatalf("expected no error but got %q", err)
+				}
+				hdrs := res.Header.Clone()
+				hdrs.Del("Content-Length")
+				hdrs.Del("Date")
+				if !cmp.Equal(tc.ExpectedHeaders, hdrs) {
+					t.Errorf("expected no diff for headers but got %s", cmp.Diff(tc.ExpectedHeaders, hdrs))
+				}
+
+			}(t)
+			err := runServer(ctx)
+			if err != nil {
+				t.Fatalf("expected no error, but got %q", err)
+			}
+		})
+	}
+}

--- a/services/frontend-service/pkg/config/config.go
+++ b/services/frontend-service/pkg/config/config.go
@@ -31,6 +31,7 @@ type ServerConfig struct {
 	AzureRedirectUrl    string `default:"" split_words:"true"`
 	Version             string `default:""`
 	SourceRepoUrl       string `default:"" split_words:"true"`
+	AllowedOrigins      string `default:"" split_words:"true"`
 }
 
 type FrontendConfig struct {


### PR DESCRIPTION
This adds a `Content-Security-Policy` and adds a proper allowed origin to cors.

Most code is actually spend to make it testable. Most notably to shut down the go http/grcp server. This was only possible using a global queue or OS signal but now it's sufficient to cancel the context it's running in.