### PR TITLE
Also lock when deploying manually

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -278,6 +278,31 @@ describe('Release Dialog', () => {
             const result = querySelectorSafe('.env-card-deploy-btn');
             fireEvent.click(result);
             expect(UpdateSidebar.get().shown).toBeTruthy();
+            expect(UpdateAction.get().actions).toEqual([
+                {
+                    action: {
+                        $case: 'deploy',
+                        deploy: {
+                            application: 'test1',
+                            environment: 'prod',
+                            ignoreAllLocks: false,
+                            lockBehavior: 2,
+                            version: 3,
+                        },
+                    },
+                },
+                {
+                    action: {
+                        $case: 'createEnvironmentApplicationLock',
+                        createEnvironmentApplicationLock: {
+                            application: 'test1',
+                            environment: 'prod',
+                            lockId: '',
+                            message: '',
+                        },
+                    },
+                },
+            ]);
         });
         it('Test using add lock button click simulation', () => {
             UpdateSidebar.set({ shown: false });
@@ -297,6 +322,19 @@ describe('Release Dialog', () => {
             const result = querySelectorSafe('.env-card-add-lock-btn');
             fireEvent.click(result);
             expect(UpdateSidebar.get().shown).toBeTruthy();
+            expect(UpdateAction.get().actions).toEqual([
+                {
+                    action: {
+                        $case: 'createEnvironmentApplicationLock',
+                        createEnvironmentApplicationLock: {
+                            application: 'test1',
+                            environment: 'prod',
+                            lockId: '',
+                            message: '',
+                        },
+                    },
+                },
+            ]);
         });
     });
 });

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -15,7 +15,7 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright 2023 freiheit.com*/
 import { EnvironmentListItem, ReleaseDialog, ReleaseDialogProps } from './ReleaseDialog';
 import { fireEvent, render } from '@testing-library/react';
-import { UpdateOverview, UpdateSidebar } from '../../utils/store';
+import { UpdateAction, UpdateOverview, UpdateSidebar } from '../../utils/store';
 import { Environment, Priority, Release, UndeploySummary } from '../../../api/api';
 import { Spy } from 'spy4js';
 import { SideBar } from '../SideBar/SideBar';
@@ -264,6 +264,7 @@ describe('Release Dialog', () => {
         });
         it('Test using deploy button click simulation', () => {
             UpdateSidebar.set({ shown: false });
+            UpdateAction.set({ actions: [] });
             setTheStore(testcase);
 
             render(
@@ -280,6 +281,7 @@ describe('Release Dialog', () => {
         });
         it('Test using add lock button click simulation', () => {
             UpdateSidebar.set({ shown: false });
+            UpdateAction.set({ actions: [] });
             setTheStore(testcase);
 
             getWrapper(testcase.props);

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -108,7 +108,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
             });
         }
         createAppLock();
-    }, [app, env.name, release.version, createAppLock]);
+    }, [app, env.name, release.version]);
     const queueInfo =
         queuedVersion === 0 ? null : (
             <div

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -108,7 +108,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
             });
         }
         createAppLock();
-    }, [app, env.name, release.version]);
+    }, [app, env.name, release.version, createAppLock]);
     const queueInfo =
         queuedVersion === 0 ? null : (
             <div

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -79,6 +79,19 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
     queuedVersion,
     className,
 }) => {
+    const createAppLock = useCallback(() => {
+        addAction({
+            action: {
+                $case: 'createEnvironmentApplicationLock',
+                createEnvironmentApplicationLock: {
+                    environment: env.name,
+                    application: app,
+                    lockId: '',
+                    message: '',
+                },
+            },
+        });
+    }, [app, env.name]);
     const deploy = useCallback(() => {
         if (release.version) {
             addAction({
@@ -94,20 +107,8 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                 },
             });
         }
-    }, [app, env.name, release.version]);
-    const createAppLock = useCallback(() => {
-        addAction({
-            action: {
-                $case: 'createEnvironmentApplicationLock',
-                createEnvironmentApplicationLock: {
-                    environment: env.name,
-                    application: app,
-                    lockId: '',
-                    message: '',
-                },
-            },
-        });
-    }, [app, env.name]);
+        createAppLock();
+    }, [app, env.name, release.version, createAppLock]);
     const queueInfo =
         queuedVersion === 0 ? null : (
             <div
@@ -181,12 +182,17 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                             onClick={createAppLock}
                             icon={<Locks className="icon" />}
                         />
-                        <Button
-                            disabled={application && application.version === release.version}
-                            className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
-                            onClick={deploy}
-                            label="Deploy"
-                        />
+                        <div
+                            title={
+                                'When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the "planned actions".'
+                            }>
+                            <Button
+                                disabled={application && application.version === release.version}
+                                className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
+                                onClick={deploy}
+                                label="Deploy & Lock"
+                            />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -198,20 +198,24 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                         Add lock
                       </span>
                     </button>
-                    <button
-                      aria-label="Deploy"
-                      class="mdc-button env-card-deploy-btn mdc-button--unelevated"
-                      disabled=""
+                    <div
+                      title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
                     >
-                      <div
-                        class="mdc-button__ripple"
-                      />
-                      <span
-                        class="mdc-button__label"
+                      <button
+                        aria-label="Deploy & Lock"
+                        class="mdc-button env-card-deploy-btn mdc-button--unelevated"
+                        disabled=""
                       >
-                        Deploy
-                      </span>
-                    </button>
+                        <div
+                          class="mdc-button__ripple"
+                        />
+                        <span
+                          class="mdc-button__label"
+                        >
+                          Deploy & Lock
+                        </span>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -426,20 +430,24 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                         Add lock
                       </span>
                     </button>
-                    <button
-                      aria-label="Deploy"
-                      class="mdc-button env-card-deploy-btn mdc-button--unelevated"
-                      disabled=""
+                    <div
+                      title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
                     >
-                      <div
-                        class="mdc-button__ripple"
-                      />
-                      <span
-                        class="mdc-button__label"
+                      <button
+                        aria-label="Deploy & Lock"
+                        class="mdc-button env-card-deploy-btn mdc-button--unelevated"
+                        disabled=""
                       >
-                        Deploy
-                      </span>
-                    </button>
+                        <div
+                          class="mdc-button__ripple"
+                        />
+                        <span
+                          class="mdc-button__label"
+                        >
+                          Deploy & Lock
+                        </span>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -563,19 +571,23 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                         Add lock
                       </span>
                     </button>
-                    <button
-                      aria-label="Deploy"
-                      class="mdc-button env-card-deploy-btn mdc-button--unelevated"
+                    <div
+                      title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
                     >
-                      <div
-                        class="mdc-button__ripple"
-                      />
-                      <span
-                        class="mdc-button__label"
+                      <button
+                        aria-label="Deploy & Lock"
+                        class="mdc-button env-card-deploy-btn mdc-button--unelevated"
                       >
-                        Deploy
-                      </span>
-                    </button>
+                        <div
+                          class="mdc-button__ripple"
+                        />
+                        <span
+                          class="mdc-button__label"
+                        >
+                          Deploy & Lock
+                        </span>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Manual deployment happen usually when there is an important bugfix to be deployed. In that scenario, usually a lock is a good idea. With this change, the "deploy" button is replaced by "deploy & lock".
![Screenshot from 2023-06-16 17-48-11](https://github.com/freiheit-com/kuberpult/assets/3481382/9d8bb0a8-da23-4b33-80b6-954a7ce18045)



SRX-S3C8AL