### PR TITLE
Refactoring: Move interceptors to frontend

### DIFF
--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -28,10 +28,6 @@ import (
 
 	"github.com/MicahParks/keyfunc/v2"
 	jwt "github.com/golang-jwt/jwt/v5"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
 func JWKSInitAzureFromJson() (*keyfunc.JWKS, error) {
@@ -99,69 +95,6 @@ func ValidateToken(jwtB64 string, jwks *keyfunc.JWKS, clientId string, tenantId 
 	}
 
 	return claims, nil
-}
-
-func authorize(ctx context.Context, jwks *keyfunc.JWKS, clientId string, tenantId string) (*User, error) {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return nil, status.Errorf(codes.InvalidArgument, "Retrieving metadata failed")
-	}
-
-	authHeader, ok := md["authorization"]
-	if !ok {
-		return nil, status.Errorf(codes.Unauthenticated, "Authorization token not supplied")
-	}
-
-	token := authHeader[0]
-	claims, err := ValidateToken(token, jwks, clientId, tenantId)
-	if err != nil {
-		return nil, status.Errorf(codes.Unauthenticated, "Invalid authorization token provided")
-	}
-	u := MakeDefaultUser()
-	if _, ok := claims["aud"]; ok && claims["aud"] == clientId {
-		u = &User{
-			Email: claims["email"].(string),
-			Name:  claims["name"].(string),
-		}
-	}
-
-	return u, nil
-}
-
-func UnaryInterceptor(ctx context.Context,
-	req interface{},
-	info *grpc.UnaryServerInfo,
-	handler grpc.UnaryHandler,
-	jwks *keyfunc.JWKS,
-	clientId string,
-	tenantId string) (interface{}, error) {
-	if info.FullMethod != "/api.v1.FrontendConfigService/GetConfig" {
-		userData, err := authorize(ctx, jwks, clientId, tenantId)
-		if err != nil {
-			return nil, err
-		}
-		ctx = ToContext(ctx, userData)
-	}
-	h, err := handler(ctx, req)
-	return h, err
-
-}
-
-func StreamInterceptor(
-	srv interface{},
-	stream grpc.ServerStream,
-	info *grpc.StreamServerInfo,
-	handler grpc.StreamHandler,
-	jwks *keyfunc.JWKS,
-	clientId string,
-	tenantId string,
-
-) error {
-	_, err := authorize(stream.Context(), jwks, clientId, tenantId)
-	if err != nil {
-		return err
-	}
-	return handler(srv, stream)
 }
 
 func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfunc.JWKS, clientId string, tenantId string, allowedPaths []string, allowedPrefixes []string) error {

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/services/frontend-service/pkg/interceptors"
 	"golang.org/x/crypto/openpgp"
 	"io"
 	"net/http"
@@ -125,7 +126,7 @@ func runServer(ctx context.Context) error {
 			req interface{},
 			info *grpc.UnaryServerInfo,
 			handler grpc.UnaryHandler) (interface{}, error) {
-			return auth.UnaryInterceptor(ctx, req, info, handler, jwks, c.AzureClientId, c.AzureTenantId)
+			return interceptors.UnaryInterceptor(ctx, req, info, handler, jwks, c.AzureClientId, c.AzureTenantId)
 		}
 		var AzureStreamInterceptor = func(
 			srv interface{},
@@ -133,7 +134,7 @@ func runServer(ctx context.Context) error {
 			info *grpc.StreamServerInfo,
 			handler grpc.StreamHandler,
 		) error {
-			return auth.StreamInterceptor(srv, stream, info, handler, jwks, c.AzureClientId, c.AzureTenantId)
+			return interceptors.StreamInterceptor(srv, stream, info, handler, jwks, c.AzureClientId, c.AzureTenantId)
 		}
 		grpcUnaryInterceptors = append(grpcUnaryInterceptors, AzureUnaryInterceptor)
 		grpcStreamInterceptors = append(grpcStreamInterceptors, AzureStreamInterceptor)

--- a/services/frontend-service/pkg/interceptors/interceptors.go
+++ b/services/frontend-service/pkg/interceptors/interceptors.go
@@ -1,0 +1,89 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+package interceptors
+
+import (
+	"context"
+	"github.com/MicahParks/keyfunc/v2"
+	"github.com/freiheit-com/kuberpult/pkg/auth"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func authorize(ctx context.Context, jwks *keyfunc.JWKS, clientId string, tenantId string) (*auth.User, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "Retrieving metadata failed")
+	}
+
+	authHeader, ok := md["authorization"]
+	if !ok {
+		return nil, status.Errorf(codes.Unauthenticated, "Authorization token not supplied")
+	}
+
+	token := authHeader[0]
+	claims, err := auth.ValidateToken(token, jwks, clientId, tenantId)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "Invalid authorization token provided")
+	}
+	u := auth.MakeDefaultUser()
+	if _, ok := claims["aud"]; ok && claims["aud"] == clientId {
+		u = &auth.User{
+			Email: claims["email"].(string),
+			Name:  claims["name"].(string),
+		}
+	}
+
+	return u, nil
+}
+
+func UnaryInterceptor(ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+	jwks *keyfunc.JWKS,
+	clientId string,
+	tenantId string) (interface{}, error) {
+	if info.FullMethod != "/api.v1.FrontendConfigService/GetConfig" {
+		userData, err := authorize(ctx, jwks, clientId, tenantId)
+		if err != nil {
+			return nil, err
+		}
+		ctx = auth.ToContext(ctx, userData)
+	}
+	h, err := handler(ctx, req)
+	return h, err
+
+}
+
+func StreamInterceptor(
+	srv interface{},
+	stream grpc.ServerStream,
+	info *grpc.StreamServerInfo,
+	handler grpc.StreamHandler,
+	jwks *keyfunc.JWKS,
+	clientId string,
+	tenantId string,
+
+) error {
+	_, err := authorize(stream.Context(), jwks, clientId, tenantId)
+	if err != nil {
+		return err
+	}
+	return handler(srv, stream)
+}


### PR DESCRIPTION
They are only used in the frontend, and it doesn't make much sense to share them, given their purpose