### PR TITLE
Add content-type nosniff header

### DIFF
--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -245,6 +245,8 @@ func runServer(ctx context.Context) error {
 			resp.Header().Set("Referrer-Policy", "no-referrer")
 			// We don't want to be displayed in frames
 			resp.Header().Set("X-Frame-Options", "DENY")
+			// Don't sniff content-type
+			resp.Header().Set("X-Content-Type-Options", "nosniff")
 			// We don't need any special browser features.
 			// This policy was generated using https://www.permissionspolicy.com/
 			// with "Disable all" for all implemented and proposed features as of may 2023.

--- a/services/frontend-service/pkg/cmd/server_test.go
+++ b/services/frontend-service/pkg/cmd/server_test.go
@@ -77,6 +77,7 @@ func TestServerHeader(t *testing.T) {
 				},
 				"Referrer-Policy":           {"no-referrer"},
 				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains;"},
+				"X-Content-Type-Options":    {"nosniff"},
 				"X-Frame-Options":           {"DENY"},
 			},
 		},


### PR DESCRIPTION
For the simple test case that was already added by the 404 handler. However, when we actually serve files, it's not. This adds it explicitly for all cases.