### PR TITLE
Use correct service names in all services

### DIFF
--- a/pkg/tracing/service.go
+++ b/pkg/tracing/service.go
@@ -1,0 +1,27 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package tracing
+
+import "os"
+
+func ServiceName(defaultName string) string {
+	env := os.Getenv("DD_SERVICE")
+	if env != "" {
+		return env
+	}
+	return defaultName
+}

--- a/pkg/tracing/service_test.go
+++ b/pkg/tracing/service_test.go
@@ -1,0 +1,53 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package tracing
+
+import "testing"
+
+func TestServiceName(t *testing.T) {
+	tcs := []struct {
+		Name         string
+		DdServiceEnv string
+		DefaultName  string
+		ExpectedName string
+	}{
+		{
+			Name:         "takes the default name without dd service name",
+			DdServiceEnv: "",
+			DefaultName:  "foo",
+			ExpectedName: "foo",
+		},
+		{
+			Name:         "prefers the dd service name over the default",
+			DdServiceEnv: "bar",
+			DefaultName:  "foo",
+			ExpectedName: "bar",
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Setenv("DD_SERVICE", tc.DdServiceEnv)
+			result := ServiceName(tc.DefaultName)
+			if result != tc.ExpectedName {
+				t.Errorf("wrong service name, expected %q, got %q", tc.ExpectedName, result)
+			}
+		})
+	}
+
+}

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -18,16 +18,18 @@ package cmd
 
 import (
 	"context"
-	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/interceptors"
 	"net/http"
 	"os"
 	"sync"
+
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/interceptors"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/freiheit-com/kuberpult/pkg/api"
 	"github.com/freiheit-com/kuberpult/pkg/logger"
 	"github.com/freiheit-com/kuberpult/pkg/setup"
+	"github.com/freiheit-com/kuberpult/pkg/tracing"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/service"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
@@ -113,10 +115,10 @@ func RunServer() {
 			defer tracer.Stop()
 
 			grpcStreamInterceptors = append(grpcStreamInterceptors,
-				grpctrace.StreamServerInterceptor(grpctrace.WithServiceName("cd-service")),
+				grpctrace.StreamServerInterceptor(grpctrace.WithServiceName(tracing.ServiceName("kuberpult-cd-service"))),
 			)
 			grpcUnaryInterceptors = append(grpcUnaryInterceptors,
-				grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName("cd-service")),
+				grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName(tracing.ServiceName("kuberpult-cd-service"))),
 			)
 		}
 

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -19,12 +19,13 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/freiheit-com/kuberpult/services/frontend-service/pkg/interceptors"
 	"io"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/freiheit-com/kuberpult/services/frontend-service/pkg/interceptors"
 
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/freiheit-com/kuberpult/services/frontend-service/pkg/config"
@@ -34,6 +35,7 @@ import (
 	"github.com/freiheit-com/kuberpult/pkg/auth"
 	"github.com/freiheit-com/kuberpult/pkg/logger"
 	"github.com/freiheit-com/kuberpult/pkg/setup"
+	"github.com/freiheit-com/kuberpult/pkg/tracing"
 	"github.com/freiheit-com/kuberpult/services/frontend-service/pkg/handler"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
@@ -112,18 +114,18 @@ func runServer(ctx context.Context) error {
 		defer tracer.Stop()
 
 		grpcStreamInterceptors = append(grpcStreamInterceptors,
-			grpctrace.StreamServerInterceptor(grpctrace.WithServiceName("frontend-service")),
+			grpctrace.StreamServerInterceptor(grpctrace.WithServiceName(tracing.ServiceName("kuberpult-frontend-service"))),
 		)
 		grpcUnaryInterceptors = append(grpcUnaryInterceptors,
-			grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName("frontend-service")),
+			grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName(tracing.ServiceName("kuberpult-frontend-service"))),
 		)
 
 		grpcClientOpts = append(grpcClientOpts,
 			grpc.WithStreamInterceptor(
-				grpctrace.StreamClientInterceptor(grpctrace.WithServiceName("frontend-service")),
+				grpctrace.StreamClientInterceptor(grpctrace.WithServiceName(tracing.ServiceName("kuberpult-frontend-service"))),
 			),
 			grpc.WithUnaryInterceptor(
-				grpctrace.UnaryClientInterceptor(grpctrace.WithServiceName("frontend-service")),
+				grpctrace.UnaryClientInterceptor(grpctrace.WithServiceName(tracing.ServiceName("kuberpult-frontend-service"))),
 			),
 		)
 	}

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/freiheit-com/kuberpult/pkg/api"
 	"github.com/freiheit-com/kuberpult/pkg/logger"
 	"github.com/freiheit-com/kuberpult/pkg/setup"
+	"github.com/freiheit-com/kuberpult/pkg/tracing"
 	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/service"
 	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/versions"
 	"github.com/kelseyhightower/envconfig"
@@ -71,10 +72,10 @@ func getGrpcClient(ctx context.Context, config Config) (api.OverviewServiceClien
 	if config.EnableTracing {
 		grpcClientOpts = append(grpcClientOpts,
 			grpc.WithStreamInterceptor(
-				grpctrace.StreamClientInterceptor(grpctrace.WithServiceName("rollout-service")),
+				grpctrace.StreamClientInterceptor(grpctrace.WithServiceName(tracing.ServiceName("kuberpult-rollout-service"))),
 			),
 			grpc.WithUnaryInterceptor(
-				grpctrace.UnaryClientInterceptor(grpctrace.WithServiceName("rollout-service")),
+				grpctrace.UnaryClientInterceptor(grpctrace.WithServiceName(tracing.ServiceName("kuberpult-rollout-service"))),
 			),
 		)
 	}


### PR DESCRIPTION
Our traces currently show up as "cd-service" and "kuberpult-cd-service" in datadog. This is due to us setting the DD_SERVICE to one value and the tell the tracer to use another. This commit fixes that to always prefer the DD_SERVICE env and adds the correct default value for testing.