### PR TITLE
Refactor checkbox to reduce material-ui usage

### DIFF
--- a/services/frontend-service/src/assets/_components.scss
+++ b/services/frontend-service/src/assets/_components.scss
@@ -18,6 +18,7 @@ Copyright 2023 freiheit.com*/
 @import 'src/ui/components/chip/chip';
 @import 'src/ui/components/textfield/textfield';
 @import 'src/ui/components/dropdown/dropdown';
+@import 'src/ui/components/dropdown/checkbox';
 @import 'src/ui/components/navigation/navList';
 @import 'src/ui/components/NavigationBar/NavigationBar';
 @import '../ui/components/LocksTable/LocksTable';

--- a/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.test.tsx
@@ -34,7 +34,7 @@ const dataSelection: TestDataSelection[] = [
         name: 'renders 2 item list',
         input: { environments: ['dev', 'staging'], open: true, onSubmit: mySubmitSpy, onCancel: myCancelSpy },
         expectedNumItems: 2,
-        clickOnButton: 'dev',
+        clickOnButton: '0',
         expectedNumSelectedAfterClick: 1,
         expectedNumDeselectedAfterClick: 1,
     },
@@ -42,7 +42,7 @@ const dataSelection: TestDataSelection[] = [
         name: 'renders 3 item list',
         input: { environments: ['dev', 'staging', 'prod'], open: true, onSubmit: mySubmitSpy, onCancel: myCancelSpy },
         expectedNumItems: 3,
-        clickOnButton: 'staging',
+        clickOnButton: '1',
         expectedNumSelectedAfterClick: 1,
         expectedNumDeselectedAfterClick: 2,
     },
