### PR TITLE
Allow ArgoCd to use Webhooks to improve performance

### DIFF
--- a/services/cd-service/pkg/argocd/render_test.go
+++ b/services/cd-service/pkg/argocd/render_test.go
@@ -39,6 +39,7 @@ func TestRender(t *testing.T) {
 kind: Application
 metadata:
   annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/dev/applications/app1/manifests
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: dev
     com.freiheit.kuberpult/team: ""
@@ -80,6 +81,7 @@ spec:
 kind: Application
 metadata:
   annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/dev/applications/app1/manifests
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: dev
     com.freiheit.kuberpult/team: ""
@@ -123,6 +125,7 @@ spec:
 kind: Application
 metadata:
   annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/dev/applications/app1/manifests
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: dev
     com.freiheit.kuberpult/team: ""
@@ -321,6 +324,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/test-env/applications/app1/manifests
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
     com.freiheit.kuberpult/team: ""
@@ -375,6 +379,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/test-env/applications/app1/manifests
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
     com.freiheit.kuberpult/team: ""
@@ -498,6 +503,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/test-env/applications/app1/manifests
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
     com.freiheit.kuberpult/team: some-team

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -442,6 +442,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/acceptance/applications/app1/manifests
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: acceptance
     com.freiheit.kuberpult/team: ""
@@ -481,6 +482,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/production/applications/app1/manifests
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: production
     com.freiheit.kuberpult/team: ""
@@ -542,6 +544,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/acceptance/applications/app1/manifests
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: acceptance
     com.freiheit.kuberpult/team: ""
@@ -2942,6 +2945,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/staging/applications/test/manifests
     com.freiheit.kuberpult/application: test
     com.freiheit.kuberpult/environment: staging
     com.freiheit.kuberpult/team: team1
@@ -2969,6 +2973,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/staging/applications/test2/manifests
     com.freiheit.kuberpult/application: test2
     com.freiheit.kuberpult/environment: staging
     com.freiheit.kuberpult/team: team2
@@ -3047,6 +3052,7 @@ kind: Application
 metadata:
   annotations:
     a: bar
+    argocd.argoproj.io/manifest-generate-paths: /environments/staging/applications/test/manifests
     b: foo
     com.freiheit.kuberpult/application: test
     com.freiheit.kuberpult/environment: staging
@@ -3133,6 +3139,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/staging/applications/test/manifests
     com.freiheit.kuberpult/application: test
     com.freiheit.kuberpult/environment: staging
     com.freiheit.kuberpult/team: ""


### PR DESCRIPTION
When having thousands of ArgoCd apps, it becomes problematic to sync the whole repository every n minutes (3 by default).

This PR introduces an annotation to tell ArgoCd: If there is a webhook incoming, compare the paths in the webhook with the paths in this annotation. ArgoCd then only needs to synchronize the files that are in that path. If not set, argoCd will synchronize every file in the whole manifest repo.

This change only has an effect, if there is a webhook configured from the git provider that triggers ArgoCd.