### PR TITLE
Refactor permission policy RBAC

### DIFF
--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -155,13 +155,14 @@ auth:
 dex:
   enabled: false
   # Defines the rbac policy when using Dex.
-  # The permissions are added using the following format (<ROLE>, <ACTION>, <ENVIRONMENT_GROUP>:<ENVIRONMENT>, <APPLICATION>, allow). 
-  # 
+  # The permissions are added using the following format (<ROLE>, <ACTION>, <ENVIRONMENT_GROUP>:<ENVIRONMENT>, <APPLICATION>, allow).
+  #
   # Available actions are: CreateLock, DeleteLock, CreateRelease, DeployRelease, CreateUndeploy, DeployUndeploy, CreateEnvironment, CreateEnvironmentApplication and DeployReleaseTrain.
-  # The following actions CreateUndeploy, DeployUndeploy and CreateEnvironmentApplication are environment independent meaning that the environment specified on the permission 
+  # The actions CreateUndeploy, DeployUndeploy and CreateEnvironmentApplication are environment independent meaning that the environment specified on the permission
   # needs to follow the following format <ENVIRONMENT_GROUP>:*, otherwise an error will be thrown.
   #
   # Example permission: Developer, CreateLock, development:development, *, allow
+  # If no group is configured for an environment, the environment group name is the same as the environment name, here "development".
   # The policy will be available on the kuberpult-rbac config map.
   policy_csv: ""
   clientId: ""

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -155,8 +155,13 @@ auth:
 dex:
   enabled: false
   # Defines the rbac policy when using Dex.
-  # The permissions are added using the following format (p, <ROLE>, <APPLICATION>, <ACTION>, <ENV>, <PERMISSION>), example:
-  # p, Developer, deployment, *, dev:development-d2, allow
+  # The permissions are added using the following format (<ROLE>, <ACTION>, <ENVIRONMENT_GROUP>:<ENVIRONMENT>, <APPLICATION>, allow). 
+  # 
+  # Available actions are: CreateLock, DeleteLock, CreateRelease, DeployRelease, CreateUndeploy, DeployUndeploy, CreateEnvironment, CreateEnvironmentApplication and DeployReleaseTrain.
+  # The following actions CreateUndeploy, DeployUndeploy and CreateEnvironmentApplication are environment independent meaning that the environment specified on the permission 
+  # needs to follow the following format <ENVIRONMENT_GROUP>:*, otherwise an error will be thrown.
+  #
+  # Example permission: Developer, CreateLock, development:development, *, allow
   # The policy will be available on the kuberpult-rbac config map.
   policy_csv: ""
   clientId: ""

