### PR TITLE
Add links to ArgoCd in the UI

### DIFF
--- a/services/frontend-service/Makefile
+++ b/services/frontend-service/Makefile
@@ -45,9 +45,10 @@ GARBAGE += bin/main
 
 export KUBERPULT_CDSERVER?=localhost:8443
 export KUBERPULT_HTTP_CD_SERVER?=http://localhost:8080
-export KUBERPULT_ALLOWED_ORIGINS?="localhost:*"
-export KUBERPULT_GIT_AUTHOR_NAME?="user-local-dev"
-export KUBERPULT_GIT_AUTHOR_EMAIL?="user-local-dev@example.com"
+export KUBERPULT_ALLOWED_ORIGINS?=localhost:*
+export KUBERPULT_GIT_AUTHOR_NAME?=user-local-dev
+export KUBERPULT_GIT_AUTHOR_EMAIL?=user-local-dev@example.com
+export KUBERPULT_ARGOCD_BASE_URL=https://cd.dev.freiheit.systems/
 run: bin/main
 	./bin/main
 

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -19,17 +19,20 @@ import { ReleaseDialog } from '../components/ReleaseDialog/ReleaseDialog';
 import { PageRoutes } from './PageRoutes';
 import '../../assets/app-v2.scss';
 import * as React from 'react';
-import { PanicOverview, showSnackbarWarn, UpdateOverview, useReleaseDialogParams } from '../utils/store';
-import { useApi } from '../utils/GrpcApi';
 import {
-    AzureAuthProvider,
+    PanicOverview,
+    showSnackbarWarn,
     UpdateFrontendConfig,
-    useAzureAuthSub,
+    UpdateOverview,
     useKuberpultVersion,
-} from '../utils/AzureAuthProvider';
+    useReleaseDialogParams,
+} from '../utils/store';
+import { useApi } from '../utils/GrpcApi';
+import { AzureAuthProvider, useAzureAuthSub } from '../utils/AzureAuthProvider';
 import { Snackbar } from '../components/snackbar/snackbar';
 import { mergeMap, retryWhen } from 'rxjs/operators';
 import { Observable, throwError, timer } from 'rxjs';
+import { GetFrontendConfigResponse } from '../../api/api';
 
 // retry strategy: retries the observable subscription with randomized exponential backoff
 // source: https://www.learnrxjs.io/learn-rxjs/operators/error_handling/retrywhen#examples
