### PR TITLE
Prepare for upgrade to node 18

### DIFF
--- a/README_DEVELOPERS.md
+++ b/README_DEVELOPERS.md
@@ -116,6 +116,7 @@ backend:
 
 - [docker](https://docs.docker.com/get-docker/) - for docker build for cd-service - optional
 - [node](https://nodejs.org/en/download/) - ensure you're using an LTS version (or use [nvm](https://github.com/nvm-sh/nvm#installing-and-updating))
+Ideally use the same version as in the [package.json](https://github.com/freiheit-com/kuberpult/blob/main/services/frontend-service/package.json#L42)
 - [pnpm](https://pnpm.io/installation)
 
 ## Libraries required

--- a/services/frontend-service/src/react-app-env.d.ts
+++ b/services/frontend-service/src/react-app-env.d.ts
@@ -13,9 +13,10 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-/// <reference types="react-scripts" />
-declare module NodeJS {
-    interface Global {
-        nextTick: () => Promise<void>;
-    }
+declare module globalThis {
+    var nextTick: () => Promise<void>;
+}
+
+declare module '*.svg' {
+    export const ReactComponent: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
 }

--- a/services/frontend-service/src/ui/utils/AzureAuthProvider.test.tsx
+++ b/services/frontend-service/src/ui/utils/AzureAuthProvider.test.tsx
@@ -85,7 +85,7 @@ describe('AuthProvider', () => {
                     <AuthenticatedTemplate>Authenticated</AuthenticatedTemplate>
                 </MsalProvider>
             );
-            await act(async () => await global.nextTick());
+            await act(async (): Promise<void> => await global.nextTick());
             await waitFor(() => expect(handleRedirectSpy).toHaveBeenCalledTimes(1));
             expect(screen.getByText('Authenticated')).toBeInTheDocument();
         });


### PR DESCRIPTION
This change should enable renovate (https://github.com/freiheit-com/kuberpult/pull/632) to succeed with the upgrade to node18