@@ -103,17 +103,17 @@ describe('EnvSelectionDialog Rendering', () => {
 
             getWrapper(testcase.input);
 
-            expect(document.querySelectorAll('.envs-dropdown-select .test-button-env-selection').length).toEqual(
+            expect(document.querySelectorAll('.envs-dropdown-select .test-button-checkbox').length).toEqual(
                 testcase.expectedNumItems
             );
-            const result = documentQuerySelectorSafe('.env-' + testcase.clickOnButton);
+            const result = documentQuerySelectorSafe('.id-' + testcase.clickOnButton);
             act(() => {
                 result.click();
             });
-            expect(document.querySelectorAll('.test-button-env-selection.enabled').length).toEqual(
+            expect(document.querySelectorAll('.test-button-checkbox.enabled').length).toEqual(
                 testcase.expectedNumSelectedAfterClick
             );
-            expect(document.querySelectorAll('.test-button-env-selection.disabled').length).toEqual(
+            expect(document.querySelectorAll('.test-button-checkbox.disabled').length).toEqual(
                 testcase.expectedNumDeselectedAfterClick
             );
         });

--- a/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.tsx
@@ -17,6 +17,7 @@ import { Dialog, DialogActions, DialogTitle } from '@material-ui/core';
 import * as React from 'react';
 import { Button } from '../button';
 import { useState } from 'react';
+import { Checkbox } from '../dropdown/checkbox';
 
 export type EnvSelectionDialogProps = {
     environments: string[];
@@ -62,15 +63,13 @@ export const EnvSelectionDialog: React.FC<EnvSelectionDialogProps> = (props) => 
                     const enabled = selectedEnvs.includes(env);
                     return (
                         <div key={env}>
-                            <Button
-                                className={
-                                    'test-button-env-selection env-' + env + ' ' + (enabled ? 'enabled' : 'disabled')
-                                }
-                                id={String(index)}
+                            <Checkbox
+                                enabled={enabled}
                                 onClick={addTeam}
-                                label={enabled ? '☑' : '☐'}
+                                id={String(index)}
+                                label={env}
+                                classes={'env' + env}
                             />
-                            {env}
                         </div>
                     );
                 })}

--- a/services/frontend-service/src/ui/components/dropdown/checkbox.scss
+++ b/services/frontend-service/src/ui/components/dropdown/checkbox.scss
@@ -1,0 +1,21 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+.checkbox-wrapper {
+    .mdc-button__label {
+        font-size: x-large;
+    }
+}

--- a/services/frontend-service/src/ui/components/dropdown/checkbox.test.tsx
+++ b/services/frontend-service/src/ui/components/dropdown/checkbox.test.tsx
@@ -1,0 +1,59 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+import { act, render } from '@testing-library/react';
+import { Checkbox, CheckboxProps } from './checkbox';
+import { documentQuerySelectorSafe } from '../../../setupTests';
+
+const getNode = (props: CheckboxProps): JSX.Element => <Checkbox {...props} />;
+
+const getWrapper = (input: CheckboxProps) => render(getNode(input));
+
+describe('Checkbox', () => {
+    interface dataT {
+        name: string;
+        input: CheckboxProps;
+        expectedText: string;
+    }
+    const mySubmitSpy = jest.fn();
+
+    const data: dataT[] = [
+        {
+            name: 'Test onClick',
+            input: { id: 'id1', enabled: true, label: 'alpha label', onClick: mySubmitSpy },
+            expectedText: 'alpha label',
+        },
+    ];
+
+    describe.each(data)(`Renders a navigation item with selected`, (testcase) => {
+        it.only(testcase.name, () => {
+            // given
+            mySubmitSpy.mockReset();
+            // when
+            getWrapper(testcase.input);
+            // then
+            const result = documentQuerySelectorSafe('.id-' + testcase.input.id);
+            expect(mySubmitSpy).toHaveBeenCalledTimes(0);
+            act(() => {
+                result.click();
+            });
+            expect(mySubmitSpy).toHaveBeenCalledTimes(1);
+
+            expect(document.querySelectorAll('.checkbox-wrapper').length).toEqual(1);
+            expect(document.querySelectorAll('.checkbox-wrapper')[0]).toHaveTextContent(testcase.expectedText);
+        });
+    });
+});

--- a/services/frontend-service/src/ui/components/dropdown/checkbox.tsx
+++ b/services/frontend-service/src/ui/components/dropdown/checkbox.tsx
@@ -1,0 +1,36 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+import * as React from 'react';
+import { Button } from '../button';
+
+export type CheckboxProps = {
+    onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    classes?: string;
+    id: string;
+    enabled: boolean;
+    label: string;
+};
+
+export const Checkbox: React.FC<CheckboxProps> = (props) => (
+    <span onClick={props.onClick} className={'checkbox-wrapper'} id={String(props.id)}>
+        <Button
+            className={'test-button-checkbox id-' + props.id + ' ' + (props.enabled ? 'enabled' : 'disabled')}
+            label={props.enabled ? '☑' : '☐'}
+        />
+        {props.label}
+    </span>
+);

--- a/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
+++ b/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
@@ -13,11 +13,13 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-import { Checkbox, FormControl, InputLabel, MenuItem, Select } from '@material-ui/core';
+import { FormControl, InputLabel, MenuItem, Select } from '@material-ui/core';
 import classNames from 'classnames';
 import { useCallback, useRef } from 'react';
 import { useTeamNames } from '../../utils/store';
 import { useSearchParams } from 'react-router-dom';
+import { Checkbox } from './checkbox';
+import * as React from 'react';
 
 export type DropdownProps = {
     className?: string;
@@ -60,8 +62,7 @@ export const DropdownSelect: React.FC<{
                 </MenuItem>
                 {teams.map((team: string) => (
                     <MenuItem key={team} value={team}>
-                        <Checkbox checked={selectedTeams?.includes(team)}></Checkbox>
-                        {team}
+                        <Checkbox id={team} enabled={selectedTeams?.includes(team)} label={team} />
                     </MenuItem>
                 ))}
             </Select>


### PR DESCRIPTION
The goal is to get rid of material-ui.
The checkbox is now used in more places, so this PR gets rid of the material-ui checkbox component.

This changes the rendering slightly, but not the behavior.

New Checkbox:
![Screenshot from 2023-07-25 17-13-40](https://github.com/freiheit-com/kuberpult/assets/3481382/159bf78c-5ed5-424b-82fb-078f694350e6)

Old Checkbox:
![Screenshot from 2023-07-25 17-15-08](https://github.com/freiheit-com/kuberpult/assets/3481382/a6ad28a7-d7a5-4642-a358-88fd04267409)

SRX-Z1SMB9