### PR TITLE
Refactoring: Use own tooltip component

### DIFF
--- a/services/frontend-service/package.json
+++ b/services/frontend-service/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "6",
     "react-scripts": "^5.0.1",
+    "react-tooltip": "^5.18.1",
     "react-use-sub": "^3.0.0",
     "rxjs": "^7.0.0"
   },

--- a/services/frontend-service/pnpm-lock.yaml
+++ b/services/frontend-service/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   react-error-overlay: 6.0.9
 
@@ -56,6 +52,9 @@ importers:
       react-scripts:
         specifier: ^5.0.1
         version: 5.0.1(@babel/plugin-syntax-flow@7.18.6)(@babel/plugin-transform-react-jsx@7.19.0)(eslint@8.38.0)(react@18.2.0)(sass@1.54.9)(typescript@5.1.6)
+      react-tooltip:
+        specifier: ^5.18.1
+        version: 5.18.1(react-dom@18.2.0)(react@18.2.0)
       react-use-sub:
         specifier: ^3.0.0
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)
@@ -1868,6 +1867,16 @@ packages:
   /@eslint/js@8.38.0:
     resolution: {integrity: sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  /@floating-ui/core@1.3.1:
+    resolution: {integrity: sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g==}
+    dev: false
+
+  /@floating-ui/dom@1.4.5:
+    resolution: {integrity: sha512-96KnRWkRnuBSSFbj0sFGwwOUd8EkiecINVl0O9wiZlZ64EkpyAOG3Xc2vKKNJmru0Z7RqWNymA+6b8OZqjgyyw==}
+    dependencies:
+      '@floating-ui/core': 1.3.1
+    dev: false
 
   /@humanwhocodes/config-array@0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
@@ -4157,10 +4166,8 @@ packages:
       - supports-color
     dev: false
 
-  /ajv-formats@2.1.1(ajv@8.11.0):
+  /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -9306,13 +9313,13 @@ packages:
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-import@14.1.0(postcss@8.4.16):
+  /postcss-import@14.1.0(postcss@8.4.23):
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.16
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.1
@@ -9326,14 +9333,14 @@ packages:
       postcss: 8.4.16
     dev: false
 
-  /postcss-js@4.0.1(postcss@8.4.16):
+  /postcss-js@4.0.1(postcss@8.4.23):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.4.21
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.16
+      postcss: 8.4.23
     dev: false
 
   /postcss-lab-function@4.2.1(postcss@8.4.16):
@@ -9347,7 +9354,7 @@ packages:
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-load-config@3.1.4(postcss@8.4.16):
+  /postcss-load-config@3.1.4(postcss@8.4.23):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -9360,7 +9367,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
-      postcss: 8.4.16
+      postcss: 8.4.23
       yaml: 1.10.2
     dev: false
 
@@ -9505,13 +9512,13 @@ packages:
       postcss: 8.4.23
     dev: false
 
-  /postcss-nested@6.0.0(postcss@8.4.16):
+  /postcss-nested@6.0.0(postcss@8.4.23):
     resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.16
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: false
 
@@ -10297,7 +10304,7 @@ packages:
       semver: 7.3.7
       source-map-loader: 3.0.2(webpack@5.77.0)
       style-loader: 3.3.2(webpack@5.77.0)
-      tailwindcss: 3.3.1(postcss@8.4.16)
+      tailwindcss: 3.3.1
       terser-webpack-plugin: 5.3.7(webpack@5.77.0)
       typescript: 5.1.6
       webpack: 5.77.0
@@ -10338,6 +10345,18 @@ packages:
       - webpack-cli
       - webpack-hot-middleware
       - webpack-plugin-serve
+    dev: false
+
+  /react-tooltip@5.18.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-5zUKoMoKHTYxobzhR160+kkHdLtB+yYO8p16aQRoz2jGcOdtV0o1enNynoA4YqQb3xTjl84N8KLNoscmgMNuSg==}
+    peerDependencies:
+      react: '>=16.14.0 || 18'
+      react-dom: '>=16.14.0 || 18'
+    dependencies:
+      '@floating-ui/dom': 1.4.5
+      classnames: 2.3.2
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react-transition-group@4.4.5(react-dom@18.2.0)(react@18.2.0):
@@ -10739,7 +10758,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1(ajv@8.11.0)
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.11.0)
     dev: false
 
@@ -11258,12 +11277,10 @@ packages:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: false
 
