### PR TITLE
Block Users without Permission from Creating Environment Locks

### DIFF
--- a/codereviewr.yaml
+++ b/codereviewr.yaml
@@ -123,6 +123,7 @@ ignoredFiles: [
     ".env",
     ".go-version",
     "services/cd-service/gitconfig",
+    "*.csv"
   ] #ignored file extensions
 testFiles: ["_test.go", "_test.dart"]
 languagesConfig:

--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -27,8 +27,8 @@ import (
 type RBACConfig struct {
 	// Indicates if Dex is enabled.
 	DexEnabled bool
-	// The RBAC policy. In later stories mapping for policies will be integrated here
-	// Policy map[string]*Permission
+	// The RBAC policy. Key is for example "p,Developer,EnvironmentLock,Create,production,allow"
+	Policy map[string]*Permission
 }
 
 // Inits the RBAC Config struct

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -34,6 +34,7 @@ package testutil
 
 import (
 	"context"
+
 	"github.com/freiheit-com/kuberpult/pkg/auth"
 	"google.golang.org/grpc/metadata"
 )
@@ -50,6 +51,21 @@ func MakeTestContext() context.Context {
 	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{
 		auth.HeaderUserEmail: auth.Encode64("myemail@example.com"),
 		auth.HeaderUserName:  auth.Encode64("my name"),
+	}))
+	return ctx
+}
+
+func MakeTestContextDexEnabled() context.Context {
+	u := auth.User{
+		Email:          "testmail@example.com",
+		Name:           "test tester",
+		DexAuthContext: &auth.DexAuthContext{Role: "developer"},
+	}
+	ctx := auth.WriteUserToContext(context.Background(), u)
+	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{
+		auth.HeaderUserEmail: auth.Encode64("myemail@example.com"),
+		auth.HeaderUserName:  auth.Encode64("my name"),
+		auth.HeaderUserRole:  auth.Encode64("Developer"),
 	}))
 	return ctx
 }

--- a/services/cd-service/Makefile
+++ b/services/cd-service/Makefile
@@ -23,6 +23,8 @@ MAKEFLAGS += --no-builtin-rules
 export CGO_ENABLED=1
 
 IMAGENAME?=$(IMAGE_REGISTRY)/kuberpult-cd-service:$(VERSION)
+export KUBERPULT_DEX_MOCK=false
+export KUBERPULT_DEX_ENABLED=false
 
 ifeq ($(WITH_DOCKER),)
 COMPILE_WITH_DOCKER := false

--- a/services/cd-service/pkg/interceptors/interceptors.go
+++ b/services/cd-service/pkg/interceptors/interceptors.go
@@ -30,9 +30,10 @@ func UnaryUserContextInterceptor(ctx context.Context,
 	req interface{},
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
-	dexEnabled bool) (interface{}, error) {
+	dexEnabled bool,
+	reader auth.GrpcContextReader) (interface{}, error) {
 
-	user, err := auth.ReadUserFromGrpcContext(ctx, dexEnabled)
+	user, err := reader.ReadUserFromGrpcContext(ctx, dexEnabled)
 	if err != nil {
 		return nil, err
 	}

--- a/services/cd-service/policy.csv
+++ b/services/cd-service/policy.csv
@@ -1,0 +1,1 @@
+p, Developer, EnvironmentLock, Create, development:development, allow


### PR DESCRIPTION
Takes the extracted role information from the GRPC context. 
When Dex is enabled then checks if associated role has permissions for createEnvironmentLock. 
Blocks user if their role does not have permissions.