### PR TITLE
services/frontend-service: Add deployedBy and deployedAt to UI

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -82,6 +82,46 @@ describe('Release Dialog', () => {
             teamName: '',
         },
         {
+            name: 'normal release with deploymentMetadata set',
+            props: {
+                app: 'test1',
+                version: 2,
+            },
+            rels: [
+                {
+                    version: 2,
+                    sourceMessage: 'test1',
+                    sourceAuthor: 'test',
+                    sourceCommitId: 'commit',
+                    createdAt: new Date(2002),
+                    undeployVersion: false,
+                    prNumber: '#1337',
+                },
+            ],
+            envs: [
+                {
+                    name: 'prod',
+                    locks: { envLock: { message: 'envLock', lockId: 'ui-envlock' } },
+                    applications: {
+                        test1: {
+                            name: 'test1',
+                            version: 2,
+                            locks: { applock: { message: 'appLock', lockId: 'ui-applock' } },
+                            queuedVersion: 0,
+                            undeployVersion: false,
+                            deploymentMetaData: { deployAuthor: 'test', deployTime: '1688467491' },
+                        },
+                    },
+                    distanceToUpstream: 0,
+                    priority: Priority.UPSTREAM,
+                },
+            ],
+            expect_message: true,
+            expect_queues: 0,
+            data_length: 2,
+            teamName: '',
+        },
+        {
             name: 'two envs release',
             props: {
                 app: 'test1',

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -78,7 +78,7 @@ describe('Release Dialog', () => {
             ],
             expect_message: true,
             expect_queues: 0,
-            data_length: 1,
+            data_length: 2,
             teamName: '',
         },
         {
@@ -142,7 +142,7 @@ describe('Release Dialog', () => {
 
             expect_message: true,
             expect_queues: 1,
-            data_length: 3,
+            data_length: 5,
             teamName: 'test me team',
         },
         {

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -138,24 +138,28 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
         }
         return otherRelease?.sourceCommitId + ': ' + otherRelease?.sourceMessage;
     };
-    const getDeploymentMetadata = (): string => {
+    const getDeploymentMetadata = (): [String, JSX.Element] => {
         if (!application) {
-            return ``;
+            return ['', <></>];
         }
         if (!(application && application.version === release.version)) {
-            return '';
+            return ['', <></>];
         }
         if (application.deploymentMetaData === null) {
-            return '';
+            return ['', <></>];
         }
         const deployedBy = application.deploymentMetaData?.deployAuthor ?? 'unknown';
         const deployedUNIX = application.deploymentMetaData?.deployTime ?? '';
         if (deployedUNIX === '') {
-            return 'Deployed by ' + deployedBy;
+            return ['Deployed by ' + deployedBy, <></>];
         }
         const deployedDate = new Date(+deployedUNIX * 1000);
-        const returnString = 'Deployed by ' + deployedBy + ' on ' + deployedDate;
-        return returnString;
+        const returnString = 'Deployed by ' + deployedBy + ' ';
+        const time = (
+            <FormattedDate createdAt={deployedDate} className={classNames('release-dialog-createdAt', className)} />
+        );
+
+        return [returnString, time];
     };
     return (
         <li key={env.name} className={classNames('env-card', className)}>
@@ -192,7 +196,11 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                         {getCommitString()}
                     </div>
                     {queueInfo}
-                    <div className={classNames('env-card-data', className)}>{getDeploymentMetadata()}</div>
+                    <div className={classNames('env-card-data', className)}>
+                        {getDeploymentMetadata().flatMap((metadata, i) => (
+                            <div key={i}>{metadata}</div>
+                        ))}
+                    </div>
                 </div>
                 <div className="content-right">
                     <div className="env-card-buttons">

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -302,7 +302,7 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                         className={className}
                         release={release}
                         version={version}
-                    // deployedAtGroup={deployedAtGroup}
+                        // deployedAtGroup={deployedAtGroup}
                     />
                 </Dialog>
             </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -138,7 +138,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
         }
         return otherRelease?.sourceCommitId + ': ' + otherRelease?.sourceMessage;
     };
-    const getDeploymentAuthor = (): string => {
+    const getDeploymentMetadata = (): string => {
         if (!application) {
             return ``;
         }
@@ -148,12 +148,13 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
         if (application.deploymentMetaData === null) {
             return '';
         }
-        var deployedUNIX = application.deploymentMetaData?.deployTime ?? '';
+        const deployedBy = application.deploymentMetaData?.deployAuthor ?? 'unknown';
+        const deployedUNIX = application.deploymentMetaData?.deployTime ?? '';
         if (deployedUNIX === '') {
-            return 'Deployed by: ' + application.deploymentMetaData?.deployAuthor;
+            return 'Deployed by: ' + deployedBy;
         }
-        var deployedDate = new Date(+deployedUNIX * 1000);
-        const returnString = 'Deployed by: ' + application.deploymentMetaData?.deployAuthor + ' on ' + deployedDate;
+        const deployedDate = new Date(+deployedUNIX * 1000);
+        const returnString = 'Deployed by ' + deployedBy + ' on ' + deployedDate;
         return returnString;
     };
     return (
@@ -191,7 +192,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                         {getCommitString()}
                     </div>
                     {queueInfo}
-                    <div className={classNames('env-card-data', className)}>{getDeploymentAuthor()}</div>
+                    <div className={classNames('env-card-data', className)}>{getDeploymentMetadata()}</div>
                 </div>
                 <div className="content-right">
                     <div className="env-card-buttons">

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -296,7 +296,13 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                             icon={<Close />}
                         />
                     </div>
-                    <EnvironmentList app={app} className={className} release={release} version={version} />
+                    <EnvironmentList
+                        app={app}
+                        className={className}
+                        release={release}
+                        version={version}
+                        // deployedAtGroup={deployedAtGroup}
+                    />
                 </Dialog>
             </div>
         ) : (

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -138,6 +138,24 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
         }
         return otherRelease?.sourceCommitId + ': ' + otherRelease?.sourceMessage;
     };
+    const getDeploymentAuthor = (): string => {
+        if (!application) {
+            return ``;
+        }
+        if (!(application && application.version === release.version)) {
+            return '';
+        }
+        if (application.deploymentMetaData === null) {
+            return '';
+        }
+        var deployedUNIX = application.deploymentMetaData?.deployTime ?? '';
+        if (deployedUNIX === '') {
+            return 'Deployed by: ' + application.deploymentMetaData?.deployAuthor;
+        }
+        var deployedDate = new Date(+deployedUNIX * 1000);
+        const returnString = 'Deployed by: ' + application.deploymentMetaData?.deployAuthor + ' on ' + deployedDate;
+        return returnString;
+    };
     return (
         <li key={env.name} className={classNames('env-card', className)}>
             <div className="env-card-header">
@@ -173,6 +191,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                         {getCommitString()}
                     </div>
                     {queueInfo}
+                    <div className={classNames('env-card-data', className)}>{getDeploymentAuthor()}</div>
                 </div>
                 <div className="content-right">
                     <div className="env-card-buttons">
@@ -277,13 +296,7 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                             icon={<Close />}
                         />
                     </div>
-                    <EnvironmentList
-                        app={app}
-                        className={className}
-                        release={release}
-                        version={version}
-                        // deployedAtGroup={deployedAtGroup}
-                    />
+                    <EnvironmentList app={app} className={className} release={release} version={version} />
                 </Dialog>
             </div>
         ) : (

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -151,7 +151,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
         const deployedBy = application.deploymentMetaData?.deployAuthor ?? 'unknown';
         const deployedUNIX = application.deploymentMetaData?.deployTime ?? '';
         if (deployedUNIX === '') {
-            return 'Deployed by: ' + deployedBy;
+            return 'Deployed by ' + deployedBy;
         }
         const deployedDate = new Date(+deployedUNIX * 1000);
         const returnString = 'Deployed by ' + deployedBy + ' on ' + deployedDate;
@@ -302,7 +302,7 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                         className={className}
                         release={release}
                         version={version}
-                        // deployedAtGroup={deployedAtGroup}
+                    // deployedAtGroup={deployedAtGroup}
                     />
                 </Dialog>
             </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -175,7 +175,9 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                   </div>
                   <div
                     class="env-card-data"
-                  />
+                  >
+                    Deployed by: undefined
+                  </div>
                 </div>
                 <div
                   class="content-right"
@@ -410,7 +412,9 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                   </div>
                   <div
                     class="env-card-data"
-                  />
+                  >
+                    Deployed by: undefined
+                  </div>
                 </div>
                 <div
                   class="content-right"

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -176,7 +176,7 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                   <div
                     class="env-card-data"
                   >
-                    Deployed by: unknown
+                    Deployed by unknown
                   </div>
                 </div>
                 <div
@@ -650,7 +650,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                   <div
                     class="env-card-data"
                   >
-                    Deployed by: unknown
+                    Deployed by unknown
                   </div>
                 </div>
                 <div

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -176,7 +176,10 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                   <div
                     class="env-card-data"
                   >
-                    Deployed by unknown
+                    <div>
+                      Deployed by unknown
+                    </div>
+                    <div />
                   </div>
                 </div>
                 <div
@@ -413,7 +416,14 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                   <div
                     class="env-card-data"
                   >
-                    Deployed by test on Tue Jul 04 2023 10:44:51 GMT+0000 (Coordinated Universal Time)
+                    <div>
+                      Deployed by test 
+                    </div>
+                    <div>
+                      <div>
+                        some formatted date
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -650,7 +660,10 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                   <div
                     class="env-card-data"
                   >
-                    Deployed by unknown
+                    <div>
+                      Deployed by unknown
+                    </div>
+                    <div />
                   </div>
                 </div>
                 <div
@@ -795,7 +808,10 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                   </div>
                   <div
                     class="env-card-data"
-                  />
+                  >
+                    <div />
+                    <div />
+                  </div>
                 </div>
                 <div
                   class="content-right"

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -173,6 +173,9 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                   >
                     commit: test1
                   </div>
+                  <div
+                    class="env-card-data"
+                  />
                 </div>
                 <div
                   class="content-right"
@@ -405,6 +408,9 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                   >
                     cafe: the other commit message 2
                   </div>
+                  <div
+                    class="env-card-data"
+                  />
                 </div>
                 <div
                   class="content-right"
@@ -546,6 +552,9 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                     666
                      was not deployed, because of a lock.
                   </div>
+                  <div
+                    class="env-card-data"
+                  />
                 </div>
                 <div
                   class="content-right"

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -176,7 +176,244 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                   <div
                     class="env-card-data"
                   >
-                    Deployed by: undefined
+                    Deployed by: unknown
+                  </div>
+                </div>
+                <div
+                  class="content-right"
+                >
+                  <div
+                    class="env-card-buttons"
+                  >
+                    <button
+                      aria-label="Add lock"
+                      class="mdc-button env-card-add-lock-btn"
+                    >
+                      <div
+                        class="mdc-button__ripple"
+                      />
+                      <svg
+                        class="icon"
+                      >
+                        Locks.svg
+                      </svg>
+                      <span
+                        class="mdc-button__label"
+                      >
+                        Add lock
+                      </span>
+                    </button>
+                    <div
+                      title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                    >
+                      <button
+                        aria-label="Deploy & Lock"
+                        class="mdc-button env-card-deploy-btn mdc-button--unelevated"
+                        disabled=""
+                      >
+                        <div
+                          class="mdc-button__ripple"
+                        />
+                        <span
+                          class="mdc-button__label"
+                        >
+                          Deploy & Lock
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div
+      data-test="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
+exports[`Release Dialog Renders the environment locks normal release with deploymentMetadata set 1`] = `
+<body
+  style="padding-right: 0px; overflow: hidden;"
+>
+  <div
+    aria-hidden="true"
+  >
+    <div>
+      <div />
+    </div>
+  </div>
+  <div
+    class="MuiModal-root MuiDialog-root release-dialog css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-test="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-142erj9-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <div
+          class="release-dialog-app-bar"
+        >
+          <div
+            class="release-dialog-app-bar-data"
+          >
+            <div
+              class="release-dialog-message"
+            >
+              <span
+                class="release-dialog-commitMessage"
+              >
+                test1
+              </span>
+            </div>
+            <div>
+              some formatted date
+            </div>
+            <div
+              class="release-dialog-author"
+            >
+              Author: test
+            </div>
+            <div
+              class="release-dialog-app"
+            >
+              App: test1 
+            </div>
+          </div>
+          <span
+            class="release-dialog-commitId"
+            title="Commit Hash of the source repository."
+          >
+            commit
+          </span>
+          <button
+            aria-label=""
+            class="mdc-button release-dialog-close"
+          >
+            <div
+              class="mdc-button__ripple"
+            />
+            <svg>
+              Close.svg
+            </svg>
+          </button>
+        </div>
+        <div
+          class="release-env-group-list"
+        >
+          <ul
+            class="release-env-list"
+          >
+            <li
+              class="env-card"
+            >
+              <div
+                class="env-card-header"
+              >
+                <div
+                  class="mdc-evolution-chip release-environment environment-priority-upstream"
+                  role="row"
+                >
+                  <span
+                    class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
+                    role="gridcell"
+                  >
+                    <span
+                      class="mdc-evolution-chip__text-name"
+                    >
+                      prod
+                    </span>
+                     
+                    <span
+                      class="mdc-evolution-chip__text-numbers"
+                    />
+                    <div
+                      class="release-environment env-locks"
+                    >
+                      <div
+                        aria-label="Lock Message: \\"envLock\\" | ID: \\"ui-envlock\\"  | Click to unlock. "
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          aria-label=""
+                          class="mdc-button button-lock"
+                        >
+                          <div
+                            class="mdc-button__ripple"
+                          />
+                          <svg
+                            class="env-card-env-lock-icon"
+                            height="16px"
+                            width="16px"
+                          >
+                            Locks_White.svg
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  class="env-card-app-locks"
+                >
+                  <div
+                    aria-label="Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
+                    class=""
+                    data-mui-internal-clone-element="true"
+                  >
+                    <button
+                      aria-label=""
+                      class="mdc-button button-lock"
+                    >
+                      <div
+                        class="mdc-button__ripple"
+                      />
+                      <svg
+                        class="env-card-app-lock"
+                      >
+                        Locks.svg
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="content-area"
+              >
+                <div
+                  class="content-left"
+                >
+                  <div
+                    class="env-card-data"
+                    title="Shows the version that is currently deployed on prod. "
+                  >
+                    commit: test1
+                  </div>
+                  <div
+                    class="env-card-data"
+                  >
+                    Deployed by test on Tue Jul 04 2023 10:44:51 GMT+0000 (Coordinated Universal Time)
                   </div>
                 </div>
                 <div
@@ -413,7 +650,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                   <div
                     class="env-card-data"
                   >
-                    Deployed by: undefined
+                    Deployed by: unknown
                   </div>
                 </div>
                 <div


### PR DESCRIPTION
Adds details on who deployed and when to the UI
<img width="1474" alt="Screenshot 2023-07-04 at 5 22 13 PM" src="https://github.com/freiheit-com/kuberpult/assets/47796934/0b685839-0da9-4d3d-82a8-712561e80aee">