-  /tailwindcss@3.3.1(postcss@8.4.16):
+  /tailwindcss@3.3.1:
     resolution: {integrity: sha512-Vkiouc41d4CEq0ujXl6oiGFQ7bA3WEhUZdTgXAhtKxSy49OmKs8rEfQmupsfF0IGW8fv2iQkp1EVUuapCFrZ9g==}
     engines: {node: '>=12.13.0'}
     hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -11279,11 +11296,11 @@ packages:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.16
-      postcss-import: 14.1.0(postcss@8.4.16)
-      postcss-js: 4.0.1(postcss@8.4.16)
-      postcss-load-config: 3.1.4(postcss@8.4.16)
-      postcss-nested: 6.0.0(postcss@8.4.16)
+      postcss: 8.4.23
+      postcss-import: 14.1.0(postcss@8.4.23)
+      postcss-js: 4.0.1(postcss@8.4.23)
+      postcss-load-config: 3.1.4(postcss@8.4.23)
+      postcss-nested: 6.0.0(postcss@8.4.23)
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
@@ -12242,3 +12259,7 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/services/frontend-service/src/assets/_base.scss
+++ b/services/frontend-service/src/assets/_base.scss
@@ -65,14 +65,14 @@ body,
 .text-regular {
     @extend .font;
     font-weight: 500;
-    font-size: 10px;
+    font-size: 12px;
     line-height: 16px;
 }
 
 .text-bold {
     @extend .font;
     font-weight: 700;
-    font-size: 10px;
+    font-size: 12px;
     line-height: 16px;
 }
 

--- a/services/frontend-service/src/assets/_components.scss
+++ b/services/frontend-service/src/assets/_components.scss
@@ -27,7 +27,7 @@ Copyright 2023 freiheit.com*/
 @import 'src/ui/components/ReleaseCardMini/ReleaseCardMini';
 @import 'src/ui/components/ReleaseDialog/ReleaseDialog';
 @import 'src/ui/components/TopAppBar/TopAppBar';
-@import 'src/ui/components/tooltip/tooltip';
+@import '../ui/components/tooltip/tooltip';
 @import 'src/ui/components/SideBar/SideBar';
 @import 'src/ui/components/snackbar/snackbar';
 @import 'src/ui/components/ServiceLane/ServiceLane';

--- a/services/frontend-service/src/setupTests.ts
+++ b/services/frontend-service/src/setupTests.ts
@@ -21,6 +21,10 @@ import { DisplayLock } from './ui/utils/store';
 // test utility to await all running promises
 global.nextTick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
 
+// CSS.supports is required a dependency of react-tooltip
+// @ts-ignore
+global.CSS = { supports: jest.fn() };
+
 export const documentQuerySelectorSafe = (selectors: string): HTMLElement => {
     const result = document.querySelector(selectors);
     if (!result) {

--- a/services/frontend-service/src/ui/components/EnvironmentCard/EnvironmentCard.scss
+++ b/services/frontend-service/src/ui/components/EnvironmentCard/EnvironmentCard.scss
@@ -77,6 +77,10 @@ Copyright 2023 freiheit.com*/
             padding-bottom: 10px;
             padding-right: 0px;
             padding-left: 0px;
+
+            .tooltip-container {
+                min-width: 40px;
+            }
         }
     }
 

--- a/services/frontend-service/src/ui/components/EnvironmentCard/EnvironmentCard.tsx
+++ b/services/frontend-service/src/ui/components/EnvironmentCard/EnvironmentCard.tsx
@@ -45,7 +45,12 @@ export const EnvironmentCard: React.FC<{ environment: Environment }> = (props) =
                 {locks.length !== 0 && (
                     <div className="environment__locks">
                         {locks.map((lock) => (
-                            <EnvironmentLockDisplay env={environment.name} lockId={lock} key={lock} />
+                            <EnvironmentLockDisplay
+                                env={environment.name}
+                                lockId={lock}
+                                key={lock}
+                                bigLockIcon={true}
+                            />
                         ))}
                     </div>
                 )}

--- a/services/frontend-service/src/ui/components/EnvironmentLockDisplay/EnvironmentLockDisplay.tsx
+++ b/services/frontend-service/src/ui/components/EnvironmentLockDisplay/EnvironmentLockDisplay.tsx
@@ -14,12 +14,31 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 import * as React from 'react';
-import { addAction, useEnvironmentLock } from '../../utils/store';
-import Tooltip from '@material-ui/core/Tooltip';
-import { Locks } from '../../../images';
+import { addAction, DisplayLock, useEnvironmentLock } from '../../utils/store';
+import { Tooltip } from '../tooltip/tooltip';
+import { Locks, LocksWhite } from '../../../images';
 import { Button } from '../button';
 
