### PR TITLE
Allow argocd to render our manifests in parallel

### DIFF
--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -879,6 +879,11 @@ func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) 
 	if err := util.WriteFile(fs, manifestFilename, manifestContent, 0666); err != nil {
 		return "", err
 	}
+	// .argocd-allow-concurrency is a special file. It signals that rendering this manifests has no side-effects and avoids holding
+	// a global lock.
+	if err := util.WriteFile(fs, fs.Join(manifestsDir, ".argocd-allow-concurrency"), []byte("# This file allows argocd to process the app in parallel."), 0666); err != nil {
+		return "", err
+	}
 
 	user, err := auth.ReadUserFromContext(ctx)
 	if err != nil {


### PR DESCRIPTION
From tracing, I saw that the rendering requests to the repo server take quiet long when you have > 2k apps. There is an option in the repo server to make this faster by avoiding the global lock. This lock is in place because some manifests renderer ( e.g. kustomize with parameter overrides ) create local files and therefore cannot run in parallel. By putting a special file in the apps root path, we can signal argocd to avoid this locking all together.

See here: https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#enable-concurrent-processing
And here: https://github.com/argoproj/argo-cd/blob/f1607fee7c3bfad8eb56a53130cf9ac7cc22dd34/reposerver/repository/repository.go#L1023