### PR TITLE
Fix broken link in small environmentGroupChip

### DIFF
--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
@@ -82,7 +82,7 @@ export const EnvironmentChip = (props: EnvironmentChipProps): JSX.Element => {
                 className="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
                 role="gridcell">
                 <span className="mdc-evolution-chip__text-name">
-                    <ArgoAppEnvLink app={app} env={smallEnvChip ? name[0].toUpperCase() : name} />
+                    {smallEnvChip ? name[0].toUpperCase() : <ArgoAppEnvLink app={app} env={name} />}
                 </span>{' '}
                 <span className="mdc-evolution-chip__text-numbers">{numberString}</span>
                 {locks}


### PR DESCRIPTION
We should not render a link in the small environmentGroupChip, because it is way too small. It also had not-so-nice css.
It was never intended to work for environmentGroups - just environments.

Now we just render text, as before.