-export const EnvironmentLockDisplay: React.FC<{ env: string; lockId: string }> = (props) => {
+export const DisplayLockRenderer: React.FC<{ lock: DisplayLock }> = (props) => {
+    const { lock } = props;
+    const hasAuthor = lock.authorEmail || lock.authorName;
+    const author = hasAuthor ? lock.authorName + '<' + lock.authorEmail + '>' : 'unknown';
+    const kind = lock.application ? 'App' : 'Environment';
+    return (
+        <div>
+            <div>
+                {kind} locked by {author}
+            </div>
+            <div>
+                with Message: <b>{lock.message} AAA</b>
+            </div>
+            <div>ID: {lock.lockId}</div>
+            <div>Click to unlock.</div>
+        </div>
+    );
+};
+
+export const EnvironmentLockDisplay: React.FC<{ env: string; lockId: string; bigLockIcon: boolean }> = (props) => {
     const { env, lockId } = props;
     const lock = useEnvironmentLock(lockId);
     const deleteLock = React.useCallback(() => {
@@ -27,19 +46,17 @@ export const EnvironmentLockDisplay: React.FC<{ env: string; lockId: string }> =
             action: { $case: 'deleteEnvironmentLock', deleteEnvironmentLock: { environment: env, lockId: lockId } },
         });
     }, [env, lockId]);
+    const content = <DisplayLockRenderer lock={lock} />;
+    const lockIcon = props.bigLockIcon ? (
+        <Locks className="environment-lock-icon" />
+    ) : (
+        <LocksWhite className="env-card-env-lock-icon fixed-size" />
+    );
     return (
-        <div className="environment-lock-display">
-            <Tooltip
-                arrow
-                title={'Lock Message: "' + lock.message + '" | ID: "' + lock.lockId + '"  | Click to unlock. '}>
-                <div>
-                    <Button
-                        icon={<Locks className="environment-lock-icon" />}
-                        onClick={deleteLock}
-                        className={'button-lock'}
-                    />
-                </div>
-            </Tooltip>
-        </div>
+        <Tooltip tooltipContent={content} id={'env-group-chip-id-' + lock.lockId}>
+            <div>
+                <Button icon={lockIcon} onClick={deleteLock} className={'button-lock'} />
+            </div>
+        </Tooltip>
     );
 };

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
@@ -57,16 +57,10 @@ Copyright 2023 freiheit.com*/
 }
 
 .release__details {
-    padding: $release-card-tooltip-padding;
-    b {
-        @extend .text-bold;
-    }
-    div {
-        @extend .text-regular;
-    }
     .release__metadata {
-        display: flex;
-        color: var(--mdc-theme-primary);
+        .date {
+            color: var(--mdc-theme-primary);
+        }
     }
 }
 

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -16,8 +16,7 @@ Copyright 2023 freiheit.com*/
 import classNames from 'classnames';
 import { Button } from '../button';
 import { Tooltip } from '../tooltip/tooltip';
-import React, { useEffect, useRef } from 'react';
-import { MDCRipple } from '@material/ripple';
+import React, { useEffect } from 'react';
 import { useOpenReleaseDialog, useReleaseOrThrow } from '../../utils/store';
 import { EnvironmentGroupChipList } from '../chip/EnvironmentGroupChip';
 import { FormattedDate } from '../FormattedDate/FormattedDate';
@@ -29,35 +28,37 @@ export type ReleaseCardProps = {
 };
 
 export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
-    const MDComponent = useRef<MDCRipple>();
-    const control = useRef<HTMLDivElement>(null);
     const { className, app, version } = props;
     // the ReleaseCard only displays actual releases, so we can assume that it exists here:
     const { createdAt, sourceMessage, sourceCommitId, sourceAuthor, undeployVersion } = useReleaseOrThrow(app, version);
     const openReleaseDialog = useOpenReleaseDialog(app, version);
 
