### PR TITLE
CreateEnvironment add Role Based Access Control

### DIFF
--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/pkg/testutil"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -28,6 +27,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/go-git/go-billy/v5/util"
@@ -707,7 +708,7 @@ func TestGc(t *testing.T) {
 			GcFrequency:        0,
 			StorageBackend:     GitBackend,
 			ExpectedGarbageMin: 906,
-			ExpectedGarbageMax: 910,
+			ExpectedGarbageMax: 913,
 		},
 		{
 			// we are going to perform 101 requests, that should trigger a gc

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -632,10 +632,28 @@ func (s *State) checkUserPermissions(ctx context.Context, env, application, acti
 			break
 		}
 	}
-	if group == "" {
+	if group == "" && action != auth.PermissionCreateEnvironment {
 		return fmt.Errorf("group not found for environment: %s", env)
 	}
 	return auth.CheckUserPermissions(RBACConfig, user, env, group, application, action)
+}
+
+// checkUserPermissionsCreateEnvironment check the permission for the environment creation action.
+// This is a "special" case because the environment group is already provided on the request.
+func (s *State) checkUserPermissionsCreateEnvironment(ctx context.Context, RBACConfig auth.RBACConfig, envConfig config.EnvironmentConfig) error {
+	if !RBACConfig.DexEnabled {
+		return nil
+	}
+	user, err := auth.ReadUserFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf(fmt.Sprintf("checkUserPermissions: user not found: %v", err))
+	}
+	envGroup := "*"
+	// If an env group is provided on the request, use it on the permission.
+	if envConfig.EnvironmentGroup != nil {
+		envGroup = *(envConfig.EnvironmentGroup)
+	}
+	return auth.CheckUserPermissions(RBACConfig, user, "*", envGroup, "*", auth.PermissionCreateEnvironment)
 }
 
 func (c *CreateEnvironmentLock) Transform(ctx context.Context, state *State) (string, error) {
@@ -806,11 +824,16 @@ func (c *DeleteEnvironmentApplicationLock) Transform(ctx context.Context, state 
 }
 
 type CreateEnvironment struct {
+	Authentication
 	Environment string
 	Config      config.EnvironmentConfig
 }
 
 func (c *CreateEnvironment) Transform(ctx context.Context, state *State) (string, error) {
+	err := state.checkUserPermissionsCreateEnvironment(ctx, c.RBACConfig, c.Config)
+	if err != nil {
+		return "", err
+	}
 	fs := state.Filesystem
 	envDir := fs.Join("environments", c.Environment)
 	// Creation of environment is possible, but configuring it is not if running in bootstrap mode.

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -632,7 +632,7 @@ func (s *State) checkUserPermissions(ctx context.Context, env, application, acti
 			break
 		}
 	}
-	if group == "" && action != auth.PermissionCreateEnvironment {
+	if group == "" {
 		return fmt.Errorf("group not found for environment: %s", env)
 	}
 	return auth.CheckUserPermissions(RBACConfig, user, env, group, application, action)

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -788,12 +788,41 @@ func TestReleaseTrainErrors(t *testing.T) {
 }
 
 func TestRbacTransformerTest(t *testing.T) {
+	envGroupProduction := "production"
 	tcs := []struct {
 		Name          string
 		ctx           context.Context
 		Transformers  []Transformer
 		ExpectedError string
 	}{
+		{Name: "able to create environment with permissions policy",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "production-p1",
+					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{
+						"developer,CreateEnvironment,*:*,*,allow": {Role: "developer"}}}}},
+			},
+		},
+		{
+			Name: "able to create environment inside environment group with permissions policy",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "production-p2",
+					Config:      config.EnvironmentConfig{EnvironmentGroup: &envGroupProduction},
+					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{
+						"developer,CreateEnvironment,production:*,*,allow": {Role: "developer"}}}}},
+			},
+		},
+		{
+			Name: "unable to create environment without permissions policy",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment:    "production-p2",
+					Config:         config.EnvironmentConfig{EnvironmentGroup: &envGroupProduction},
+					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}}},
+			},
+			ExpectedError: "user does not have permissions for: developer,CreateEnvironment,production:*,*,allow",
+		},
 		{
 			Name: "able to create undeploy with permissions policy",
 			Transformers: []Transformer{

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -795,10 +795,12 @@ func TestRbacTransformerTest(t *testing.T) {
 		Transformers  []Transformer
 		ExpectedError string
 	}{
-		{Name: "able to create environment with permissions policy",
+		{
+			Name: "able to create environment with permissions policy",
 			Transformers: []Transformer{
 				&CreateEnvironment{
 					Environment: "production-p1",
+					Config:      config.EnvironmentConfig{EnvironmentGroup: nil},
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{
 						"developer,CreateEnvironment,*:*,*,allow": {Role: "developer"}}}}},
 			},

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -903,11 +903,13 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
 				},
 				&CreateUndeployApplicationVersion{
-					Application:    "app1",
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
+					Application: "app1",
+					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{
+						"developer,CreateUndeploy,production:*,app1,allow": {Role: "developer"},
+					}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,CreateUndeploy,production:*,app1,allow",
+			ExpectedError: "user does not have permissions for: developer,CreateUndeploy,staging:*,app1,allow",
 		},
 		{
 			Name: "able to create release train with permissions policy",

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -244,6 +244,7 @@ func (d *BatchServer) processAction(
 				ArgoCd:           argocd,
 				EnvironmentGroup: conf.EnvironmentGroup,
 			},
+			Authentication: repository.Authentication{RBACConfig: d.RBACConfig},
 		}
 		return transformer, nil, nil
 	}


### PR DESCRIPTION
Adds the Role Based Access Control to CreateEnvironment. Two cases were considered for this action:
- The user provides and environment group. In this case the specified permission needs to have `<ENV_GROUP>:*` specified. 
- The user only provides the environment name. In this case the specified permission needs to have `*:*` for the env field specified.

Rev: DSN-J1WO8X