### PR TITLE
Make git author configurable in helm chart & refactor context usage

### DIFF
--- a/README_DEVELOPERS.md
+++ b/README_DEVELOPERS.md
@@ -45,7 +45,11 @@ When the services are running with `docker-compose`, start evans like this:
 
 `evans --host localhost --port 8443  -r`
 
-`api.v1@localhost:8443> service DeployService`
+```
+header author-name=YXV0aG9y
+header author-email=YXV0aG9yQGF1dGhvcg==
+service DeployService
+```
 
 ```
 api.v1.DeployService@localhost:8443> call Deploy
@@ -56,6 +60,15 @@ ignoreAllLocks (TYPE_BOOL) => false
 ✔ Queue
 {}
 ```
+
+
+#### Why the author headers?
+
+With a recent change, the cd-service now always expect author headers to be set, both in grpc and http endpoints.
+`/release` is the exception to that, but it logs a warning, when there is no author.
+(And of course `/health` is another exception).
+The frontend-service is now the only point that knows about default-author (see helm chart `git.author.name` & `git.author.email`).
+The frontend-service can be called with headers, then those will be used. If none are found, we use the default headers from the helm chart.
 
 ### Test that setup was done correctly
 

--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -83,6 +83,10 @@ spec:
             cpu: "{{ .Values.frontend.resources.requests.cpu }}"
             memory: "{{ .Values.frontend.resources.requests.memory }}"
         env:
+        - name: KUBERPULT_GIT_AUTHOR_NAME
+          value: {{ .Values.git.author.name | quote }}
+        - name: KUBERPULT_GIT_AUTHOR_EMAIL
+          value: {{ .Values.git.author.email | quote }}
         - name: KUBERPULT_CDSERVER
           value: kuberpult-cd-service:8443
         - name: KUBERPULT_HTTP_CD_SERVER

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -6,6 +6,9 @@ git:
   url:  # git@github.com/.../...
   branch: "master"
   sourceRepoUrl: ""
+  author:
+    name: local.user@example.com
+    email: defaultUser
 
 hub: europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
 

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -17,6 +17,8 @@ services:
       - KUBERPULT_CDSERVER=kuberpult-cd-service:8443
       - KUBERPULT_ROLLOUTSERVER=kuberpult-rollout-service:8443
       - KUBERPULT_HTTP_CD_SERVER=http://kuberpult-cd-service:8080
+      - KUBERPULT_GIT_AUTHOR_NAME="integration tester"
+      - KUBERPULT_GIT_AUTHOR_EMAIL="integration.tester@example.com"
     ports:
       - "8081:8081"
     depends_on:

--- a/infrastructure/scripts/create-testdata/create-release.sh
+++ b/infrastructure/scripts/create-testdata/create-release.sh
@@ -44,14 +44,14 @@ echo ${msgs[$index]}" "$commit_id > "${commit_message_file}"
 
 ls ${commit_message_file}
 
-release_version=()
+release_version=''
 case "${RELEASE_VERSION:-}" in
 	'') echo "No RELEASE_VERSION set. Using non-idempotent versioning scheme";;
 	*[!0-9]*) echo "Please set the env variable RELEASE_VERSION to a number"; exit 1;;
-	*) release_version=(--form-string "version=${RELEASE_VERSION:-}");;
+	*) release_version='--form-string '"version=${RELEASE_VERSION:-}";;
 esac
 
-echo "release version:" "${release_version[@]}"
+echo "release version:" "${release_version}"
 
 configuration=()
 configuration+=("--form" "team=${applicationOwnerTeam}")
@@ -77,11 +77,13 @@ done
 echo commit id: ${commit_id}
 
 
-curl http://localhost:8081/release \
+curl http://localhost:8080/release \
+  -H "author-email:dW5kZWZpbmVkLXVzZXJAZXhhbXBsZS5jb20=" \
+  -H "author-name:dW5kZWZpbmVkLXVzZXI=" \
   --form-string "application=$name" \
   --form-string "source_commit_id=${commit_id}" \
   --form-string "source_author=${author}" \
-  "${release_version[@]}" \
+  ${release_version} \
   --form "source_message=<${commit_message_file}" \
   "${configuration[@]}" \
   "${manifests[@]}"

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -21,49 +21,49 @@ import (
 	"testing"
 )
 
