### PR TITLE
Do not ignore git push errors

### DIFF
--- a/services/cd-service/Makefile
+++ b/services/cd-service/Makefile
@@ -77,7 +77,9 @@ run: docker
 	docker run --rm -e KUBERPULT_GIT_URL="/repository_remote" -e KUBERPULT_GIT_BRANCH=master -p 8080:8080 -p 8443:8443 -v $(shell pwd)/repository_remote:/repository_remote $(IMAGENAME)
 else
 run: build
-	KUBERPULT_GIT_URL="./repository_remote" KUBERPULT_GIT_BRANCH=master ./bin/main
+	#KUBERPULT_GIT_URL="./repository_remote" KUBERPULT_GIT_BRANCH=master ./bin/main
+#	KUBERPULT_GIT_URL="git@github.com:sven-urbanski-freiheit-com/manifest-test.git" KUBERPULT_GIT_BRANCH="main" KUBERPULT_GIT_SSH_KEY="../../private.key" KUBERPULT_GIT_SSH_KNOWN_HOSTS=../../known_hosts_github  ./bin/main
+	KUBERPULT_GIT_URL="git@github.com:freiheit-com/fdc-standard-setup-dev-env-manifest.git" KUBERPULT_GIT_BRANCH="main" KUBERPULT_GIT_SSH_KEY="../../private.key" KUBERPULT_GIT_SSH_KNOWN_HOSTS=../../known_hosts_github  ./bin/main
 endif
 
 bin/main: bin/ $(ALL_GO_FILES) | proto

--- a/services/cd-service/Makefile
+++ b/services/cd-service/Makefile
@@ -77,9 +77,7 @@ run: docker
 	docker run --rm -e KUBERPULT_GIT_URL="/repository_remote" -e KUBERPULT_GIT_BRANCH=master -p 8080:8080 -p 8443:8443 -v $(shell pwd)/repository_remote:/repository_remote $(IMAGENAME)
 else
 run: build
-	#KUBERPULT_GIT_URL="./repository_remote" KUBERPULT_GIT_BRANCH=master ./bin/main
-#	KUBERPULT_GIT_URL="git@github.com:sven-urbanski-freiheit-com/manifest-test.git" KUBERPULT_GIT_BRANCH="main" KUBERPULT_GIT_SSH_KEY="../../private.key" KUBERPULT_GIT_SSH_KNOWN_HOSTS=../../known_hosts_github  ./bin/main
-	KUBERPULT_GIT_URL="git@github.com:freiheit-com/fdc-standard-setup-dev-env-manifest.git" KUBERPULT_GIT_BRANCH="main" KUBERPULT_GIT_SSH_KEY="../../private.key" KUBERPULT_GIT_SSH_KNOWN_HOSTS=../../known_hosts_github  ./bin/main
+	KUBERPULT_GIT_URL="./repository_remote" KUBERPULT_GIT_BRANCH=master ./bin/main
 endif
 
 bin/main: bin/ $(ALL_GO_FILES) | proto

