### PR TITLE
WIP Call ArgoCd app refresh

### DIFF
--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -293,6 +293,9 @@ argocd:
   token: "$token"
   server: "argocd-server.${ARGO_NAMESPACE}.svc.cluster.local"
   insecure: true
+  refresh:
+    enabled: true
+    token: "$token"
 pgp:
   keyRing: |
 $(sed -e "s/^/    /" <./kuberpult-keyring.gpg)

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -156,6 +156,12 @@ spec:
         - name: KUBERPULT_BOOTSTRAP_MODE
           value: "{{ .Values.environment_configs.bootstrap_mode }}"
 {{- end }}
+        - name: KUBERPULT_ARGO_SERVER_URL
+          value: "{{ .Values.argocd.server }}"
+        - name: KUBERPULT_ARGO_REFRESH_ENABLED
+          value: "{{ .Values.argocd.refresh }}"
+        - name: KUBERPULT_ARGO_REFRESH_TOKEN
+          value: "{{ .Values.argocd.token }}"
         - name: KUBERPULT_ENABLE_SQLITE
           value: "{{ .Values.cd.enableSqlite }}"
         volumeMounts:

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -97,6 +97,18 @@ argocd:
   server: ""
   # Disables tls verification. This is useful when running in the same cluster as argocd and using a self-signed certificate.
   insecure: false
+  refresh:
+    # Refresh is an beta feature as of now. It is only intended for massive amounts of apps (>~2k), when argoCd is struggling to keep up with syncing apps.
+    # When enabled, kuberpult will talk to argoCd and inform it to "refresh" (argoCd terminology) an app, whenever it changes.
+    # This is much more efficient than argoCd's way: By default argoCd checks every app with each new commit (after waiting for the `reconciliation.timeout`).
+    # When refresh is enabled, it is recommended to increase the reconciliation.timeout in argocd to reduce load, for example to "10m", or "0s" for `never`.
+    # See here https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/
+    # You must ensure that kuberpult can connect to argocd via `argocd.server`. This should be simple if argoCd and kuberpult run on the same cluster.
+    enabled: false
+    # The token is required if enabled=true.
+    # It must have the argocd capabilities "apiKey, login".
+    # Go to https://<kuberpulturl>/settings/accounts to create a token for a user
+    token: ""
 
 datadogTracing:
   enabled: false

--- a/services/cd-service/Dockerfile
+++ b/services/cd-service/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.18
 LABEL org.opencontainers.image.source https://github.com/freiheit-com/kuberpult
 RUN apk --update add ca-certificates tzdata libgit2 git sqlite-libs
+RUN wget https://github.com/argoproj/argo-cd/releases/download/v2.1.2/argocd-linux-amd64 -O /usr/local/bin/argocd && chmod +x /usr/local/bin/argocd
 ENV TZ=Europe/Berlin
 COPY gitconfig /etc/gitconfig
 COPY bin/main /

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -43,23 +43,26 @@ import (
 
 type Config struct {
 	// these will be mapped to "KUBERPULT_GIT_URL", etc.
-	GitUrl            string `required:"true" split_words:"true"`
-	GitBranch         string `default:"master" split_words:"true"`
-	BootstrapMode     bool   `default:"false" split_words:"true"`
-	GitCommitterEmail string `default:"kuberpult@freiheit.com" split_words:"true"`
-	GitCommitterName  string `default:"kuberpult" split_words:"true"`
-	GitSshKey         string `default:"/etc/ssh/identity" split_words:"true"`
-	GitSshKnownHosts  string `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
-	PgpKeyRing        string `split_words:"true"`
-	AzureEnableAuth   bool   `default:"false" split_words:"true"`
-	DexEnabled        bool   `default:"false" split_words:"true"`
-	DexRbacPolicy     string `split_words:"true"`
-	EnableTracing     bool   `default:"false" split_words:"true"`
-	EnableMetrics     bool   `default:"false" split_words:"true"`
-	DogstatsdAddr     string `default:"127.0.0.1:8125" split_words:"true"`
-	EnableSqlite      bool   `default:"true" split_words:"true"`
-	DexMock           bool   `default:"false" split_words:"true"`
-	DexMockRole       string `default:"Developer" split_words:"true"`
+	GitUrl             string `required:"true" split_words:"true"`
+	GitBranch          string `default:"master" split_words:"true"`
+	BootstrapMode      bool   `default:"false" split_words:"true"`
+	GitCommitterEmail  string `default:"kuberpult@freiheit.com" split_words:"true"`
+	GitCommitterName   string `default:"kuberpult" split_words:"true"`
+	GitSshKey          string `default:"/etc/ssh/identity" split_words:"true"`
+	GitSshKnownHosts   string `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
+	PgpKeyRing         string `split_words:"true"`
+	AzureEnableAuth    bool   `default:"false" split_words:"true"`
+	DexEnabled         bool   `default:"false" split_words:"true"`
+	DexRbacPolicy      string `split_words:"true"`
+	EnableTracing      bool   `default:"false" split_words:"true"`
+	EnableMetrics      bool   `default:"false" split_words:"true"`
+	DogstatsdAddr      string `default:"127.0.0.1:8125" split_words:"true"`
+	EnableSqlite       bool   `default:"true" split_words:"true"`
+	DexMock            bool   `default:"false" split_words:"true"`
+	DexMockRole        string `default:"Developer" split_words:"true"`
+	ArgoServerUrl      string `default:"" split_words:"true"`
+	ArgoRefreshEnabled bool   `default:"false" split_words:"true"`
+	ArgoRefreshToken   string `default:"" split_words:"true"`
 }
 
 func (c *Config) storageBackend() repository.StorageBackend {
@@ -157,6 +160,11 @@ func RunServer() {
 			BootstrapMode:          c.BootstrapMode,
 			EnvironmentConfigsPath: "./environment_configs.json",
 			StorageBackend:         c.storageBackend(),
+			ArgoCdRefreshConfig: repository.ArgoCdRefreshConfig{
+				Enabled: c.ArgoRefreshEnabled,
+				Token:   c.ArgoRefreshToken,
+				Server:  c.ArgoServerUrl,
+			},
 		})
 		if err != nil {
 			logger.FromContext(ctx).Fatal("repository.new.error", zap.Error(err), zap.String("git.url", c.GitUrl), zap.String("git.branch", c.GitBranch))


### PR DESCRIPTION
This feature is off by default.
It allows kuberpult to call argoCd directly to inform it that an app has changed. This is a performance improvement.
See values.yaml.tpl for further explanations.