### PR TITLE
Render spinner while loading

### DIFF
--- a/services/frontend-service/package.json
+++ b/services/frontend-service/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "6",
     "react-scripts": "^5.0.1",
+    "react-spinners": "^0.13.8",
     "react-tooltip": "^5.18.1",
     "react-use-sub": "^3.0.0",
     "rxjs": "^7.0.0"

--- a/services/frontend-service/pnpm-lock.yaml
+++ b/services/frontend-service/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       react-scripts:
         specifier: ^5.0.1
         version: 5.0.1(@babel/plugin-syntax-flow@7.18.6)(@babel/plugin-transform-react-jsx@7.19.0)(eslint@8.38.0)(react@18.2.0)(sass@1.54.9)(typescript@5.1.6)
+      react-spinners:
+        specifier: ^0.13.8
+        version: 0.13.8(react-dom@18.2.0)(react@18.2.0)
       react-tooltip:
         specifier: ^5.18.1
         version: 5.18.1(react-dom@18.2.0)(react@18.2.0)
@@ -10345,6 +10348,16 @@ packages:
       - webpack-cli
       - webpack-hot-middleware
       - webpack-plugin-serve
+    dev: false
+
+  /react-spinners@0.13.8(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || 18
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || 18
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react-tooltip@5.18.1(react-dom@18.2.0)(react@18.2.0):

--- a/services/frontend-service/src/assets/_components.scss
+++ b/services/frontend-service/src/assets/_components.scss
@@ -35,6 +35,7 @@ Copyright 2023 freiheit.com*/
 @import 'src/ui/components/ServiceLane/Warnings';
 @import 'src/ui/components/navigation/navListItem';
 @import '../ui/components/EnvironmentCard/EnvironmentCard';
+@import 'src/ui/components/Spinner/Spinner';
 @import 'src/ui/components/EnvironmentLockDisplay/EnvironmentLockDisplay';
 @import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 @import url('https://fonts.googleapis.com/icon?family=Inter');

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -84,6 +84,7 @@ export const App: React.FC = () => {
                 .subscribe(
                     (result) => {
                         UpdateOverview.set(result);
+                        UpdateOverview.set({ loaded: true });
                         PanicOverview.set({ error: '' });
                     },
                     (error) => {

--- a/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
@@ -53,77 +53,98 @@ const sampleEnvsB: Environment[] = [
     },
 ];
 
-interface dataT {
-    name: string;
-    environmentGroups: EnvironmentGroup[];
-    expected: number;
-    expectedEnvHeaderWrapper: number;
-}
-
-const cases: dataT[] = [
-    {
-        name: '1 group 1 env',
-        environmentGroups: [
-            {
-                environments: [sampleEnvsA[0]],
-                distanceToUpstream: 1,
-                environmentGroupName: 'g1',
-            },
-        ],
-        expected: 1,
-        expectedEnvHeaderWrapper: 1,
-    },
-    {
-        name: '2 group 1 env each',
-        environmentGroups: [
-            {
-                environments: [sampleEnvsA[0]],
-                distanceToUpstream: 1,
-                environmentGroupName: 'g1',
-            },
-            {
-                environments: [sampleEnvsB[0]],
-                distanceToUpstream: 1,
-                environmentGroupName: 'g1',
-            },
-        ],
-        expected: 1,
-        expectedEnvHeaderWrapper: 2,
-    },
-    {
-        name: '1 group 2 env',
-        environmentGroups: [
-            {
-                environments: sampleEnvsA,
-                distanceToUpstream: 1,
-                environmentGroupName: 'g1',
-            },
-            {
-                environments: sampleEnvsB,
-                distanceToUpstream: 1,
-                environmentGroupName: 'g2',
-            },
-        ],
-        expected: 2,
-        expectedEnvHeaderWrapper: 4,
-    },
-];
-
 describe('Environment Lane', () => {
     const getNode = () => <EnvironmentsPage />;
     const getWrapper = () => render(getNode());
 
+    interface dataT {
+        name: string;
+        environmentGroups: EnvironmentGroup[];
+        loaded: boolean;
+        expected: number;
+        expectedEnvHeaderWrapper: number;
+        expectedMainContent: number;
+        spinnerExpected: number;
+    }
+    const cases: dataT[] = [
+        {
+            name: '1 group 1 env',
+            environmentGroups: [
+                {
+                    environments: [sampleEnvsA[0]],
+                    distanceToUpstream: 1,
+                    environmentGroupName: 'g1',
+                },
+            ],
+            loaded: true,
+            expected: 1,
+            expectedEnvHeaderWrapper: 1,
+            expectedMainContent: 1,
+            spinnerExpected: 0,
+        },
+        {
+            name: '2 group 1 env each',
+            environmentGroups: [
+                {
+                    environments: [sampleEnvsA[0]],
+                    distanceToUpstream: 1,
+                    environmentGroupName: 'g1',
+                },
+                {
+                    environments: [sampleEnvsB[0]],
+                    distanceToUpstream: 1,
+                    environmentGroupName: 'g1',
+                },
+            ],
+            loaded: true,
+            expected: 1,
+            expectedEnvHeaderWrapper: 2,
+            expectedMainContent: 1,
+            spinnerExpected: 0,
+        },
+        {
+            name: '1 group 2 env',
+            environmentGroups: [
+                {
+                    environments: sampleEnvsA,
+                    distanceToUpstream: 1,
+                    environmentGroupName: 'g1',
+                },
+                {
+                    environments: sampleEnvsB,
+                    distanceToUpstream: 1,
+                    environmentGroupName: 'g2',
+                },
+            ],
+            loaded: true,
+            expected: 2,
+            expectedEnvHeaderWrapper: 4,
+            expectedMainContent: 1,
+            spinnerExpected: 0,
+        },
+        {
+            name: 'just the spinner',
+            environmentGroups: [],
+            loaded: false,
+            expected: 0,
+            expectedEnvHeaderWrapper: 0,
+            expectedMainContent: 0,
+            spinnerExpected: 1,
+        },
+    ];
     describe.each(cases)('Renders a row of environments', (testcase) => {
         it(testcase.name, () => {
             //given
             UpdateOverview.set({
                 environmentGroups: testcase.environmentGroups,
+                loaded: testcase.loaded,
             });
-            const { container } = getWrapper();
             // when
+            const { container } = getWrapper();
             // then
+            expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.spinnerExpected);
             expect(container.getElementsByClassName('environment-group-lane')).toHaveLength(testcase.expected);
-            expect(container.getElementsByClassName('main-content')).toHaveLength(1);
+            expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedMainContent);
             expect(container.getElementsByClassName('environment-lane__header')).toHaveLength(
                 testcase.expectedEnvHeaderWrapper
             );

--- a/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.tsx
@@ -13,8 +13,9 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-import { useEnvironmentGroups, useEnvironments } from '../../utils/store';
+import { useEnvironmentGroups, useEnvironments, useOverviewLoaded } from '../../utils/store';
 import { EnvironmentCard, EnvironmentGroupCard } from '../../components/EnvironmentCard/EnvironmentCard';
+import { Spinner } from '../../components/Spinner/Spinner';
 
 export const EnvironmentsPage: React.FC = () => {
     const envsGroups = useEnvironmentGroups();
@@ -22,6 +23,13 @@ export const EnvironmentsPage: React.FC = () => {
     // note that in all cases, envsGroups.length <= envs.length
     // if they are equal (envsGroups.length === envs.length), then there are effectively no groups, but the cd-server still returns each env wrapped in a group
     const useGroups = envsGroups.length !== envs.length;
+
+    // note that the config is definitely loaded here, because it's ensured in AzureAuthProvider
+    const overviewLoaded = useOverviewLoaded();
+    if (!overviewLoaded) {
+        return <Spinner message={'Overview'} />;
+    }
+
     if (useGroups) {
         return (
             <main className="main-content">

--- a/services/frontend-service/src/ui/Pages/Home/Home.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Home/Home.test.tsx
@@ -46,6 +46,7 @@ describe('App', () => {
         };
         UpdateOverview.set({
             applications: sampleApps,
+            loaded: true,
         });
         getWrapper();
 
@@ -53,6 +54,16 @@ describe('App', () => {
         expect(mock_ServiceLane.ServiceLane.getCallArgument(0, 0)).toStrictEqual({ application: sampleApps.app1 });
         expect(mock_ServiceLane.ServiceLane.getCallArgument(1, 0)).toStrictEqual({ application: sampleApps.app2 });
         expect(mock_ServiceLane.ServiceLane.getCallArgument(2, 0)).toStrictEqual({ application: sampleApps.app3 });
+    });
+    it('Renders Spinner', () => {
+        // given
+        UpdateOverview.set({
+            loaded: false,
+        });
+        // when
+        const { container } = getWrapper();
+        // then
+        expect(container.getElementsByClassName('spinner')).toHaveLength(1);
     });
 });
 

--- a/services/frontend-service/src/ui/Pages/Home/Home.tsx
+++ b/services/frontend-service/src/ui/Pages/Home/Home.tsx
@@ -15,7 +15,9 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright 2023 freiheit.com*/
 import { ServiceLane } from '../../components/ServiceLane/ServiceLane';
 import { useSearchParams } from 'react-router-dom';
-import { useFilteredApps, useSearchedApplications } from '../../utils/store';
+import { useFilteredApps, useOverviewLoaded, useSearchedApplications } from '../../utils/store';
+import { Spinner } from '../../components/Spinner/Spinner';
+import React from 'react';
 
 export const Home: React.FC = () => {
     const [params] = useSearchParams();
@@ -25,6 +27,11 @@ export const Home: React.FC = () => {
     const searchedApp = useSearchedApplications(filteredApps, appNameParam);
 
     const apps = Object.values(searchedApp);
+
+    const loaded = useOverviewLoaded();
+    if (!loaded) {
+        return <Spinner message={'Overview'} />;
+    }
 
     return (
         <main className="main-content">

--- a/services/frontend-service/src/ui/Pages/Locks/LocksPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Locks/LocksPage.test.tsx
@@ -34,9 +34,22 @@ describe('LocksPage', () => {
     const getWrapper = () => render(getNode());
 
     it('Renders full app', () => {
+        UpdateOverview.set({
+            loaded: true,
+        });
         const { container } = getWrapper();
         expect(container.getElementsByClassName('mdc-data-table')[0]).toHaveTextContent('Environment Locks');
         expect(container.getElementsByClassName('mdc-data-table')[1]).toHaveTextContent('Application Locks');
+    });
+    it('Renders spinner', () => {
+        // given
+        UpdateOverview.set({
+            loaded: false,
+        });
+        // when
+        const { container } = getWrapper();
+        // then
+        expect(container.getElementsByClassName('spinner')).toHaveLength(1);
     });
 });
 

--- a/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
@@ -15,8 +15,9 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright 2023 freiheit.com*/
 import { useMemo } from 'react';
 import { LocksTable } from '../../components/LocksTable/LocksTable';
-import { searchCustomFilter, sortLocks, useEnvironments } from '../../utils/store';
+import { searchCustomFilter, sortLocks, useEnvironments, useOverviewLoaded } from '../../utils/store';
 import { useSearchParams } from 'react-router-dom';
+import { Spinner } from '../../components/Spinner/Spinner';
 
 const applicationFieldHeaders = [
     'Date',
@@ -78,6 +79,11 @@ export const LocksPage: React.FC = () => {
             ),
         [appNameParam, envs]
     );
+    // note that the config is definitely loaded here, because it's ensured in AzureAuthProvider
+    const overviewLoaded = useOverviewLoaded();
+    if (!overviewLoaded) {
+        return <Spinner message={'Overview'} />;
+    }
     return (
         <main className="main-content">
             <LocksTable headerTitle="Environment Locks" columnHeaders={environmentFieldHeaders} locks={envLocks} />

--- a/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
@@ -1,0 +1,61 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+import { render } from '@testing-library/react';
+import { UpdateOverview } from '../../utils/store';
+import { MemoryRouter } from 'react-router-dom';
+import { ReleasesPage } from './ReleasesPage';
+
+describe('LocksPage', () => {
+    const getNode = (): JSX.Element | any => (
+        <MemoryRouter>
+            <ReleasesPage />
+        </MemoryRouter>
+    );
+    const getWrapper = () => render(getNode());
+
+    interface dataEnvT {
+        name: string;
+        loaded: boolean;
+        expectedNumMainContent: number;
+        expectedNumSpinner: number;
+    }
+
+    const sampleEnvData: dataEnvT[] = [
+        {
+            name: 'renders main',
+            loaded: true,
+            expectedNumMainContent: 1,
+            expectedNumSpinner: 0,
+        },
+        {
+            name: 'renders spinner',
+            loaded: false,
+            expectedNumMainContent: 0,
+            expectedNumSpinner: 1,
+        },
+    ];
+
+    describe.each(sampleEnvData)(`Renders ReleasesPage`, (testcase) => {
+        it(testcase.name, () => {
+            UpdateOverview.set({
+                loaded: testcase.loaded,
+            });
+            const { container } = getWrapper();
+            expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedNumMainContent);
+            expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.expectedNumSpinner);
+        });
+    });
+});

--- a/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.tsx
@@ -14,10 +14,19 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 import { Releases } from '../../components/Releases/Releases';
+import { useOverviewLoaded } from '../../utils/store';
+import { Spinner } from '../../components/Spinner/Spinner';
 
 export const ReleasesPage: React.FC = () => {
     const url = window.location.pathname.split('/');
     const app_name = url[url.length - 1];
+
+    // note that the config is definitely loaded here, because it's ensured in AzureAuthProvider
+    const overviewLoaded = useOverviewLoaded();
+    if (!overviewLoaded) {
+        return <Spinner message={'Overview'} />;
+    }
+
     return (
         <main className="main-content">
             <Releases app={app_name} />

--- a/services/frontend-service/src/ui/components/Spinner/Spinner.scss
+++ b/services/frontend-service/src/ui/components/Spinner/Spinner.scss
@@ -1,0 +1,29 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+.spinner {
+    z-index: 10000;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    /* bring your own prefixes */
+    transform: translate(-50%, -50%);
+    .spinner-animation {
+    }
+    .spinner-message {
+        margin-top: 20px;
+    }
+}

--- a/services/frontend-service/src/ui/components/Spinner/Spinner.test.tsx
+++ b/services/frontend-service/src/ui/components/Spinner/Spinner.test.tsx
@@ -1,0 +1,39 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+import { render } from '@testing-library/react';
+import React from 'react';
+import { Spinner } from './Spinner';
+
+const cases: { name: string }[] = [
+    {
+        name: 'Renders',
+    },
+];
+
+describe('Spinner', () => {
+    const getNode = () => <Spinner message={'hello'} />;
+    const getWrapper = () => render(getNode());
+
+    describe.each(cases)('Renders', (testcase) => {
+        it(testcase.name, () => {
+            //given
+            // when
+            const { container } = getWrapper();
+            // then
+            expect(container.firstChild).toMatchSnapshot();
+        });
+    });
+});

--- a/services/frontend-service/src/ui/components/Spinner/Spinner.tsx
+++ b/services/frontend-service/src/ui/components/Spinner/Spinner.tsx
@@ -1,0 +1,30 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+import * as React from 'react';
+
+import { PacmanLoader } from 'react-spinners';
+
+export const Spinner: React.FC<{ message: string }> = (props): JSX.Element => {
+    const { message } = props;
+    return (
+        <div className={'spinner'}>
+            <div className={'spinner-animation'}>
+                <PacmanLoader color="var(--mdc-theme-primary)" loading={true} size={100} speedMultiplier={1} />
+            </div>
+            <div className={'spinner-message'}>Loading {message}...</div>
+        </div>
+    );
+};

--- a/services/frontend-service/src/ui/components/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Spinner Renders Renders 1`] = `
+<div
+  class="spinner"
+>
+  <div
+    class="spinner-animation"
+  >
+    <span
+      style="display: inherit; position: relative; font-size: 0px; height: 200px; width: 200px;"
+    >
+      <span
+        style="width: 0px; height: 0px; border-right: 100px solid transparent; border-top: 100px solid transparent; border-radius: 100px; position: absolute; animation: react-spinners-PacmanLoader-pacman-1 0.8s infinite ease-in-out; animation-fill-mode: both;"
+      />
+      <span
+        style="width: 0px; height: 0px; border-right: 100px solid transparent; border-bottom: 100px solid transparent; border-radius: 100px; position: absolute; animation: react-spinners-PacmanLoader-pacman-2 0.8s infinite ease-in-out; animation-fill-mode: both;"
+      />
+      <span
+        style="width: 33.333333333333336px; height: 33.333333333333336px; margin: 2px; border-radius: 100%; transform: translate(0, -25px); position: absolute; top: 100px; left: 400px; animation: react-spinners-PacmanLoader-ball 1s 0.5s infinite linear; animation-fill-mode: both;"
+      />
+      <span
+        style="width: 33.333333333333336px; height: 33.333333333333336px; margin: 2px; border-radius: 100%; transform: translate(0, -25px); position: absolute; top: 100px; left: 400px; animation: react-spinners-PacmanLoader-ball 1s 0.75s infinite linear; animation-fill-mode: both;"
+      />
+      <span
+        style="width: 33.333333333333336px; height: 33.333333333333336px; margin: 2px; border-radius: 100%; transform: translate(0, -25px); position: absolute; top: 100px; left: 400px; animation: react-spinners-PacmanLoader-ball 1s 1s infinite linear; animation-fill-mode: both;"
+      />
+      <span
+        style="width: 33.333333333333336px; height: 33.333333333333336px; margin: 2px; border-radius: 100%; transform: translate(0, -25px); position: absolute; top: 100px; left: 400px; animation: react-spinners-PacmanLoader-ball 1s 1.25s infinite linear; animation-fill-mode: both;"
+      />
+    </span>
+  </div>
+  <div
+    class="spinner-message"
+  >
+    Loading 
+    hello
+    ...
+  </div>
+</div>
+`;

--- a/services/frontend-service/src/ui/utils/AzureAuthProvider.test.tsx
+++ b/services/frontend-service/src/ui/utils/AzureAuthProvider.test.tsx
@@ -243,4 +243,22 @@ describe('AuthProvider', () => {
             expect(getByText(container, /Welcome to kuberpult/i)).toBeInTheDocument();
         });
     });
+    describe('Spinner renders', () => {
+        it('Spinner is rendered when the config is not loaded', () => {
+            // given
+            UpdateFrontendConfig.set({
+                configReady: false,
+            });
+
+            // when
+            const { container } = render(
+                <AzureAuthProvider>
+                    <div className={'welcome-kuberpult-test'}>Welcome to kuberpult</div>
+                </AzureAuthProvider>
+            );
+
+            // then
+            expect(container.getElementsByClassName('spinner')).toHaveLength(1);
+        });
+    });
 });

--- a/services/frontend-service/src/ui/utils/AzureAuthProvider.tsx
+++ b/services/frontend-service/src/ui/utils/AzureAuthProvider.tsx
@@ -28,6 +28,7 @@ import { createStore } from 'react-use-sub';
 import { grpc } from '@improbable-eng/grpc-web';
 import { useFrontendConfig } from './store';
 import { AuthenticationResult } from '@azure/msal-common';
+import { Spinner } from '../components/Spinner/Spinner';
 
 type AzureAuthSubType = {
     authHeader: grpc.Metadata & {
@@ -127,7 +128,9 @@ export const AzureAutoSignIn = (): JSX.Element => {
 export const AzureAuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const { configs, configReady } = useFrontendConfig((c) => c);
     const msalInstance = React.useMemo(() => new PublicClientApplication(getMsalConfig(configs)), [configs]);
-    if (!configReady) return null;
+    if (!configReady) {
+        return <Spinner message={'Configuration'} />;
+    }
 
     const useAzureAuth = configs.authConfig?.azureAuth?.enabled;
     if (!useAzureAuth) {

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -45,13 +45,18 @@ export interface DisplayLock {
 export const displayLockUniqueId = (displayLock: DisplayLock): string =>
     'dl-' + displayLock.lockId + '-' + displayLock.environment + '-' + displayLock.application;
 
-const emptyOverview: GetOverviewResponse = {
+type EnhancedOverview = GetOverviewResponse & { loaded: boolean };
+
+const emptyOverview: EnhancedOverview = {
     applications: {},
     environmentGroups: [],
     gitRevision: '',
+    loaded: false,
 };
 const [useOverview, UpdateOverview_] = createStore(emptyOverview);
 export const UpdateOverview = UpdateOverview_; // we do not want to export "useOverview". The store.tsx should act like a facade to the data.
+
+export const useOverviewLoaded = (): boolean => useOverview(({ loaded }) => loaded);
 
 const emptyBatch: BatchRequest = { actions: [] };
 export const [useAction, UpdateAction] = createStore(emptyBatch);
@@ -611,6 +616,8 @@ export const [useFrontendConfig, UpdateFrontendConfig] = createStore<FrontendCon
     },
     configReady: false,
 });
+
+export const useConfigReady = (): boolean => useFrontendConfig(({ configReady }) => configReady);
 
 export const useKuberpultVersion = (): string => useFrontendConfig((configs) => configs.configs.kuberpultVersion);
 export const useArgoCdBaseUrl = (): string | undefined =>


### PR DESCRIPTION
This renders a spinner (in the "pacman style") while loading data.

We differentiate between loading the configuration and the overview.

Examples for 'react-spinner': https://www.davidhu.io/react-spinners/

![Screenshot from 2023-08-07 16-17-03](https://github.com/freiheit-com/kuberpult/assets/3481382/1a07e713-4803-451e-9ca7-b77a11d89152)

