### PR TITLE
Bugfix: Display locks only for the correct  application

### DIFF
--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -300,7 +300,7 @@ export const useFilteredApplicationLocks = (appNameParam: string | null): Displa
                     );
                 });
         });
-    const filteredLocks = finalLocks.filter((val) => searchCustomFilter(appNameParam, val.application));
+    const filteredLocks = finalLocks.filter((val) => appNameParam === val.application);
     return sortLocks(filteredLocks, 'newestToOldest');
 };
 


### PR DESCRIPTION
In the previous implementation locks would also be displayed on apps that names are contained in a locked app's name.