### PR TITLE
Replaced x/go-crypto with ProtonMail/go-crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
-	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8
 	github.com/acomagu/bufpipe v1.0.4 // indirect
 	github.com/argoproj/gitops-engine v0.7.1-0.20230526233214-ad9a694fe4bc
 	github.com/argoproj/pkg v0.13.7-0.20221221191914-44694015343d // indirect

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -31,7 +31,7 @@ import (
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 	grpctrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"

--- a/services/cd-service/pkg/service/service.go
+++ b/services/cd-service/pkg/service/service.go
@@ -27,13 +27,13 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	pgperrors "github.com/ProtonMail/go-crypto/openpgp/errors"
 	"github.com/freiheit-com/kuberpult/pkg/logger"
 	xpath "github.com/freiheit-com/kuberpult/pkg/path"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/valid"
 	"go.uber.org/zap"
-	"golang.org/x/crypto/openpgp"
-	pgperrors "golang.org/x/crypto/openpgp/errors"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -123,7 +123,7 @@ func (s *Service) ServeHTTPRelease(tail string, w http.ResponseWriter, r *http.R
 							fmt.Fprintf(w, "Internal: %s", err)
 							return
 						} else {
-							if _, err := openpgp.CheckArmoredDetachedSignature(s.KeyRing, bytes.NewReader(content), bytes.NewReader(signature)); err != nil {
+							if _, err := openpgp.CheckArmoredDetachedSignature(s.KeyRing, bytes.NewReader(content), bytes.NewReader(signature), nil); err != nil {
 								if err != pgperrors.ErrUnknownIssuer {
 									w.WriteHeader(500)
 									fmt.Fprintf(w, "Internal: Invalid Signature: %s", err)

--- a/services/cd-service/pkg/service/service_test.go
+++ b/services/cd-service/pkg/service/service_test.go
@@ -30,7 +30,7 @@ import (
 	"testing"
 
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
 func TestServeHttp(t *testing.T) {

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/freiheit-com/kuberpult/services/frontend-service/pkg/interceptors"
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"io"
 	"net/http"
 	"os"

--- a/services/frontend-service/pkg/handler/environments.go
+++ b/services/frontend-service/pkg/handler/environments.go
@@ -20,9 +20,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	pgperrors "github.com/ProtonMail/go-crypto/openpgp/errors"
 	"github.com/freiheit-com/kuberpult/pkg/api"
-	"golang.org/x/crypto/openpgp"
-	pgperrors "golang.org/x/crypto/openpgp/errors"
 	"net/http"
 )
 
@@ -59,7 +59,7 @@ func (s Server) handleCreateEnvironment(w http.ResponseWriter, req *http.Request
 	}
 
 	if signature, ok := form.Value["signature"]; ok {
-		if _, err := openpgp.CheckArmoredDetachedSignature(s.KeyRing, bytes.NewReader([]byte(config[0])), bytes.NewReader([]byte(signature[0]))); err != nil {
+		if _, err := openpgp.CheckArmoredDetachedSignature(s.KeyRing, bytes.NewReader([]byte(config[0])), bytes.NewReader([]byte(signature[0])), nil); err != nil {
 			if err != pgperrors.ErrUnknownIssuer {
 				w.WriteHeader(http.StatusInternalServerError)
 				fmt.Fprintf(w, "Internal: Invalid Signature: %s", err)

--- a/services/frontend-service/pkg/handler/handle.go
+++ b/services/frontend-service/pkg/handler/handle.go
@@ -18,7 +18,7 @@ package handler
 
 import (
 	"fmt"
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"net/http"
 
 	"github.com/freiheit-com/kuberpult/pkg/api"

--- a/services/frontend-service/pkg/handler/handle_test.go
+++ b/services/frontend-service/pkg/handler/handle_test.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 
 	"github.com/freiheit-com/kuberpult/pkg/api"
 	"github.com/google/go-cmp/cmp"

--- a/services/frontend-service/pkg/handler/locks.go
+++ b/services/frontend-service/pkg/handler/locks.go
@@ -21,10 +21,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	pgperrors "github.com/ProtonMail/go-crypto/openpgp/errors"
 	"github.com/freiheit-com/kuberpult/pkg/api"
 	xpath "github.com/freiheit-com/kuberpult/pkg/path"
-	"golang.org/x/crypto/openpgp"
-	pgperrors "golang.org/x/crypto/openpgp/errors"
 	"io"
 	"net/http"
 	"strings"
@@ -82,7 +82,7 @@ func (s Server) handlePutEnvironmentLock(w http.ResponseWriter, req *http.Reques
 			return
 		}
 
-		if _, err := openpgp.CheckArmoredDetachedSignature(s.KeyRing, strings.NewReader(environment+lockID), strings.NewReader(signature)); err != nil {
+		if _, err := openpgp.CheckArmoredDetachedSignature(s.KeyRing, strings.NewReader(environment+lockID), strings.NewReader(signature), nil); err != nil {
 			if err != pgperrors.ErrUnknownIssuer {
 				w.WriteHeader(500)
 				fmt.Fprintf(w, "Internal: Invalid Signature: %s", err)
@@ -127,7 +127,7 @@ func (s Server) handleDeleteEnvironmentLock(w http.ResponseWriter, req *http.Req
 			return
 		}
 
-		if _, err := openpgp.CheckArmoredDetachedSignature(s.KeyRing, strings.NewReader(environment+lockID), bytes.NewReader(signature)); err != nil {
+		if _, err := openpgp.CheckArmoredDetachedSignature(s.KeyRing, strings.NewReader(environment+lockID), bytes.NewReader(signature), nil); err != nil {
 			if err != pgperrors.ErrUnknownIssuer {
 				w.WriteHeader(500)
 				fmt.Fprintf(w, "Internal: Invalid Signature: %s", err)

--- a/services/frontend-service/pkg/handler/releasetrain.go
+++ b/services/frontend-service/pkg/handler/releasetrain.go
@@ -24,9 +24,9 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	pgperrors "github.com/ProtonMail/go-crypto/openpgp/errors"
 	"github.com/freiheit-com/kuberpult/pkg/api"
-	"golang.org/x/crypto/openpgp"
-	pgperrors "golang.org/x/crypto/openpgp/errors"
 )
 
 func (s Server) handleReleaseTrain(w http.ResponseWriter, req *http.Request, target, tail string) {
@@ -60,7 +60,7 @@ func (s Server) handleReleaseTrain(w http.ResponseWriter, req *http.Request, tar
 			return
 		}
 
-		if _, err := openpgp.CheckArmoredDetachedSignature(s.KeyRing, strings.NewReader(target), bytes.NewReader(signature)); err != nil {
+		if _, err := openpgp.CheckArmoredDetachedSignature(s.KeyRing, strings.NewReader(target), bytes.NewReader(signature), nil); err != nil {
 			if err != pgperrors.ErrUnknownIssuer {
 				w.WriteHeader(500)
 				fmt.Fprintf(w, "Internal: Invalid Signature: %s", err)


### PR DESCRIPTION
The x/go-crypto package is deprecated in the sense that _known bugs are not fixed_. Apparently there are real world bugs: https://github.com/orgs/community/discussions/27607#discussioncomment-3414366
The replacement promises to fix them