@@ -62,7 +65,7 @@ export const App: React.FC = () => {
         api.configService()
             .GetConfig({}) // the config service does not require authorisation
             .then(
-                (result) => {
+                (result: GetFrontendConfigResponse) => {
                     UpdateFrontendConfig.set({ configs: result, configReady: true });
                 },
                 (error) => {

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -14,6 +14,10 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 .release-dialog {
+    a {
+        color: white;
+    }
+
     div.MuiPaper-root {
         background-color: transparent;
         border-radius: $release-dialog-outer-border-radius;

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -29,6 +29,7 @@ import { Button } from '../button';
 import { Close, Locks } from '../../../images';
 import { EnvironmentChip } from '../chip/EnvironmentGroupChip';
 import { FormattedDate } from '../FormattedDate/FormattedDate';
+import { ArgoAppLink, ArgoTeamLink } from '../../utils/Links';
 
 export type ReleaseDialogProps = {
     className?: string;
@@ -160,6 +161,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
             <div className="env-card-header">
                 <EnvironmentChip
                     env={env}
+                    app={app}
                     className={'release-environment'}
                     key={env.name}
                     groupNameOverride={undefined}
@@ -287,7 +289,9 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                                 {release?.sourceAuthor ? 'Author: ' + release?.sourceAuthor : ''}
                             </div>
                             <div className={classNames('release-dialog-app', className)}>
-                                {`App: ${app} ` + (team ? ` | Team: ${team}` : '')}
+                                {'App: '}
+                                <ArgoAppLink app={app} />
+                                <ArgoTeamLink team={team} />
                             </div>
                         </div>
                         <span className={classNames('release-dialog-commitId', className)} title={undeployVersionTitle}>
@@ -299,13 +303,7 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                             icon={<Close />}
                         />
                     </div>
-                    <EnvironmentList
-                        app={app}
-                        className={className}
-                        release={release}
-                        version={version}
-                        // deployedAtGroup={deployedAtGroup}
-                    />
+                    <EnvironmentList app={app} className={className} release={release} version={version} />
                 </Dialog>
             </div>
         ) : (

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -60,7 +60,10 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
             <div
               class="release-dialog-app"
             >
-              App: test1 
+              App: 
+              <span>
+                test1
+              </span>
             </div>
           </div>
           <span
@@ -104,7 +107,9 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                     <span
                       class="mdc-evolution-chip__text-name"
                     >
-                      prod
+                      <span>
+                        prod
+                      </span>
                     </span>
                      
                     <span
@@ -119,7 +124,7 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                         <a
                           data-tooltip-delay-hide="50"
                           data-tooltip-place="bottom"
-                          href="javascript:void(0);"
+                          href="#"
                           id="tooltipenv-group-chip-id-ui-envlock"
                         >
                           <div>
@@ -303,7 +308,10 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
             <div
               class="release-dialog-app"
             >
-              App: test1 
+              App: 
+              <span>
+                test1
+              </span>
             </div>
           </div>
           <span
@@ -347,7 +355,9 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                     <span
                       class="mdc-evolution-chip__text-name"
                     >
-                      prod
+                      <span>
+                        prod
+                      </span>
                     </span>
                      
                     <span
@@ -362,7 +372,7 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                         <a
                           data-tooltip-delay-hide="50"
                           data-tooltip-place="bottom"
-                          href="javascript:void(0);"
+                          href="#"
                           id="tooltipenv-group-chip-id-ui-envlock"
                         >
                           <div>
@@ -550,7 +560,13 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
             <div
               class="release-dialog-app"
             >
-              App: test1  | Team: test me team
+              App: 
+              <span>
+                test1
+              </span>
+              <span>
+                test me team
+              </span>
             </div>
           </div>
           <span
@@ -594,7 +610,9 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                     <span
                       class="mdc-evolution-chip__text-name"
                     >
-                      prod
+                      <span>
+                        prod
+                      </span>
                     </span>
                      
                     <span
@@ -609,7 +627,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                         <a
                           data-tooltip-delay-hide="50"
                           data-tooltip-place="bottom"
-                          href="javascript:void(0);"
+                          href="#"
                           id="tooltipenv-group-chip-id-ui-envlock"
                         >
                           <div>
@@ -738,7 +756,9 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                     <span
                       class="mdc-evolution-chip__text-name"
                     >
-                      dev
+                      <span>
+                        dev
+                      </span>
                     </span>
                      
                     <span
@@ -753,7 +773,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                         <a
                           data-tooltip-delay-hide="50"
                           data-tooltip-place="bottom"
-                          href="javascript:void(0);"
+                          href="#"
                           id="tooltipenv-group-chip-id-ui-envlock"
                         >
                           <div>
@@ -940,7 +960,10 @@ exports[`Release Dialog Renders the environment locks undeploy version release 1
             <div
               class="release-dialog-app"
             >
-              App: test1 
+              App: 
+              <span>
+                test1
+              </span>
             </div>
           </div>
           <span

--- a/services/frontend-service/src/ui/components/TopAppBar/TopAppBar.tsx
+++ b/services/frontend-service/src/ui/components/TopAppBar/TopAppBar.tsx
@@ -23,8 +23,7 @@ import { ShowBarWhite } from '../../../images';
 import { useSearchParams } from 'react-router-dom';
 import { Dropdown } from '../dropdown/dropdown';
 import classNames from 'classnames';
-import { UpdateSidebar, useAllWarnings, useSidebarShown } from '../../utils/store';
-import { useKuberpultVersion } from '../../utils/AzureAuthProvider';
+import { UpdateSidebar, useAllWarnings, useKuberpultVersion, useSidebarShown } from '../../utils/store';
 import { Warning } from '../../../api/api';
 
 export const TopAppBar: React.FC = () => {

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.test.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.test.tsx
@@ -35,7 +35,7 @@ describe('EnvironmentChip', () => {
         applications: {},
     };
     const getNode = (overloads?: Partial<EnvironmentChipProps>) => (
-        <EnvironmentChip className={'chip--test'} env={env} {...overloads} />
+        <EnvironmentChip app="app2" className={'chip--test'} env={env} {...overloads} />
     );
     const getWrapper = (overloads?: Partial<EnvironmentChipProps>) => render(getNode(overloads));
     it('renders a chip', () => {
@@ -57,7 +57,9 @@ describe('EnvironmentChip', () => {
                 <span
                   class="mdc-evolution-chip__text-name"
                 >
-                  Test Me
+                  <span>
+                    Test Me
+                  </span>
                 </span>
                  
                 <span
@@ -170,7 +172,7 @@ describe.each(envChipData)(`EnvironmentChip with envPrio Classname`, (testcase) 
             ],
         });
         // then
-        const getNode = () => <EnvironmentChip className={'chip--hello'} env={testcase.env} />;
+        const getNode = () => <EnvironmentChip app="app1" className={'chip--hello'} env={testcase.env} />;
         const getWrapper = () => render(getNode());
         const { container } = getWrapper();
         expect(container.firstChild).toHaveClass(
@@ -210,7 +212,9 @@ const envGroupChipData: Array<TestDataGroups> = [
 
 describe.each(envGroupChipData)(`EnvironmentGroupChip with different envs`, (testcase) => {
     it(`with envPrio=${testcase.expectedClass}`, () => {
-        const getNode = () => <EnvironmentGroupChip className={'chip--hello'} envGroup={testcase.envGroup} />;
+        const getNode = () => (
+            <EnvironmentGroupChip app="app1" className={'chip--hello'} envGroup={testcase.envGroup} />
+        );
         const getWrapper = () => render(getNode());
         const { container } = getWrapper();
         expect(container.querySelector('.mdc-evolution-chip__text-name')?.textContent).toContain(

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 import { EnvironmentGroupExtended, getPriorityClassName, useCurrentlyDeployedAtGroup } from '../../utils/store';
 import { LocksWhite } from '../../../images';
 import { EnvironmentLockDisplay } from '../EnvironmentLockDisplay/EnvironmentLockDisplay';
+import { ArgoAppEnvLink } from '../../utils/Links';
 
 export const AppLockSummary: React.FC<{
     app: string;
@@ -40,6 +41,7 @@ export const AppLockSummary: React.FC<{
 export type EnvironmentChipProps = {
     className: string;
     env: Environment;
+    app: string;
     groupNameOverride?: string;
     numberEnvsDeployed?: number;
     numberEnvsInGroup?: number;
@@ -47,7 +49,7 @@ export type EnvironmentChipProps = {
 };
 
 export const EnvironmentChip = (props: EnvironmentChipProps): JSX.Element => {
-    const { className, env, smallEnvChip } = props;
+    const { className, env, smallEnvChip, app } = props;
     const priorityClassName = getPriorityClassName(env);
     const name = props.groupNameOverride ? props.groupNameOverride : env.name;
     const numberString =
@@ -59,7 +61,12 @@ export const EnvironmentChip = (props: EnvironmentChipProps): JSX.Element => {
     const locks = !smallEnvChip ? (
         <div className={classNames(className, 'env-locks')}>
             {Object.values(env.locks).map((lock) => (
-                <EnvironmentLockDisplay env={env.name} lockId={lock.lockId} bigLockIcon={false} />
+                <EnvironmentLockDisplay
+                    env={env.name}
+                    lockId={lock.lockId}
+                    bigLockIcon={false}
+                    key={'key-' + env.name + '-' + lock.lockId}
+                />
             ))}
         </div>
     ) : (
@@ -74,7 +81,9 @@ export const EnvironmentChip = (props: EnvironmentChipProps): JSX.Element => {
             <span
                 className="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
                 role="gridcell">
-                <span className="mdc-evolution-chip__text-name">{smallEnvChip ? name[0].toUpperCase() : name}</span>{' '}
+                <span className="mdc-evolution-chip__text-name">
+                    <ArgoAppEnvLink app={app} env={smallEnvChip ? name[0].toUpperCase() : name} />
+                </span>{' '}
                 <span className="mdc-evolution-chip__text-numbers">{numberString}</span>
                 {locks}
             </span>
@@ -85,9 +94,10 @@ export const EnvironmentChip = (props: EnvironmentChipProps): JSX.Element => {
 export const EnvironmentGroupChip = (props: {
     className: string;
     envGroup: EnvironmentGroupExtended;
+    app: string;
     smallEnvChip?: boolean;
 }): JSX.Element => {
-    const { className, envGroup, smallEnvChip } = props;
+    const { className, envGroup, app, smallEnvChip } = props;
 
     // we display it different if there's only one env in this group:
     const displayAsGroup = envGroup.environments.length >= 2;
@@ -97,6 +107,7 @@ export const EnvironmentGroupChip = (props: {
                 <EnvironmentChip
                     className={className}
                     env={envGroup.environments[0]}
+                    app={app}
                     groupNameOverride={envGroup.environmentGroupName}
                     numberEnvsDeployed={envGroup.environments.length}
                     numberEnvsInGroup={envGroup.numberOfEnvsInGroup}
@@ -110,6 +121,7 @@ export const EnvironmentGroupChip = (props: {
         <EnvironmentChip
             className={className}
             env={envGroup.environments[0]}
+            app={app}
             groupNameOverride={undefined}
             numberEnvsDeployed={1}
             numberEnvsInGroup={envGroup.numberOfEnvsInGroup}
@@ -132,6 +144,7 @@ export const EnvironmentGroupChipList: React.FC<EnvChipListProps> = (props) => {
             {deployedAt.map((envGroup) => (
                 <EnvironmentGroupChip
                     key={envGroup.environmentGroupName}
+                    app={props.app}
                     envGroup={envGroup}
                     className={'release-environment'}
                     smallEnvChip={props.smallEnvChip}

--- a/services/frontend-service/src/ui/components/tooltip/__snapshots__/tooltip.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/tooltip/__snapshots__/tooltip.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Tooltip Renders a tooltip 1`] = `
   <a
     data-tooltip-delay-hide="50"
     data-tooltip-place="bottom"
-    href="javascript:void(0);"
+    href="#"
     id="tooltiptest-tooltip"
   >
     <button>

--- a/services/frontend-service/src/ui/components/tooltip/tooltip.tsx
+++ b/services/frontend-service/src/ui/components/tooltip/tooltip.tsx
@@ -20,8 +20,7 @@ export const Tooltip = (props: { children: JSX.Element; tooltipContent: JSX.Elem
     const delayHide = 50; // for debugging the css, increase this to 1000000
 
     // The React tooltip really wants us to use a href, but also we don't want to do anything on click:
-    // eslint-disable-next-line no-script-url
-    const href = 'javascript:void(0);';
+    const href = '#';
     return (
         <div className={'tooltip-container'}>
             <a href={href} id={'tooltip' + id} data-tooltip-place="bottom" data-tooltip-delay-hide={delayHide}>

--- a/services/frontend-service/src/ui/utils/AzureAuthProvider.test.tsx
+++ b/services/frontend-service/src/ui/utils/AzureAuthProvider.test.tsx
@@ -14,17 +14,12 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 import { act, getByText, render, screen, waitFor } from '@testing-library/react';
-import {
-    AcquireToken,
-    AzureAuthProvider,
-    AzureAuthSub,
-    AzureAutoSignIn,
-    UpdateFrontendConfig,
-} from './AzureAuthProvider';
+import { AcquireToken, AzureAuthProvider, AzureAuthSub, AzureAutoSignIn } from './AzureAuthProvider';
 import { Crypto } from '@peculiar/webcrypto';
 import { PublicClientApplication, IPublicClientApplication, Configuration, AccountInfo } from '@azure/msal-browser';
 import { AuthenticatedTemplate, MsalProvider, UnauthenticatedTemplate } from '@azure/msal-react';
 import { AuthenticationResult } from '@azure/msal-common';
+import { UpdateFrontendConfig } from './store';
 
 const makeAuthenticationResult = (partial: Partial<AuthenticationResult>): AuthenticationResult => ({
     authority: 'authority',

--- a/services/frontend-service/src/ui/utils/AzureAuthProvider.tsx
+++ b/services/frontend-service/src/ui/utils/AzureAuthProvider.tsx
@@ -26,21 +26,7 @@ import {
 import { GetFrontendConfigResponse } from '../../api/api';
 import { createStore } from 'react-use-sub';
 import { grpc } from '@improbable-eng/grpc-web';
-
-type FrontendConfig = {
-    configs: GetFrontendConfigResponse;
-    configReady: boolean;
-};
-
-export const [useFrontendConfig, UpdateFrontendConfig] = createStore<FrontendConfig>({
-    configs: {
-        sourceRepoUrl: '',
-        kuberpultVersion: '0',
-    },
-    configReady: false,
-});
-
-export const useKuberpultVersion = (): string => useFrontendConfig((configs) => configs.configs.kuberpultVersion);
+import { useFrontendConfig } from './store';
 
 type AzureAuthSubType = {
     authHeader: grpc.Metadata & {

--- a/services/frontend-service/src/ui/utils/Links.test.tsx
+++ b/services/frontend-service/src/ui/utils/Links.test.tsx
@@ -1,0 +1,137 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ArgoAppEnvLink, ArgoAppLink, ArgoTeamLink } from './Links';
+import { GetFrontendConfigResponse_ArgoCD } from '../../api/api';
+import { UpdateFrontendConfig } from './store';
+
+const setupArgoCd = (baseUrl: string | undefined) => {
+    const argo: GetFrontendConfigResponse_ArgoCD | undefined = baseUrl
+        ? {
+              baseUrl: baseUrl,
+          }
+        : undefined;
+    UpdateFrontendConfig.set({
+        configs: {
+            argoCd: argo,
+            authConfig: undefined,
+            kuberpultVersion: 'dontcare',
+            sourceRepoUrl: 'dontcare',
+        },
+    });
+};
+
+describe('ArgoTeamLink', () => {
+    const cases: {
+        name: string;
+        team: string | undefined;
+        baseUrl: string | undefined;
+    }[] = [
+        {
+            name: 'with team, without url',
+            team: 'foo',
+            baseUrl: undefined,
+        },
+        {
+            name: 'with team, with url',
+            team: 'foo',
+            baseUrl: 'https://example.com/argo/',
+        },
+        {
+            name: 'without team, with url',
+            team: undefined,
+            baseUrl: 'https://example.com/argo/',
+        },
+    ];
+    describe.each(cases)('Renders properly', (testcase) => {
+        const getNode = () => <ArgoTeamLink team={testcase.team} />;
+        const getWrapper = () => render(getNode());
+        it(testcase.name, () => {
+            //given
+            setupArgoCd(testcase.baseUrl);
+            getWrapper();
+            // when
+            // then
+            expect(document.body).toMatchSnapshot();
+        });
+    });
+});
+
+describe('ArgoAppEnvLink', () => {
+    const cases: {
+        name: string;
+        app: string;
+        env: string;
+        baseUrl: string | undefined;
+    }[] = [
+        {
+            name: ' without url',
+            app: 'foo',
+            env: 'dev',
+            baseUrl: undefined,
+        },
+        {
+            name: ' with url',
+            app: 'foo',
+            env: 'dev',
+            baseUrl: 'https://example.com/argo/',
+        },
+    ];
+    describe.each(cases)('Renders properly', (testcase) => {
+        const getNode = () => <ArgoAppEnvLink app={testcase.app} env={testcase.env} />;
+        const getWrapper = () => render(getNode());
+        it(testcase.name, () => {
+            //given
+            setupArgoCd(testcase.baseUrl);
+            getWrapper();
+            // when
+            // then
+            expect(document.body).toMatchSnapshot();
+        });
+    });
+});
+
+describe('ArgoAppLink', () => {
+    const cases: {
+        name: string;
+        app: string;
+        baseUrl: string | undefined;
+    }[] = [
+        {
+            name: 'without url',
+            app: 'foo',
+            baseUrl: undefined,
+        },
+        {
+            name: 'with url',
+            app: 'foo',
+            baseUrl: 'https://example.com/argo/',
+        },
+    ];
+    describe.each(cases)('Renders properly', (testcase) => {
+        const getNode = () => <ArgoAppLink app={testcase.app} />;
+        const getWrapper = () => render(getNode());
+        it(testcase.name, () => {
+            //given
+            setupArgoCd(testcase.baseUrl);
+            getWrapper();
+            // when
+            // then
+            expect(document.body).toMatchSnapshot();
+        });
+    });
+});

--- a/services/frontend-service/src/ui/utils/Links.tsx
+++ b/services/frontend-service/src/ui/utils/Links.tsx
@@ -1,0 +1,90 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+import React from 'react';
+import { useArgoCdBaseUrl } from './store';
+
+export const deriveArgoAppLink = (baseUrl: string | undefined, app: string): string | undefined => {
+    if (baseUrl) {
+        const baseUrlSlash = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+        return baseUrlSlash + 'applications?search=-' + app;
+    }
+    return '';
+};
+
+export const deriveArgoAppEnvLink = (baseUrl: string | undefined, app: string, env: string): string | undefined => {
+    if (baseUrl) {
+        const baseUrlSlash = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+        return baseUrlSlash + 'applications?search=' + env + '-' + app;
+    }
+    return '';
+};
+
+export const deriveArgoTeamLink = (baseUrl: string | undefined, team: string): string | undefined => {
+    if (baseUrl) {
+        const baseUrlSlash = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+        return baseUrlSlash + 'applications?&labels=' + encodeURIComponent('com.freiheit.kuberpult/team=') + team;
+    }
+    return '';
+};
+
+export const ArgoTeamLink: React.FC<{ team: string | undefined }> = (props): JSX.Element | null => {
+    const { team } = props;
+    const argoBaseUrl = useArgoCdBaseUrl();
+    if (!team) {
+        return null;
+    }
+    if (!argoBaseUrl) {
+        // just render as text, because we do not have a base url:
+        return <span>{team}</span>;
+    }
+    return (
+        <span>
+            {' | Team: '}
+            <a title={'Opens the team in ArgoCd'} href={deriveArgoTeamLink(argoBaseUrl, team)}>
+                {team}
+            </a>
+        </span>
+    );
+};
+
+export const ArgoAppLink: React.FC<{ app: string }> = (props): JSX.Element => {
+    const { app } = props;
+    const argoBaseUrl = useArgoCdBaseUrl();
+    if (!argoBaseUrl) {
+        // just render as text, because we do not have a base url:
+        return <span>{app}</span>;
+    }
+    return (
+        <a title={'Opens this app in ArgoCd for all environments'} href={deriveArgoAppLink(argoBaseUrl, app)}>
+            {app}
+        </a>
+    );
+};
+
+export const ArgoAppEnvLink: React.FC<{ app: string; env: string }> = (props): JSX.Element => {
+    const { app, env } = props;
+    const argoBaseUrl = useArgoCdBaseUrl();
+    if (!argoBaseUrl) {
+        // just render as text, because we do not have a base url:
+        return <span>{env}</span>;
+    }
+    return (
+        <a title={'Opens the app in ArgoCd for this environment'} href={deriveArgoAppEnvLink(argoBaseUrl, app, env)}>
+            {env}
+        </a>
+    );
+};

--- a/services/frontend-service/src/ui/utils/__snapshots__/Links.test.tsx.snap
+++ b/services/frontend-service/src/ui/utils/__snapshots__/Links.test.tsx.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ArgoAppEnvLink Renders properly  with url 1`] = `
+<body>
+  <div>
+    <a
+      href="https://example.com/argo/applications?search=dev-foo"
+      title="Opens the app in ArgoCd for this environment"
+    >
+      dev
+    </a>
+  </div>
+</body>
+`;
+
+exports[`ArgoAppEnvLink Renders properly  without url 1`] = `
+<body>
+  <div>
+    <span>
+      dev
+    </span>
+  </div>
+</body>
+`;
+
+exports[`ArgoAppLink Renders properly with url 1`] = `
+<body>
+  <div>
+    <a
+      href="https://example.com/argo/applications?search=-foo"
+      title="Opens this app in ArgoCd for all environments"
+    >
+      foo
+    </a>
+  </div>
+</body>
+`;
+
+exports[`ArgoAppLink Renders properly without url 1`] = `
+<body>
+  <div>
+    <span>
+      foo
+    </span>
+  </div>
+</body>
+`;
+
+exports[`ArgoTeamLink Renders properly with team, with url 1`] = `
+<body>
+  <div>
+    <span>
+       | Team: 
+      <a
+        href="https://example.com/argo/applications?&labels=com.freiheit.kuberpult%2Fteam%3Dfoo"
+        title="Opens the team in ArgoCd"
+      >
+        foo
+      </a>
+    </span>
+  </div>
+</body>
+`;
+
+exports[`ArgoTeamLink Renders properly with team, without url 1`] = `
+<body>
+  <div>
+    <span>
+      foo
+    </span>
+  </div>
+</body>
+`;
+
+exports[`ArgoTeamLink Renders properly without team, with url 1`] = `
+<body>
+  <div />
+</body>
+`;

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -20,6 +20,7 @@ import {
     BatchRequest,
     Environment,
     EnvironmentGroup,
+    GetFrontendConfigResponse,
     GetOverviewResponse,
     Priority,
     Release,
@@ -238,8 +239,8 @@ export const useTeamNames = (): string[] =>
         ),
     ]);
 
-export const useTeamFromApplication = (app: string): string =>
-    useOverview(({ applications }) => applications[app]?.team?.trim() || '');
+export const useTeamFromApplication = (app: string): string | undefined =>
+    useOverview(({ applications }) => applications[app]?.team?.trim());
 
 // returns warnings from all apps
 export const useAllWarnings = (): Warning[] =>
@@ -597,3 +598,20 @@ export const useNavigateWithSearchParams = (to: string): { navURL: string; navCa
         }, [navURL, navigate]),
     };
 };
+
+type FrontendConfig = {
+    configs: GetFrontendConfigResponse;
+    configReady: boolean;
+};
+
+export const [useFrontendConfig, UpdateFrontendConfig] = createStore<FrontendConfig>({
+    configs: {
+        sourceRepoUrl: '',
+        kuberpultVersion: '0',
+    },
+    configReady: false,
+});
+
+export const useKuberpultVersion = (): string => useFrontendConfig((configs) => configs.configs.kuberpultVersion);
+export const useArgoCdBaseUrl = (): string | undefined =>
+    useFrontendConfig((configs) => configs.configs.argoCd?.baseUrl);


### PR DESCRIPTION
Links will be rendered in 3 places in the Release Dialog:
* on the app name: It links to the app (in all envs)
* on the team name: It links to the team
* on the environment chip: It links to the app in that environment

Also moved some react hooks to store.tsx, because they had nothing to do with AzureAuth.

In order to see the links, the helm value "argocd.baseUrl" must be set.

Reference: SRX-MF4E9M


![Screenshot from 2023-08-02 13-46-50](https://github.com/freiheit-com/kuberpult/assets/3481382/32aa3e25-ebd2-46a6-8401-93d914c17177)

