### PR TITLE
Do not render undeployed argoApps

### DIFF
--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -34,6 +34,7 @@ package testutil
 
 import (
 	"context"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/config"
 
 	"github.com/freiheit-com/kuberpult/pkg/auth"
 	"google.golang.org/grpc/metadata"
@@ -73,4 +74,25 @@ func MakeTestContextDexEnabledUser(role string) context.Context {
 		auth.HeaderUserRole:  auth.Encode64(role),
 	}))
 	return ctx
+}
+
+func MakeEnvConfigLatest(argoCd *config.EnvironmentConfigArgoCd) config.EnvironmentConfig {
+	return config.EnvironmentConfig{
+		Upstream: &config.EnvironmentConfigUpstream{
+			Latest: true,
+		},
+		ArgoCd:           argoCd,
+		EnvironmentGroup: nil,
+	}
+}
+
+func MakeEnvConfigUpstream(upstream string, argoCd *config.EnvironmentConfigArgoCd) config.EnvironmentConfig {
+	return config.EnvironmentConfig{
+		Upstream: &config.EnvironmentConfigUpstream{
+			Latest:      false,
+			Environment: upstream,
+		},
+		ArgoCd:           argoCd,
+		EnvironmentGroup: nil,
+	}
 }

--- a/services/cd-service/pkg/argocd/render.go
+++ b/services/cd-service/pkg/argocd/render.go
@@ -119,7 +119,7 @@ func RenderV1Alpha1(gitUrl string, gitBranch string, config config.EnvironmentCo
 	}
 	syncOptions := config.ArgoCd.SyncOptions
 	for _, appData := range appsData {
-		appManifest, err := RenderApp(gitUrl, gitBranch, config.ArgoCd.ApplicationAnnotations, env, appData, applicationDestination, ignoreDifferences, syncOptions)
+		appManifest, err := RenderAppEnv(gitUrl, gitBranch, config.ArgoCd.ApplicationAnnotations, env, appData, applicationDestination, ignoreDifferences, syncOptions)
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +128,7 @@ func RenderV1Alpha1(gitUrl string, gitBranch string, config config.EnvironmentCo
 	return ([]byte)(strings.Join(buf, "---\n")), nil
 }
 
-func RenderApp(gitUrl string, gitBranch string, applicationAnnotations map[string]string, env string, appData AppData, destination v1alpha1.ApplicationDestination, ignoreDifferences []v1alpha1.ResourceIgnoreDifferences, syncOptions v1alpha1.SyncOptions) (string, error) {
+func RenderAppEnv(gitUrl string, gitBranch string, applicationAnnotations map[string]string, env string, appData AppData, destination v1alpha1.ApplicationDestination, ignoreDifferences []v1alpha1.ResourceIgnoreDifferences, syncOptions v1alpha1.SyncOptions) (string, error) {
 	name := appData.AppName
 	annotations := map[string]string{}
 	labels := map[string]string{}

--- a/services/cd-service/pkg/argocd/render_test.go
+++ b/services/cd-service/pkg/argocd/render_test.go
@@ -184,7 +184,7 @@ spec:
 				syncOptions = []string{"ApplyOutOfSyncOnly=true"}
 			)
 
-			actualResult, err := RenderApp(GitUrl, gitBranch, annotations, env, appData, destination, ignoreDifferences, syncOptions)
+			actualResult, err := RenderAppEnv(GitUrl, gitBranch, annotations, env, appData, destination, ignoreDifferences, syncOptions)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This avoids the error in argoCd `rpc error: code = Unknown desc = environments/<env>/applications/<app>/manifests: app path does not exist`

This is usually a problem when creating a new app, because generally all manifest are created in the source repo at once, including for production environments.
However, once submitted to kuberpult via /release endpoint, kuberpult rendered the ArgoCd manifests for **all** environments, even those that are not deployed yet (like production).

With this change, kuberpult will only render the apps in an environment, if it is deployed there.

Reference: SRX-638BGR