--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -95,7 +95,7 @@ func (c *policyConfig) validateEnvs(envs, action string) error {
 	}
 	// Actions that are environment independent need to follow the format <ENVIRONMENT_GROUP:*>.
 	if isEnvironmentIndependent(action) {
-		if e[1] == "*" {
+		if envName == "*" {
 			return nil
 		}
 		return fmt.Errorf("the action %s requires the environment * and got %s", action, envs)

--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -37,7 +37,7 @@ const (
 	PermissionCreateUndeploy               = "CreateUndeploy"
 	PermissionDeployUndeploy               = "DeployUndeploy"
 	PermissionCreateEnvironment            = "CreateEnvironment"
-	PermissionCreateEnvironmentApplication = "CreateEnvironmentApplication"
+	PermissionDeleteEnvironmentApplication = "DeleteEnvironmentApplication"
 	PermissionDeployReleaseTrain           = "DeployReleaseTrain"
 )
 
@@ -61,7 +61,7 @@ func initPolicyConfig() policyConfig {
 			PermissionCreateUndeploy,
 			PermissionDeployUndeploy,
 			PermissionCreateEnvironment,
-			PermissionCreateEnvironmentApplication,
+			PermissionDeleteEnvironmentApplication,
 			PermissionDeployReleaseTrain},
 	}
 }

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -626,7 +626,7 @@ func (s *State) checkUserPermissions(ctx context.Context, env, application, acti
 
 func (c *CreateEnvironmentLock) Transform(ctx context.Context, state *State) (string, error) {
 
-	err := state.checkUserPermissions(ctx, c.Environment, "*", "CreateLock", c.RBACConfig)
+	err := state.checkUserPermissions(ctx, c.Environment, "*", auth.PermissionCreateLock, c.RBACConfig)
 	if err != nil {
 		return "", err
 	}
@@ -694,7 +694,7 @@ type DeleteEnvironmentLock struct {
 }
 
 func (c *DeleteEnvironmentLock) Transform(ctx context.Context, state *State) (string, error) {
-	err := state.checkUserPermissions(ctx, c.Environment, "*", "DeleteLock", c.RBACConfig)
+	err := state.checkUserPermissions(ctx, c.Environment, "*", auth.PermissionDeleteLock, c.RBACConfig)
 	if err != nil {
 		return "", err
 	}
@@ -736,7 +736,7 @@ type CreateEnvironmentApplicationLock struct {
 
 func (c *CreateEnvironmentApplicationLock) Transform(ctx context.Context, state *State) (string, error) {
 	// Note: it's possible to lock an application BEFORE it's even deployed to the environment.
-	err := state.checkUserPermissions(ctx, c.Environment, "*", "CreateLock", c.RBACConfig)
+	err := state.checkUserPermissions(ctx, c.Environment, "*", auth.PermissionCreateLock, c.RBACConfig)
 	if err != nil {
 		return "", err
 	}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -626,7 +626,7 @@ func (s *State) checkUserPermissions(ctx context.Context, env, application, acti
 
 func (c *CreateEnvironmentLock) Transform(ctx context.Context, state *State) (string, error) {
 
-	err := state.checkUserPermissions(ctx, c.Environment, "EnvironmentLock", "Create", c.RBACConfig)
+	err := state.checkUserPermissions(ctx, c.Environment, "*", "CreateLock", c.RBACConfig)
 	if err != nil {
 		return "", err
 	}
@@ -694,7 +694,7 @@ type DeleteEnvironmentLock struct {
 }
 
 func (c *DeleteEnvironmentLock) Transform(ctx context.Context, state *State) (string, error) {
-	err := state.checkUserPermissions(ctx, c.Environment, "EnvironmentLock", "Delete", c.RBACConfig)
+	err := state.checkUserPermissions(ctx, c.Environment, "*", "DeleteLock", c.RBACConfig)
 	if err != nil {
 		return "", err
 	}
@@ -736,7 +736,7 @@ type CreateEnvironmentApplicationLock struct {
 
 func (c *CreateEnvironmentApplicationLock) Transform(ctx context.Context, state *State) (string, error) {
 	// Note: it's possible to lock an application BEFORE it's even deployed to the environment.
-	err := state.checkUserPermissions(ctx, c.Environment, "EnvironmentApplicationLock", "Create", c.RBACConfig)
+	err := state.checkUserPermissions(ctx, c.Environment, "*", "CreateLock", c.RBACConfig)
 	if err != nil {
 		return "", err
 	}

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -802,23 +802,22 @@ func TestRbacTransformerTest(t *testing.T) {
 					Message:     "don't",
 					LockId:      "manual",
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{
-						"p,developer,EnvironmentLock,Create,production:production,allow": {Role: "developer"}}}},
+						"developer,CreateLock,production:production,*,allow": {Role: "developer"}}}},
 				},
 			},
 		},
 		{
 			Name: "unable to create environment lock without permissions policy",
 			Transformers: []Transformer{
-				&CreateEnvironment{Environment: "dev"},
+				&CreateEnvironment{Environment: "production"},
 				&CreateEnvironmentLock{
-					Environment: "dev",
-					Message:     "don't",
-					LockId:      "manual",
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{
-						"p,developer,EnvironmentLock,Create,production:production,allow": {Role: "developer"}}}},
+					Environment:    "production",
+					Message:        "don't",
+					LockId:         "manual",
+					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: p,developer,EnvironmentLock,Create,dev:dev,allow",
+			ExpectedError: "user does not have permissions for: developer,CreateLock,dev:dev,*,allow",
 		},
 		{
 			Name: "unable to delete environment lock without permissions policy",
@@ -829,16 +828,15 @@ func TestRbacTransformerTest(t *testing.T) {
 					Message:     "don't",
 					LockId:      "manual",
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{
-						"p,developer,EnvironmentLock,Create,production:production,allow": {Role: "developer"}}}},
+						"developer,CreateLock,production:production,*,allow": {Role: "developer"}}}},
 				},
 				&DeleteEnvironmentLock{
-					Environment: "production",
-					LockId:      "manual",
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{
-						"p,developer,EnvironmentLock,Create,production:production,allow": {Role: "developer"}}}},
+					Environment:    "production",
+					LockId:         "manual",
+					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: p,developer,EnvironmentLock,Delete,production:production,allow",
+			ExpectedError: "user does not have permissions for: developer,DeleteLock,production:production,*,allow",
 		},
 		{
 			Name: "able to delete environment lock with permissions policy",
@@ -849,19 +847,19 @@ func TestRbacTransformerTest(t *testing.T) {
 					Message:     "don't",
 					LockId:      "manual",
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{
-						"p,developer,EnvironmentLock,Create,production:production,allow": {Role: "developer"}}}},
+						"developer,CreateLock,production:production,*,allow": {Role: "developer"}}}},
 				},
 				&DeleteEnvironmentLock{
 					Environment: "production",
 					LockId:      "manual",
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{
-						"p,developer,EnvironmentLock,Create,production:production,allow": {Role: "developer"},
-						"p,developer,EnvironmentLock,Delete,production:production,allow": {Role: "developer"}}}},
+						"developer,CreateLock,production:production,*,allow": {Role: "developer"},
+						"developer,DeleteLock,production:production,*,allow": {Role: "developer"}}}},
 				},
 			},
 		},
 		{
-			Name: "unable to delete environment application lock without permissions policy",
+			Name: "unable to create environment application lock without permissions policy",
 			Transformers: []Transformer{
 				&CreateEnvironment{Environment: "production"},
 				&CreateApplicationVersion{
@@ -878,10 +876,10 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: p,developer,EnvironmentApplicationLock,Create,production:production,allow",
+			ExpectedError: "user does not have permissions for: developer,CreateLock,production:production,*,allow",
 		},
 		{
-			Name: "able to delete environment application lock with correct permissions policy",
+			Name: "able to create environment application lock with correct permissions policy",
 			Transformers: []Transformer{
 				&CreateEnvironment{Environment: "production"},
 				&CreateApplicationVersion{
@@ -896,7 +894,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Message:     "don't",
 					LockId:      "manual",
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{
-						"p,developer,EnvironmentApplicationLock,Create,production:production,allow": {Role: "developer"},
+						"developer,CreateLock,production:production,*,allow": {Role: "developer"},
 					}}},
 				},
 			},

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -817,7 +817,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,CreateLock,dev:dev,*,allow",
+			ExpectedError: "user does not have permissions for: developer,CreateLock,production:production,*,allow",
 		},
 		{
 			Name: "unable to delete environment lock without permissions policy",

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -169,7 +169,7 @@ func TestBatchServiceWorks(t *testing.T) {
 			Batch:         getBatchActions(),
 			context:       testutil.MakeTestContextDexEnabled(),
 			svc:           &BatchServer{},
-			expectedError: status.Errorf(codes.PermissionDenied, "user does not have permissions for: p,developer,EnvironmentLock,Create,production:production,allow").Error(),
+			expectedError: status.Errorf(codes.PermissionDenied, "user does not have permissions for: developer,CreateLock,production:production,*,allow").Error(),
 		},
 		{
 			Name: "testing Dex setup with permissions",
@@ -196,9 +196,8 @@ func TestBatchServiceWorks(t *testing.T) {
 				RBACConfig: auth.RBACConfig{
 					DexEnabled: true,
 					Policy: map[string]*auth.Permission{
-						"p,developer,EnvironmentLock,Create,production:production,allow":            {Role: "Developer"},
-						"p,developer,EnvironmentLock,Delete,production:production,allow":            {Role: "Developer"},
-						"p,developer,EnvironmentApplicationLock,Create,production:production,allow": {Role: "Developer"},
+						"developer,CreateLock,production:production,*,allow": {Role: "Developer"},
+						"developer,DeleteLock,production:production,*,allow": {Role: "Developer"},
 					}}},
 		},
 	}

--- a/services/cd-service/policy.csv
+++ b/services/cd-service/policy.csv
@@ -1,1 +1,1 @@
-p, Developer, EnvironmentLock, Create, development:development, allow
+Developer, CreateLock, development:development, *, allow


### PR DESCRIPTION
Refactors the permission policy to follow the following format: `<ROLE>, <ACTION>, <ENVIRONMENT_GROUP>:<ENVIRONMENT>, <APPLICATION>, allow`

The allowed actions are: `CreateLock`, `DeleteLock`, `CreateRelease`, `DeployRelease`, `CreateUndeploy`, `DeployUndeploy`, `CreateEnvironment`, `CreateEnvironmentApplication` and `DeployReleaseTrain`.

The following actions `CreateUndeploy`, `DeployUndeploy` and `CreateEnvironmentApplication` are environment independent meaning that the environment specified on the permission needs to follow the following format `<ENVIRONMENT_GROUP>:*`, otherwise an error will be thrown.