### PR TITLE
Refactored error handling in batch endpoint

### DIFF
--- a/services/cd-service/pkg/httperrors/httperrors.go
+++ b/services/cd-service/pkg/httperrors/httperrors.go
@@ -30,8 +30,8 @@ func InternalError(ctx context.Context, err error) error {
 	return status.Error(codes.Internal, "internal error")
 }
 
-func PublicError(ctx context.Context, err error) error {
+func InvalidArgumentError(ctx context.Context, err error) error {
 	logger := logger.FromContext(ctx)
-	logger.Error("grpc.internal", zap.Error(err))
+	logger.Warn("grpc.invalidArgument", zap.Error(err))
 	return status.Error(codes.InvalidArgument, "error: "+err.Error())
 }

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -22,7 +22,6 @@ import (
 	"github.com/freiheit-com/kuberpult/pkg/api"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/httperrors"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
-	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/valid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -34,69 +33,13 @@ type BatchServer struct {
 
 const maxBatchActions int = 100
 
-func ValidateEnvironmentLock(
-	actionType string, // "create" | "delete"
-	env string,
-	id string,
-) error {
-	if !valid.EnvironmentName(env) {
-		return status.Error(codes.InvalidArgument, fmt.Sprintf("cannot %s environment lock: invalid environment: '%s'", actionType, env))
-	}
-	if !valid.LockId(id) {
-		return status.Error(codes.InvalidArgument, fmt.Sprintf("cannot %s environment lock: invalid lock id: '%s'", actionType, id))
-	}
-	return nil
-}
-
-func ValidateEnvironmentApplicationLock(
-	actionType string, // "create" | "delete"
-	env string,
-	app string,
-	id string,
-) error {
-	if !valid.EnvironmentName(env) {
-		return status.Error(codes.InvalidArgument, fmt.Sprintf("cannot %s environment application lock: invalid environment: '%s'", actionType, env))
-	}
-	if !valid.ApplicationName(app) {
-		return status.Error(codes.InvalidArgument, fmt.Sprintf("cannot %s environment application lock: invalid application: '%s'", actionType, app))
-	}
-	if !valid.LockId(id) {
-		return status.Error(codes.InvalidArgument, fmt.Sprintf("cannot %s environment application lock: invalid lock id: '%s'", actionType, id))
-	}
-	return nil
-}
-
-func ValidateDeployment(
-	env string,
-	app string,
-) error {
-	if !valid.EnvironmentName(env) {
-		return status.Error(codes.InvalidArgument, fmt.Sprintf("cannot deploy environment application lock: invalid environment: '%s'", env))
-	}
-	if !valid.ApplicationName(app) {
-		return status.Error(codes.InvalidArgument, fmt.Sprintf("cannot deploy environment application lock: invalid application: '%s'", app))
-	}
-	return nil
-}
-
-func ValidateApplication(
-	app string,
-) error {
-	if !valid.ApplicationName(app) {
-		return status.Error(codes.InvalidArgument, fmt.Sprintf("cannot create undeploy version: invalid application: '%s'", app))
-	}
-	return nil
-}
-
 func (d *BatchServer) processAction(
+	ctx context.Context,
 	batchAction *api.BatchAction,
 ) (repository.Transformer, error) {
 	switch action := batchAction.Action.(type) {
 	case *api.BatchAction_CreateEnvironmentLock:
 		act := action.CreateEnvironmentLock
-		if err := ValidateEnvironmentLock("create", act.Environment, act.LockId); err != nil {
-			return nil, err
-		}
 		return &repository.CreateEnvironmentLock{
 			Environment: act.Environment,
 			LockId:      act.LockId,
@@ -104,18 +47,12 @@ func (d *BatchServer) processAction(
 		}, nil
 	case *api.BatchAction_DeleteEnvironmentLock:
 		act := action.DeleteEnvironmentLock
-		if err := ValidateEnvironmentLock("delete", act.Environment, act.LockId); err != nil {
-			return nil, err
-		}
 		return &repository.DeleteEnvironmentLock{
 			Environment: act.Environment,
 			LockId:      act.LockId,
 		}, nil
 	case *api.BatchAction_CreateEnvironmentApplicationLock:
 		act := action.CreateEnvironmentApplicationLock
-		if err := ValidateEnvironmentApplicationLock("create", act.Environment, act.Application, act.LockId); err != nil {
-			return nil, err
-		}
 		return &repository.CreateEnvironmentApplicationLock{
 			Environment: act.Environment,
 			Application: act.Application,
@@ -124,9 +61,6 @@ func (d *BatchServer) processAction(
 		}, nil
 	case *api.BatchAction_DeleteEnvironmentApplicationLock:
 		act := action.DeleteEnvironmentApplicationLock
-		if err := ValidateEnvironmentApplicationLock("delete", act.Environment, act.Application, act.LockId); err != nil {
-			return nil, err
-		}
 		return &repository.DeleteEnvironmentApplicationLock{
 			Environment: act.Environment,
 			Application: act.Application,
@@ -134,25 +68,16 @@ func (d *BatchServer) processAction(
 		}, nil
 	case *api.BatchAction_PrepareUndeploy:
 		act := action.PrepareUndeploy
-		if err := ValidateApplication(act.Application); err != nil {
-			return nil, err
-		}
 		return &repository.CreateUndeployApplicationVersion{
 			Application: act.Application,
 		}, nil
 	case *api.BatchAction_Undeploy:
 		act := action.Undeploy
-		if err := ValidateApplication(act.Application); err != nil {
-			return nil, err
-		}
 		return &repository.UndeployApplication{
 			Application: act.Application,
 		}, nil
 	case *api.BatchAction_Deploy:
 		act := action.Deploy
-		if err := ValidateDeployment(act.Environment, act.Application); err != nil {
-			return nil, err
-		}
 		b := act.LockBehavior
 		if act.IgnoreAllLocks {
 			// the UI currently sets this to true,
@@ -171,8 +96,10 @@ func (d *BatchServer) processAction(
 			Environment: act.Environment,
 			Application: act.Application,
 		}, nil
+	default:
+		//action
+		return nil, httperrors.InvalidArgumentError(ctx, fmt.Errorf("processAction: cannot process action: invalid action type %T", action))
 	}
-	return nil, status.Error(codes.InvalidArgument, "processAction: cannot process action: invalid action type")
 }
 
 func (d *BatchServer) ProcessBatch(
@@ -184,15 +111,20 @@ func (d *BatchServer) ProcessBatch(
 	}
 	transformers := make([]repository.Transformer, 0, maxBatchActions)
 	for _, batchAction := range in.GetActions() {
-		transformer, err := d.processAction(batchAction)
+		transformer, err := d.processAction(ctx, batchAction)
 		if err != nil {
-			// Validation error
 			return nil, err
 		}
 		transformers = append(transformers, transformer)
 	}
 	err := d.Repository.Apply(ctx, transformers...)
 	if err != nil {
+		statusErr, ok := status.FromError(err)
+		if ok && statusErr != nil {
+			// if it is a status error, we return to the caller without change:
+			return nil, err
+		}
+		// otherwise, we use InternalError to print the error and return just a generic error message to the caller:
 		return nil, httperrors.InternalError(ctx, fmt.Errorf("could not apply transformer: %w", err))
 	}
 	return &emptypb.Empty{}, nil

--- a/services/cd-service/pkg/service/deploy.go
+++ b/services/cd-service/pkg/service/deploy.go
@@ -36,9 +36,6 @@ func (d *DeployServiceServer) Deploy(
 	ctx context.Context,
 	in *api.DeployRequest,
 ) (*emptypb.Empty, error) {
-	if err := ValidateDeployment(in.Environment, in.Application); err != nil {
-		return nil, err
-	}
 	b := in.LockBehavior
 	if in.IgnoreAllLocks {
 		// the UI currently sets this to true,

--- a/services/cd-service/pkg/service/lock.go
+++ b/services/cd-service/pkg/service/lock.go
@@ -31,11 +31,7 @@ type LockServiceServer struct {
 func (l *LockServiceServer) CreateEnvironmentLock(
 	ctx context.Context,
 	in *api.CreateEnvironmentLockRequest) (*emptypb.Empty, error) {
-	err := ValidateEnvironmentLock("create", in.Environment, in.LockId)
-	if err != nil {
-		return nil, err
-	}
-	err = l.Repository.Apply(ctx, &repository.CreateEnvironmentLock{
+	err := l.Repository.Apply(ctx, &repository.CreateEnvironmentLock{
 		Environment: in.Environment,
 		LockId:      in.LockId,
 		Message:     in.Message,
@@ -49,11 +45,7 @@ func (l *LockServiceServer) CreateEnvironmentLock(
 func (l *LockServiceServer) DeleteEnvironmentLock(
 	ctx context.Context,
 	in *api.DeleteEnvironmentLockRequest) (*emptypb.Empty, error) {
-	err := ValidateEnvironmentLock("delete", in.Environment, in.LockId)
-	if err != nil {
-		return nil, err
-	}
-	err = l.Repository.Apply(ctx, &repository.DeleteEnvironmentLock{
+	err := l.Repository.Apply(ctx, &repository.DeleteEnvironmentLock{
 		Environment: in.Environment,
 		LockId:      in.LockId,
 	})
@@ -66,11 +58,7 @@ func (l *LockServiceServer) DeleteEnvironmentLock(
 func (l *LockServiceServer) CreateEnvironmentApplicationLock(
 	ctx context.Context,
 	in *api.CreateEnvironmentApplicationLockRequest) (*emptypb.Empty, error) {
-	err := ValidateEnvironmentApplicationLock("create", in.Environment, in.Application, in.LockId)
-	if err != nil {
-		return nil, err
-	}
-	err = l.Repository.Apply(ctx, &repository.CreateEnvironmentApplicationLock{
+	err := l.Repository.Apply(ctx, &repository.CreateEnvironmentApplicationLock{
 		Environment: in.Environment,
 		Application: in.Application,
 		LockId:      in.LockId,
@@ -85,11 +73,7 @@ func (l *LockServiceServer) CreateEnvironmentApplicationLock(
 func (l *LockServiceServer) DeleteEnvironmentApplicationLock(
 	ctx context.Context,
 	in *api.DeleteEnvironmentApplicationLockRequest) (*emptypb.Empty, error) {
-	err := ValidateEnvironmentApplicationLock("delete", in.Environment, in.Application, in.LockId)
-	if err != nil {
-		return nil, err
-	}
-	err = l.Repository.Apply(ctx, &repository.DeleteEnvironmentApplicationLock{
+	err := l.Repository.Apply(ctx, &repository.DeleteEnvironmentApplicationLock{
 		Environment: in.Environment,
 		Application: in.Application,
 		LockId:      in.LockId,


### PR DESCRIPTION
Now the batch endpoint can easily distinguish between internal and public errors. Public errors are sent back to the client.
Internal errors are logged only and the client just receives "internal error"

To achieve this, the validation functions have all been inlined into the transformers. This way the transformers are self sufficient, and validations do not need to be duplicated either.