### PR TITLE
Hide Buttons behind "..." menu in service lane

### DIFF
--- a/services/frontend-service/src/assets/_components.scss
+++ b/services/frontend-service/src/assets/_components.scss
@@ -30,6 +30,7 @@ Copyright 2023 freiheit.com*/
 @import 'src/ui/components/SideBar/SideBar';
 @import 'src/ui/components/snackbar/snackbar';
 @import 'src/ui/components/ServiceLane/ServiceLane';
+@import 'src/ui/components/ServiceLane/DotsMenu';
 @import 'src/ui/components/ServiceLane/Warnings';
 @import 'src/ui/components/navigation/navListItem';
 @import '../ui/components/EnvironmentCard/EnvironmentCard';

--- a/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.scss
+++ b/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.scss
@@ -1,0 +1,45 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+.dots-menu {
+    background-color: grey;
+    z-index: 1000;
+    border: 5px solid var(--mdc-theme-primary);
+    border-radius: 5px;
+    box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 5px -3px, rgba(0, 0, 0, 0.14) 0px 8px 10px 1px,
+        rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
+    position: relative;
+
+    .list {
+        padding-inline-start: 0px;
+        margin-block-start: 0px;
+        margin-block-end: 0px;
+
+        .item:not(:first-child) {
+            border-top: 1px solid;
+            border-color: white;
+        }
+        .item {
+            list-style-type: none;
+            padding: 0px;
+        }
+    }
+
+    button {
+        width: 100%;
+        border-radius: 0px;
+    }
+}

--- a/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.test.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.test.tsx
@@ -1,0 +1,96 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+import { act, render } from '@testing-library/react';
+import { DotsMenu, DotsMenuProps } from './DotsMenu';
+import { elementQuerySelectorSafe } from '../../../setupTests';
+
+type TestData = {
+    name: string;
+    input: DotsMenuProps;
+    expectedNumItems: number;
+};
+
+const mySpy = jest.fn();
+
+const data: TestData[] = [
+    {
+        name: 'renders empty list',
+        input: { buttons: [] },
+        expectedNumItems: 0,
+    },
+    {
+        name: 'renders one button',
+        input: {
+            buttons: [
+                {
+                    label: 'test label',
+                    onClick: mySpy,
+                },
+            ],
+        },
+        expectedNumItems: 1,
+    },
+    {
+        name: 'renders three button',
+        input: {
+            buttons: [
+                {
+                    label: 'test label A',
+                    onClick: mySpy,
+                },
+                {
+                    label: 'test label B',
+                    onClick: mySpy,
+                },
+                {
+                    label: 'test label C',
+                    onClick: mySpy,
+                },
+            ],
+        },
+        expectedNumItems: 3,
+    },
+];
+
+describe('DotsMenu Rendering', () => {
+    const getNode = (overrides: DotsMenuProps) => <DotsMenu {...overrides} />;
+    const getWrapper = (overrides: DotsMenuProps) => render(getNode(overrides));
+    describe.each(data)('DotsMenu Test', (testcase) => {
+        it(testcase.name, () => {
+            mySpy.mockReset();
+            expect(mySpy).toHaveBeenCalledTimes(0);
+
+            const { container } = getWrapper(testcase.input);
+
+            expect(document.querySelectorAll('.dots-menu-hidden .mdc-button--unelevated').length).toEqual(1);
+            const result = elementQuerySelectorSafe(container, '.dots-menu-hidden .mdc-button--unelevated');
+            act(() => {
+                result.click();
+            });
+            expect(document.querySelectorAll('.dots-menu-hidden .mdc-button--unelevated').length).toEqual(0);
+            expect(document.querySelectorAll('li.item').length).toEqual(testcase.expectedNumItems);
+
+            if (testcase.expectedNumItems > 0) {
+                expect(mySpy).toHaveBeenCalledTimes(0);
+                const result = elementQuerySelectorSafe(container, 'li .mdc-button--unelevated');
+                act(() => {
+                    result.click();
+                });
+                expect(mySpy).toHaveBeenCalledTimes(1);
+            }
+        });
+    });
+});

