### PR TITLE
Add App/Environment wildcard permission check

### DIFF
--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -214,6 +214,7 @@ func CheckUserPermissions(rbacConfig RBACConfig, user *User, env, envGroup, appl
 		return nil
 	}
 	// Check if the permission exists.
+	// TODO (BB): This needs to be a loop over all permutations. Envs can also be "*".
 	permissionsWanted := fmt.Sprintf(PermissionTemplate, user.DexAuthContext.Role, action, envGroup, env, application)
 	_, permissionsExist = rbacConfig.Policy[permissionsWanted]
 	if permissionsExist {

--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -39,6 +39,8 @@ const (
 	PermissionCreateEnvironment            = "CreateEnvironment"
 	PermissionDeleteEnvironmentApplication = "DeleteEnvironmentApplication"
 	PermissionDeployReleaseTrain           = "DeployReleaseTrain"
+	// The default permission template.
+	PermissionTemplate = "%s,%s,%s:%s,%s,allow"
 )
 
 // All static rbac information that is required to check authentication of a given user.
@@ -122,7 +124,7 @@ func (c *policyConfig) validateApplication(app string) error {
 // followed <ENVIRONMENT_GROUP:*>.
 func isEnvironmentIndependent(action string) bool {
 	switch action {
-	case "CreateUndeploy", "DeployUndeploy", "CreateEnvironmentApplication":
+	case PermissionCreateUndeploy, PermissionDeployUndeploy, PermissionDeleteEnvironmentApplication:
 		return true
 	}
 	return false
@@ -201,11 +203,22 @@ func ReadRbacPolicy(dexEnabled bool) (policy map[string]*Permission, err error) 
 
 // Checks user permissions on the RBAC policy.
 func CheckUserPermissions(rbacConfig RBACConfig, user *User, env, envGroup, application, action string) error {
-	permissionsWanted := fmt.Sprintf("%s,%s,%s:%s,%s,allow", user.DexAuthContext.Role, action, envGroup, env, application)
-	_, permissionsExist := rbacConfig.Policy[permissionsWanted]
-	if !permissionsExist {
-		return status.Errorf(codes.PermissionDenied, fmt.Sprintf("user does not have permissions for: %s", permissionsWanted))
+	// If the action is environment independent, the env format is <ENVIRONMENT_GROUP>:*
+	if isEnvironmentIndependent(action) {
+		env = "*"
 	}
-
-	return nil
+	// Check for wildcard application permission.
+	permissionApplicationWildcard := fmt.Sprintf(PermissionTemplate, user.DexAuthContext.Role, action, envGroup, env, "*")
+	_, permissionsExist := rbacConfig.Policy[permissionApplicationWildcard]
+	if permissionsExist {
+		return nil
+	}
+	// Check if the permission exists.
+	permissionsWanted := fmt.Sprintf(PermissionTemplate, user.DexAuthContext.Role, action, envGroup, env, application)
+	_, permissionsExist = rbacConfig.Policy[permissionsWanted]
+	if permissionsExist {
+		return nil
+	}
+	// The permission is not found. Return an error.
+	return status.Errorf(codes.PermissionDenied, fmt.Sprintf("user does not have permissions for: %s", permissionsWanted))
 }

--- a/pkg/auth/rbac_test.go
+++ b/pkg/auth/rbac_test.go
@@ -17,9 +17,12 @@ Copyright 2023 freiheit.com*/
 package auth
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestValidateRbacPermission(t *testing.T) {
@@ -82,6 +85,77 @@ func TestValidateRbacPermission(t *testing.T) {
 			} else {
 				if diff := cmp.Diff(permission, tc.WantPermission); diff != "" {
 					t.Errorf("got %v, want %v, diff (-want +got) %s", permission, tc.WantPermission, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckUserPermissions(t *testing.T) {
+	tcs := []struct {
+		Name        string
+		rbacConfig  RBACConfig
+		user        *User
+		env         string
+		envGroup    string
+		application string
+		action      string
+		WantError   string
+	}{
+		{
+			Name:        "Check user permission works as expected",
+			user:        &User{DexAuthContext: &DexAuthContext{Role: "Developer"}},
+			env:         "production",
+			envGroup:    "production",
+			application: "app1",
+			action:      PermissionCreateLock,
+			rbacConfig: RBACConfig{DexEnabled: true, Policy: map[string]*Permission{
+				"Developer,CreateLock,production:production,app1,allow": {Role: "Developer"},
+			}},
+		},
+		{
+			Name:        "Application Wildcard works as expected",
+			user:        &User{DexAuthContext: &DexAuthContext{Role: "Developer"}},
+			env:         "production",
+			envGroup:    "production",
+			application: "app1",
+			action:      PermissionCreateLock,
+			rbacConfig: RBACConfig{DexEnabled: true, Policy: map[string]*Permission{
+				"Developer,CreateLock,production:production,*,allow": {Role: "Developer"},
+			}},
+		},
+		{
+			Name:        "Environment independent works as expected",
+			user:        &User{DexAuthContext: &DexAuthContext{Role: "Developer"}},
+			env:         "production",
+			envGroup:    "production",
+			application: "app1",
+			action:      PermissionCreateUndeploy,
+			rbacConfig: RBACConfig{DexEnabled: true, Policy: map[string]*Permission{
+				"Developer,CreateUndeploy,production:*,*,allow": {Role: "Developer"},
+			}},
+		},
+		{
+			Name:        "User does not have permission",
+			user:        &User{DexAuthContext: &DexAuthContext{Role: "Developer"}},
+			env:         "production",
+			envGroup:    "production",
+			application: "app1",
+			action:      PermissionCreateLock,
+			rbacConfig: RBACConfig{DexEnabled: true, Policy: map[string]*Permission{
+				"Developer,CreateLock,staging:staging,app1,allow": {Role: "Developer"},
+			}},
+			WantError: status.Errorf(codes.PermissionDenied, fmt.Sprintf("user does not have permissions for: %s", "Developer,CreateLock,production:production,app1,allow")).Error(),
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			err := CheckUserPermissions(tc.rbacConfig, tc.user, tc.env, tc.envGroup, tc.application, tc.action)
+			if err != nil {
+				if diff := cmp.Diff(tc.WantError, err.Error()); diff != "" {
+					t.Errorf("Error mismatch (-want +got):\n%s", diff)
 				}
 			}
 		})


### PR DESCRIPTION
Add the following 2 cases for the permission check:
- If it is an environment independent action the, the expected format is `<ENVIRONMENT_GROUP>:*`.
- Checks for an wildcard `*` permission for applications.

Rev: DSN-J1WO8X