### PR TITLE
UI: Delete environments from an app

### DIFF
--- a/services/cd-service/pkg/interceptors/interceptors.go
+++ b/services/cd-service/pkg/interceptors/interceptors.go
@@ -18,9 +18,7 @@ package interceptors
 
 import (
 	"context"
-	"fmt"
 	"github.com/freiheit-com/kuberpult/pkg/auth"
-	"github.com/freiheit-com/kuberpult/pkg/logger"
 	"google.golang.org/grpc"
 )
 
@@ -31,7 +29,6 @@ func UnaryUserContextInterceptor(ctx context.Context,
 	req interface{},
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler) (interface{}, error) {
-	logger.FromContext(ctx).Warn(fmt.Sprintf("UnaryUserContextInterceptor start "))
 
 	user, err := auth.ReadUserFromGrpcContext(ctx)
 	if err != nil {

--- a/services/frontend-service/src/setupTests.ts
+++ b/services/frontend-service/src/setupTests.ts
@@ -37,7 +37,7 @@ export const documentQuerySelectorSafe = (selectors: string): HTMLElement => {
 export const elementQuerySelectorSafe = (element: HTMLElement, selectors: string): HTMLElement => {
     const result = element.querySelector(selectors);
     if (!result) {
-        throw new Error('elementQuerySelectorSafe: did not find in selector in document ' + selectors);
+        throw new Error('elementQuerySelectorSafe: did not find in selector in element ' + selectors);
     }
     if (!(result instanceof HTMLElement)) {
         throw new Error(

--- a/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.scss
+++ b/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.scss
@@ -15,6 +15,19 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright 2023 freiheit.com*/
 
 .dots-menu {
+    button {
+        width: 100%;
+        border-radius: 0px;
+        .mdc-button-__label {
+            font-size: x-large;
+        }
+        svg {
+            margin-right: 10px;
+        }
+    }
+}
+
+.dots-menu-open {
     background-color: grey;
     z-index: 1000;
     border: 5px solid var(--mdc-theme-primary);
@@ -37,9 +50,12 @@ Copyright 2023 freiheit.com*/
             padding: 0px;
         }
     }
+}
 
+.dots-menu-hidden {
     button {
-        width: 100%;
-        border-radius: 0px;
+        .mdc-button__label {
+            font-size: x-large;
+        }
     }
 }

--- a/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.tsx
@@ -29,10 +29,10 @@ export type DotsMenuProps = {
 
 export const DotsMenu: React.FC<DotsMenuProps> = (props) => {
     const [open, setOpen] = useState(false);
-    const myOpen = React.useCallback(() => {
+    const openMenu = React.useCallback(() => {
         setOpen(true);
     }, []);
-    const myClose = React.useCallback(() => {
+    const closeMenu = React.useCallback(() => {
         setOpen(false);
     }, []);
     const memoizedOnClick = React.useCallback(
@@ -46,14 +46,14 @@ export const DotsMenu: React.FC<DotsMenuProps> = (props) => {
 
     if (!open) {
         return (
-            <div className={'dots-menu-hidden'}>
-                <Button className="mdc-button--unelevated" label={'⋮'} onClick={myOpen} />
+            <div className={'dots-menu dots-menu-hidden'}>
+                <Button className="mdc-button--unelevated" label={'⋮'} onClick={openMenu} />
             </div>
         );
     }
 
     return (
-        <div className={'dots-menu'} onMouseLeave={myClose}>
+        <div className={'dots-menu dots-menu-open'} onMouseLeave={closeMenu}>
             <ul className={'list'}>
                 {props.buttons.map((button, index) => (
                     <li className={'item'} key={'button-menu-' + String(index)}>

--- a/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.test.tsx
@@ -1,0 +1,146 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+import { act, render } from '@testing-library/react';
+import { documentQuerySelectorSafe } from '../../../setupTests';
+import { EnvSelectionDialog, EnvSelectionDialogProps } from './EnvSelectionDialog';
+
+type TestDataSelection = {
+    name: string;
+    input: EnvSelectionDialogProps;
+    expectedNumItems: number;
+    clickOnButton: string;
+    expectedNumSelectedAfterClick: number;
+    expectedNumDeselectedAfterClick: number;
+};
+
+const mySubmitSpy = jest.fn();
+const myCancelSpy = jest.fn();
+
+const dataSelection: TestDataSelection[] = [
+    {
+        name: 'renders 2 item list',
+        input: { environments: ['dev', 'staging'], open: true, onSubmit: mySubmitSpy, onCancel: myCancelSpy },
+        expectedNumItems: 2,
+        clickOnButton: 'dev',
+        expectedNumSelectedAfterClick: 1,
+        expectedNumDeselectedAfterClick: 1,
+    },
+    {
+        name: 'renders 3 item list',
+        input: { environments: ['dev', 'staging', 'prod'], open: true, onSubmit: mySubmitSpy, onCancel: myCancelSpy },
+        expectedNumItems: 3,
+        clickOnButton: 'staging',
+        expectedNumSelectedAfterClick: 1,
+        expectedNumDeselectedAfterClick: 2,
+    },
+];
+
+type TestDataOpenClose = {
+    name: string;
+    input: EnvSelectionDialogProps;
+    expectedNumElements: number;
+};
+const dataOpenClose: TestDataOpenClose[] = [
+    {
+        name: 'renders open dialog',
+        input: { environments: ['dev', 'staging', 'prod'], open: true, onSubmit: mySubmitSpy, onCancel: myCancelSpy },
+        expectedNumElements: 1,
+    },
+    {
+        name: 'renders closed dialog',
+        input: { environments: ['dev', 'staging', 'prod'], open: false, onSubmit: mySubmitSpy, onCancel: myCancelSpy },
+        expectedNumElements: 0,
+    },
+];
+
+type TestDataCallbacks = {
+    name: string;
+    input: EnvSelectionDialogProps;
+    clickThis: string;
+    expectedCancelCallCount: number;
+    expectedSubmitCallCount: number;
+};
+const dataCallbacks: TestDataCallbacks[] = [
+    {
+        name: 'renders open dialog',
+        input: { environments: ['dev', 'staging', 'prod'], open: true, onSubmit: mySubmitSpy, onCancel: myCancelSpy },
+        clickThis: '.test-button-cancel',
+        expectedCancelCallCount: 1,
+        expectedSubmitCallCount: 0,
+    },
+    {
+        name: 'renders closed dialog',
+        input: { environments: ['dev', 'staging', 'prod'], open: true, onSubmit: mySubmitSpy, onCancel: myCancelSpy },
+        clickThis: '.test-button-confirm',
+        expectedCancelCallCount: 0,
+        expectedSubmitCallCount: 1,
+    },
+];
+
+const getNode = (overrides: EnvSelectionDialogProps) => <EnvSelectionDialog {...overrides} />;
+const getWrapper = (overrides: EnvSelectionDialogProps) => render(getNode(overrides));
+
+describe('EnvSelectionDialog Rendering', () => {
+    describe.each(dataSelection)('EnvSelectionDialog Test', (testcase) => {
+        it(testcase.name, () => {
+            mySubmitSpy.mockReset();
+            myCancelSpy.mockReset();
+            expect(mySubmitSpy).toHaveBeenCalledTimes(0);
+            expect(myCancelSpy).toHaveBeenCalledTimes(0);
+
+            getWrapper(testcase.input);
+
+            expect(document.querySelectorAll('.envs-dropdown-select .test-button-env-selection').length).toEqual(
+                testcase.expectedNumItems
+            );
+            const result = documentQuerySelectorSafe('.env-' + testcase.clickOnButton);
+            act(() => {
+                result.click();
+            });
+            expect(document.querySelectorAll('.test-button-env-selection.enabled').length).toEqual(
+                testcase.expectedNumSelectedAfterClick
+            );
+            expect(document.querySelectorAll('.test-button-env-selection.disabled').length).toEqual(
+                testcase.expectedNumDeselectedAfterClick
+            );
+        });
+    });
+    describe.each(dataOpenClose)('EnvSelectionDialog open/close', (testcase) => {
+        it(testcase.name, () => {
+            getWrapper(testcase.input);
+            expect(document.querySelectorAll('.envs-dropdown-select').length).toEqual(testcase.expectedNumElements);
+        });
+    });
+    describe.each(dataCallbacks)('EnvSelectionDialog callbacks', (testcase) => {
+        it(testcase.name, () => {
+            mySubmitSpy.mockReset();
+            myCancelSpy.mockReset();
+            expect(mySubmitSpy).toHaveBeenCalledTimes(0);
+            expect(myCancelSpy).toHaveBeenCalledTimes(0);
+
+            getWrapper(testcase.input);
+
+            const theButton = documentQuerySelectorSafe(testcase.clickThis);
+            act(() => {
+                theButton.click();
+            });
+            documentQuerySelectorSafe(testcase.clickThis); // should not crash
+
+            expect(myCancelSpy).toHaveBeenCalledTimes(testcase.expectedCancelCallCount);
+            expect(mySubmitSpy).toHaveBeenCalledTimes(testcase.expectedSubmitCallCount);
+        });
+    });
+});

--- a/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.tsx
@@ -1,0 +1,85 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+import { Dialog, DialogActions, DialogTitle } from '@material-ui/core';
+import * as React from 'react';
+import { Button } from '../button';
+import { useState } from 'react';
+
+export type EnvSelectionDialogProps = {
+    environments: string[];
+    onSubmit: (selectedEnvs: string[]) => void;
+    onCancel: () => void;
+    open: boolean;
+};
+
+export const EnvSelectionDialog: React.FC<EnvSelectionDialogProps> = (props) => {
+    const [selectedEnvs, setSelectedEnvs] = useState<string[]>([]);
+
+    const onConfirm = React.useCallback(() => {
+        props.onSubmit(selectedEnvs);
+        setSelectedEnvs([]);
+    }, [props, selectedEnvs]);
+
+    const onCancel = React.useCallback(() => {
+        props.onCancel();
+        setSelectedEnvs([]);
+    }, [props]);
+
+    const addTeam = React.useCallback(
+        (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+            const index = Number(e.currentTarget.id);
+            const newTeam = props.environments[index];
+            const indexOf = selectedEnvs.indexOf(newTeam);
+            if (indexOf >= 0) {
+                const copy = selectedEnvs.concat();
+                copy.splice(indexOf, 1);
+                setSelectedEnvs(copy);
+            } else {
+                setSelectedEnvs(selectedEnvs.concat(newTeam));
+            }
+        },
+        [props.environments, selectedEnvs]
+    );
+
+    return (
+        <Dialog open={props.open}>
+            <DialogTitle id="alert-dialog-title">{'Select all environments to be removed:'}</DialogTitle>
+            <div className="envs-dropdown-select">
+                {props.environments.map((env: string, index: number) => {
+                    const enabled = selectedEnvs.includes(env);
+                    return (
+                        <div key={env}>
+                            <Button
+                                className={
+                                    'test-button-env-selection env-' + env + ' ' + (enabled ? 'enabled' : 'disabled')
+                                }
+                                id={String(index)}
+                                onClick={addTeam}
+                                label={enabled ? '☑' : '☐'}
+                            />
+                            {env}
+                        </div>
+                    );
+                })}
+            </div>
+
+            <DialogActions>
+                <Button label="Cancel" onClick={onCancel} className={'test-button-cancel'} />
+                <Button label="Confirm" onClick={onConfirm} className={'test-button-confirm'} />
+            </DialogActions>
+        </Dialog>
+    );
+};

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.test.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.test.tsx
@@ -407,6 +407,8 @@ describe('Action details', () => {
                 type: ActionTypes.CreateEnvironmentLock,
                 name: 'Create Env Lock',
                 dialogTitle: 'Are you sure you want to add this environment lock?',
+                tooltip:
+                    'An environment lock will prevent automated process from changing the deployed version - note that kuberpult users can still deploy despite locks.',
                 summary: 'Create new environment lock on foo',
                 environment: 'foo',
             },
@@ -431,6 +433,7 @@ describe('Action details', () => {
                 name: 'Delete Env Lock',
                 dialogTitle: 'Are you sure you want to delete this environment lock?',
                 summary: 'Delete environment lock on foo with the message: "bar"',
+                tooltip: 'This will only remove the lock, it will not automatically deploy anything.',
                 environment: 'foo',
                 lockId: 'ui-v2-1337',
                 lockMessage: 'bar',
@@ -454,6 +457,8 @@ describe('Action details', () => {
                 name: 'Create App Lock',
                 dialogTitle: 'Are you sure you want to add this application lock?',
                 summary: 'Create new application lock for "bread" on foo',
+                tooltip:
+                    'An app lock will prevent automated process from changing the deployed version - note that kuberpult users can still deploy despite locks.',
                 environment: 'foo',
                 application: 'bread',
             },
@@ -479,6 +484,7 @@ describe('Action details', () => {
                 name: 'Delete App Lock',
                 dialogTitle: 'Are you sure you want to delete this application lock?',
                 summary: 'Delete application lock for "bar" on foo with the message: "bar"',
+                tooltip: 'This will only remove the lock, it will not automatically deploy anything.',
                 environment: 'foo',
                 application: 'bar',
                 lockId: 'ui-v2-1337',
@@ -504,6 +510,7 @@ describe('Action details', () => {
                 name: 'Deploy',
                 dialogTitle: 'Please be aware:',
                 summary: 'Deploy version 1337 of "bread" to foo',
+                tooltip: '',
                 environment: 'foo',
                 application: 'bread',
                 version: 1337,
@@ -523,7 +530,7 @@ describe('Action details', () => {
                 type: ActionTypes.PrepareUndeploy,
                 name: 'Prepare Undeploy',
                 dialogTitle: 'Are you sure you want to start undeploy?',
-                description:
+                tooltip:
                     'The new version will go through the same cycle as any other versions' +
                     ' (e.g. development->staging->production). ' +
                     'The behavior is similar to any other version that is created normally.',
@@ -545,8 +552,28 @@ describe('Action details', () => {
                 type: ActionTypes.Undeploy,
                 name: 'Undeploy',
                 dialogTitle: 'Are you sure you want to undeploy this application?',
-                description: 'This application will be deleted permanently',
+                tooltip: 'This application will be deleted permanently',
                 summary: 'Undeploy and delete Application "foo"',
+                application: 'foo',
+            },
+        },
+        {
+            name: 'test delete env from app action',
+            action: {
+                action: {
+                    $case: 'deleteEnvFromApp',
+                    deleteEnvFromApp: {
+                        environment: 'dev',
+                        application: 'foo',
+                    },
+                },
+            },
+            expectedDetails: {
+                type: ActionTypes.DeleteEnvFromApp,
+                name: 'Delete an Environment from App',
+                dialogTitle: 'Are you sure you want to delete environments from this application?',
+                tooltip: 'These environments will be deleted permanently from this application',
+                summary: 'Delete environment "dev" from application "foo"',
                 application: 'foo',
             },
         },

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -43,6 +43,7 @@ export enum ActionTypes {
     DeleteEnvironmentLock,
     CreateApplicationLock,
     DeleteApplicationLock,
+    DeleteEnvFromApp,
     UNKNOWN,
 }
 
@@ -51,7 +52,7 @@ export type ActionDetails = {
     name: string;
     summary: string;
     dialogTitle: string;
-    description?: string;
+    tooltip: string;
 
     // action details optional
     environment?: string;
@@ -73,6 +74,8 @@ export const getActionDetails = (
                 name: 'Create Env Lock',
                 dialogTitle: 'Are you sure you want to add this environment lock?',
                 summary: 'Create new environment lock on ' + action.createEnvironmentLock.environment,
+                tooltip:
+                    'An environment lock will prevent automated process from changing the deployed version - note that kuberpult users can still deploy despite locks.',
                 environment: action.createEnvironmentLock.environment,
             };
         case 'deleteEnvironmentLock':
@@ -86,6 +89,7 @@ export const getActionDetails = (
                     ' with the message: "' +
                     envLocks.find((lock) => lock.lockId === action.deleteEnvironmentLock.lockId)?.message +
                     '"',
+                tooltip: 'This will only remove the lock, it will not automatically deploy anything.',
                 environment: action.deleteEnvironmentLock.environment,
                 lockId: action.deleteEnvironmentLock.lockId,
                 lockMessage: envLocks.find((lock) => lock.lockId === action.deleteEnvironmentLock.lockId)?.message,
@@ -100,6 +104,8 @@ export const getActionDetails = (
                     action.createEnvironmentApplicationLock.application +
                     '" on ' +
                     action.createEnvironmentApplicationLock.environment,
+                tooltip:
+                    'An app lock will prevent automated process from changing the deployed version - note that kuberpult users can still deploy despite locks.',
                 environment: action.createEnvironmentApplicationLock.environment,
                 application: action.createEnvironmentApplicationLock.application,
             };
@@ -116,6 +122,7 @@ export const getActionDetails = (
                     ' with the message: "' +
                     appLocks.find((lock) => lock.lockId === action.deleteEnvironmentApplicationLock.lockId)?.message +
                     '"',
+                tooltip: 'This will only remove the lock, it will not automatically deploy anything.',
                 environment: action.deleteEnvironmentApplicationLock.environment,
                 application: action.deleteEnvironmentApplicationLock.application,
                 lockId: action.deleteEnvironmentApplicationLock.lockId,
@@ -134,6 +141,7 @@ export const getActionDetails = (
                     action.deploy.application +
                     '" to ' +
                     action.deploy.environment,
+                tooltip: '',
                 environment: action.deploy.environment,
                 application: action.deploy.application,
                 version: action.deploy.version,
@@ -143,7 +151,7 @@ export const getActionDetails = (
                 type: ActionTypes.PrepareUndeploy,
                 name: 'Prepare Undeploy',
                 dialogTitle: 'Are you sure you want to start undeploy?',
-                description:
+                tooltip:
                     'The new version will go through the same cycle as any other versions' +
                     ' (e.g. development->staging->production). ' +
                     'The behavior is similar to any other version that is created normally.',
@@ -155,9 +163,23 @@ export const getActionDetails = (
                 type: ActionTypes.Undeploy,
                 name: 'Undeploy',
                 dialogTitle: 'Are you sure you want to undeploy this application?',
-                description: 'This application will be deleted permanently',
+                tooltip: 'This application will be deleted permanently',
                 summary: 'Undeploy and delete Application "' + action.undeploy.application + '"',
                 application: action.undeploy.application,
+            };
+        case 'deleteEnvFromApp':
+            return {
+                type: ActionTypes.DeleteEnvFromApp,
+                name: 'Delete an Environment from App',
+                dialogTitle: 'Are you sure you want to delete environments from this application?',
+                tooltip: 'These environments will be deleted permanently from this application',
+                summary:
+                    'Delete environment "' +
+                    action.deleteEnvFromApp.environment +
+                    '" from application "' +
+                    action.deleteEnvFromApp.application +
+                    '"',
+                application: action.deleteEnvFromApp.application,
             };
         default:
             return {
@@ -165,6 +187,7 @@ export const getActionDetails = (
                 name: 'invalid',
                 dialogTitle: 'invalid',
                 summary: 'invalid',
+                tooltip: 'invalid',
             };
     }
 };
@@ -237,7 +260,7 @@ export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children:
         );
     return (
         <>
-            <div className="mdc-drawer-sidebar-list-item-text">
+            <div className="mdc-drawer-sidebar-list-item-text" title={actionDetails.tooltip}>
                 <div className="mdc-drawer-sidebar-list-item-text-name">{actionDetails.name}</div>
                 <div className="mdc-drawer-sidebar-list-item-text-summary">{actionDetails.summary}</div>
                 {deleteAllSection}

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -552,6 +552,31 @@ export const useCurrentlyDeployedAtGroup = (application: string, version: number
     }, [environmentGroups, application, version]);
 };
 
+/**
+ * returns the environments where an application is currently deployed
+ */
+export const useCurrentlyExistsAtGroup = (application: string): EnvironmentGroupExtended[] => {
+    const environmentGroups: EnvironmentGroup[] = useEnvironmentGroups();
+    return useMemo(() => {
+        const envGroups: EnvironmentGroupExtended[] = [];
+        environmentGroups.forEach((group: EnvironmentGroup) => {
+            const envs = group.environments.filter((env) => env.applications[application]);
+            if (envs.length > 0) {
+                // we need to make a copy of the group here, because we want to remove some envs.
+                // but that should not have any effect on the group saved in the store.
+                const groupCopy: EnvironmentGroupExtended = {
+                    environmentGroupName: group.environmentGroupName,
+                    environments: envs,
+                    distanceToUpstream: group.distanceToUpstream,
+                    numberOfEnvsInGroup: group.environments.length,
+                };
+                envGroups.push(groupCopy);
+            }
+        });
+        return envGroups;
+    }, [environmentGroups, application]);
+};
+
 // Get all releases for an app
 export const useReleasesForApp = (app: string): Release[] =>
     useOverview(({ applications }) => applications[app]?.releases?.sort((a, b) => b.version - a.version));


### PR DESCRIPTION
Adds a button to the "..." menu that allows the user to delete environments from one app.

It is possible to select multiple envs, but it is not allowed to delete all environments.

Also this re-enables the tooltip in the planned actions and gets rid of some unnecessary logs.

Story SRX-36LKZS


![Screenshot from 2023-07-07 10-43-38](https://github.com/freiheit-com/kuberpult/assets/3481382/cfa29859-f1fa-41b7-83d3-74c5214c6356)

![image](https://github.com/freiheit-com/kuberpult/assets/3481382/162fe2e2-023f-4e1f-bd37-78816b4ce9b6)