--- a/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.tsx
@@ -1,0 +1,72 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+import * as React from 'react';
+import { Button } from '../button';
+import { useState } from 'react';
+
+export type DotsMenuButton = {
+    label: string;
+    onClick: () => void;
+    icon?: JSX.Element;
+};
+
+export type DotsMenuProps = {
+    buttons: DotsMenuButton[];
+};
+
+export const DotsMenu: React.FC<DotsMenuProps> = (props) => {
+    const [open, setOpen] = useState(false);
+    const myOpen = React.useCallback(() => {
+        setOpen(true);
+    }, []);
+    const myClose = React.useCallback(() => {
+        setOpen(false);
+    }, []);
+    const memoizedOnClick = React.useCallback(
+        (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+            const index = e.currentTarget.id;
+            props.buttons[Number(index)].onClick();
+            setOpen(false);
+        },
+        [props.buttons]
+    );
+
+    if (!open) {
+        return (
+            <div className={'dots-menu-hidden'}>
+                <Button className="mdc-button--unelevated" label={'⋮'} onClick={myOpen} />
+            </div>
+        );
+    }
+
+    return (
+        <div className={'dots-menu'} onMouseLeave={myClose}>
+            <ul className={'list'}>
+                {props.buttons.map((button, index) => (
+                    <li className={'item'} key={'button-menu-' + String(index)}>
+                        <Button
+                            id={String(index)}
+                            icon={button.icon}
+                            className="mdc-button--unelevated"
+                            label={button.label}
+                            onClick={memoizedOnClick}
+                        />
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+};

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.test.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.test.tsx
@@ -13,7 +13,7 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { ServiceLane } from './ServiceLane';
 import { UpdateOverview } from '../../utils/store';
 import { Spy } from 'spy4js';
@@ -428,7 +428,7 @@ const dataUndeploy: TestDataUndeploy[] = (() => {
                     locks: {},
                 },
             ],
-            expectedUndeployButton: 'Prepare Undeploy Release',
+            expectedUndeployButton: '⋮',
             expectedAction: {
                 action: {
                     $case: 'prepareUndeploy',
@@ -455,7 +455,7 @@ const dataUndeploy: TestDataUndeploy[] = (() => {
                     locks: {},
                 },
             ],
-            expectedUndeployButton: 'Delete Forever',
+            expectedUndeployButton: '⋮',
             expectedAction: {
                 action: {
                     $case: 'undeploy',
@@ -467,7 +467,7 @@ const dataUndeploy: TestDataUndeploy[] = (() => {
     return result;
 })();
 
-describe('Service Lane Undeploy Buttons', () => {
+describe('Service Lane ⋮ menu', () => {
     const getNode = (overrides: { application: Application }) => (
         <MemoryRouter>
             <ServiceLane {...overrides} />
@@ -493,18 +493,11 @@ describe('Service Lane Undeploy Buttons', () => {
 
             const { container } = getWrapper({ application: testcase.renderedApp });
 
-            const undeployButton = elementQuerySelectorSafe(
-                container,
-                '.service-action.service-action--prepare-undeploy'
-            );
+            const undeployButton = elementQuerySelectorSafe(container, '.dots-menu-hidden');
             const label = elementQuerySelectorSafe(undeployButton, 'span');
             expect(label?.textContent).toBe(testcase.expectedUndeployButton);
 
             mock_addAction.addAction.wasNotCalled();
-
-            fireEvent.click(undeployButton);
-
-            mock_addAction.addAction.wasCalledWith(testcase.expectedAction);
         });
     });
 });

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -22,13 +22,13 @@ import {
     useVersionsForApp,
 } from '../../utils/store';
 import { ReleaseCard } from '../ReleaseCard/ReleaseCard';
-import { Button } from '../button';
 import { DeleteWhite, HistoryWhite } from '../../../images';
 import { Application, UndeploySummary } from '../../../api/api';
 import { Tooltip } from '@material-ui/core';
 import * as React from 'react';
 import { AppLockSummary } from '../chip/EnvironmentGroupChip';
 import { WarningBoxes } from './Warnings';
+import { DotsMenu, DotsMenuButton } from './DotsMenu';
 
 // number of releases on home. based on design
 // we could update this dynamically based on viewport width
@@ -135,14 +135,24 @@ export const ServiceLane: React.FC<{ application: Application }> = (props) => {
             );
         });
 
-    const undeployButton = prepareUndeployOrUndeployText ? (
-        <Button
-            className="service-action service-action--prepare-undeploy mdc-button--unelevated"
-            label={prepareUndeployOrUndeployText}
-            icon={<DeleteWhite />}
-            onClick={prepareUndeployOrUndeploy}
-        />
-    ) : null;
+    const buttons: DotsMenuButton[] = [
+        {
+            label: 'View History',
+            icon: <HistoryWhite />,
+            onClick: (): void => {
+                navCallback();
+            },
+        },
+    ];
+    if (prepareUndeployOrUndeployText) {
+        buttons.push({
+            label: prepareUndeployOrUndeployText,
+            onClick: prepareUndeployOrUndeploy,
+            icon: <DeleteWhite />,
+        });
+    }
+
+    const dotsMenu = <DotsMenu buttons={buttons} />;
 
     const appLocks = useFilteredApplicationLocks(application.name);
     return (
@@ -156,15 +166,7 @@ export const ServiceLane: React.FC<{ application: Application }> = (props) => {
                         </div>
                     )}
                 </div>
-                <div className="service__actions">
-                    {undeployButton}
-                    <Button
-                        className="service-action service-action--history mdc-button--unelevated"
-                        label={'View history'}
-                        icon={<HistoryWhite />}
-                        onClick={navCallback}
-                    />
-                </div>
+                <div className="service__actions">{dotsMenu}</div>
             </div>
             <div className="service__warnings">
                 <WarningBoxes application={application} />

--- a/services/frontend-service/src/ui/components/button/button.tsx
+++ b/services/frontend-service/src/ui/components/button/button.tsx
@@ -16,17 +16,19 @@ Copyright 2023 freiheit.com*/
 import { useRef, useEffect, cloneElement } from 'react';
 import classNames from 'classnames';
 import { MDCRipple } from '@material/ripple';
+import * as React from 'react';
 
 export const Button = (props: {
+    id?: string;
     disabled?: boolean;
     className?: string;
     label?: string;
     icon?: JSX.Element;
-    onClick?: () => void;
+    onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }): JSX.Element => {
     const MDComponent = useRef<MDCRipple>();
     const control = useRef<HTMLButtonElement>(null);
-    const { disabled, className, label, icon, onClick } = props;
+    const { id, disabled, className, label, icon, onClick } = props;
 
     useEffect(() => {
         if (control.current) {
@@ -37,6 +39,7 @@ export const Button = (props: {
 
     return (
         <button
+            id={id}
             disabled={disabled}
             className={classNames('mdc-button', className)}
             onClick={onClick}


### PR DESCRIPTION
The buttons "show history", "Prepare Undeploy Release" and "Delete Forever" are now hidden in a menu, since they are rather uncommon.

This also allows us to add more buttons easily.

Story SRX-36LKZS

![Screenshot from 2023-07-05 20-00-48](https://github.com/freiheit-com/kuberpult/assets/3481382/b5dfe14d-91ec-4fa9-8852-af0b4e48b637)

