### PR TITLE
Allow style elements from emotionjs

### DIFF
--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -236,10 +236,11 @@ func runServer(ctx context.Context) error {
 			/**
 			- self is generally sufficient for most sources
 			- fonts.googleapis.com is used for font hosting
+			- unsafe-inline is needed at the moment to make emotionjs work
 			- fonts.gstatic.con is used for font hosting
 			- login.microsoftonline.com is used for azure login
 			*/
-			resp.Header().Set("Content-Security-Policy", "default-src 'self'; style-src-elem 'self' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' login.microsoftonline.com; child-src 'none'")
+			resp.Header().Set("Content-Security-Policy", "default-src 'self'; style-src-elem 'self' fonts.googleapis.com 'unsafe-inline'; font-src fonts.gstatic.com; connect-src 'self' login.microsoftonline.com; child-src 'none'")
 			// We are not using referrer headers.
 			resp.Header().Set("Referrer-Policy", "no-referrer")
 			// We don't want to be displayed in frames

--- a/services/frontend-service/pkg/cmd/server_test.go
+++ b/services/frontend-service/pkg/cmd/server_test.go
@@ -44,7 +44,7 @@ func TestServerHeader(t *testing.T) {
 			ExpectedHeaders: http.Header{
 				"Content-Type": {"text/plain; charset=utf-8"},
 				"Content-Security-Policy": {
-					"default-src 'self'; style-src-elem 'self' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' login.microsoftonline.com; child-src 'none'",
+					"default-src 'self'; style-src-elem 'self' fonts.googleapis.com 'unsafe-inline'; font-src fonts.gstatic.com; connect-src 'self' login.microsoftonline.com; child-src 'none'",
 				},
 				"Permission-Policy": {
 					"accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-read=(), clipboard-write=(), gamepad=(), speaker-selection=()",
@@ -70,7 +70,7 @@ func TestServerHeader(t *testing.T) {
 				"Access-Control-Allow-Credentials": {"true"},
 				"Access-Control-Allow-Origin":      {"https://kuberpult.fdc"},
 				"Allow":                            {"OPTIONS, GET, HEAD"},
-				"Content-Security-Policy":          {"default-src 'self'; style-src-elem 'self' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' login.microsoftonline.com; child-src 'none'"},
+				"Content-Security-Policy":          {"default-src 'self'; style-src-elem 'self' fonts.googleapis.com 'unsafe-inline'; font-src fonts.gstatic.com; connect-src 'self' login.microsoftonline.com; child-src 'none'"},
 
 				"Permission-Policy": {
 					"accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-read=(), clipboard-write=(), gamepad=(), speaker-selection=()",


### PR DESCRIPTION
emotionjs injects dyanmic sytle elements. This of course conflicts with CSP. There are some complicated ways around this with csp nonce. However, we want to get rid of emotionjs anyway. In the meantime, we have to use unsafe-inline.