### PR TITLE
Added error messages and error logs to the release endpoint

### DIFF
--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -169,7 +169,7 @@ func RunServer() {
 					Register: func(mux *http.ServeMux) {
 						handler := logger.WithHttpLogger(httpServerLogger, repositoryService)
 						if c.EnableTracing {
-							handler = httptrace.WrapHandler(handler, "cd-service", "/")
+							handler = httptrace.WrapHandler(handler, "kuberpult-cd-service", "/")
 						}
 						mux.Handle("/", handler)
 					},


### PR DESCRIPTION
The /release endpoint is  very silent at the moment. Let's make it more chatty.