### PR TITLE
Add a dummy user to the rollout service

### DIFF
--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -21,8 +21,16 @@ import (
 	"fmt"
 
 	"github.com/freiheit-com/kuberpult/pkg/api"
+	"github.com/freiheit-com/kuberpult/pkg/auth"
 	"k8s.io/utils/lru"
 )
+
+// This is a the user that the rollout service uses to query the versions.
+// It is not written to the repository.
+var RolloutServiceUser auth.User = auth.User{
+	Email: "kuberpult-rollout-service@local",
+	Name:  "kuberpult-rollout-service",
+}
 
 type VersionClient interface {
 	GetVersion(ctx context.Context, revision, environment, application string) (uint64, error)
@@ -39,6 +47,7 @@ func (v *versionClient) GetVersion(ctx context.Context, revision, environment, a
 	entry, ok := v.cache.Get(revision)
 	if !ok {
 		var err error
+		ctx = auth.WriteUserToGrpcContext(ctx, RolloutServiceUser)
 		overview, err = v.client.GetOverview(ctx, &api.GetOverviewRequest{
 			GitRevision: revision,
 		})

--- a/services/rollout-service/pkg/versions/versions_test.go
+++ b/services/rollout-service/pkg/versions/versions_test.go
@@ -21,8 +21,10 @@ import (
 	"testing"
 
 	"github.com/freiheit-com/kuberpult/pkg/api"
+	"github.com/google/go-cmp/cmp"
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -31,14 +33,17 @@ type expectedVersion struct {
 	Environment     string
 	Application     string
 	DeployedVersion uint64
+	Metadata        metadata.MD
 }
 
 type mockOverviewClient struct {
-	Responses map[string]*api.GetOverviewResponse
+	Responses    map[string]*api.GetOverviewResponse
+	LastMetadata metadata.MD
 }
 
 // GetOverview implements api.OverviewServiceClient
 func (m *mockOverviewClient) GetOverview(ctx context.Context, in *api.GetOverviewRequest, opts ...grpc.CallOption) (*api.GetOverviewResponse, error) {
+	m.LastMetadata, _ = metadata.FromOutgoingContext(ctx)
 	if resp := m.Responses[in.GitRevision]; resp != nil {
 		return resp, nil
 	}
@@ -92,6 +97,12 @@ func TestVersionClient(t *testing.T) {
 			GitRevision: "5678",
 		},
 	}
+	defaultMetadata := metadata.MD{
+		// Base64 of "kuberpult-rollout-service@local"
+		"author-email": {"a3ViZXJwdWx0LXJvbGxvdXQtc2VydmljZUBsb2NhbA=="},
+		// Base64 of "kuberpult-rollout-service"
+		"author-name": {"a3ViZXJwdWx0LXJvbGxvdXQtc2VydmljZQ=="},
+	}
 
 	tcs := []struct {
 		Name             string
@@ -107,12 +118,14 @@ func TestVersionClient(t *testing.T) {
 					Environment:     "staging",
 					Application:     "foo",
 					DeployedVersion: 1,
+					Metadata:        defaultMetadata,
 				},
 				{
 					Revision:        "5678",
 					Environment:     "staging",
 					Application:     "bar",
 					DeployedVersion: 2,
+					Metadata:        defaultMetadata,
 				},
 			},
 		},
@@ -125,12 +138,14 @@ func TestVersionClient(t *testing.T) {
 					Environment:     "staging",
 					Application:     "bar",
 					DeployedVersion: 0, // bar is deployed in rev 5678 but not in 1234
+					Metadata:        defaultMetadata,
 				},
 				{
 					Revision:        "1234",
 					Environment:     "production",
 					Application:     "foo",
 					DeployedVersion: 0, // foo is deployed in rev 1234 but not in env production
+					Metadata:        defaultMetadata,
 				},
 			},
 		},
@@ -138,9 +153,9 @@ func TestVersionClient(t *testing.T) {
 	for _, tc := range tcs {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
-			vc := New(&mockOverviewClient{Responses: tc.Responses})
+			mc := &mockOverviewClient{Responses: tc.Responses}
+			vc := New(mc)
 			for _, ev := range tc.ExpectedVersions {
-
 				version, err := vc.GetVersion(context.Background(), ev.Revision, ev.Environment, ev.Application)
 				if err != nil {
 					t.Errorf("expected no error for %s/%s@%s, but got %q", ev.Environment, ev.Application, ev.Revision, err)
@@ -148,6 +163,9 @@ func TestVersionClient(t *testing.T) {
 				}
 				if version != ev.DeployedVersion {
 					t.Errorf("expected version %d to be deployed for %s/%s@%s but got %d", ev.DeployedVersion, ev.Environment, ev.Application, ev.Revision, version)
+				}
+				if !cmp.Equal(mc.LastMetadata, ev.Metadata) {
+					t.Errorf("mismachted metadata %s", cmp.Diff(mc.LastMetadata, ev.Metadata))
 				}
 			}
 		})


### PR DESCRIPTION
The cd service requires a user in the grpc metadata. It can be literally anything but it must be there.