-func TestAuthContextFunctions(t *testing.T) {
+func TestToFromContext(t *testing.T) {
 	tcs := []struct {
 		Name         string
-		Author       *User
-		ExpectedUser *User
+		Author       User
+		ExpectedUser User
 	}{
 		{
 			Name: "User is fully specified",
-			Author: &User{
+			Author: User{
 				Email: "new@test.com",
 				Name:  "New",
 			},
-			ExpectedUser: &User{
+			ExpectedUser: User{
 				Email: "new@test.com",
 				Name:  "New",
 			},
 		},
 		{
 			Name: "Name is not specified",
-			Author: &User{
+			Author: User{
 				Email: "new@test.com",
 			},
-			ExpectedUser: &User{
+			ExpectedUser: User{
 				Email: "new@test.com",
-				Name:  "new@test.com",
+				Name:  "",
 			},
 		},
 		{
 			Name: "Email is not specified",
-			Author: &User{
+			Author: User{
 				Name: "my name",
 			},
-			ExpectedUser: &User{
-				Email: "local.user@freiheit.com",
-				Name:  "defaultUser",
+			ExpectedUser: User{
+				Email: "",
+				Name:  "my name",
 			},
 		},
 		{
 			Name:   "User is not specified",
-			Author: nil,
-			ExpectedUser: &User{
-				Email: "local.user@freiheit.com",
-				Name:  "defaultUser",
+			Author: User{},
+			ExpectedUser: User{
+				Email: "",
+				Name:  "",
 			},
 		},
 	}
@@ -72,8 +72,11 @@ func TestAuthContextFunctions(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			ctx := ToContext(context.Background(), tc.Author)
-			u := Extract(ctx)
+			ctx := WriteUserToContext(context.Background(), tc.Author)
+			u, err := ReadUserFromContext(ctx)
+			if err != nil {
+				t.Fatalf("Unexpected error: %#v \n", err)
+			}
 			if u.Email != tc.ExpectedUser.Email {
 				t.Fatalf("Unexpected Email was extracted from context.\nexpected: %#v \nrecieved: %#v \n", tc.ExpectedUser.Email, u.Email)
 			}
@@ -82,5 +85,4 @@ func TestAuthContextFunctions(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -18,11 +18,13 @@ package cmd
 
 import (
 	"context"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/interceptors"
 	"net/http"
 	"os"
 	"sync"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/freiheit-com/kuberpult/pkg/api"
 	"github.com/freiheit-com/kuberpult/pkg/logger"
 	"github.com/freiheit-com/kuberpult/pkg/setup"
@@ -31,7 +33,6 @@ import (
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
-	"github.com/ProtonMail/go-crypto/openpgp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 	grpctrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
@@ -104,6 +105,7 @@ func RunServer() {
 		}
 		grpcUnaryInterceptors := []grpc.UnaryServerInterceptor{
 			grpc_zap.UnaryServerInterceptor(grpcServerLogger),
+			interceptors.UnaryUserContextInterceptor,
 		}
 
 		if c.EnableTracing {

--- a/services/cd-service/pkg/httperrors/httperrors.go
+++ b/services/cd-service/pkg/httperrors/httperrors.go
@@ -35,3 +35,7 @@ func PublicError(ctx context.Context, err error) error {
 	logger.Error("grpc.public", zap.Error(err))
 	return status.Error(codes.InvalidArgument, "error: "+err.Error())
 }
+
+func AuthError(ctx context.Context, err error) error {
+	return status.Error(codes.Unauthenticated, "error: "+err.Error())
+}

--- a/services/cd-service/pkg/interceptors/interceptors.go
+++ b/services/cd-service/pkg/interceptors/interceptors.go
@@ -1,0 +1,44 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package interceptors
+
+import (
+	"context"
+	"fmt"
+	"github.com/freiheit-com/kuberpult/pkg/auth"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
+	"google.golang.org/grpc"
+)
+
+// UnaryUserContextInterceptor assumes that there is a user in the context
+// if there is no user, it will return an auth error.
+// if there is a user, it will be written to the context.
+func UnaryUserContextInterceptor(ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler) (interface{}, error) {
+	logger.FromContext(ctx).Warn(fmt.Sprintf("UnaryUserContextInterceptor start "))
+
+	user, err := auth.ReadUserFromGrpcContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ctx = auth.WriteUserToContext(ctx, *user)
+
+	h, err := handler(ctx, req)
+	return h, err
+}

--- a/services/cd-service/pkg/repository/queue.go
+++ b/services/cd-service/pkg/repository/queue.go
@@ -25,7 +25,9 @@ Many parallel requests can happen in a CI with many microservices that all call 
 This queue does not improve the latency, because each request still waits for the push to finish.
 */
 
-import "context"
+import (
+	"context"
+)
 
 type queue struct {
 	elements chan element

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/testutil"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -50,7 +51,7 @@ func TestNew(t *testing.T) {
 			Setup: func(t *testing.T, remoteDir, localDir string) {
 				// run the initialization code once
 				_, err := New(
-					context.Background(),
+					testutil.MakeTestContext(),
 					RepositoryConfig{
 						URL:  "file://" + remoteDir,
 						Path: localDir,
@@ -76,7 +77,7 @@ func TestNew(t *testing.T) {
 			Setup: func(t *testing.T, remoteDir, localDir string) {
 				// run the initialization code once
 				repo, err := New(
-					context.Background(),
+					testutil.MakeTestContext(),
 					RepositoryConfig{
 						URL:  remoteDir,
 						Path: localDir,
@@ -85,7 +86,7 @@ func TestNew(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				err = repo.Apply(context.Background(), &CreateApplicationVersion{
+				err = repo.Apply(testutil.MakeTestContext(), &CreateApplicationVersion{
 					Application: "foo",
 					Manifests: map[string]string{
 						"development": "foo",
@@ -111,7 +112,7 @@ func TestNew(t *testing.T) {
 			Setup: func(t *testing.T, remoteDir, localDir string) {
 				// run the initialization code once
 				repo, err := New(
-					context.Background(),
+					testutil.MakeTestContext(),
 					RepositoryConfig{
 						URL:  remoteDir,
 						Path: t.TempDir(),
@@ -120,7 +121,7 @@ func TestNew(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				err = repo.Apply(context.Background(), &CreateApplicationVersion{
+				err = repo.Apply(testutil.MakeTestContext(), &CreateApplicationVersion{
 					Application: "foo",
 					Manifests: map[string]string{
 						"development": "foo",
@@ -146,7 +147,7 @@ func TestNew(t *testing.T) {
 			Branch: "not-master",
 			Setup:  func(t *testing.T, remoteDir, localDir string) {},
 			Test: func(t *testing.T, repo Repository, remoteDir string) {
-				err := repo.Apply(context.Background(), &CreateApplicationVersion{
+				err := repo.Apply(testutil.MakeTestContext(), &CreateApplicationVersion{
 					Application: "foo",
 					Manifests: map[string]string{
 						"development": "foo",
@@ -220,7 +221,7 @@ func TestNew(t *testing.T) {
 					}
 					t.Fatal(err)
 				}
-				err = repo.Apply(context.Background(), &CreateApplicationVersion{
+				err = repo.Apply(testutil.MakeTestContext(), &CreateApplicationVersion{
 					Application: "foo",
 					Manifests: map[string]string{
 						"development": "foo",
@@ -266,7 +267,7 @@ func TestNew(t *testing.T) {
 			cmd.Wait()
 			tc.Setup(t, remoteDir, localDir)
 			repo, err := New(
-				context.Background(),
+				testutil.MakeTestContext(),
 				RepositoryConfig{
 					URL:    "file://" + remoteDir,
 					Path:   localDir,
@@ -312,7 +313,7 @@ func TestBootstrapModeNew(t *testing.T) {
 
 			if tc.PreInitialize {
 				_, err := New(
-					context.Background(),
+					testutil.MakeTestContext(),
 					RepositoryConfig{
 						URL:  "file://" + remoteDir,
 						Path: localDir,
@@ -326,7 +327,7 @@ func TestBootstrapModeNew(t *testing.T) {
 			environmentConfigsPath := filepath.Join(remoteDir, "..", "environment_configs.json")
 
 			repo, err := New(
-				context.Background(),
+				testutil.MakeTestContext(),
 				RepositoryConfig{
 					URL:                    "file://" + remoteDir,
 					Path:                   localDir,
@@ -373,7 +374,7 @@ func TestBootstrapModeReadConfig(t *testing.T) {
 			}
 
 			repo, err := New(
-				context.Background(),
+				testutil.MakeTestContext(),
 				RepositoryConfig{
 					URL:                    "file://" + remoteDir,
 					Path:                   localDir,
@@ -438,7 +439,7 @@ func TestBootstrapError(t *testing.T) {
 			}
 
 			_, err := New(
-				context.Background(),
+				testutil.MakeTestContext(),
 				RepositoryConfig{
 					URL:                    "file://" + remoteDir,
 					Path:                   localDir,
@@ -546,7 +547,7 @@ func TestConfigReload(t *testing.T) {
 		}
 
 		repo, err := New(
-			context.Background(),
+			testutil.MakeTestContext(),
 			RepositoryConfig{
 				URL:  remoteDir,
 				Path: t.TempDir(),
@@ -562,7 +563,7 @@ func TestConfigReload(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err := repo.Apply(context.Background(), &CreateApplicationVersion{
+			err := repo.Apply(testutil.MakeTestContext(), &CreateApplicationVersion{
 				Application: "foo",
 				Manifests: map[string]string{
 					"development": "foo",
@@ -670,7 +671,7 @@ func TestConfigValidity(t *testing.T) {
 			}
 
 			_, err = New(
-				context.Background(),
+				testutil.MakeTestContext(),
 				RepositoryConfig{
 					URL:  remoteDir,
 					Path: t.TempDir(),
@@ -738,7 +739,7 @@ func TestGc(t *testing.T) {
 			cmd := exec.Command("git", "init", "--bare", remoteDir)
 			cmd.Start()
 			cmd.Wait()
-			ctx := context.Background()
+			ctx := testutil.MakeTestContext()
 			repo, err := New(
 				ctx,
 				RepositoryConfig{
@@ -832,7 +833,7 @@ func TestRetrySsh(t *testing.T) {
 			repo.backOffProvider = func() backoff.BackOff {
 				return backoff.WithMaxRetries(&backoff.ZeroBackOff{}, 5)
 			}
-			resp := repo.Push(context.Background(), func() error {
+			resp := repo.Push(testutil.MakeTestContext(), func() error {
 				counter++
 				if counter > tc.NumOfFailures {
 					return nil
@@ -968,7 +969,7 @@ func TestApplyQueuePanic(t *testing.T) {
 			cmd.Start()
 			cmd.Wait()
 			repo, err := New(
-				context.Background(),
+				testutil.MakeTestContext(),
 				RepositoryConfig{
 					URL:  "file://" + remoteDir,
 					Path: localDir,
@@ -982,13 +983,13 @@ func TestApplyQueuePanic(t *testing.T) {
 			finished := make(chan struct{})
 			started := make(chan struct{}, 1)
 			go func() {
-				repo.Apply(context.Background(), &SlowTransformer{finished, started})
+				repo.Apply(testutil.MakeTestContext(), &SlowTransformer{finished, started})
 			}()
 			<-started
 			// The worker go routine is now blocked. We can move some items into the queue now.
 			results := make([]<-chan error, len(tc.Actions))
 			for i, action := range tc.Actions {
-				results[i] = repoInternal.applyDeferred(context.Background(), action.Transformer)
+				results[i] = repoInternal.applyDeferred(testutil.MakeTestContext(), action.Transformer)
 			}
 			defer func() {
 				if r := recover(); r == nil {
@@ -1001,7 +1002,7 @@ func TestApplyQueuePanic(t *testing.T) {
 					}
 				}
 			}()
-			repoInternal.ProcessQueue(context.Background())
+			repoInternal.ProcessQueue(testutil.MakeTestContext())
 		})
 	}
 }
@@ -1193,7 +1194,7 @@ func TestApplyQueue(t *testing.T) {
 			cmd.Start()
 			cmd.Wait()
 			repo, err := New(
-				context.Background(),
+				testutil.MakeTestContext(),
 				RepositoryConfig{
 					URL:  "file://" + remoteDir,
 					Path: localDir,
@@ -1207,13 +1208,13 @@ func TestApplyQueue(t *testing.T) {
 			finished := make(chan struct{})
 			started := make(chan struct{}, 1)
 			go func() {
-				repo.Apply(context.Background(), &SlowTransformer{finished, started})
+				repo.Apply(testutil.MakeTestContext(), &SlowTransformer{finished, started})
 			}()
 			<-started
 			// The worker go routine is now blocked. We can move some items into the queue now.
 			results := make([]<-chan error, len(tc.Actions))
 			for i, action := range tc.Actions {
-				ctx, cancel := context.WithCancel(context.Background())
+				ctx, cancel := context.WithCancel(testutil.MakeTestContext())
 				if action.CancelBeforeAdd {
 					cancel()
 				}
@@ -1325,7 +1326,7 @@ func BenchmarkApplyQueue(t *testing.B) {
 	createGitWithCommit(remoteDir, localDir, t)
 
 	repo, err := New(
-		context.Background(),
+		testutil.MakeTestContext(),
 		RepositoryConfig{
 			URL:  "file://" + remoteDir,
 			Path: localDir,
@@ -1340,12 +1341,12 @@ func BenchmarkApplyQueue(t *testing.B) {
 	expectedResults := make([]error, t.N)
 	expectedReleases := make(map[int]bool, t.N)
 	tf, _ := getTransformer(0)
-	repoInternal.Apply(context.Background(), tf)
+	repoInternal.Apply(testutil.MakeTestContext(), tf)
 
 	t.StartTimer()
 	for i := 0; i < t.N; i++ {
 		tf, expectedResult := getTransformer(i)
-		results[i] = repoInternal.applyDeferred(context.Background(), tf)
+		results[i] = repoInternal.applyDeferred(testutil.MakeTestContext(), tf)
 		expectedResults[i] = expectedResult
 		if expectedResult == nil {
 			expectedReleases[i+1] = true
@@ -1422,7 +1423,7 @@ func TestProcessQueueOnce(t *testing.T) {
 			PushUpdateFunc: DefaultPushUpdate,
 			PushActionFunc: DefaultPushActionCallback,
 			Element: element{
-				ctx: context.Background(),
+				ctx: testutil.MakeTestContext(),
 				transformers: []Transformer{
 					&EmptyTransformer{},
 				},
@@ -1438,7 +1439,7 @@ func TestProcessQueueOnce(t *testing.T) {
 			},
 			PushActionFunc: DefaultPushActionCallback,
 			Element: element{
-				ctx: context.Background(),
+				ctx: testutil.MakeTestContext(),
 				transformers: []Transformer{
 					&EmptyTransformer{},
 				},
@@ -1457,7 +1458,7 @@ func TestProcessQueueOnce(t *testing.T) {
 				}
 			},
 			Element: element{
-				ctx: context.Background(),
+				ctx: testutil.MakeTestContext(),
 				transformers: []Transformer{
 					&EmptyTransformer{},
 				},
@@ -1479,7 +1480,7 @@ func TestProcessQueueOnce(t *testing.T) {
 			cmd.Start()
 			cmd.Wait()
 			repo, actualError := New(
-				context.Background(),
+				testutil.MakeTestContext(),
 				RepositoryConfig{
 					URL:  "file://" + remoteDir,
 					Path: localDir,
@@ -1489,7 +1490,7 @@ func TestProcessQueueOnce(t *testing.T) {
 				t.Fatalf("new: expected no error, got '%e'", actualError)
 			}
 			repoInternal := repo.(*repository)
-			repoInternal.ProcessQueueOnce(context.Background(), tc.Element, tc.PushUpdateFunc, tc.PushActionFunc)
+			repoInternal.ProcessQueueOnce(testutil.MakeTestContext(), tc.Element, tc.PushUpdateFunc, tc.PushActionFunc)
 
 			result := tc.Element.result
 			actualError = <-result

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/testutil"
 	"io"
 	"os/exec"
 	"path"
@@ -286,7 +287,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err := repo.ApplyTransformersInternal(context.Background(), tc.Transformers...)
+			commitMsg, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -366,7 +367,7 @@ func TestCreateUndeployApplicationVersionErrors(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			_, updatedState, _ := repo.ApplyTransformersInternal(context.Background(), tc.Transformers...)
+			_, updatedState, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 
 			fileData, err := util.ReadFile(updatedState.Filesystem, updatedState.Filesystem.Join(updatedState.Filesystem.Root(), tc.expectedPath))
 
@@ -429,11 +430,11 @@ func TestDeployApplicationVersion(t *testing.T) {
 			expectedPath:                "environments/acceptance/applications/app1/manifests/manifests.yaml",
 			expectedFileData:            []byte("acceptance"),
 			expectedDeployedByPath:      "environments/acceptance/applications/app1/deployed_by",
-			expectedDeployedByData:      []byte("defaultUser"),
+			expectedDeployedByData:      []byte("test tester"),
 			expectedDeployedAtPath:      "environments/acceptance/applications/app1/deployed_at_utc",
 			expectedDeployedAtData:      []byte(timeNowOld.UTC().String()),
 			expectedDeployedByEmailPath: "environments/acceptance/applications/app1/deployed_by_email",
-			expectedDeployedByEmailData: []byte("local.user@freiheit.com"),
+			expectedDeployedByEmailData: []byte("testmail@example.com"),
 		},
 		{
 			Name: "successfully deploy an empty manifest",
@@ -459,17 +460,17 @@ func TestDeployApplicationVersion(t *testing.T) {
 			expectedPath:                "environments/acceptance/applications/app1/manifests/manifests.yaml",
 			expectedFileData:            []byte(" "),
 			expectedDeployedByPath:      "environments/acceptance/applications/app1/deployed_by",
-			expectedDeployedByData:      []byte("defaultUser"),
+			expectedDeployedByData:      []byte("test tester"),
 			expectedDeployedAtPath:      "environments/acceptance/applications/app1/deployed_at_utc",
 			expectedDeployedAtData:      []byte(timeNowOld.UTC().String()),
 			expectedDeployedByEmailPath: "environments/acceptance/applications/app1/deployed_by_email",
-			expectedDeployedByEmailData: []byte("local.user@freiheit.com"),
+			expectedDeployedByEmailData: []byte("testmail@example.com"),
 		},
 	}
 	for _, tc := range tcs {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
-			ctxWithTime := withTimeNow(context.Background(), timeNowOld)
+			ctxWithTime := withTimeNow(testutil.MakeTestContext(), timeNowOld)
 			t.Parallel()
 			repo := setupRepositoryTest(t)
 			_, updatedState, err := repo.ApplyTransformersInternal(ctxWithTime, tc.Transformers...)
@@ -583,7 +584,7 @@ func TestCreateApplicationVersionWithVersion(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			_, updatedState, _ := repo.ApplyTransformersInternal(context.Background(), tc.Transformers...)
+			_, updatedState, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 
 			fileData, err := util.ReadFile(updatedState.Filesystem, updatedState.Filesystem.Join(updatedState.Filesystem.Root(), tc.expectedPath))
 
@@ -684,7 +685,7 @@ func TestUndeployErrors(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err := repo.ApplyTransformersInternal(context.Background(), tc.Transformers...)
+			commitMsg, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -758,7 +759,7 @@ func TestReleaseTrainErrors(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err := repo.ApplyTransformersInternal(context.Background(), tc.Transformers...)
+			commitMsg, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -1086,14 +1087,14 @@ func TestTransformer(t *testing.T) {
 					"manual": {
 						Message: "don't",
 						CreatedBy: Actor{
-							Name:  "defaultUser",
-							Email: "local.user@freiheit.com",
+							Name:  "test tester",
+							Email: "testmail@example.com",
 						},
 						CreatedAt: timeNowOld,
 					},
 				}
 				if !reflect.DeepEqual(locks, expected) {
-					t.Fatalf("mismatched locks. expected: %#v, actual: %#v", expected, locks)
+					t.Fatalf("mismatched locks. expected:\n%#v\nactual:\n%#v", expected, locks)
 				}
 			},
 		},
@@ -1123,14 +1124,14 @@ func TestTransformer(t *testing.T) {
 					"manual": {
 						Message: "don't",
 						CreatedBy: Actor{
-							Name:  "defaultUser",
-							Email: "local.user@freiheit.com",
+							Name:  "test tester",
+							Email: "testmail@example.com",
 						},
 						CreatedAt: timeNowOld,
 					},
 				}
 				if !reflect.DeepEqual(locks, expected) {
-					t.Fatalf("mismatched locks. expected: %#v, actual: %#v", expected, locks)
+					t.Fatalf("mismatched locks. expected:\n%#v\n, actual:\n%#v", expected, locks)
 				}
 			},
 		},
@@ -1158,8 +1159,8 @@ func TestTransformer(t *testing.T) {
 					"manual": {
 						Message: "just don't",
 						CreatedBy: Actor{
-							Name:  "defaultUser",
-							Email: "local.user@freiheit.com",
+							Name:  "test tester",
+							Email: "testmail@example.com",
 						},
 						CreatedAt: timeNowOld,
 					},
@@ -2280,7 +2281,7 @@ spec:
 			cmd.Start()
 			cmd.Wait()
 			repo, err := New(
-				context.Background(),
+				testutil.MakeTestContext(),
 				RepositoryConfig{
 					URL:            remoteDir,
 					Path:           localDir,
@@ -2294,7 +2295,7 @@ spec:
 			}
 
 			for i, tf := range tc.Transformers {
-				ctxWithTime := withTimeNow(context.Background(), timeNowOld)
+				ctxWithTime := withTimeNow(testutil.MakeTestContext(), timeNowOld)
 				err = repo.Apply(ctxWithTime, tf)
 				if err != nil {
 					if tc.ErrorTest != nil && i == len(tc.Transformers)-1 {
@@ -2467,7 +2468,7 @@ func setupRepositoryTest(t *testing.T) Repository {
 	cmd.Start()
 	cmd.Wait()
 	repo, err := New(
-		context.Background(),
+		testutil.MakeTestContext(),
 		RepositoryConfig{
 			URL:            remoteDir,
 			Path:           localDir,
@@ -2527,13 +2528,13 @@ func TestAllErrorsHandledDeleteEnvironmentLock(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			repo := setupRepositoryTest(t)
-			err := repo.Apply(context.Background(), &CreateEnvironment{
+			err := repo.Apply(testutil.MakeTestContext(), &CreateEnvironment{
 				Environment: "dev",
 			})
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = repo.Apply(context.Background(), &injectErr{
+			err = repo.Apply(testutil.MakeTestContext(), &injectErr{
 				Transformer: &DeleteEnvironmentLock{
 					Environment: "dev",
 					LockId:      "foo",
@@ -2589,13 +2590,13 @@ func TestAllErrorsHandledDeleteEnvironmentApplicationLock(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			repo := setupRepositoryTest(t)
-			err := repo.Apply(context.Background(), &CreateEnvironment{
+			err := repo.Apply(testutil.MakeTestContext(), &CreateEnvironment{
 				Environment: "dev",
 			})
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = repo.Apply(context.Background(), &injectErr{
+			err = repo.Apply(testutil.MakeTestContext(), &injectErr{
 				Transformer: &DeleteEnvironmentApplicationLock{
 					Environment: "dev",
 					Application: "bar",
@@ -2712,7 +2713,7 @@ func TestUpdateDatadogMetrics(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			_, _, err := repo.ApplyTransformersInternal(context.Background(), tc.Transformers...)
+			_, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 
 			if err != nil {
 				t.Fatalf("Got an unexpected error: %v", err)
@@ -2866,7 +2867,7 @@ func TestDeleteEnvFromApp(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err := repo.ApplyTransformersInternal(context.Background(), tc.Transformers...)
+			commitMsg, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -2972,7 +2973,7 @@ func TestDeleteLocks(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err := repo.ApplyTransformersInternal(context.Background(), tc.Transformers...)
+			commitMsg, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/testutil"
 	"google.golang.org/grpc/status"
 	"os/exec"
 	"path"
@@ -140,7 +141,7 @@ func TestBatchServiceWorks(t *testing.T) {
 				t.Fatal(err)
 			}
 			for _, tr := range tc.Setup {
-				if err := repo.Apply(context.Background(), tr); err != nil {
+				if err := repo.Apply(testutil.MakeTestContext(), tr); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -148,7 +149,7 @@ func TestBatchServiceWorks(t *testing.T) {
 				Repository: repo,
 			}
 			_, err = svc.ProcessBatch(
-				context.Background(),
+				testutil.MakeTestContext(),
 				&api.BatchRequest{
 					Actions: tc.Batch,
 				},
@@ -250,7 +251,7 @@ func TestBatchServiceErrors(t *testing.T) {
 				t.Fatal(err)
 			}
 			for _, tr := range tc.Setup {
-				if err := repo.Apply(context.Background(), tr); err != nil {
+				if err := repo.Apply(testutil.MakeTestContext(), tr); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -258,7 +259,7 @@ func TestBatchServiceErrors(t *testing.T) {
 				Repository: repo,
 			}
 			_, err = svc.ProcessBatch(
-				context.Background(),
+				testutil.MakeTestContext(),
 				&api.BatchRequest{
 					Actions: tc.Batch,
 				},
@@ -323,7 +324,7 @@ func TestBatchServiceLimit(t *testing.T) {
 				t.Fatal(err)
 			}
 			for _, tr := range tc.Setup {
-				if err := repo.Apply(context.Background(), tr); err != nil {
+				if err := repo.Apply(testutil.MakeTestContext(), tr); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -331,7 +332,7 @@ func TestBatchServiceLimit(t *testing.T) {
 				Repository: repo,
 			}
 			_, err = svc.ProcessBatch(
-				context.Background(),
+				testutil.MakeTestContext(),
 				&api.BatchRequest{
 					Actions: tc.Batch,
 				},
@@ -376,7 +377,7 @@ func setupRepositoryTest(t *testing.T) (repository.Repository, error) {
 	cmd.Start()
 	cmd.Wait()
 	repo, err := repository.New(
-		context.Background(),
+		testutil.MakeTestContext(),
 		repository.RepositoryConfig{
 			URL:            remoteDir,
 			Path:           localDir,

--- a/services/cd-service/pkg/service/deploy_test.go
+++ b/services/cd-service/pkg/service/deploy_test.go
@@ -17,7 +17,7 @@ Copyright 2023 freiheit.com*/
 package service
 
 import (
-	"context"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"testing"
 
@@ -62,7 +62,7 @@ func TestDeployService(t *testing.T) {
 			},
 			Test: func(t *testing.T, svc *DeployServiceServer) {
 				_, err := svc.Deploy(
-					context.Background(),
+					testutil.MakeTestContext(),
 					&api.DeployRequest{
 						Environment: "production",
 						Application: "test",
@@ -111,7 +111,7 @@ func TestDeployService(t *testing.T) {
 			},
 			Test: func(t *testing.T, svc *DeployServiceServer) {
 				_, err := svc.Deploy(
-					context.Background(),
+					testutil.MakeTestContext(),
 					&api.DeployRequest{
 						Environment:  "production",
 						Application:  "test",
@@ -148,7 +148,7 @@ func TestDeployService(t *testing.T) {
 				t.Fatal(err)
 			}
 			for _, tr := range tc.Setup {
-				if err := repo.Apply(context.Background(), tr); err != nil {
+				if err := repo.Apply(testutil.MakeTestContext(), tr); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -260,7 +260,7 @@ The release train deployed 0 services from 'acceptance' to 'production' for team
 				t.Fatal(err)
 			}
 
-			ctx := context.Background()
+			ctx := testutil.MakeTestContext()
 			initTransformers := []repository.Transformer{
 				&repository.CreateEnvironment{
 					Environment: envAcceptance,
@@ -463,7 +463,7 @@ The release train deployed 0 services from 'acceptance-pt' to 'production-pt' fo
 				t.Fatal(err)
 			}
 
-			ctx := context.Background()
+			ctx := testutil.MakeTestContext()
 			initTransformers := []repository.Transformer{
 				&repository.CreateEnvironment{
 					Environment: envAcceptancePT,
@@ -580,7 +580,7 @@ func TestReleaseTrain(t *testing.T) {
 			},
 			Test: func(t *testing.T, svc *DeployServiceServer) {
 				resp, err := svc.ReleaseTrain(
-					context.Background(),
+					testutil.MakeTestContext(),
 					&api.ReleaseTrainRequest{
 						Target: "acceptance",
 						Team:   "team",
@@ -613,7 +613,7 @@ func TestReleaseTrain(t *testing.T) {
 			},
 			Test: func(t *testing.T, svc *DeployServiceServer) {
 				resp, err := svc.ReleaseTrain(
-					context.Background(),
+					testutil.MakeTestContext(),
 					&api.ReleaseTrainRequest{
 						Target: "acceptance",
 						Team:   "team",
@@ -639,7 +639,7 @@ func TestReleaseTrain(t *testing.T) {
 				t.Fatal(err)
 			}
 			for _, tr := range tc.Setup {
-				if err := repo.Apply(context.Background(), tr); err != nil {
+				if err := repo.Apply(testutil.MakeTestContext(), tr); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/services/cd-service/pkg/service/lock_test.go
+++ b/services/cd-service/pkg/service/lock_test.go
@@ -19,6 +19,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/testutil"
 	"testing"
 
 	"github.com/freiheit-com/kuberpult/pkg/api"
@@ -76,7 +77,7 @@ func TestLockingService(t *testing.T) {
 	for _, tc := range tcs {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
-			logs := testlogger.Wrap(context.Background(), func(ctx context.Context) {
+			logs := testlogger.Wrap(testutil.MakeTestContext(), func(ctx context.Context) {
 				repo, err := setupRepositoryTest(t)
 				if err != nil {
 					t.Fatal(err)
@@ -144,7 +145,7 @@ func TestInvalidCreateEnvironmentLockArguments(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			logs := testlogger.Wrap(context.Background(), func(ctx context.Context) {
+			logs := testlogger.Wrap(testutil.MakeTestContext(), func(ctx context.Context) {
 				svc := &LockServiceServer{}
 				_, err := svc.CreateEnvironmentLock(
 					ctx,
@@ -221,7 +222,7 @@ func TestInvalidCreateEnvironmentApplicationLockArguments(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			logs := testlogger.Wrap(context.Background(), func(ctx context.Context) {
+			logs := testlogger.Wrap(testutil.MakeTestContext(), func(ctx context.Context) {
 				svc := &LockServiceServer{}
 				_, err := svc.CreateEnvironmentApplicationLock(
 					ctx,
@@ -280,7 +281,7 @@ func TestErrorLock(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			logs := testlogger.Wrap(context.Background(), func(ctx context.Context) {
+			logs := testlogger.Wrap(testutil.MakeTestContext(), func(ctx context.Context) {
 				svc := &LockServiceServer{
 					Repository: testrepository.Failing(testerror),
 				}

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -175,7 +175,7 @@ func (o *OverviewServiceServer) getOverview(
 							}
 						}
 					}
-					deployAuthor, deployTime, err := s.GetDeploymentMetaData(envName, appName)
+					deployAuthor, deployTime, err := s.GetDeploymentMetaData(ctx, envName, appName)
 					if err != nil {
 						return nil, err
 					}

--- a/services/cd-service/pkg/testutil/testutil.go
+++ b/services/cd-service/pkg/testutil/testutil.go
@@ -1,0 +1,55 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+/*
+This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com
+*/
+package testutil
+
+import (
+	"context"
+	"github.com/freiheit-com/kuberpult/pkg/auth"
+	"google.golang.org/grpc/metadata"
+)
+
+func MakeTestContext() context.Context {
+	u := auth.User{
+		Email: "testmail@example.com",
+		Name:  "test tester",
+	}
+	ctx := auth.WriteUserToContext(context.Background(), u)
+
+	// for some specific calls we need to set the *incoming* grpc context
+	// this happens when we call a function like `ProcessBatch` directly in the test
+	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{
+		auth.HeaderUserEmail: auth.Encode64("myemail@example.com"),
+		auth.HeaderUserName:  auth.Encode64("my name"),
+	}))
+	return ctx
+}

--- a/services/frontend-service/Makefile
+++ b/services/frontend-service/Makefile
@@ -46,6 +46,8 @@ GARBAGE += bin/main
 export KUBERPULT_CDSERVER?=localhost:8443
 export KUBERPULT_HTTP_CD_SERVER?=http://localhost:8080
 export KUBERPULT_ALLOWED_ORIGINS?="localhost:*"
+export KUBERPULT_GIT_AUTHOR_NAME?="user-local-dev"
+export KUBERPULT_GIT_AUTHOR_EMAIL?="user-local-dev@example.com"
 run: bin/main
 	./bin/main
 

--- a/services/frontend-service/pkg/config/config.go
+++ b/services/frontend-service/pkg/config/config.go
@@ -32,6 +32,8 @@ type ServerConfig struct {
 	Version             string `default:""`
 	SourceRepoUrl       string `default:"" split_words:"true"`
 	AllowedOrigins      string `default:"" split_words:"true"`
+	GitAuthorName       string `default:"" split_words:"true"`
+	GitAuthorEmail      string `default:"" split_words:"true"`
 }
 
 type FrontendConfig struct {

--- a/services/frontend-service/pkg/handler/release.go
+++ b/services/frontend-service/pkg/handler/release.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"fmt"
+	"github.com/freiheit-com/kuberpult/pkg/auth"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -28,6 +29,15 @@ func (s Server) HandleRelease(w http.ResponseWriter, req *http.Request, tail str
 		http.Error(w, fmt.Sprintf("Release does not accept additional path arguments, got: %s", tail), http.StatusNotFound)
 		return
 	}
+	// we just always use the default user here:
+	user := &auth.User{
+		Email: s.Config.GitAuthorEmail,
+		Name:  s.Config.GitAuthorName,
+	}
+	auth.WriteUserToHttpHeader(req, *user)
+
+	//this is http in both!!
+	//	author gets lost because we are not writing to the context (I assume)
 	url, err := url.Parse(s.Config.HttpCdServer + "/release")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Make git author configurable in helm chart & refactor context usage
    
This is technically not a breaking change, but it is recommended to now set the author and email when invoking the /release endpoint. Note that both headers must be base-64 encoded. See create-release.sh for a valid example call with headers. If you do not provide these headers, the git author will be set to "empty".
    
New helm chart variables can be set, but they come with the same default values as before:
    
* git.author.name
* git.author.email
    
This also refactored how to access the context.
    
The cd-service now always* returns an error when the context should be there but is not, instead of always falling back to default values.
    
Exception is the release endpoint, as this would be a breaking change. (And of course /health does not require any headers)
    
The frontend-service still uses the headers if supplied, but falls back to the default values that are configured in the helm chart.
    
This effects all endpoints, http and grpc.
    
The context functions (formerly "Extract", etc) have been refactored, so they do exactly one thing, e.g. reading from one context.
There are 3 options: grpc context, go context and http headers. All have a function for reading and writing respectively.
    
Story SRX-6SMIU3