-    useEffect(() => {
-        if (control.current) {
-            MDComponent.current = new MDCRipple(control.current);
-        }
-        return (): void => MDComponent.current?.destroy();
-    }, []);
+    useEffect(() => {}, []);
 
     const tooltipContents = (
-        <h2 className="mdc-tooltip__title release__details">
+        <div className="mdc-tooltip__title_ release__details">
             {!!sourceMessage && <b>{sourceMessage}</b>}
-            {!!sourceCommitId && <Button className="release__hash" label={sourceCommitId} />}
-            {!!sourceAuthor && <div>{'| ' + sourceAuthor + ' |'}</div>}
-            {!!createdAt && (
-                <div className="release__metadata">
-                    <FormattedDate createdAt={createdAt} />
+            {!!sourceCommitId && (
+                <div className={'release__hash--container'}>
+                    <Button className="release__hash" label={'' + sourceCommitId} />
                 </div>
             )}
-        </h2>
+            {!!sourceAuthor && (
+                <div>
+                    <span>Author:</span> {sourceAuthor}
+                </div>
+            )}
+            {!!createdAt && (
+                <div className="release__metadata">
+                    <span>Created </span>
+                    <FormattedDate className={'date'} createdAt={createdAt} />
+                </div>
+            )}
+        </div>
     );
     const firstLine = sourceMessage.split('\n')[0];
     return (
-        <Tooltip id={app + version} content={tooltipContents}>
+        <Tooltip id={app + version} tooltipContent={tooltipContents}>
             <div className="release-card__container">
                 <div className="release__environments">
                     <EnvironmentGroupChipList app={props.app} version={props.version} smallEnvChip />
@@ -65,7 +66,7 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
                 <div className={classNames('mdc-card release-card', className)}>
                     <div
                         className="mdc-card__primary-action release-card__description"
-                        ref={control}
+                        // ref={control}
                         tabIndex={0}
                         onClick={openReleaseDialog}>
                         <div className="release-card__header">

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -110,6 +110,12 @@ Copyright 2023 freiheit.com*/
                     top: $release-dialog-label-displacement;
                     left: $release-dialog-label-displacement;
                     height: 42px;
+
+                    .tooltip-container button {
+                        width: 16px;
+                        height: 16px;
+                    }
+
                     .env-card-label {
                         display: flex;
 
@@ -130,7 +136,7 @@ Copyright 2023 freiheit.com*/
                 .env-card-app-locks {
                     display: flex;
                     position: relative;
-                    top: 20px;
+                    top: 10px;
                     right: 36px;
                     flex-direction: row;
                     gap: 13px;

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -13,7 +13,7 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-import { Dialog, Tooltip } from '@material-ui/core';
+import { Dialog } from '@material-ui/core';
 import classNames from 'classnames';
 import React, { useCallback } from 'react';
 import { Environment, EnvironmentGroup, Lock, LockBehavior, Release } from '../../../api/api';
@@ -36,8 +36,6 @@ export type ReleaseDialogProps = {
     version: number;
 };
 
-export type EnvSortOrder = { [index: string]: number };
-
 export const AppLock: React.FC<{
     env: Environment;
     app: string;
@@ -52,15 +50,11 @@ export const AppLock: React.FC<{
         });
     }, [app, env.name, lock.lockId]);
     return (
-        <Tooltip
-            key={lock.lockId}
-            arrow
-            title={'Lock Message: "' + lock.message + '" | ID: "' + lock.lockId + '"  | Click to unlock. '}
+        <div
+            title={'App Lock Message: "' + lock.message + '" | ID: "' + lock.lockId + '"  | Click to unlock. '}
             onClick={deleteAppLock}>
-            <div>
-                <Button icon={<Locks className="env-card-app-lock" />} className={'button-lock'} />
-            </div>
-        </Tooltip>
+            <Button icon={<Locks className="env-card-app-lock" />} className={'button-lock'} />
+        </div>
     );
 };
 

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -114,25 +114,30 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                       class="release-environment env-locks"
                     >
                       <div
-                        aria-label="Lock Message: \\"envLock\\" | ID: \\"ui-envlock\\"  | Click to unlock. "
-                        class=""
-                        data-mui-internal-clone-element="true"
+                        class="tooltip-container"
                       >
-                        <button
-                          aria-label=""
-                          class="mdc-button button-lock"
+                        <a
+                          data-tooltip-delay-hide="50"
+                          data-tooltip-place="bottom"
+                          href="javascript:void(0);"
+                          id="tooltipenv-group-chip-id-ui-envlock"
                         >
-                          <div
-                            class="mdc-button__ripple"
-                          />
-                          <svg
-                            class="env-card-env-lock-icon"
-                            height="16px"
-                            width="16px"
-                          >
-                            Locks_White.svg
-                          </svg>
-                        </button>
+                          <div>
+                            <button
+                              aria-label=""
+                              class="mdc-button button-lock"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <svg
+                                class="env-card-env-lock-icon fixed-size"
+                              >
+                                Locks_White.svg
+                              </svg>
+                            </button>
+                          </div>
+                        </a>
                       </div>
                     </div>
                   </span>
@@ -141,9 +146,7 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                   class="env-card-app-locks"
                 >
                   <div
-                    aria-label="Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
-                    class=""
-                    data-mui-internal-clone-element="true"
+                    title="App Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
                   >
                     <button
                       aria-label=""
@@ -354,25 +357,30 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                       class="release-environment env-locks"
                     >
                       <div
-                        aria-label="Lock Message: \\"envLock\\" | ID: \\"ui-envlock\\"  | Click to unlock. "
-                        class=""
-                        data-mui-internal-clone-element="true"
+                        class="tooltip-container"
                       >
-                        <button
-                          aria-label=""
-                          class="mdc-button button-lock"
+                        <a
+                          data-tooltip-delay-hide="50"
+                          data-tooltip-place="bottom"
+                          href="javascript:void(0);"
+                          id="tooltipenv-group-chip-id-ui-envlock"
                         >
-                          <div
-                            class="mdc-button__ripple"
-                          />
-                          <svg
-                            class="env-card-env-lock-icon"
-                            height="16px"
-                            width="16px"
-                          >
-                            Locks_White.svg
-                          </svg>
-                        </button>
+                          <div>
+                            <button
+                              aria-label=""
+                              class="mdc-button button-lock"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <svg
+                                class="env-card-env-lock-icon fixed-size"
+                              >
+                                Locks_White.svg
+                              </svg>
+                            </button>
+                          </div>
+                        </a>
                       </div>
                     </div>
                   </span>
@@ -381,9 +389,7 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                   class="env-card-app-locks"
                 >
                   <div
-                    aria-label="Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
-                    class=""
-                    data-mui-internal-clone-element="true"
+                    title="App Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
                   >
                     <button
                       aria-label=""
@@ -598,25 +604,30 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                       class="release-environment env-locks"
                     >
                       <div
-                        aria-label="Lock Message: \\"envLock\\" | ID: \\"ui-envlock\\"  | Click to unlock. "
-                        class=""
-                        data-mui-internal-clone-element="true"
+                        class="tooltip-container"
                       >
-                        <button
-                          aria-label=""
-                          class="mdc-button button-lock"
+                        <a
+                          data-tooltip-delay-hide="50"
+                          data-tooltip-place="bottom"
+                          href="javascript:void(0);"
+                          id="tooltipenv-group-chip-id-ui-envlock"
                         >
-                          <div
-                            class="mdc-button__ripple"
-                          />
-                          <svg
-                            class="env-card-env-lock-icon"
-                            height="16px"
-                            width="16px"
-                          >
-                            Locks_White.svg
-                          </svg>
-                        </button>
+                          <div>
+                            <button
+                              aria-label=""
+                              class="mdc-button button-lock"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <svg
+                                class="env-card-env-lock-icon fixed-size"
+                              >
+                                Locks_White.svg
+                              </svg>
+                            </button>
+                          </div>
+                        </a>
                       </div>
                     </div>
                   </span>
@@ -625,9 +636,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                   class="env-card-app-locks"
                 >
                   <div
-                    aria-label="Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
-                    class=""
-                    data-mui-internal-clone-element="true"
+                    title="App Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
                   >
                     <button
                       aria-label=""
@@ -739,25 +748,30 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                       class="release-environment env-locks"
                     >
                       <div
-                        aria-label="Lock Message: \\"envLock\\" | ID: \\"ui-envlock\\"  | Click to unlock. "
-                        class=""
-                        data-mui-internal-clone-element="true"
+                        class="tooltip-container"
                       >
-                        <button
-                          aria-label=""
-                          class="mdc-button button-lock"
+                        <a
+                          data-tooltip-delay-hide="50"
+                          data-tooltip-place="bottom"
+                          href="javascript:void(0);"
+                          id="tooltipenv-group-chip-id-ui-envlock"
                         >
-                          <div
-                            class="mdc-button__ripple"
-                          />
-                          <svg
-                            class="env-card-env-lock-icon"
-                            height="16px"
-                            width="16px"
-                          >
-                            Locks_White.svg
-                          </svg>
-                        </button>
+                          <div>
+                            <button
+                              aria-label=""
+                              class="mdc-button button-lock"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <svg
+                                class="env-card-env-lock-icon fixed-size"
+                              >
+                                Locks_White.svg
+                              </svg>
+                            </button>
+                          </div>
+                        </a>
                       </div>
                     </div>
                   </span>
@@ -766,9 +780,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                   class="env-card-app-locks"
                 >
                   <div
-                    aria-label="Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
-                    class=""
-                    data-mui-internal-clone-element="true"
+                    title="App Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
                   >
                     <button
                       aria-label=""

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.test.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.test.tsx
@@ -630,7 +630,7 @@ describe('Service Lane AppLockSummary', () => {
             const { container } = getWrapper({ application: testcase.renderedApp });
 
             const appLockSummary = container.querySelector('.test-app-lock-summary div');
-            expect(appLockSummary?.attributes.getNamedItem('aria-label')?.value).toBe(testcase.expected);
+            expect(appLockSummary?.attributes.getNamedItem('title')?.value).toBe(testcase.expected);
         });
     });
 });

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -27,7 +27,6 @@ import {
 import { ReleaseCard } from '../ReleaseCard/ReleaseCard';
 import { DeleteWhite, HistoryWhite } from '../../../images';
 import { Application, Environment, UndeploySummary } from '../../../api/api';
-import { Tooltip } from '@material-ui/core';
 import * as React from 'react';
 import { AppLockSummary } from '../chip/EnvironmentGroupChip';
 import { WarningBoxes } from './Warnings';
@@ -62,8 +61,8 @@ function getNumberOfReleasesBetween(releases: number[], higherVersion: number, l
     return releases.findIndex((ver) => ver === lowerVersion) - releases.findIndex((ver) => ver === higherVersion) - 1;
 }
 
-const DiffElement = (diff: number): JSX.Element => (
-    <div className="service-lane__diff--container">
+const DiffElement: React.FC<{ diff: number; title: string }> = ({ diff, title }) => (
+    <div className="service-lane__diff--container" title={title}>
         <div className="service-lane__diff--dot" />
         <div className="service-lane__diff--dot" />
         <div className="service-lane__diff--number">{diff}</div>
@@ -132,9 +131,10 @@ export const ServiceLane: React.FC<{ application: Application }> = (props) => {
                 <div key={application.name + '-' + rel} className="service-lane__diff">
                     <ReleaseCard app={application.name} version={rel} key={application.name + '-' + rel} />
                     {!!diff && (
-                        <Tooltip title={'There are ' + diff + ' more releases hidden. Click on History to view more'}>
-                            {DiffElement(diff)}
-                        </Tooltip>
+                        <DiffElement
+                            diff={diff}
+                            title={'There are ' + diff + ' more releases hidden. Click on History to view more'}
+                        />
                     )}
                 </div>
             );

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.test.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.test.tsx
@@ -71,7 +71,7 @@ describe('EnvironmentChip', () => {
         `);
     });
     it('renders a short form tag chip', () => {
-        const { container } = getWrapper({
+        const wrapper = getWrapper({
             smallEnvChip: true,
             env: {
                 ...env,
@@ -81,21 +81,43 @@ describe('EnvironmentChip', () => {
                 },
             },
         });
+        const { container } = wrapper;
         expect(container.querySelector('.mdc-evolution-chip__text-name')?.textContent).toBe(env.name[0].toUpperCase());
         // only show one lock icon in the small env tag
         expect(container.querySelectorAll('.env-card-env-lock-icon').length).toBe(1);
     });
     it('renders env locks in big env chip', () => {
-        const { container } = getWrapper({
+        UpdateOverview.set({
+            environmentGroups: [
+                {
+                    environments: [
+                        {
+                            ...env,
+                            locks: {
+                                'test-lock1': makeLock('test-lock1'),
+                                'test-lock2': makeLock('test-lock2'),
+                            },
+                        },
+                    ],
+                    environmentGroupName: 'dontcare',
+                    distanceToUpstream: 0,
+                },
+            ],
+        });
+
+        const wrapper = getWrapper({
+            // big chip shows all locks
+            smallEnvChip: false,
             env: {
                 ...env,
                 locks: {
-                    lock1: makeLock('test-lock1'),
-                    lock2: makeLock('test-lock2'),
+                    'test-lock1': makeLock('test-lock1'),
+                    'test-lock2': makeLock('test-lock2'),
                 },
             },
         });
-        // big chip shows all locks
+
+        const { container } = wrapper;
         expect(container.querySelectorAll('.env-card-env-lock-icon').length).toBe(2);
         const lock1 = container.querySelectorAll('.button-lock')[0];
         fireEvent.click(lock1);

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
@@ -14,45 +14,11 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 import classNames from 'classnames';
-import { Environment, Lock } from '../../../api/api';
-import React, { useCallback } from 'react';
-import {
-    addAction,
-    EnvironmentGroupExtended,
-    getPriorityClassName,
-    useCurrentlyDeployedAtGroup,
-} from '../../utils/store';
-import { Tooltip } from '@material-ui/core';
-import { Button } from '../button';
+import { Environment } from '../../../api/api';
+import React from 'react';
+import { EnvironmentGroupExtended, getPriorityClassName, useCurrentlyDeployedAtGroup } from '../../utils/store';
 import { LocksWhite } from '../../../images';
-
-export const EnvLock: React.FC<{
-    env: string;
-    lock: Lock;
-}> = ({ env, lock }) => {
-    const deleteEnvLock = useCallback(() => {
-        addAction({
-            action: {
-                $case: 'deleteEnvironmentLock',
-                deleteEnvironmentLock: { environment: env, lockId: lock.lockId },
-            },
-        });
-    }, [env, lock.lockId]);
-    return (
-        <Tooltip
-            key={lock.lockId}
-            arrow
-            title={'Lock Message: "' + lock.message + '" | ID: "' + lock.lockId + '"  | Click to unlock. '}>
-            <div>
-                <Button
-                    icon={<LocksWhite className="env-card-env-lock-icon" width="16px" height="16px" />}
-                    className={'button-lock'}
-                    onClick={deleteEnvLock}
-                />
-            </div>
-        </Tooltip>
-    );
-};
+import { EnvironmentLockDisplay } from '../EnvironmentLockDisplay/EnvironmentLockDisplay';
 
 export const AppLockSummary: React.FC<{
     app: string;
@@ -60,15 +26,14 @@ export const AppLockSummary: React.FC<{
 }> = ({ app, numLocks }) => {
     const plural = numLocks === 1 ? 'lock' : 'locks';
     return (
-        <Tooltip
+        <div
             key={'app-lock-hint-' + app}
-            arrow
             title={'"' + app + '" has ' + numLocks + ' application ' + plural + '. Click on a tile to see details.'}>
             <div>
                 &nbsp;
                 <LocksWhite className="env-card-env-lock-icon" width="16px" height="16px" />
             </div>
-        </Tooltip>
+        </div>
     );
 };
 
@@ -94,7 +59,7 @@ export const EnvironmentChip = (props: EnvironmentChipProps): JSX.Element => {
     const locks = !smallEnvChip ? (
         <div className={classNames(className, 'env-locks')}>
             {Object.values(env.locks).map((lock) => (
-                <EnvLock env={env.name} lock={lock} key={lock.lockId} />
+                <EnvironmentLockDisplay env={env.name} lockId={lock.lockId} bigLockIcon={false} />
             ))}
         </div>
     ) : (

--- a/services/frontend-service/src/ui/components/chip/chip.scss
+++ b/services/frontend-service/src/ui/components/chip/chip.scss
@@ -45,6 +45,9 @@ Copyright 2023 freiheit.com*/
     @extend .text-bold;
     white-space: nowrap;
     float: right;
+    .tooltip {
+        font-weight: 400;
+    }
 }
 
 .environment-priority-prod {

--- a/services/frontend-service/src/ui/components/tooltip/__snapshots__/tooltip.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/tooltip/__snapshots__/tooltip.test.tsx.snap
@@ -2,39 +2,17 @@
 
 exports[`Tooltip Renders a tooltip 1`] = `
 <div
-  class="mdc-tooltip-wrapper--rich"
+  class="tooltip-container"
 >
-  <div
-    aria-expanded="false"
-    aria-haspopup="dialog"
-    class="mdc-tooltip__container"
-    data-tooltip-id="tt-test-tooltip"
+  <a
+    data-tooltip-delay-hide="50"
+    data-tooltip-place="bottom"
+    href="javascript:void(0);"
+    id="tooltiptest-tooltip"
   >
     <button>
       click me
     </button>
-  </div>
-  <div
-    aria-hidden="true"
-    class="mdc-tooltip mdc-tooltip--rich"
-    id="tt-test-tooltip"
-    role="dialog"
-    tabindex="-1"
-  >
-    <div
-      class="mdc-tooltip__surface mdc-tooltip__surface-animation"
-    >
-      <div
-        class="mdc-tooltip__caret-surface-top"
-      />
-      <div
-        class="mdc-tooltip__content"
-      >
-        <div>
-          I'm inside the tooltip
-        </div>
-      </div>
-    </div>
-  </div>
+  </a>
 </div>
 `;

--- a/services/frontend-service/src/ui/components/tooltip/tooltip.scss
+++ b/services/frontend-service/src/ui/components/tooltip/tooltip.scss
@@ -13,9 +13,30 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-@use '@material/tooltip/styles';
+@use '../../../../node_modules/@material/tooltip/styles';
 
-.mdc-tooltip.mdc-tooltip--rich {
+.tooltip-container {
+    a {
+        text-decoration: none;
+    }
+    .tooltip {
+        z-index: 1000;
+        background-color: white;
+        color: black;
+        font-size: 14px;
+        border-radius: 8px;
+        .release__hash--container {
+            padding: 2px 0px 0px 0px;
+
+            .release__hash {
+                padding: 0;
+            }
+        }
+    }
+}
+
+.mdc-tooltip.mdc-tooltip--rich2 {
+    position: relative;
     // !important to overwrite the default styling of the Tooltip.
     // The `mdc-tooltip--rich` is restricted to be placed on one of the 4 corners of a component
     // https://github.com/material-components/material-components-web/blob/066d9439b7f1bf11426153573560b35462a3b9d5/packages/mdc-tooltip/README.md?plain=1#L281-L286

--- a/services/frontend-service/src/ui/components/tooltip/tooltip.test.tsx
+++ b/services/frontend-service/src/ui/components/tooltip/tooltip.test.tsx
@@ -19,7 +19,11 @@ import { Tooltip } from './tooltip';
 
 describe('Tooltip', () => {
     const getNode = (): JSX.Element => (
-        <Tooltip content={<div>I'm inside the tooltip</div>} children={<button>click me</button>} id={'test-tooltip'} />
+        <Tooltip
+            tooltipContent={<div>I'm inside the tooltip</div>}
+            children={<button>click me</button>}
+            id={'test-tooltip'}
+        />
     );
     const getWrapper = () => render(getNode());
 

--- a/services/frontend-service/src/ui/components/tooltip/tooltip.tsx
+++ b/services/frontend-service/src/ui/components/tooltip/tooltip.tsx
@@ -13,42 +13,23 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-import { useEffect, useRef } from 'react';
-import { MDCTooltip } from '@material/tooltip';
+import { Tooltip as TooltipReact } from 'react-tooltip';
 
-export const Tooltip = (props: { children: JSX.Element; content: JSX.Element; id: string }): JSX.Element => {
-    const MDComponent = useRef<MDCTooltip>();
-    const control = useRef<HTMLDivElement>(null);
-    const { children, content, id } = props;
+export const Tooltip = (props: { children: JSX.Element; tooltipContent: JSX.Element; id: string }): JSX.Element => {
+    const { children, tooltipContent, id } = props;
+    const delayHide = 50; // for debugging the css, increase this to 1000000
 
-    useEffect(() => {
-        if (control.current) {
-            MDComponent.current = new MDCTooltip(control.current);
-        }
-        return (): void => MDComponent.current?.destroy();
-    }, []);
-
+    // The React tooltip really wants us to use a href, but also we don't want to do anything on click:
+    // eslint-disable-next-line no-script-url
+    const href = 'javascript:void(0);';
     return (
-        <div className="mdc-tooltip-wrapper--rich">
-            <div
-                data-tooltip-id={'tt-' + id}
-                className="mdc-tooltip__container"
-                aria-haspopup="dialog"
-                aria-expanded="false">
+        <div className={'tooltip-container'}>
+            <a href={href} id={'tooltip' + id} data-tooltip-place="bottom" data-tooltip-delay-hide={delayHide}>
                 {children}
-            </div>
-            <div
-                id={'tt-' + id}
-                ref={control}
-                className="mdc-tooltip mdc-tooltip--rich"
-                aria-hidden="true"
-                tabIndex={-1}
-                role="dialog">
-                <div className="mdc-tooltip__surface mdc-tooltip__surface-animation">
-                    <div className="mdc-tooltip__caret-surface-top" />
-                    <div className="mdc-tooltip__content">{content}</div>
-                </div>
-            </div>
+            </a>
+            <TooltipReact className={'tooltip'} anchorSelect={'#tooltip' + id} border={'solid 2px lightgray'}>
+                {tooltipContent}
+            </TooltipReact>
         </div>
     );
 };

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -330,7 +330,7 @@ export const useEnvironmentLock = (lockId: string): DisplayLock => {
             }
         }
     }
-    throw new Error('lock with id not found: ' + lockId);
+    throw new Error('env lock with id not found: ' + lockId);
 };
 
 export const searchCustomFilter = (queryContent: string | null, val: string | undefined): string => {


### PR DESCRIPTION
We now have 2 tooltips: tooltip.tsx, our own implementation using react-tooltip. the "title" attribute for simple text-only tooltips.

Also simplified the EnvironmentLockDisplay a bit.

New Tooltip on Environments page:
![Screenshot from 2023-08-01 10-54-24](https://github.com/freiheit-com/kuberpult/assets/3481382/83db14e7-bce2-44f0-9013-0727468b1595)

New Tooltip on Service Lane:
![Screenshot from 2023-08-01 10-55-47](https://github.com/freiheit-com/kuberpult/assets/3481382/ae633f22-e912-4367-8534-4792f05fa527)


SRX-Z1SMB9