### PR TITLE
Revert "Allow argocd to render our manifests in parallel"

### DIFF
--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -879,11 +879,6 @@ func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) 
 	if err := util.WriteFile(fs, manifestFilename, manifestContent, 0666); err != nil {
 		return "", err
 	}
-	// .argocd-allow-concurrency is a special file. It signals that rendering this manifests has no side-effects and avoids holding
-	// a global lock.
-	if err := util.WriteFile(fs, fs.Join(manifestsDir, ".argocd-allow-concurrency"), []byte("# This file allows argocd to process the app in parallel."), 0666); err != nil {
-		return "", err
-	}
 
 	user, err := auth.ReadUserFromContext(ctx)
 	if err != nil {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -395,18 +395,17 @@ func TestCreateUndeployApplicationVersionErrors(t *testing.T) {
 
 func TestDeployApplicationVersion(t *testing.T) {
 	tcs := []struct {
-		Name                         string
-		Transformers                 []Transformer
-		expectedError                string
-		expectedPath                 string
-		expectedFileData             []byte
-		expectedDeployedByPath       string
-		expectedDeployedByData       []byte
-		expectedDeployedByEmailPath  string
-		expectedDeployedByEmailData  []byte
-		expectedDeployedAtPath       string
-		expectedDeployedAtData       []byte
-		expectedArgocdConcurrentPath string
+		Name                        string
+		Transformers                []Transformer
+		expectedError               string
+		expectedPath                string
+		expectedFileData            []byte
+		expectedDeployedByPath      string
+		expectedDeployedByData      []byte
+		expectedDeployedByEmailPath string
+		expectedDeployedByEmailData []byte
+		expectedDeployedAtPath      string
+		expectedDeployedAtData      []byte
 	}{
 		{
 			Name: "successfully deploy a full manifest",
@@ -428,16 +427,15 @@ func TestDeployApplicationVersion(t *testing.T) {
 					LockBehaviour: api.LockBehavior_Fail,
 				},
 			},
-			expectedError:                "",
-			expectedPath:                 "environments/acceptance/applications/app1/manifests/manifests.yaml",
-			expectedFileData:             []byte("acceptance"),
-			expectedDeployedByPath:       "environments/acceptance/applications/app1/deployed_by",
-			expectedDeployedByData:       []byte("test tester"),
-			expectedDeployedAtPath:       "environments/acceptance/applications/app1/deployed_at_utc",
-			expectedDeployedAtData:       []byte(timeNowOld.UTC().String()),
-			expectedDeployedByEmailPath:  "environments/acceptance/applications/app1/deployed_by_email",
-			expectedDeployedByEmailData:  []byte("testmail@example.com"),
-			expectedArgocdConcurrentPath: "environments/acceptance/applications/app1/manifests/.argocd-allow-concurrency",
+			expectedError:               "",
+			expectedPath:                "environments/acceptance/applications/app1/manifests/manifests.yaml",
+			expectedFileData:            []byte("acceptance"),
+			expectedDeployedByPath:      "environments/acceptance/applications/app1/deployed_by",
+			expectedDeployedByData:      []byte("test tester"),
+			expectedDeployedAtPath:      "environments/acceptance/applications/app1/deployed_at_utc",
+			expectedDeployedAtData:      []byte(timeNowOld.UTC().String()),
+			expectedDeployedByEmailPath: "environments/acceptance/applications/app1/deployed_by_email",
+			expectedDeployedByEmailData: []byte("testmail@example.com"),
 		},
 		{
 			Name: "successfully deploy an empty manifest",
@@ -459,16 +457,15 @@ func TestDeployApplicationVersion(t *testing.T) {
 					LockBehaviour: api.LockBehavior_Fail,
 				},
 			},
-			expectedError:                "",
-			expectedPath:                 "environments/acceptance/applications/app1/manifests/manifests.yaml",
-			expectedFileData:             []byte(" "),
-			expectedDeployedByPath:       "environments/acceptance/applications/app1/deployed_by",
-			expectedDeployedByData:       []byte("test tester"),
-			expectedDeployedAtPath:       "environments/acceptance/applications/app1/deployed_at_utc",
-			expectedDeployedAtData:       []byte(timeNowOld.UTC().String()),
-			expectedDeployedByEmailPath:  "environments/acceptance/applications/app1/deployed_by_email",
-			expectedDeployedByEmailData:  []byte("testmail@example.com"),
-			expectedArgocdConcurrentPath: "environments/acceptance/applications/app1/manifests/.argocd-allow-concurrency",
+			expectedError:               "",
+			expectedPath:                "environments/acceptance/applications/app1/manifests/manifests.yaml",
+			expectedFileData:            []byte(" "),
+			expectedDeployedByPath:      "environments/acceptance/applications/app1/deployed_by",
+			expectedDeployedByData:      []byte("test tester"),
+			expectedDeployedAtPath:      "environments/acceptance/applications/app1/deployed_at_utc",
+			expectedDeployedAtData:      []byte(timeNowOld.UTC().String()),
+			expectedDeployedByEmailPath: "environments/acceptance/applications/app1/deployed_by_email",
+			expectedDeployedByEmailData: []byte("testmail@example.com"),
 		},
 	}
 	for _, tc := range tcs {
@@ -520,11 +517,6 @@ func TestDeployApplicationVersion(t *testing.T) {
 			}
 			if !cmp.Equal(DeployedAtData, tc.expectedDeployedAtData) {
 				t.Fatalf("Expected '%v', got '%v'", string(tc.expectedDeployedAtData), string(DeployedAtData))
-			}
-			// Argocd doesnt read this file but just checks that it's there.
-			argocdAllowConcurrentFile := updatedState.Filesystem.Join(updatedState.Filesystem.Root(), tc.expectedArgocdConcurrentPath)
-			if _, err := updatedState.Filesystem.Stat(argocdAllowConcurrentFile); err != nil {
-				t.Errorf("expected file %q to exist, but got error %q", tc.expectedArgocdConcurrentPath, err)
 			}
 		})
 	}


### PR DESCRIPTION
Reverts freiheit-com/kuberpult#822

I read the documentation and the code in the repository doesn't actually work as documented. Actually it seems like this file is only considered for helm charts ( which is irrelevant for us ).

Here is the code for helm charts, checking the file: https://github.com/argoproj/argo-cd/blob/f1607fee7c3bfad8eb56a53130cf9ac7cc22dd34/reposerver/repository/repository.go#L1064
Here is the code for manifest dirs, not checking the file at all: https://github.com/argoproj/argo-cd/blob/f1607fee7c3bfad8eb56a53130cf9ac7cc22dd34/reposerver/repository/repository.go#L1538C16-L1538C16

Given that the documentation is probably misleading, I would revert this for now.