--- a/services/cd-service/pkg/httperrors/httperrors.go
+++ b/services/cd-service/pkg/httperrors/httperrors.go
@@ -32,6 +32,6 @@ func InternalError(ctx context.Context, err error) error {
 
 func PublicError(ctx context.Context, err error) error {
 	logger := logger.FromContext(ctx)
-	logger.Error("grpc.internal", zap.Error(err))
+	logger.Error("grpc.public", zap.Error(err))
 	return status.Error(codes.InvalidArgument, "error: "+err.Error())
 }

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -350,9 +350,8 @@ func (r *repository) ProcessQueueOnce(ctx context.Context, e element) {
 	elements = append(elements, r.drainQueue()...)
 
 	var pushCallbackSuccess = false
-	var pushUpdate = func(refname string, status string) error {
-		logger.Warn(fmt.Sprintf("SU DEBUG updated refname: '%s' with status '%s'", refname, status))
-		pushCallbackSuccess = refname == fmt.Sprintf("refs/heads/%s", r.config.Branch) && status == ""
+	var pushUpdate = func(refName string, status string) error {
+		pushCallbackSuccess = refName == fmt.Sprintf("refs/heads/%s", r.config.Branch) && status == ""
 		return nil
 	}
 	pushOptions := git.PushOptions{

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -393,9 +393,7 @@ func (r *repository) ProcessQueueOnce(ctx context.Context, e element, callback P
 	}
 
 	// Try pushing once
-	logger.Error(fmt.Sprintf("SU DEBUG before push"))
 	err = r.Push(e.ctx, pushAction(pushOptions, r))
-	logger.Error(fmt.Sprintf("SU DEBUG after push, error=%v", err))
 	if err != nil {
 		gerr := err.(*git.GitError)
 		// If it doesn't work because the branch diverged, try reset and apply again.

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -420,7 +420,6 @@ func (r *repository) ProcessQueueOnce(ctx context.Context, e element, callback P
 		}
 	}
 	r.notify.Notify()
-	logger.Error(fmt.Sprintf("SU DEBUG after notify"))
 }
 
 func (r *repository) ApplyTransformersInternal(ctx context.Context, transformers ...Transformer) ([]string, *State, error) {

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -872,6 +872,12 @@ func (s *SlowTransformer) Transform(ctx context.Context, state *State) (string, 
 	return "ok", nil
 }
 
+type EmptyTransformer struct{}
+
+func (p *EmptyTransformer) Transform(ctx context.Context, state *State) (string, error) {
+	return "nothing happened", nil
+}
+
 type PanicTransformer struct{}
 
 func (p *PanicTransformer) Transform(ctx context.Context, state *State) (string, error) {
@@ -1354,5 +1360,155 @@ func BenchmarkApplyQueue(t *testing.B) {
 	releases, _ := repo.State().Releases("foo")
 	if !cmp.Equal(expectedReleases, convertToSet(releases)) {
 		t.Fatal("Output mismatch (-want +got):\n", cmp.Diff(expectedReleases, convertToSet(releases)))
+	}
+}
+
+func TestPushUpdate(t *testing.T) {
+	tcs := []struct {
+		Name            string
+		InputBranch     string
+		InputRefName    string
+		InputStatus     string
+		ExpectedSuccess bool
+	}{
+		{
+			Name:            "Should succeed",
+			InputBranch:     "main",
+			InputRefName:    "refs/heads/main",
+			InputStatus:     "",
+			ExpectedSuccess: true,
+		},
+		{
+			Name:            "Should fail because wrong branch",
+			InputBranch:     "main",
+			InputRefName:    "refs/heads/master",
+			InputStatus:     "",
+			ExpectedSuccess: false,
+		},
+		{
+			Name:            "Should fail because status not empty",
+			InputBranch:     "master",
+			InputRefName:    "refs/heads/master",
+			InputStatus:     "i am the status, stopping this from working",
+			ExpectedSuccess: false,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			var success = false
+			actualError := DefaultPushUpdate(tc.InputBranch, &success)(tc.InputRefName, tc.InputStatus)
+			if success != tc.ExpectedSuccess {
+				t.Fatal(fmt.Sprintf("expected sucess=%t but got %t", tc.ExpectedSuccess, success))
+			}
+			if actualError != nil {
+				t.Fatal(fmt.Sprintf("expected no error but got %s but got none", actualError))
+			}
+		})
+	}
+}
+
+func TestProcessQueueOnce(t *testing.T) {
+	tcs := []struct {
+		Name           string
+		Element        element
+		PushUpdateFunc PushUpdateFunc
+		PushActionFunc PushActionCallbackFunc
+		ExpectedError  error
+	}{
+		{
+			Name:           "success",
+			PushUpdateFunc: DefaultPushUpdate,
+			PushActionFunc: DefaultPushActionCallback,
+			Element: element{
+				ctx: context.Background(),
+				transformers: []Transformer{
+					&EmptyTransformer{},
+				},
+				result: make(chan error, 1),
+			},
+			ExpectedError: nil,
+		},
+		{
+			Name: "failure because DefaultPushUpdate is wrong (branch protection)",
+			PushUpdateFunc: func(s string, success *bool) git.PushUpdateReferenceCallback {
+				*success = false
+				return nil
+			},
+			PushActionFunc: DefaultPushActionCallback,
+			Element: element{
+				ctx: context.Background(),
+				transformers: []Transformer{
+					&EmptyTransformer{},
+				},
+				result: make(chan error, 1),
+			},
+			ExpectedError: errors.New("failed to push - this indicates that branch protection is enabled in 'file://$DIR/remote' on branch 'master'"),
+		},
+		{
+			Name: "failure because error is returned in push (ssh key has read only access)",
+			PushUpdateFunc: func(s string, success *bool) git.PushUpdateReferenceCallback {
+				return nil
+			},
+			PushActionFunc: func(options git.PushOptions, r *repository) PushActionFunc {
+				return func() error {
+					return git.MakeGitError(1)
+				}
+			},
+			Element: element{
+				ctx: context.Background(),
+				transformers: []Transformer{
+					&EmptyTransformer{},
+				},
+				result: make(chan error, 1),
+			},
+			ExpectedError: errors.New("rpc error: code = InvalidArgument desc = error: could not push to manifest repository 'file://$DIR/remote' on branch 'master' - this indicates that the ssh key does not have write access"),
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			// create a remote
+			dir := t.TempDir()
+			t.Logf("tmp dir: %s", dir)
+			remoteDir := path.Join(dir, "remote")
+			localDir := path.Join(dir, "local")
+			cmd := exec.Command("git", "init", "--bare", remoteDir)
+			cmd.Start()
+			cmd.Wait()
+			repo, actualError := New(
+				context.Background(),
+				RepositoryConfig{
+					URL:  "file://" + remoteDir,
+					Path: localDir,
+				},
+			)
+			if actualError != nil {
+				t.Fatalf("new: expected no error, got '%e'", actualError)
+			}
+			repoInternal := repo.(*repository)
+			repoInternal.ProcessQueueOnce(context.Background(), tc.Element, tc.PushUpdateFunc, tc.PushActionFunc)
+
+			t.Logf("after processQueueOnce")
+
+			result := tc.Element.result
+			actualError = <-result
+			if tc.ExpectedError == nil && actualError == nil {
+				return
+			}
+			if tc.ExpectedError == nil && actualError != nil {
+				t.Fatalf("result error is not:\n\"%v\"\nbut got:\n\"%v\"", nil, actualError.Error())
+			}
+			if tc.ExpectedError != nil && actualError == nil {
+				t.Fatalf("result error is not:\n\"%v\"\nbut got:\n\"%v\"", tc.ExpectedError, nil)
+			}
+			expectedError := strings.ReplaceAll(tc.ExpectedError.Error(), "$DIR", dir)
+			if actualError.Error() != expectedError {
+				t.Errorf("result error is not:\n\"%v\"\nbut got:\n\"%v\"", expectedError, actualError.Error())
+			}
+		})
 	}
 }

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -1473,7 +1473,6 @@ func TestProcessQueueOnce(t *testing.T) {
 
 			// create a remote
 			dir := t.TempDir()
-			t.Logf("tmp dir: %s", dir)
 			remoteDir := path.Join(dir, "remote")
 			localDir := path.Join(dir, "local")
 			cmd := exec.Command("git", "init", "--bare", remoteDir)
@@ -1491,8 +1490,6 @@ func TestProcessQueueOnce(t *testing.T) {
 			}
 			repoInternal := repo.(*repository)
 			repoInternal.ProcessQueueOnce(context.Background(), tc.Element, tc.PushUpdateFunc, tc.PushActionFunc)
-
-			t.Logf("after processQueueOnce")
 
 			result := tc.Element.result
 			actualError = <-result

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -192,7 +192,6 @@ func (d *BatchServer) ProcessBatch(
 	}
 	err := d.Repository.Apply(ctx, transformers...)
 	if err != nil {
-		//return nil, httperrors.InternalError(ctx, fmt.Errorf("could not apply transformer: %w", err))
 		return nil, err
 	}
 	return &emptypb.Empty{}, nil

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/freiheit-com/kuberpult/pkg/api"
-	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/httperrors"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/valid"
 	"google.golang.org/grpc/codes"
@@ -193,7 +192,8 @@ func (d *BatchServer) ProcessBatch(
 	}
 	err := d.Repository.Apply(ctx, transformers...)
 	if err != nil {
-		return nil, httperrors.InternalError(ctx, fmt.Errorf("could not apply transformer: %w", err))
+		//return nil, httperrors.InternalError(ctx, fmt.Errorf("could not apply transformer: %w", err))
+		return nil, err
 	}
 	return &emptypb.Empty{}, nil
 }


### PR DESCRIPTION
Do not ignore git push errors
    
Also return readible error in case we cannot push to the manifest repo.
    
2 error cases are handled in this PR:
1) the ssh key does only have read only access. This returns a normal error (at least on github)
2) there is a branch protection rule stopping access. This is not a normal error, but signaled via the "PushUpdateReferenceCallback"

In both cases we return the error to the caller instead of "internal error".

In order to test these 2 error cases, I had to introduce 2 Callbacks for `ProcessQueueOnce`.

This is the solution for https://github.com/freiheit-com/kuberpult/issues/712