### PR TITLE
Separate tags for services

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -29,6 +29,10 @@
 
 # Copyright 2023 freiheit.com
 
+{{- if .Values.tag }}
+{{ fail "Values.tag cannot be used anymore. If you have to overwrite the tag, use cd.tag or frontend.tag instead"}}
+{{ end -}}
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -38,7 +42,7 @@ metadata:
     app: kuberpult-cd-service
 {{- if .Values.datadogTracing.enabled }}
     tags.datadoghq.com/service: kuberpult-cd-service
-    tags.datadoghq.com/version: {{ .Values.cdTag }}
+    tags.datadoghq.com/version: {{ .Values.cd.tag }}
     tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
 {{- end }}
 spec:
@@ -53,9 +57,9 @@ spec:
 {{- if .Values.datadogTracing.enabled }}
         tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
         tags.datadoghq.com/service: kuberpult-cd-service
-        tags.datadoghq.com/version: {{ .Values.cdTag }}
+        tags.datadoghq.com/version: {{ .Values.cd.tag }}
       annotations:
-        apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-cd-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ .Values.cdTag }}"}'
+        apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-cd-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ .Values.cd.tag }}"}'
 {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -64,7 +68,7 @@ spec:
       {{- end }}
       containers:
       - name: service
-        image: "{{ .Values.hub }}/{{ .Values.cd.image }}:{{ .Values.cdTag }}"
+        image: "{{ .Values.hub }}/{{ .Values.cd.image }}:{{ .Values.cd.tag }}"
         ports:
           - name: http
             containerPort: 8080

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -38,7 +38,7 @@ metadata:
     app: kuberpult-cd-service
 {{- if .Values.datadogTracing.enabled }}
     tags.datadoghq.com/service: kuberpult-cd-service
-    tags.datadoghq.com/version: {{ .Values.tag }}
+    tags.datadoghq.com/version: {{ .Values.cdTag }}
     tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
 {{- end }}
 spec:
@@ -53,9 +53,9 @@ spec:
 {{- if .Values.datadogTracing.enabled }}
         tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
         tags.datadoghq.com/service: kuberpult-cd-service
-        tags.datadoghq.com/version: {{ .Values.tag }}
+        tags.datadoghq.com/version: {{ .Values.cdTag }}
       annotations:
-        apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-cd-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ .Values.tag }}"}'
+        apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-cd-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ .Values.cdTag }}"}'
 {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -64,7 +64,7 @@ spec:
       {{- end }}
       containers:
       - name: service
-        image: "{{ .Values.hub }}/{{ .Values.cd.image }}:{{ .Values.tag }}"
+        image: "{{ .Values.hub }}/{{ .Values.cd.image }}:{{ .Values.cdTag }}"
         ports:
           - name: http
             containerPort: 8080

--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -52,7 +52,7 @@ spec:
       {{- end }}
       containers:
       - name: service
-        image: "{{ .Values.hub }}/{{ .Values.frontend.image }}:{{ .Values.tag }}"
+        image: "{{ .Values.hub }}/{{ .Values.frontend.image }}:{{ .Values.frontendTag }}"
         ports:
           - name: http
             containerPort: 8081
@@ -82,7 +82,7 @@ spec:
         - name: KUBERPULT_ARGOCD_BASE_URL
           value: {{ .Values.argocd.baseUrl | quote }}
         - name: KUBERPULT_VERSION
-          value: {{ .Values.tag | quote}}
+          value: {{ .Values.frontendTag | quote}}
         - name: KUBERPULT_SOURCE_REPO_URL
           value: {{ .Values.git.sourceRepoUrl | quote}}
         - name: LOG_FORMAT

--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -29,6 +29,7 @@
 
 # Copyright 2023 freiheit.com
 
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -52,7 +53,7 @@ spec:
       {{- end }}
       containers:
       - name: service
-        image: "{{ .Values.hub }}/{{ .Values.frontend.image }}:{{ .Values.frontendTag }}"
+        image: "{{ .Values.hub }}/{{ .Values.frontend.image }}:{{ .Values.frontend.tag }}"
         ports:
           - name: http
             containerPort: 8081
@@ -82,7 +83,7 @@ spec:
         - name: KUBERPULT_ARGOCD_BASE_URL
           value: {{ .Values.argocd.baseUrl | quote }}
         - name: KUBERPULT_VERSION
-          value: {{ .Values.frontendTag | quote}}
+          value: {{ .Values.frontend.tag | quote}}
         - name: KUBERPULT_SOURCE_REPO_URL
           value: {{ .Values.git.sourceRepoUrl | quote}}
         - name: LOG_FORMAT

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -8,7 +8,11 @@ git:
   sourceRepoUrl: ""
 
 hub: europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
-tag: "$VERSION"
+# In MOST cases, do NOT overwrite the version tags.
+# Generally speaking, kuberpult only guarantees that running with the same version of frontend and cd service will work.
+# For testing purposes, we allow to overwrite the tags individually, to test an old frontend service with a new cd service.
+frontendTag: "$VERSION"
+cdTag: "$VERSION"
 
 log:
   # Possible values are "gcp" for a gcp-optimized format and "default" for json

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -8,11 +8,6 @@ git:
   sourceRepoUrl: ""
 
 hub: europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
-# In MOST cases, do NOT overwrite the version tags.
-# Generally speaking, kuberpult only guarantees that running with the same version of frontend and cd service will work.
-# For testing purposes, we allow to overwrite the tags individually, to test an old frontend service with a new cd service.
-frontendTag: "$VERSION"
-cdTag: "$VERSION"
 
 log:
   # Possible values are "gcp" for a gcp-optimized format and "default" for json
@@ -21,6 +16,10 @@ log:
   level: "WARN"
 cd:
   image: kuberpult-cd-service
+# In MOST cases, do NOT overwrite the "tag".
+# In general, kuberpult only guarantees that running with the same version of frontend and cd service will work.
+# For testing purposes, we allow to overwrite the tags individually, to test an old frontend service with a new cd service.
+  tag: "$VERSION"
   backendConfig:
     create: false   # Add backend config for health checks on GKE only
     timeoutSec: 300  # 30sec is the default on gcp loadbalancers, however kuberpult needs more with parallel requests. It is the time how long the loadbalancer waits for kuberpult to finish calls to the rest endpoint "release"
@@ -34,6 +33,10 @@ cd:
   enableSqlite: true
 frontend:
   image: kuberpult-frontend-service
+# In MOST cases, do NOT overwrite the "tag".
+# In general, kuberpult only guarantees that running with the same version of frontend and cd service will work.
+# For testing purposes, we allow to overwrite the tags individually, to test an old frontend service with a new cd service.
+  tag: "$VERSION"
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
This is *technically* a breaking change.

This change allows to specify different docker image tags for the cd service and the frontend service.

However, this is only the case if you specify the "tag" in the helm chart. It is rather unlikely that you do this.
In almost every case, kuberpult should run with the same version for all microservices (cd services and frontend service).