### PR TITLE
Add Dex RBAC Config Map

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -144,6 +144,10 @@ spec:
         - name: KUBERPULT_PGP_KEY_RING
           value: /keyring/keyring.gpg
 {{- end }}
+{{- if .Values.dex.enabled }}
+        - name: KUBERPULT_DEX_RBAC_POLICY
+          value: /kuberpult-rbac/policy.csv
+{{- end }}
         - name: KUBERPULT_AZURE_ENABLE_AUTH
           value: "{{ .Values.auth.azureAuth.enabled }}"
         - name: KUBERPULT_DEX_ENABLE

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -194,6 +194,11 @@ spec:
             path: environment_configs.json
           name: environment-configs
 {{- end }}
+{{- if .Values.dex.enabled }}
+      - name: kuberpult-rbac
+        configMap:
+          name: kuberpult-rbac
+{{- end }}
 {{- if .Values.dogstatsdMetrics.enabled }}
       - name: dsdsocket
         hostPath:
@@ -260,4 +265,13 @@ metadata:
   name: environment-configs
 data:
   environment_configs.json: {{ required ".Values.environment_configs.environment_configs_json is required when .Values.environment_configs.bootstrap is true" .Values.environment_configs.environment_configs_json | quote }}
+{{- end }}
+{{- if .Values.dex.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kuberpult-rbac
+data:
+  policy: {{ .Values.dex.policy | toJson }}
 {{- end }}

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -146,6 +146,12 @@ spec:
 {{- end }}
         - name: KUBERPULT_AZURE_ENABLE_AUTH
           value: "{{ .Values.auth.azureAuth.enabled }}"
+        - name: KUBERPULT_DEX_ENABLE
+          value: "{{ .Values.dex.enabled }}" 
+ {{- if .Values.dex.enabled }}
+        - name: KUBERPULT_DEX_RBAC_POLICY
+          value: /kuberpult-rbac/policy.csv
+{{- end }}
 {{- if .Values.environment_configs.bootstrap_mode }}
         - name: KUBERPULT_BOOTSTRAP_MODE
           value: "{{ .Values.environment_configs.bootstrap_mode }}"
@@ -161,6 +167,10 @@ spec:
         - name: keyring
           mountPath: /keyring
 {{- end }}
+{{- if .Values.dex.enabled }}
+        - name: kuberpult-rbac
+          mountPath: /kuberpult-rbac/policy.csv
+{{- end }} 
 {{- if .Values.dogstatsdMetrics.enabled }}
         - name: dsdsocket
           mountPath: {{ .Values.dogstatsdMetrics.hostSocketPath }}
@@ -273,5 +283,5 @@ kind: ConfigMap
 metadata:
   name: kuberpult-rbac
 data:
-  policy: {{ .Values.dex.policy | toJson }}
+  policy.csv: {{ .Values.dex.policy_csv | quote}}
 {{- end }}

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -147,11 +147,7 @@ spec:
         - name: KUBERPULT_AZURE_ENABLE_AUTH
           value: "{{ .Values.auth.azureAuth.enabled }}"
         - name: KUBERPULT_DEX_ENABLE
-          value: "{{ .Values.dex.enabled }}" 
- {{- if .Values.dex.enabled }}
-        - name: KUBERPULT_DEX_RBAC_POLICY
-          value: /kuberpult-rbac/policy.csv
-{{- end }}
+          value: "{{ .Values.dex.enabled }}"
 {{- if .Values.environment_configs.bootstrap_mode }}
         - name: KUBERPULT_BOOTSTRAP_MODE
           value: "{{ .Values.environment_configs.bootstrap_mode }}"
@@ -169,7 +165,7 @@ spec:
 {{- end }}
 {{- if .Values.dex.enabled }}
         - name: kuberpult-rbac
-          mountPath: /kuberpult-rbac/policy.csv
+          mountPath: /kuberpult-rbac
 {{- end }} 
 {{- if .Values.dogstatsdMetrics.enabled }}
         - name: dsdsocket

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -155,11 +155,8 @@ auth:
 
 dex:
   enabled: true
-  # 
-  # Defines the rbac policy when using Dex. 
-  #
-  # The permissions are added using the following format (p, <ROLE>, <APPLICATION>, <ACTION>, <ENV>, <PERMISSION>), example: 
+  # Defines the rbac policy when using Dex.
+  # The permissions are added using the following format (p, <ROLE>, <APPLICATION>, <ACTION>, <ENV>, <PERMISSION>), example:
   # p, Developer, deployment, *, dev:development-d2, allow
-  #
   # The policy will be available on the kuberpult-rbac config map.
   policy_csv: ""

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -152,3 +152,14 @@ auth:
     cloudInstance: "https://login.microsoftonline.com/"
     clientId: ""
     tenantId: ""
+
+dex:
+  enabled: true
+  # 
+  # Defines the rbac policy when using Dex. 
+  #
+  # The permissions are added using the following format (p, <ROLE>, <APPLICATION>, <ACTION>, <ENV>, <PERMISSION>), example: 
+  # p, Developer, deployment, *, dev:development-d2, allow
+  #
+  # The policy will be available on the kuberpult-rbac config map.
+  policy_csv: ""

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -108,7 +108,7 @@ func RunServer() {
 
 		dexRbacPolicy, err := c.readRbacPolicy()
 		if err != nil {
-			logger.FromContext(ctx).Fatal("pgp.read.error", zap.Error(err))
+			logger.FromContext(ctx).Fatal("dex.read.error", zap.Error(err))
 		}
 		if c.DexEnable && dexRbacPolicy == "" {
 			logger.FromContext(ctx).Fatal("dex.policy.error: dexRbacPolicy is required when \"KUBERPULT_DEX_ENABLE\" is true")

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -53,10 +53,17 @@ type Config struct {
 	GitSshKnownHosts  string `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
 	PgpKeyRing        string `split_words:"true"`
 	AzureEnableAuth   bool   `default:"false" split_words:"true"`
+	DexEnable         bool   `default:"false" split_words:"true"`
+	DexRbacPolicy     string `split_words:"true"`
 	EnableTracing     bool   `default:"false" split_words:"true"`
 	EnableMetrics     bool   `default:"false" split_words:"true"`
 	DogstatsdAddr     string `default:"127.0.0.1:8125" split_words:"true"`
 	EnableSqlite      bool   `default:"true" split_words:"true"`
+}
+
+// TODO (BB): Read and parse RBAC rules
+func (c *Config) readRbacPolicy() (string, error) {
+	return c.DexRbacPolicy, nil
 }
 
 func (c *Config) readPgpKeyRing() (openpgp.KeyRing, error) {
@@ -97,6 +104,14 @@ func RunServer() {
 		}
 		if c.AzureEnableAuth && pgpKeyRing == nil {
 			logger.FromContext(ctx).Fatal("azure.auth.error: pgpKeyRing is required to authenticate manifests when \"KUBERPULT_AZURE_ENABLE_AUTH\" is true")
+		}
+
+		dexRbacPolicy, err := c.readRbacPolicy()
+		if err != nil {
+			logger.FromContext(ctx).Fatal("pgp.read.error", zap.Error(err))
+		}
+		if c.DexEnable && dexRbacPolicy == "" {
+			logger.FromContext(ctx).Fatal("dex.policy.error: dexRbacPolicy is required when \"KUBERPULT_DEX_ENABLE\" is true")
 		}
 
 		grpcServerLogger := logger.FromContext(ctx).Named("grpc_server")


### PR DESCRIPTION
If Dex is enabled, adds the config map specifying the Policy to be used. 

Rev: SN-CV2ND9