### PR TITLE
Tell ArgoCd to sync apps

### DIFF
--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -274,7 +274,7 @@ frontend:
       cpu: 0.05
   tag: "${IMAGE_TAG_FRONTEND}"
 rollout:
-  enabled: true
+  enabled: false
   resources:
     limits:
       memory: 200Mi
@@ -319,7 +319,6 @@ waitForDeployment "default" "app=kuberpult-frontend-service"
 portForwardAndWait "default" "deployment/kuberpult-frontend-service" "8081" "8081"
 print "connection to frontend service successful"
 
-waitForDeployment "default" "app=kuberpult-rollout-service"
 
 
 

--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -184,14 +184,13 @@ helm repo add argo-cd https://argoproj.github.io/argo-helm
 
 helm uninstall argocd || echo "did not uninstall argo"
 cat <<YAML > argocd-values.yml
-timeout:
-  reconciliation: 0s
 configs:
   ssh:
     knownHosts: |
 $(sed -e "s/^/        /" <../../services/cd-service/known_hosts)
   cm:
     accounts.kuberpult: apiKey
+    timeout.reconciliation: 0s
   rbac:
     policy.csv: |
       p, role:kuberpult, applications, get, */*, allow
@@ -228,7 +227,7 @@ spec:
     server: https://kubernetes.default.svc
   project: test-env
   source:
-    path: ./argocd/v1alpha1
+    path: argocd/v1alpha1
     repoURL: ssh://git@server.${GIT_NAMESPACE}.svc.cluster.local/git/repos/manifests
     targetRevision: HEAD
   syncPolicy:
@@ -250,6 +249,7 @@ echo "argocd token: $token"
 
 kubectl create ns development
 kubectl create ns development2
+kubectl create ns staging
 
 ## kuberpult
 print 'installing kuberpult helm chart...'

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -111,6 +111,8 @@ spec:
           value: {{ .Values.log.level | quote }}
         - name: KUBERPULT_ARGO_CD_SERVER
           value: {{ .Values.argocd.server | quote }}
+        - name: KUBERPULT_ARGO_CD_INSECURE
+          value: {{ .Values.argocd.insecure | quote }}
 {{- if .Values.datadogTracing.enabled }}
         - name: DD_AGENT_HOST
           valueFrom:

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -109,6 +109,8 @@ spec:
           value: {{ .Values.log.format | quote }}
         - name: LOG_LEVEL
           value: {{ .Values.log.level | quote }}
+        - name: KUBERPULT_ARGO_CD_SERVER
+          value: {{ .Values.argocd.server | quote }}
 {{- if .Values.datadogTracing.enabled }}
         - name: DD_AGENT_HOST
           valueFrom:

--- a/infrastructure/scripts/create-testdata/create-release.sh
+++ b/infrastructure/scripts/create-testdata/create-release.sh
@@ -67,7 +67,7 @@ cat <<EOF > "${file}"
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "$name"-dummy-config-map
+  name: $name-dummy-config-map
   namespace: "$env"
 data:
   key: value

--- a/infrastructure/scripts/create-testdata/create-release.sh
+++ b/infrastructure/scripts/create-testdata/create-release.sh
@@ -61,15 +61,17 @@ for env in development development2 staging fakeprod-de fakeprod-ca
 do
   file=$(mktemp "${TMPDIR:-/tmp}/$env.XXXXXX")
   signatureFile=$(mktemp "${TMPDIR:-/tmp}/$env.XXXXXX")
+  randomValue=$(LC_CTYPE=C tr -dc a-f0-9 </dev/urandom | head -c 12 ; echo '')
 cat <<EOF > "${file}"
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dummy-config-map
+  name: "$name"-dummy-config-map
   namespace: "$env"
 data:
   key: value
+  random: "${randomValue}"
 ---
 EOF
   echo "wrote file ${file}"

--- a/services/cd-service/pkg/argocd/v1alpha1/types.go
+++ b/services/cd-service/pkg/argocd/v1alpha1/types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
 )
 
 type SyncOptions []string
@@ -161,4 +162,186 @@ type ResourceIgnoreDifferences struct {
 	JSONPointers          []string `json:"jsonPointers,omitempty" protobuf:"bytes,5,opt,name=jsonPointers"`
 	JqPathExpressions     []string `json:"jqPathExpressions,omitempty" protobuf:"bytes,6,opt,name=jqPathExpressions"`
 	ManagedFieldsManagers []string `json:"managedFieldsManagers,omitempty" protobuf:"bytes,7,opt,name=managedFieldsManagers"`
+}
+
+// Types for Git Webhooks
+
+type Repository struct {
+	ID       int64  `json:"id"`
+	NodeID   string `json:"node_id"`
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	Owner    struct {
+		Login             string `json:"login"`
+		ID                int64  `json:"id"`
+		NodeID            string `json:"node_id"`
+		AvatarURL         string `json:"avatar_url"`
+		GravatarID        string `json:"gravatar_id"`
+		URL               string `json:"url"`
+		HTMLURL           string `json:"html_url"`
+		FollowersURL      string `json:"followers_url"`
+		FollowingURL      string `json:"following_url"`
+		GistsURL          string `json:"gists_url"`
+		StarredURL        string `json:"starred_url"`
+		SubscriptionsURL  string `json:"subscriptions_url"`
+		OrganizationsURL  string `json:"organizations_url"`
+		ReposURL          string `json:"repos_url"`
+		EventsURL         string `json:"events_url"`
+		ReceivedEventsURL string `json:"received_events_url"`
+		Type              string `json:"type"`
+		SiteAdmin         bool   `json:"site_admin"`
+	} `json:"owner"`
+	Private          bool      `json:"private"`
+	HTMLURL          string    `json:"html_url"`
+	Description      string    `json:"description"`
+	Fork             bool      `json:"fork"`
+	URL              string    `json:"url"`
+	ForksURL         string    `json:"forks_url"`
+	KeysURL          string    `json:"keys_url"`
+	CollaboratorsURL string    `json:"collaborators_url"`
+	TeamsURL         string    `json:"teams_url"`
+	HooksURL         string    `json:"hooks_url"`
+	IssueEventsURL   string    `json:"issue_events_url"`
+	EventsURL        string    `json:"events_url"`
+	AssigneesURL     string    `json:"assignees_url"`
+	BranchesURL      string    `json:"branches_url"`
+	TagsURL          string    `json:"tags_url"`
+	BlobsURL         string    `json:"blobs_url"`
+	GitTagsURL       string    `json:"git_tags_url"`
+	GitRefsURL       string    `json:"git_refs_url"`
+	TreesURL         string    `json:"trees_url"`
+	StatusesURL      string    `json:"statuses_url"`
+	LanguagesURL     string    `json:"languages_url"`
+	StargazersURL    string    `json:"stargazers_url"`
+	ContributorsURL  string    `json:"contributors_url"`
+	SubscribersURL   string    `json:"subscribers_url"`
+	SubscriptionURL  string    `json:"subscription_url"`
+	CommitsURL       string    `json:"commits_url"`
+	GitCommitsURL    string    `json:"git_commits_url"`
+	CommentsURL      string    `json:"comments_url"`
+	IssueCommentURL  string    `json:"issue_comment_url"`
+	ContentsURL      string    `json:"contents_url"`
+	CompareURL       string    `json:"compare_url"`
+	MergesURL        string    `json:"merges_url"`
+	ArchiveURL       string    `json:"archive_url"`
+	DownloadsURL     string    `json:"downloads_url"`
+	IssuesURL        string    `json:"issues_url"`
+	PullsURL         string    `json:"pulls_url"`
+	MilestonesURL    string    `json:"milestones_url"`
+	NotificationsURL string    `json:"notifications_url"`
+	LabelsURL        string    `json:"labels_url"`
+	ReleasesURL      string    `json:"releases_url"`
+	CreatedAt        int64     `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	PushedAt         int64     `json:"pushed_at"`
+	GitURL           string    `json:"git_url"`
+	SSHURL           string    `json:"ssh_url"`
+	CloneURL         string    `json:"clone_url"`
+	SvnURL           string    `json:"svn_url"`
+	Homepage         *string   `json:"homepage"`
+	Size             int64     `json:"size"`
+	StargazersCount  int64     `json:"stargazers_count"`
+	WatchersCount    int64     `json:"watchers_count"`
+	Language         *string   `json:"language"`
+	HasIssues        bool      `json:"has_issues"`
+	HasDownloads     bool      `json:"has_downloads"`
+	HasWiki          bool      `json:"has_wiki"`
+	HasPages         bool      `json:"has_pages"`
+	ForksCount       int64     `json:"forks_count"`
+	MirrorURL        *string   `json:"mirror_url"`
+	OpenIssuesCount  int64     `json:"open_issues_count"`
+	Forks            int64     `json:"forks"`
+	OpenIssues       int64     `json:"open_issues"`
+	Watchers         int64     `json:"watchers"`
+	DefaultBranch    string    `json:"default_branch"`
+	Stargazers       int64     `json:"stargazers"`
+	MasterBranch     string    `json:"master_branch"`
+}
+
+// PushPayload was copied from argoCd's payload.go, to ensure we use the same format
+// PushPayload contains the information for GitHub's push hook event
+type PushPayload struct {
+	Ref        string   `json:"ref"`
+	Before     string   `json:"before"`
+	After      string   `json:"after"`
+	Created    bool     `json:"created"`
+	Deleted    bool     `json:"deleted"`
+	Forced     bool     `json:"forced"`
+	BaseRef    *string  `json:"base_ref"`
+	Compare    string   `json:"compare"`
+	Commits    []Commit `json:"commits"`
+	HeadCommit struct {
+		ID        string `json:"id"`
+		NodeID    string `json:"node_id"`
+		TreeID    string `json:"tree_id"`
+		Distinct  bool   `json:"distinct"`
+		Message   string `json:"message"`
+		Timestamp string `json:"timestamp"`
+		URL       string `json:"url"`
+		Author    struct {
+			Name     string `json:"name"`
+			Email    string `json:"email"`
+			Username string `json:"username"`
+		} `json:"author"`
+		Committer struct {
+			Name     string `json:"name"`
+			Email    string `json:"email"`
+			Username string `json:"username"`
+		} `json:"committer"`
+		Added    []string `json:"added"`
+		Removed  []string `json:"removed"`
+		Modified []string `json:"modified"`
+	} `json:"head_commit"`
+	Repository Repository `json:"repository"`
+	Pusher     struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	} `json:"pusher"`
+	Sender struct {
+		Login             string `json:"login"`
+		ID                int64  `json:"id"`
+		NodeID            string `json:"node_id"`
+		AvatarURL         string `json:"avatar_url"`
+		GravatarID        string `json:"gravatar_id"`
+		URL               string `json:"url"`
+		HTMLURL           string `json:"html_url"`
+		FollowersURL      string `json:"followers_url"`
+		FollowingURL      string `json:"following_url"`
+		GistsURL          string `json:"gists_url"`
+		StarredURL        string `json:"starred_url"`
+		SubscriptionsURL  string `json:"subscriptions_url"`
+		OrganizationsURL  string `json:"organizations_url"`
+		ReposURL          string `json:"repos_url"`
+		EventsURL         string `json:"events_url"`
+		ReceivedEventsURL string `json:"received_events_url"`
+		Type              string `json:"type"`
+		SiteAdmin         bool   `json:"site_admin"`
+	} `json:"sender"`
+	Installation struct {
+		ID int `json:"id"`
+	} `json:"installation"`
+}
+
+type Commit struct {
+	Sha       string `json:"sha"`
+	ID        string `json:"id"`
+	NodeID    string `json:"node_id"`
+	TreeID    string `json:"tree_id"`
+	Distinct  bool   `json:"distinct"`
+	Message   string `json:"message"`
+	Timestamp string `json:"timestamp"`
+	URL       string `json:"url"`
+	Author    struct {
+		Name     string `json:"name"`
+		Email    string `json:"email"`
+		Username string `json:"username"`
+	} `json:"author"`
+	Committer struct {
+		Name     string `json:"name"`
+		Email    string `json:"email"`
+		Username string `json:"username"`
+	} `json:"committer"`
+	Added    []string `json:"added"`
+	Removed  []string `json:"removed"`
+	Modified []string `json:"modified"`
 }

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -157,6 +157,7 @@ func RunServer() {
 			BootstrapMode:          c.BootstrapMode,
 			EnvironmentConfigsPath: "./environment_configs.json",
 			StorageBackend:         c.storageBackend(),
+			ArgoWebhookUrl:         "example.com", // TODO SU
 		})
 		if err != nil {
 			logger.FromContext(ctx).Fatal("repository.new.error", zap.Error(err), zap.String("git.url", c.GitUrl), zap.String("git.branch", c.GitBranch))

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -61,6 +61,7 @@ type Config struct {
 	DexMock           bool   `default:"false" split_words:"true"`
 	DexMockRole       string `default:"Developer" split_words:"true"`
 	ArgoCdServer      string `default:"" split_words:"true"`
+	ArgoCdInsecure    bool   `default:"false" split_words:"true"`
 }
 
 func (c *Config) storageBackend() repository.StorageBackend {
@@ -158,6 +159,7 @@ func RunServer() {
 			BootstrapMode:          c.BootstrapMode,
 			EnvironmentConfigsPath: "./environment_configs.json",
 			StorageBackend:         c.storageBackend(),
+			ArgoInsecure:           c.ArgoCdInsecure,
 			ArgoWebhookUrl:         c.ArgoCdServer,
 		})
 		if err != nil {

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -60,6 +60,7 @@ type Config struct {
 	EnableSqlite      bool   `default:"true" split_words:"true"`
 	DexMock           bool   `default:"false" split_words:"true"`
 	DexMockRole       string `default:"Developer" split_words:"true"`
+	ArgoCdServer      string `default:"" split_words:"true"`
 }
 
 func (c *Config) storageBackend() repository.StorageBackend {
@@ -157,7 +158,7 @@ func RunServer() {
 			BootstrapMode:          c.BootstrapMode,
 			EnvironmentConfigsPath: "./environment_configs.json",
 			StorageBackend:         c.storageBackend(),
-			ArgoWebhookUrl:         "example.com", // TODO SU
+			ArgoWebhookUrl:         c.ArgoCdServer,
 		})
 		if err != nil {
 			logger.FromContext(ctx).Fatal("repository.new.error", zap.Error(err), zap.String("git.url", c.GitUrl), zap.String("git.branch", c.GitBranch))

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -442,19 +442,22 @@ func (r *repository) ProcessQueueOnce(ctx context.Context, e element, callback P
 		logger.Warn(fmt.Sprintf("ArgoWebhookUrl: parent: %s", parentCommit.Id()))
 
 		argoResult := ArgoWebhookData{
-			webURLs:  []string{"https://github.com/freiheit-com"},
+			htmlUrl:  []string{"https://github.com/freiheit-com"},
 			revision: "refs/heads/" + r.config.Branch,
 			change: changeInfo{
-				shaBefore: headStr,
-				shaAfter:  parentCommit.Id().String(),
+				payloadBefore: headStr,
+				payloadAfter:  parentCommit.Id().String(),
 			},
 			defaultBranch: r.config.Branch, // this is questionable, but maybe ok
 			Commits: []commit{
 				// TODO
+				// Because we are in ProcessQueueOnce there can only be 1 commit (but multiple files)
 				{
-					Added:    nil,
-					Modified: nil,
-					Removed:  nil,
+					Added: nil,
+					Modified: []string{
+						"",
+					},
+					Removed: nil,
 				},
 			},
 		}
@@ -465,8 +468,8 @@ func (r *repository) ProcessQueueOnce(ctx context.Context, e element, callback P
 }
 
 type changeInfo struct {
-	shaBefore string
-	shaAfter  string
+	payloadBefore string
+	payloadAfter  string
 }
 type commit struct {
 	Added    []string
@@ -475,8 +478,8 @@ type commit struct {
 }
 
 type ArgoWebhookData struct {
-	webURLs       []string
-	revision      string
+	htmlUrl       []string
+	revision      string // aka "ref"
 	change        changeInfo
 	defaultBranch string
 	Commits       []commit

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -868,21 +868,21 @@ type SlowTransformer struct {
 	started  chan struct{}
 }
 
-func (s *SlowTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
+func (s *SlowTransformer) Transform(ctx context.Context, state *State) (string, *TransformerResult, error) {
 	s.started <- struct{}{}
 	<-s.finished
-	return "ok", nil, &TransformerResult{}
+	return "ok", &TransformerResult{}, nil
 }
 
 type EmptyTransformer struct{}
 
-func (p *EmptyTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
-	return "nothing happened", nil, &TransformerResult{}
+func (p *EmptyTransformer) Transform(ctx context.Context, state *State) (string, *TransformerResult, error) {
+	return "nothing happened", &TransformerResult{}, nil
 }
 
 type PanicTransformer struct{}
 
-func (p *PanicTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
+func (p *PanicTransformer) Transform(ctx context.Context, state *State) (string, *TransformerResult, error) {
 	panic("panic tranformer")
 }
 
@@ -890,14 +890,14 @@ var TransformerError = errors.New("error transformer")
 
 type ErrorTransformer struct{}
 
-func (p *ErrorTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
-	return "error", TransformerError, nil
+func (p *ErrorTransformer) Transform(ctx context.Context, state *State) (string, *TransformerResult, error) {
+	return "error", nil, TransformerError
 }
 
 type InvalidJsonTransformer struct{}
 
-func (p *InvalidJsonTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
-	return "error", invalidJson, nil
+func (p *InvalidJsonTransformer) Transform(ctx context.Context, state *State) (string, *TransformerResult, error) {
+	return "error", nil, invalidJson
 }
 
 func convertToSet(list []uint64) map[int]bool {

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -868,21 +868,21 @@ type SlowTransformer struct {
 	started  chan struct{}
 }
 
-func (s *SlowTransformer) Transform(ctx context.Context, state *State) (string, error) {
+func (s *SlowTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	s.started <- struct{}{}
 	<-s.finished
-	return "ok", nil
+	return "ok", nil, changes
 }
 
 type EmptyTransformer struct{}
 
-func (p *EmptyTransformer) Transform(ctx context.Context, state *State) (string, error) {
-	return "nothing happened", nil
+func (p *EmptyTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
+	return "nothing happened", nil, changes
 }
 
 type PanicTransformer struct{}
 
-func (p *PanicTransformer) Transform(ctx context.Context, state *State) (string, error) {
+func (p *PanicTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	panic("panic tranformer")
 }
 
@@ -890,14 +890,14 @@ var TransformerError = errors.New("error transformer")
 
 type ErrorTransformer struct{}
 
-func (p *ErrorTransformer) Transform(ctx context.Context, state *State) (string, error) {
-	return "error", TransformerError
+func (p *ErrorTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
+	return "error", TransformerError, changes
 }
 
 type InvalidJsonTransformer struct{}
 
-func (p *InvalidJsonTransformer) Transform(ctx context.Context, state *State) (string, error) {
-	return "error", invalidJson
+func (p *InvalidJsonTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
+	return "error", invalidJson, changes
 }
 
 func convertToSet(list []uint64) map[int]bool {

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -871,13 +871,13 @@ type SlowTransformer struct {
 func (s *SlowTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	s.started <- struct{}{}
 	<-s.finished
-	return "ok", nil, changes
+	return "ok", nil, &TransformerResult{}
 }
 
 type EmptyTransformer struct{}
 
 func (p *EmptyTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
-	return "nothing happened", nil, changes
+	return "nothing happened", nil, &TransformerResult{}
 }
 
 type PanicTransformer struct{}
@@ -891,13 +891,13 @@ var TransformerError = errors.New("error transformer")
 type ErrorTransformer struct{}
 
 func (p *ErrorTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
-	return "error", TransformerError, changes
+	return "error", TransformerError, nil
 }
 
 type InvalidJsonTransformer struct{}
 
 func (p *InvalidJsonTransformer) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
-	return "error", invalidJson, changes
+	return "error", invalidJson, nil
 }
 
 func convertToSet(list []uint64) map[int]bool {

--- a/services/cd-service/pkg/repository/testrepository/testrepository.go
+++ b/services/cd-service/pkg/repository/testrepository/testrepository.go
@@ -41,7 +41,7 @@ func (fr *failingRepository) Push(ctx context.Context, pushAction func() error) 
 	return fr.err
 }
 
-func (fr *failingRepository) ApplyTransformersInternal(ctx context.Context, transformers ...repository.Transformer) ([]string, *repository.State, error, *repository.TransformerResult) {
+func (fr *failingRepository) ApplyTransformersInternal(ctx context.Context, transformers ...repository.Transformer) ([]string, *repository.State, error, []*repository.TransformerResult) {
 	return nil, nil, fr.err, nil
 }
 

--- a/services/cd-service/pkg/repository/testrepository/testrepository.go
+++ b/services/cd-service/pkg/repository/testrepository/testrepository.go
@@ -41,8 +41,8 @@ func (fr *failingRepository) Push(ctx context.Context, pushAction func() error) 
 	return fr.err
 }
 
-func (fr *failingRepository) ApplyTransformersInternal(ctx context.Context, transformers ...repository.Transformer) ([]string, *repository.State, error) {
-	return nil, nil, fr.err
+func (fr *failingRepository) ApplyTransformersInternal(ctx context.Context, transformers ...repository.Transformer) ([]string, *repository.State, error, *repository.TransformerResult) {
+	return nil, nil, fr.err, nil
 }
 
 func (fr *failingRepository) State() *repository.State {

--- a/services/cd-service/pkg/repository/testrepository/testrepository.go
+++ b/services/cd-service/pkg/repository/testrepository/testrepository.go
@@ -41,8 +41,8 @@ func (fr *failingRepository) Push(ctx context.Context, pushAction func() error) 
 	return fr.err
 }
 
-func (fr *failingRepository) ApplyTransformersInternal(ctx context.Context, transformers ...repository.Transformer) ([]string, *repository.State, error, []*repository.TransformerResult) {
-	return nil, nil, fr.err, nil
+func (fr *failingRepository) ApplyTransformersInternal(ctx context.Context, transformers ...repository.Transformer) ([]string, *repository.State, []*repository.TransformerResult, error) {
+	return nil, nil, nil, fr.err
 }
 
 func (fr *failingRepository) State() *repository.State {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -538,7 +538,14 @@ func (u *DeleteEnvFromApp) Transform(ctx context.Context, state *State) (string,
 		return "", wrapFileError(err, envAppDir, thisSprintf("Cannot delete app.'")), nil
 	}
 
-	changes := &TransformerResult{} // TODO implement
+	changes := &TransformerResult{
+		ChangedApps: []AppEnv{
+			{
+				App: u.Application,
+				Env: u.Environment,
+			},
+		},
+	}
 	return fmt.Sprintf("Environment '%v' was removed from application '%v' successfully.", u.Environment, u.Application), nil, changes
 }
 

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
 	"io"
 	"io/fs"
 	"os"
@@ -149,12 +150,12 @@ func GetRepositoryStateAndUpdateMetrics(repo Repository) {
 
 // A Transformer updates the files in the worktree
 type Transformer interface {
-	Transform(context.Context, *State) (commitMsg string, e error)
+	Transform(context.Context, *State) (commitMsg string, e error, changes *TransformerResult)
 }
 
-type TransformerFunc func(context.Context, *State) (string, error)
+type TransformerFunc func(context.Context, *State) (string, error, *TransformerResult)
 
-func (t TransformerFunc) Transform(ctx context.Context, state *State) (string, error) {
+func (t TransformerFunc) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	return (t)(ctx, state)
 }
 
@@ -194,76 +195,77 @@ func GetLastRelease(fs billy.Filesystem, application string) (uint64, error) {
 	}
 }
 
-func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) (string, error) {
+func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	fs := state.Filesystem
 	version, err := c.calculateVersion(fs)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	if !valid.ApplicationName(c.Application) {
-		return "", grpc.PublicError(ctx, fmt.Errorf("invalid application name: '%s' - must match regexp '%s' and <= %d characters", c.Application, valid.AppNameRegExp, valid.MaxAppNameLen))
+		return "", grpc.PublicError(ctx, fmt.Errorf("invalid application name: '%s' - must match regexp '%s' and <= %d characters", c.Application, valid.AppNameRegExp, valid.MaxAppNameLen)), nil
 	}
 	releaseDir := releasesDirectoryWithVersion(fs, c.Application, version)
 	appDir := applicationDirectory(fs, c.Application)
 	if err = fs.MkdirAll(releaseDir, 0777); err != nil {
-		return "", err
+		return "", err, nil
 	}
 
 	configs, err := state.GetEnvironmentConfigs()
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 
 	if c.SourceCommitId != "" {
 		if err := util.WriteFile(fs, fs.Join(releaseDir, "source_commit_id"), []byte(c.SourceCommitId), 0666); err != nil {
-			return "", err
+			return "", err, nil
 		}
 	}
 	if c.SourceAuthor != "" {
 		if err := util.WriteFile(fs, fs.Join(releaseDir, "source_author"), []byte(c.SourceAuthor), 0666); err != nil {
-			return "", err
+			return "", err, nil
 		}
 	}
 	if c.SourceMessage != "" {
 		if err := util.WriteFile(fs, fs.Join(releaseDir, "source_message"), []byte(c.SourceMessage), 0666); err != nil {
-			return "", err
+			return "", err, nil
 		}
 	}
 	if err := util.WriteFile(fs, fs.Join(releaseDir, "created_at"), []byte(getTimeNow(ctx).Format(time.RFC3339)), 0666); err != nil {
-		return "", err
+		return "", err, nil
 	}
 	if c.Team != "" {
 		if err := util.WriteFile(fs, fs.Join(appDir, "team"), []byte(c.Team), 0666); err != nil {
-			return "", err
+			return "", err, nil
 		}
 	}
 	if c.SourceRepoUrl != "" {
 		if err := util.WriteFile(fs, fs.Join(appDir, "sourceRepoUrl"), []byte(c.SourceRepoUrl), 0666); err != nil {
-			return "", err
+			return "", err, nil
 		}
 	}
 	result := ""
 	isLatest, err := isLatestsVersion(state, c.Application, version)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	if !isLatest {
 		// check that we can actually backfill this version
 		oldVersions, err := findOldApplicationVersions(state, c.Application)
 		if err != nil {
-			return "", err
+			return "", err, nil
 		}
 		for _, oldVersion := range oldVersions {
 			if version == oldVersion {
-				return "", ErrReleaseTooOld
+				return "", ErrReleaseTooOld, nil
 			}
 		}
 	}
 
+	changes := &TransformerResult{}
 	for env, man := range c.Manifests {
 		err := state.checkUserPermissions(ctx, env, c.Application, auth.PermissionCreateRelease, c.RBACConfig)
 		if err != nil {
-			return "", err
+			return "", err, nil
 		}
 		envDir := fs.Join(releaseDir, "environments", env)
 
@@ -274,11 +276,12 @@ func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) 
 		}
 
 		if err = fs.MkdirAll(envDir, 0777); err != nil {
-			return "", err
+			return "", err, nil
 		}
 		if err := util.WriteFile(fs, fs.Join(envDir, "manifests.yaml"), []byte(man), 0666); err != nil {
-			return "", err
+			return "", err, nil
 		}
+		changes.AddAppEnv(c.Application, env)
 		if hasUpstream && config.Upstream.Latest && isLatest {
 			d := &DeployApplicationVersion{
 				Environment:    env,
@@ -287,19 +290,20 @@ func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) 
 				LockBehaviour:  api.LockBehavior_Record,
 				Authentication: c.Authentication,
 			}
-			deployResult, err := d.Transform(ctx, state)
+			deployResult, err, subChanges := d.Transform(ctx, state)
+			changes.Combine(subChanges)
 			if err != nil {
 				_, ok := err.(*LockedError)
 				if ok {
 					continue // LockedErrors are expected
 				} else {
-					return "", err
+					return "", err, nil
 				}
 			}
 			result = result + deployResult + "\n"
 		}
 	}
-	return fmt.Sprintf("created version %d of %q\n%s", version, c.Application, result), nil
+	return fmt.Sprintf("created version %d of %q\n%s", version, c.Application, result), nil, changes
 }
 
 func (c *CreateApplicationVersion) calculateVersion(bfs billy.Filesystem) (uint64, error) {
@@ -343,37 +347,38 @@ type CreateUndeployApplicationVersion struct {
 	Application string
 }
 
-func (c *CreateUndeployApplicationVersion) Transform(ctx context.Context, state *State) (string, error) {
+func (c *CreateUndeployApplicationVersion) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	fs := state.Filesystem
 	lastRelease, err := GetLastRelease(fs, c.Application)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
+	changes := &TransformerResult{}
 	if lastRelease == 0 {
-		return "", fmt.Errorf("cannot undeploy non-existing application '%v'", c.Application)
+		return "", fmt.Errorf("cannot undeploy non-existing application '%v'", c.Application), nil
 	}
 
 	releaseDir := releasesDirectoryWithVersion(fs, c.Application, lastRelease+1)
 	if err = fs.MkdirAll(releaseDir, 0777); err != nil {
-		return "", err
+		return "", err, nil
 	}
 
 	configs, err := state.GetEnvironmentConfigs()
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	// this is a flag to indicate that this is the special "undeploy" version
 	if err := util.WriteFile(fs, fs.Join(releaseDir, "undeploy"), []byte(""), 0666); err != nil {
-		return "", err
+		return "", err, nil
 	}
 	if err := util.WriteFile(fs, fs.Join(releaseDir, "created_at"), []byte(getTimeNow(ctx).Format(time.RFC3339)), 0666); err != nil {
-		return "", err
+		return "", err, nil
 	}
 	result := ""
 	for env := range configs {
 		err := state.checkUserPermissions(ctx, env, c.Application, auth.PermissionCreateUndeploy, c.RBACConfig)
 		if err != nil {
-			return "", err
+			return "", err, nil
 		}
 		envDir := fs.Join(releaseDir, "environments", env)
 
@@ -384,15 +389,16 @@ func (c *CreateUndeployApplicationVersion) Transform(ctx context.Context, state 
 		}
 
 		if err = fs.MkdirAll(envDir, 0777); err != nil {
-			return "", err
+			return "", err, nil
 		}
 		// note that the manifest is empty here!
 		// but actually it's not quite empty!
 		// The function we are using in DeployApplication version is `util.WriteFile`. And that does not allow overwriting files with empty content.
 		// We work around this unusual behavior by writing a space into the file
 		if err := util.WriteFile(fs, fs.Join(envDir, "manifests.yaml"), []byte(" "), 0666); err != nil {
-			return "", err
+			return "", err, nil
 		}
+		changes.AddAppEnv(c.Application, env)
 		if hasUpstream && config.Upstream.Latest {
 			d := &DeployApplicationVersion{
 				Environment: env,
@@ -402,19 +408,20 @@ func (c *CreateUndeployApplicationVersion) Transform(ctx context.Context, state 
 				LockBehaviour:  api.LockBehavior_Record,
 				Authentication: c.Authentication,
 			}
-			deployResult, err := d.Transform(ctx, state)
+			deployResult, err, subChanges := d.Transform(ctx, state)
+			changes.Combine(subChanges)
 			if err != nil {
 				_, ok := err.(*LockedError)
 				if ok {
 					continue // locked error are expected
 				} else {
-					return "", err
+					return "", err, nil
 				}
 			}
 			result = result + deployResult + "\n"
 		}
 	}
-	return fmt.Sprintf("created undeploy-version %d of '%v'\n%s", lastRelease+1, c.Application, result), nil
+	return fmt.Sprintf("created undeploy-version %d of '%v'\n%s", lastRelease+1, c.Application, result), nil, changes
 }
 
 type UndeployApplication struct {
@@ -422,33 +429,33 @@ type UndeployApplication struct {
 	Application string
 }
 
-func (u *UndeployApplication) Transform(ctx context.Context, state *State) (string, error) {
+func (u *UndeployApplication) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	fs := state.Filesystem
 	lastRelease, err := GetLastRelease(fs, u.Application)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	if lastRelease == 0 {
-		return "", fmt.Errorf("UndeployApplication: error cannot undeploy non-existing application '%v'", u.Application)
+		return "", fmt.Errorf("UndeployApplication: error cannot undeploy non-existing application '%v'", u.Application), nil
 	}
 	isUndeploy, err := state.IsUndeployVersion(u.Application, lastRelease)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	if !isUndeploy {
-		return "", fmt.Errorf("UndeployApplication: error last release is not un-deployed application version of '%v'", u.Application)
+		return "", fmt.Errorf("UndeployApplication: error last release is not un-deployed application version of '%v'", u.Application), nil
 	}
 	appDir := applicationDirectory(fs, u.Application)
 	configs, err := state.GetEnvironmentConfigs()
 	for env := range configs {
 		err := state.checkUserPermissions(ctx, env, u.Application, auth.PermissionDeployUndeploy, u.RBACConfig)
 		if err != nil {
-			return "", err
+			return "", err, nil
 		}
 		envAppDir := environmentApplicationDirectory(fs, env, u.Application)
 		entries, err := fs.ReadDir(envAppDir)
 		if err != nil {
-			return "", wrapFileError(err, envAppDir, "UndeployApplication: Could not open application directory. Does the app exist?")
+			return "", wrapFileError(err, envAppDir, "UndeployApplication: Could not open application directory. Does the app exist?"), nil
 		}
 		if entries == nil {
 			// app was never deployed on this env, so we must ignore it!
@@ -458,7 +465,7 @@ func (u *UndeployApplication) Transform(ctx context.Context, state *State) (stri
 		appLocksDir := fs.Join(envAppDir, "locks")
 		err = fs.Remove(appLocksDir)
 		if err != nil {
-			return "", fmt.Errorf("UndeployApplication: cannot delete app locks '%v'", appLocksDir)
+			return "", fmt.Errorf("UndeployApplication: cannot delete app locks '%v'", appLocksDir), nil
 		}
 
 		versionDir := fs.Join(envAppDir, "version")
@@ -472,22 +479,23 @@ func (u *UndeployApplication) Transform(ctx context.Context, state *State) (stri
 
 		_, err = fs.Stat(undeployFile)
 		if err != nil && errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("UndeployApplication: error cannot un-deploy application '%v' the release '%v' is not un-deployed: '%v'", u.Application, env, undeployFile)
+			return "", fmt.Errorf("UndeployApplication: error cannot un-deploy application '%v' the release '%v' is not un-deployed: '%v'", u.Application, env, undeployFile), nil
 		}
 
 	}
 	// remove application
 	if err = fs.Remove(appDir); err != nil {
-		return "", err
+		return "", err, nil
 	}
 	for env := range configs {
 		appDir := environmentApplicationDirectory(fs, env, u.Application)
 		// remove environment application
 		if err := fs.Remove(appDir); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("UndeployApplication: unexpected error application '%v' environment '%v': '%w'", u.Application, env, err)
+			return "", fmt.Errorf("UndeployApplication: unexpected error application '%v' environment '%v': '%w'", u.Application, env, err), nil
 		}
 	}
-	return fmt.Sprintf("application '%v' was deleted successfully", u.Application), nil
+	changes := &TransformerResult{} // TODO implement
+	return fmt.Sprintf("application '%v' was deleted successfully", u.Application), nil, changes
 }
 
 type DeleteEnvFromApp struct {
@@ -496,10 +504,10 @@ type DeleteEnvFromApp struct {
 	Environment string
 }
 
-func (u *DeleteEnvFromApp) Transform(ctx context.Context, state *State) (string, error) {
+func (u *DeleteEnvFromApp) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	err := state.checkUserPermissions(ctx, u.Environment, u.Application, auth.PermissionDeleteEnvironmentApplication, u.RBACConfig)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	fs := state.Filesystem
 	thisSprintf := func(format string, a ...any) string {
@@ -507,30 +515,31 @@ func (u *DeleteEnvFromApp) Transform(ctx context.Context, state *State) (string,
 	}
 
 	if u.Application == "" {
-		return "", fmt.Errorf(thisSprintf("Need to provide the application"))
+		return "", fmt.Errorf(thisSprintf("Need to provide the application")), nil
 	}
 
 	if u.Environment == "" {
-		return "", fmt.Errorf(thisSprintf("Need to provide the environment"))
+		return "", fmt.Errorf(thisSprintf("Need to provide the environment")), nil
 	}
 
 	envAppDir := environmentApplicationDirectory(fs, u.Environment, u.Application)
 	entries, err := fs.ReadDir(envAppDir)
 	if err != nil {
-		return "", wrapFileError(err, envAppDir, thisSprintf("Could not open application directory. Does the app exist?"))
+		return "", wrapFileError(err, envAppDir, thisSprintf("Could not open application directory. Does the app exist?")), nil
 	}
 
 	if entries == nil {
 		// app was never deployed on this env, so that's unusual - but for idempotency we treat it just like a success case:
-		return fmt.Sprintf("Attempted to remove environment '%v' from application '%v' but it did not exist.", u.Environment, u.Application), nil
+		return fmt.Sprintf("Attempted to remove environment '%v' from application '%v' but it did not exist.", u.Environment, u.Application), nil, nil
 	}
 
 	err = fs.Remove(envAppDir)
 	if err != nil {
-		return "", wrapFileError(err, envAppDir, thisSprintf("Cannot delete app.'"))
+		return "", wrapFileError(err, envAppDir, thisSprintf("Cannot delete app.'")), nil
 	}
 
-	return fmt.Sprintf("Environment '%v' was removed from application '%v' successfully.", u.Environment, u.Application), nil
+	changes := &TransformerResult{} // TODO implement
+	return fmt.Sprintf("Environment '%v' was removed from application '%v' successfully.", u.Environment, u.Application), nil, changes
 }
 
 type CleanupOldApplicationVersions struct {
@@ -577,11 +586,11 @@ func findOldApplicationVersions(state *State, name string) ([]uint64, error) {
 	return versions[0 : positionOfOldestVersion-(keptVersionsOnCleanup-1)], err
 }
 
-func (c *CleanupOldApplicationVersions) Transform(ctx context.Context, state *State) (string, error) {
+func (c *CleanupOldApplicationVersions) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	fs := state.Filesystem
 	oldVersions, err := findOldApplicationVersions(state, c.Application)
 	if err != nil {
-		return "", fmt.Errorf("cleanup: could not get application releases for app '%s': %w", c.Application, err)
+		return "", fmt.Errorf("cleanup: could not get application releases for app '%s': %w", c.Application, err), nil
 	}
 
 	msg := ""
@@ -590,16 +599,17 @@ func (c *CleanupOldApplicationVersions) Transform(ctx context.Context, state *St
 		releasesDir := releasesDirectoryWithVersion(fs, c.Application, oldRelease)
 		_, err := fs.Stat(releasesDir)
 		if err != nil {
-			return "", wrapFileError(err, releasesDir, "CleanupOldApplicationVersions: could not stat")
+			return "", wrapFileError(err, releasesDir, "CleanupOldApplicationVersions: could not stat"), nil
 		}
 		err = fs.Remove(releasesDir)
 		if err != nil {
 			return "", fmt.Errorf("CleanupOldApplicationVersions: Unexpected error app %s: %w",
-				c.Application, err)
+				c.Application, err), nil
 		}
 		msg = fmt.Sprintf("%sremoved version %d of app %v as cleanup\n", msg, oldRelease, c.Application)
 	}
-	return msg, nil
+	changes := &TransformerResult{} // TODO implement
+	return msg, nil, changes
 }
 
 func wrapFileError(e error, filename string, message string) error {
@@ -661,25 +671,25 @@ func (s *State) checkUserPermissionsCreateEnvironment(ctx context.Context, RBACC
 	return auth.CheckUserPermissions(RBACConfig, user, "*", envGroup, "*", auth.PermissionCreateEnvironment)
 }
 
-func (c *CreateEnvironmentLock) Transform(ctx context.Context, state *State) (string, error) {
-
+func (c *CreateEnvironmentLock) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	err := state.checkUserPermissions(ctx, c.Environment, "*", auth.PermissionCreateLock, c.RBACConfig)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	fs := state.Filesystem
 	envDir := fs.Join("environments", c.Environment)
 	if _, err := fs.Stat(envDir); err != nil {
-		return "", fmt.Errorf("error accessing dir %q: %w", envDir, err)
+		return "", fmt.Errorf("error accessing dir %q: %w", envDir, err), nil
 	} else {
 		if chroot, err := fs.Chroot(envDir); err != nil {
-			return "", err
+			return "", err, nil
 		} else {
 			if err := createLock(ctx, chroot, c.LockId, c.Message); err != nil {
-				return "", err
+				return "", err, nil
 			} else {
 				GaugeEnvLockMetric(fs, c.Environment)
-				return fmt.Sprintf("Created lock %q on environment %q", c.LockId, c.Environment), nil
+				changes := &TransformerResult{}
+				return fmt.Sprintf("Created lock %q on environment %q", c.LockId, c.Environment), nil, changes
 			}
 		}
 	}
@@ -730,36 +740,37 @@ type DeleteEnvironmentLock struct {
 	LockId      string
 }
 
-func (c *DeleteEnvironmentLock) Transform(ctx context.Context, state *State) (string, error) {
+func (c *DeleteEnvironmentLock) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	err := state.checkUserPermissions(ctx, c.Environment, "*", auth.PermissionDeleteLock, c.RBACConfig)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	fs := state.Filesystem
 	lockDir := fs.Join("environments", c.Environment, "locks", c.LockId)
 	if err := fs.Remove(lockDir); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", fmt.Errorf("failed to delete directory %q: %w", lockDir, err)
+		return "", fmt.Errorf("failed to delete directory %q: %w", lockDir, err), nil
 	} else {
 		s := State{
 			Filesystem: fs,
 		}
 		apps, err := s.GetEnvironmentApplications(c.Environment)
 		if err != nil {
-			return "", fmt.Errorf("environment applications for %q not found: %v", c.Environment, err.Error())
+			return "", fmt.Errorf("environment applications for %q not found: %v", c.Environment, err.Error()), nil
 		}
 
 		additionalMessageFromDeployment := ""
 		for _, appName := range apps {
 			queueMessage, err := s.ProcessQueue(ctx, fs, c.Environment, appName)
 			if err != nil {
-				return "", err
+				return "", err, nil
 			}
 			if queueMessage != "" {
 				additionalMessageFromDeployment = additionalMessageFromDeployment + "\n" + queueMessage
 			}
 		}
 		GaugeEnvLockMetric(fs, c.Environment)
-		return fmt.Sprintf("Deleted lock %q on environment %q%s", c.LockId, c.Environment, additionalMessageFromDeployment), nil
+		changes := &TransformerResult{}
+		return fmt.Sprintf("Deleted lock %q on environment %q%s", c.LockId, c.Environment, additionalMessageFromDeployment), nil, changes
 	}
 }
 
@@ -771,29 +782,30 @@ type CreateEnvironmentApplicationLock struct {
 	Message     string
 }
 
-func (c *CreateEnvironmentApplicationLock) Transform(ctx context.Context, state *State) (string, error) {
+func (c *CreateEnvironmentApplicationLock) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	// Note: it's possible to lock an application BEFORE it's even deployed to the environment.
 	err := state.checkUserPermissions(ctx, c.Environment, c.Application, auth.PermissionCreateLock, c.RBACConfig)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	fs := state.Filesystem
 	envDir := fs.Join("environments", c.Environment)
 	if _, err := fs.Stat(envDir); err != nil {
-		return "", fmt.Errorf("error accessing dir %q: %w", envDir, err)
+		return "", fmt.Errorf("error accessing dir %q: %w", envDir, err), nil
 	} else {
 		appDir := fs.Join(envDir, "applications", c.Application)
 		if err := fs.MkdirAll(appDir, 0777); err != nil {
-			return "", err
+			return "", err, nil
 		}
 		if chroot, err := fs.Chroot(appDir); err != nil {
-			return "", err
+			return "", err, nil
 		} else {
 			if err := createLock(ctx, chroot, c.LockId, c.Message); err != nil {
-				return "", err
+				return "", err, nil
 			} else {
 				GaugeEnvAppLockMetric(fs, c.Environment, c.Application)
-				return fmt.Sprintf("Created lock %q on environment %q for application %q", c.LockId, c.Environment, c.Application), nil
+				changes := &TransformerResult{} // TODO implement
+				return fmt.Sprintf("Created lock %q on environment %q for application %q", c.LockId, c.Environment, c.Application), nil, changes
 			}
 		}
 	}
@@ -806,25 +818,26 @@ type DeleteEnvironmentApplicationLock struct {
 	LockId      string
 }
 
-func (c *DeleteEnvironmentApplicationLock) Transform(ctx context.Context, state *State) (string, error) {
+func (c *DeleteEnvironmentApplicationLock) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	err := state.checkUserPermissions(ctx, c.Environment, c.Application, auth.PermissionDeleteLock, c.RBACConfig)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	fs := state.Filesystem
 	lockDir := fs.Join("environments", c.Environment, "applications", c.Application, "locks", c.LockId)
 	if err := fs.Remove(lockDir); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", fmt.Errorf("failed to delete directory %q: %w", lockDir, err)
+		return "", fmt.Errorf("failed to delete directory %q: %w", lockDir, err), nil
 	} else {
 		s := State{
 			Filesystem: fs,
 		}
 		queueMessage, err := s.ProcessQueue(ctx, fs, c.Environment, c.Application)
 		if err != nil {
-			return "", err
+			return "", err, nil
 		}
 		GaugeEnvAppLockMetric(fs, c.Environment, c.Application)
-		return fmt.Sprintf("Deleted lock %q on environment %q for application %q%s", c.LockId, c.Environment, c.Application, queueMessage), nil
+		changes := &TransformerResult{}
+		return fmt.Sprintf("Deleted lock %q on environment %q for application %q%s", c.LockId, c.Environment, c.Application, queueMessage), nil, changes
 	}
 }
 
@@ -834,32 +847,33 @@ type CreateEnvironment struct {
 	Config      config.EnvironmentConfig
 }
 
-func (c *CreateEnvironment) Transform(ctx context.Context, state *State) (string, error) {
+func (c *CreateEnvironment) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	err := state.checkUserPermissionsCreateEnvironment(ctx, c.RBACConfig, c.Config)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	fs := state.Filesystem
 	envDir := fs.Join("environments", c.Environment)
 	// Creation of environment is possible, but configuring it is not if running in bootstrap mode.
 	// Configuration needs to be done by modifying config map in source repo
 	if state.BootstrapMode && c.Config != (config.EnvironmentConfig{}) {
-		return "", fmt.Errorf("Cannot create or update configuration in bootstrap mode. Please update configuration in config map instead.")
+		return "", fmt.Errorf("Cannot create or update configuration in bootstrap mode. Please update configuration in config map instead."), nil
 	}
 	if err := fs.MkdirAll(envDir, 0777); err != nil {
-		return "", err
+		return "", err, nil
 	} else {
 		configFile := fs.Join(envDir, "config.json")
 		file, err := fs.OpenFile(configFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
 		if err != nil {
-			return "", fmt.Errorf("error creating config: %w", err)
+			return "", fmt.Errorf("error creating config: %w", err), nil
 		}
 		enc := json.NewEncoder(file)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(c.Config); err != nil {
-			return "", fmt.Errorf("error writing json: %w", err)
+			return "", fmt.Errorf("error writing json: %w", err), nil
 		}
-		return fmt.Sprintf("create environment %q", c.Environment), file.Close()
+		changes := &TransformerResult{} // TODO implement
+		return fmt.Sprintf("create environment %q", c.Environment), file.Close(), changes
 	}
 }
 
@@ -869,25 +883,25 @@ type QueueApplicationVersion struct {
 	Version     uint64
 }
 
-func (c *QueueApplicationVersion) Transform(ctx context.Context, state *State) (string, error) {
+func (c *QueueApplicationVersion) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	fs := state.Filesystem
 	// Create a symlink to the release
 	applicationDir := fs.Join("environments", c.Environment, "applications", c.Application)
 	if err := fs.MkdirAll(applicationDir, 0777); err != nil {
-		return "", err
+		return "", err, nil
 	}
 	queuedVersionFile := fs.Join(applicationDir, queueFileName)
 	if err := fs.Remove(queuedVersionFile); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", err
+		return "", err, nil
 	}
 	releaseDir := releasesDirectoryWithVersion(fs, c.Application, c.Version)
 	if err := fs.Symlink(fs.Join("..", "..", "..", "..", releaseDir), queuedVersionFile); err != nil {
-		return "", err
+		return "", err, nil
 	}
 
 	// TODO SU: maybe check here if that version is already deployed? or somewhere else ... or not at all...
-
-	return fmt.Sprintf("Queued version %d of app %q in env %q", c.Version, c.Application, c.Environment), nil
+	changes := &TransformerResult{}
+	return fmt.Sprintf("Queued version %d of app %q in env %q", c.Version, c.Application, c.Environment), nil, changes
 }
 
 type DeployApplicationVersion struct {
@@ -898,10 +912,10 @@ type DeployApplicationVersion struct {
 	LockBehaviour api.LockBehavior
 }
 
-func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) (string, error) {
+func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	err := state.checkUserPermissions(ctx, c.Environment, c.Application, auth.PermissionDeployRelease, c.RBACConfig)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	fs := state.Filesystem
 	// Check that the release exist and fetch manifest
@@ -909,10 +923,10 @@ func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) 
 	manifest := fs.Join(releaseDir, "environments", c.Environment, "manifests.yaml")
 	manifestContent := []byte{}
 	if file, err := fs.Open(manifest); err != nil {
-		return "", wrapFileError(err, manifest, "could not open manifest")
+		return "", wrapFileError(err, manifest, "could not open manifest"), nil
 	} else {
 		if content, err := io.ReadAll(file); err != nil {
-			return "", err
+			return "", err, nil
 		} else {
 			manifestContent = content
 		}
@@ -927,11 +941,11 @@ func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) 
 		)
 		envLocks, err = state.GetEnvironmentLocks(c.Environment)
 		if err != nil {
-			return "", err
+			return "", err, nil
 		}
 		appLocks, err = state.GetEnvironmentApplicationLocks(c.Environment, c.Application)
 		if err != nil {
-			return "", err
+			return "", err, nil
 		}
 		if len(envLocks) > 0 || len(appLocks) > 0 {
 			switch c.LockBehaviour {
@@ -946,7 +960,7 @@ func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) 
 				return "", &LockedError{
 					EnvironmentApplicationLocks: appLocks,
 					EnvironmentLocks:            envLocks,
-				}
+				}, nil
 			case api.LockBehavior_Ignore:
 				// just continue
 			}
@@ -955,20 +969,21 @@ func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) 
 	// Create a symlink to the release
 	applicationDir := fs.Join("environments", c.Environment, "applications", c.Application)
 	if err := fs.MkdirAll(applicationDir, 0777); err != nil {
-		return "", err
+		return "", err, nil
 	}
 	versionFile := fs.Join(applicationDir, "version")
 	if err := fs.Remove(versionFile); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", err
+		return "", err, nil
 	}
 	if err := fs.Symlink(fs.Join("..", "..", "..", "..", releaseDir), versionFile); err != nil {
-		return "", err
+		return "", err, nil
 	}
 	// Copy the manifest for argocd
 	manifestsDir := fs.Join(applicationDir, "manifests")
 	if err := fs.MkdirAll(manifestsDir, 0777); err != nil {
-		return "", err
+		return "", err, nil
 	}
+	changes := &TransformerResult{}
 	manifestFilename := fs.Join(manifestsDir, "manifests.yaml")
 	// note that the manifest is empty here!
 	// but actually it's not quite empty!
@@ -978,23 +993,25 @@ func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) 
 		manifestContent = []byte(" ")
 	}
 	if err := util.WriteFile(fs, manifestFilename, manifestContent, 0666); err != nil {
-		return "", err
+		return "", err, nil
 	}
+	changes.AddAppEnv(c.Application, c.Environment)
+	logger.FromContext(ctx).Warn(fmt.Sprintf("DeployApp: changes added: %v+", changes))
 
 	user, err := auth.ReadUserFromContext(ctx)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 
 	if err := util.WriteFile(fs, fs.Join(applicationDir, "deployed_by"), []byte(user.Name), 0666); err != nil {
-		return "", err
+		return "", err, nil
 	}
 	if err := util.WriteFile(fs, fs.Join(applicationDir, "deployed_by_email"), []byte(user.Email), 0666); err != nil {
-		return "", err
+		return "", err, nil
 	}
 
 	if err := util.WriteFile(fs, fs.Join(applicationDir, "deployed_at_utc"), []byte(getTimeNow(ctx).UTC().String()), 0666); err != nil {
-		return "", err
+		return "", err, nil
 	}
 
 	s := State{
@@ -1002,17 +1019,20 @@ func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) 
 	}
 	err = s.DeleteQueuedVersionIfExists(c.Environment, c.Application)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 	d := &CleanupOldApplicationVersions{
 		Application: c.Application,
 	}
-	transform, err := d.Transform(ctx, state)
+	transform, err, subChanges := d.Transform(ctx, state)
+	logger.FromContext(ctx).Warn(fmt.Sprintf("DeployApp: sub changes: %v+", subChanges))
+	changes.Combine(subChanges)
 	if err != nil {
-		return "", err
+		return "", err, nil
 	}
 
-	return fmt.Sprintf("deployed version %d of %q to %q\n%s", c.Version, c.Application, c.Environment, transform), nil
+	logger.FromContext(ctx).Warn(fmt.Sprintf("DeployApp: combined changes: %v+", changes))
+	return fmt.Sprintf("deployed version %d of %q to %q\n%s", c.Version, c.Application, c.Environment, transform), nil, changes
 }
 
 type ReleaseTrain struct {
@@ -1061,17 +1081,17 @@ func generateReleaseTrainResponse(envDeployedMsg, envSkippedMsg map[string]strin
 	return resp
 }
 
-func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, error) {
+func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	var targetGroupName = c.Target
 
 	configs, err := state.GetEnvironmentConfigs()
 	if err != nil {
-		return "", grpc.InternalError(ctx, err)
+		return "", grpc.InternalError(ctx, err), nil
 	}
 	var envGroupConfigs = getEnvironmentGroupsEnvironmentsOrEnvironment(configs, targetGroupName)
 
 	if len(envGroupConfigs) == 0 {
-		return "", grpc.PublicError(ctx, fmt.Errorf("could not find environment group or environment configs for '%v'", targetGroupName))
+		return "", grpc.PublicError(ctx, fmt.Errorf("could not find environment group or environment configs for '%v'", targetGroupName)), nil
 	}
 
 	// this to sort the env, to make sure that for the same input we always got the same output
@@ -1083,6 +1103,7 @@ func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, err
 
 	envDeployedMsg := make(map[string]string)
 	envSkippedMsg := make(map[string]string)
+	changes := &TransformerResult{}
 	for _, envName := range envGroups {
 		envConfig := envGroupConfigs[envName]
 		if envConfig.Upstream == nil {
@@ -1091,7 +1112,7 @@ func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, err
 		}
 		err := state.checkUserPermissions(ctx, envName, "*", auth.PermissionDeployReleaseTrain, c.RBACConfig)
 		if err != nil {
-			return "", err
+			return "", err, nil
 		}
 
 		var upstreamLatest = envConfig.Upstream.Latest
@@ -1113,13 +1134,13 @@ func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, err
 		if !upstreamLatest {
 			_, ok := configs[upstreamEnvName]
 			if !ok {
-				return fmt.Sprintf("Could not find environment config for upstream env %q. Target env was %q", upstreamEnvName, envName), err
+				return fmt.Sprintf("Could not find environment config for upstream env %q. Target env was %q", upstreamEnvName, envName), err, nil
 			}
 		}
 
 		envLocks, err := state.GetEnvironmentLocks(envName)
 		if err != nil {
-			return "", grpc.InternalError(ctx, fmt.Errorf("could not get lock for environment %q: %w", envName, err))
+			return "", grpc.InternalError(ctx, fmt.Errorf("could not get lock for environment %q: %w", envName, err)), nil
 		}
 		if len(envLocks) > 0 {
 			envSkippedMsg[envName] = fmt.Sprintf("Target Environment '%s' is locked - skipping.\n", envName)
@@ -1130,12 +1151,12 @@ func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, err
 		if upstreamLatest {
 			apps, err = state.GetApplications()
 			if err != nil {
-				return "", grpc.InternalError(ctx, fmt.Errorf("could not get all applications for %q: %w", source, err))
+				return "", grpc.InternalError(ctx, fmt.Errorf("could not get all applications for %q: %w", source, err)), nil
 			}
 		} else {
 			apps, err = state.GetEnvironmentApplications(upstreamEnvName)
 			if err != nil {
-				return "", grpc.PublicError(ctx, fmt.Errorf("upstream environment (%q) does not have applications: %w", upstreamEnvName, err))
+				return "", grpc.PublicError(ctx, fmt.Errorf("upstream environment (%q) does not have applications: %w", upstreamEnvName, err)), nil
 			}
 		}
 		sort.Strings(apps)
@@ -1146,25 +1167,25 @@ func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, err
 		for _, appName := range apps {
 			if c.Team != "" {
 				if team, err := state.GetApplicationTeamOwner(appName); err != nil {
-					return "", nil
+					return "", nil, nil
 				} else if c.Team != team {
 					continue
 				}
 			}
 			currentlyDeployedVersion, err := state.GetEnvironmentApplicationVersion(envName, appName)
 			if err != nil {
-				return "", grpc.PublicError(ctx, fmt.Errorf("application %q in env %q does not have a version deployed: %w", appName, envName, err))
+				return "", grpc.PublicError(ctx, fmt.Errorf("application %q in env %q does not have a version deployed: %w", appName, envName, err)), nil
 			}
 			var versionToDeploy uint64
 			if upstreamLatest {
 				versionToDeploy, err = GetLastRelease(state.Filesystem, appName)
 				if err != nil {
-					return "", grpc.PublicError(ctx, fmt.Errorf("application %q does not have a latest deployed: %w", appName, err))
+					return "", grpc.PublicError(ctx, fmt.Errorf("application %q does not have a latest deployed: %w", appName, err)), nil
 				}
 			} else {
 				upstreamVersion, err := state.GetEnvironmentApplicationVersion(upstreamEnvName, appName)
 				if err != nil {
-					return "", grpc.PublicError(ctx, fmt.Errorf("application %q does not have a version deployed in env %q: %w", appName, upstreamEnvName, err))
+					return "", grpc.PublicError(ctx, fmt.Errorf("application %q does not have a version deployed in env %q: %w", appName, upstreamEnvName, err)), nil
 				}
 				if upstreamVersion == nil {
 					envSkippedMsg[envName] += fmt.Sprintf("skipping because there is no version for application %q in env %q \n", appName, upstreamEnvName)
@@ -1184,7 +1205,7 @@ func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, err
 				LockBehaviour:  api.LockBehavior_Record,
 				Authentication: c.Authentication,
 			}
-			transform, err := d.Transform(ctx, state)
+			transform, err, subChanges := d.Transform(ctx, state)
 			if err != nil {
 				_, ok := err.(*LockedError)
 				if ok {
@@ -1193,8 +1214,9 @@ func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, err
 				if errors.Is(err, os.ErrNotExist) {
 					continue // some apps do not exist on all envs, we ignore those
 				}
-				return "", grpc.InternalError(ctx, fmt.Errorf("unexpected error while deploying app %q to env %q: %w", appName, envName, err))
+				return "", grpc.InternalError(ctx, fmt.Errorf("unexpected error while deploying app %q to env %q: %w", appName, envName, err)), nil
 			}
+			changes.Combine(subChanges)
 			numServices += 1
 			completeMessage = completeMessage + transform + "\n"
 		}
@@ -1205,5 +1227,5 @@ func (c *ReleaseTrain) Transform(ctx context.Context, state *State) (string, err
 		envDeployedMsg[envName] = fmt.Sprintf("The release train deployed %d services from '%s' to '%s'%s\n%s\n", numServices, source, envName, teamInfo, completeMessage)
 	}
 
-	return generateReleaseTrainResponse(envDeployedMsg, envSkippedMsg, targetGroupName), nil
+	return generateReleaseTrainResponse(envDeployedMsg, envSkippedMsg, targetGroupName), nil, changes
 }

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -545,6 +545,11 @@ func (u *DeleteEnvFromApp) Transform(ctx context.Context, state *State) (string,
 				Env: u.Environment,
 			},
 		},
+		DeletedRootApps: []RootApp{
+			{
+				Env: u.Environment,
+			},
+		},
 	}
 	return fmt.Sprintf("Environment '%v' was removed from application '%v' successfully.", u.Environment, u.Application), nil, changes
 }
@@ -1003,7 +1008,7 @@ func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) 
 		return "", err, nil
 	}
 	changes.AddAppEnv(c.Application, c.Environment)
-	logger.FromContext(ctx).Warn(fmt.Sprintf("DeployApp: changes added: %v+", changes))
+	logger.FromContext(ctx).Info(fmt.Sprintf("DeployApp: changes added: %v+", changes))
 
 	user, err := auth.ReadUserFromContext(ctx)
 	if err != nil {
@@ -1032,13 +1037,13 @@ func (c *DeployApplicationVersion) Transform(ctx context.Context, state *State) 
 		Application: c.Application,
 	}
 	transform, err, subChanges := d.Transform(ctx, state)
-	logger.FromContext(ctx).Warn(fmt.Sprintf("DeployApp: sub changes: %v+", subChanges))
+	logger.FromContext(ctx).Info(fmt.Sprintf("DeployApp: sub changes: %v+", subChanges))
 	changes.Combine(subChanges)
 	if err != nil {
 		return "", err, nil
 	}
 
-	logger.FromContext(ctx).Warn(fmt.Sprintf("DeployApp: combined changes: %v+", changes))
+	logger.FromContext(ctx).Info(fmt.Sprintf("DeployApp: combined changes: %v+", changes))
 	return fmt.Sprintf("deployed version %d of %q to %q\n%s", c.Version, c.Application, c.Environment, transform), nil, changes
 }
 

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1009,6 +1009,212 @@ func TestReleaseTrainErrors(t *testing.T) {
 	}
 }
 
+func TestTransformerChanges(t *testing.T) {
+	tcs := []struct {
+		Name              string
+		Transformers      []Transformer
+		expectedCommitMsg string
+		expectedChanges   *TransformerResult
+	}{
+		{
+			Name: "Deploy 1 app, another app locked by app lock",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: envProduction,
+					Config:      testutil.MakeEnvConfigUpstream(envAcceptance, nil),
+				},
+				&CreateEnvironment{
+					Environment: envAcceptance,
+					Config:      testutil.MakeEnvConfigLatest(nil),
+				},
+				&CreateEnvironmentApplicationLock{
+					Environment: envProduction,
+					Application: "foo",
+					LockId:      "foo-id",
+					Message:     "foo",
+				},
+				&CreateApplicationVersion{
+					Application: "foo",
+					Manifests: map[string]string{
+						envProduction: envProduction,
+						envAcceptance: envAcceptance,
+					},
+				},
+				&CreateApplicationVersion{
+					Application: "bar",
+					Manifests: map[string]string{
+						envProduction: envProduction,
+						envAcceptance: envAcceptance,
+					},
+				},
+				&ReleaseTrain{
+					Target: envProduction,
+				},
+			},
+			expectedChanges: &TransformerResult{
+				ChangedApps: []AppEnv{
+					// foo is locked, so it should not appear here
+					{
+						App: "bar",
+						Env: envProduction,
+					},
+				},
+			},
+		},
+		{
+			Name: "env lock",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: envProduction,
+					Config:      testutil.MakeEnvConfigUpstream(envAcceptance, nil),
+				},
+				&CreateEnvironment{
+					Environment: envAcceptance,
+					Config:      testutil.MakeEnvConfigLatest(nil),
+				},
+				&CreateEnvironmentLock{
+					Environment: envProduction,
+					LockId:      "foo-id",
+					Message:     "foo",
+				},
+				&CreateApplicationVersion{
+					Application: "foo",
+					Manifests: map[string]string{
+						envProduction: envProduction,
+						envAcceptance: envAcceptance,
+					},
+				},
+				&CreateApplicationVersion{
+					Application: "bar",
+					Manifests: map[string]string{
+						envProduction: envProduction,
+						envAcceptance: envAcceptance,
+					},
+				},
+				&ReleaseTrain{
+					Target: envProduction,
+				},
+			},
+			expectedChanges: &TransformerResult{
+				ChangedApps: nil,
+			},
+		},
+		{
+			Name: "create env lock",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: envProduction,
+					Config:      testutil.MakeEnvConfigUpstream(envAcceptance, nil),
+				},
+				&CreateEnvironmentLock{
+					Environment: envProduction,
+					LockId:      "foo-id",
+					Message:     "foo",
+				},
+			},
+			expectedChanges: &TransformerResult{
+				ChangedApps: nil,
+			},
+		},
+		{
+			Name: "create env",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: envProduction,
+					Config:      testutil.MakeEnvConfigUpstream(envAcceptance, nil),
+				},
+			},
+			expectedChanges: &TransformerResult{
+				ChangedApps: nil,
+			},
+		},
+		{
+			Name: "delete env from app",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: envAcceptance,
+					Config:      testutil.MakeEnvConfigLatest(nil),
+				},
+				&CreateEnvironment{
+					Environment: envProduction,
+					Config:      testutil.MakeEnvConfigUpstream(envAcceptance, nil),
+				},
+				&CreateApplicationVersion{
+					Application: "foo",
+					Manifests: map[string]string{
+						envProduction: envProduction,
+						envAcceptance: envAcceptance,
+					},
+				},
+				&DeleteEnvFromApp{
+					Application: "foo",
+					Environment: envAcceptance,
+				},
+			},
+			expectedChanges: &TransformerResult{
+				ChangedApps: []AppEnv{
+					{
+						App: "foo",
+						Env: envAcceptance,
+					},
+				},
+			},
+		},
+		{
+			Name: "deploy",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: envAcceptance,
+					Config:      testutil.MakeEnvConfigLatest(nil),
+				},
+				&CreateEnvironment{
+					Environment: envProduction,
+					Config:      testutil.MakeEnvConfigUpstream(envAcceptance, nil),
+				},
+				&CreateApplicationVersion{
+					Application: "foo",
+					Manifests: map[string]string{
+						envProduction: envProduction,
+						envAcceptance: envAcceptance,
+					},
+				},
+				&DeployApplicationVersion{
+					Authentication: Authentication{},
+					Environment:    envProduction,
+					Application:    "foo",
+					Version:        1,
+				},
+			},
+			expectedChanges: &TransformerResult{
+				ChangedApps: []AppEnv{
+					{
+						App: "foo",
+						Env: envProduction,
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			repo := setupRepositoryTest(t)
+			_, _, err, actualChanges := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			// we only diff the changes from the last transformer here:
+			lastChanges := actualChanges[len(actualChanges)-1]
+			// note that we only check the LAST error here:
+			if err != nil {
+				t.Fatalf("Expected no error: %v", err)
+			}
+
+			if diff := cmp.Diff(lastChanges, tc.expectedChanges); diff != "" {
+				t.Errorf("got %v, want %v, diff (-want +got) %s", lastChanges, tc.expectedChanges, diff)
+			}
+		})
+	}
+}
+
 func TestRbacTransformerTest(t *testing.T) {
 	envGroupProduction := "production"
 	tcs := []struct {
@@ -3429,7 +3635,7 @@ type injectErr struct {
 func (i *injectErr) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	original := state.Filesystem
 	state.Filesystem = i.collector.WithError(state.Filesystem, i.operation, i.filename, i.err)
-	s, err, _ := i.Transformer.Transform(ctx, state)
+	s, err, changes := i.Transformer.Transform(ctx, state)
 	state.Filesystem = original
 	return s, err, changes
 }

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1158,6 +1158,11 @@ func TestTransformerChanges(t *testing.T) {
 						Env: envAcceptance,
 					},
 				},
+				DeletedRootApps: []RootApp{
+					{
+						Env: envAcceptance,
+					},
+				},
 			},
 		},
 		{

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -290,7 +290,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			commitMsg, _, err, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -370,7 +370,7 @@ func TestCreateUndeployApplicationVersionErrors(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			_, updatedState, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			_, updatedState, _, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 
 			fileData, err := util.ReadFile(updatedState.Filesystem, updatedState.Filesystem.Join(updatedState.Filesystem.Root(), tc.expectedPath))
 
@@ -698,7 +698,7 @@ func TestDeployApplicationVersion(t *testing.T) {
 			ctxWithTime := withTimeNow(testutil.MakeTestContext(), timeNowOld)
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			_, updatedState, err := repo.ApplyTransformersInternal(ctxWithTime, tc.Transformers...)
+			_, updatedState, err, _ := repo.ApplyTransformersInternal(ctxWithTime, tc.Transformers...)
 			if err != nil {
 				t.Fatalf("Expected no error when applying: %v", err)
 			}
@@ -809,7 +809,7 @@ func TestCreateApplicationVersionWithVersion(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			_, updatedState, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			_, updatedState, _, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 
 			fileData, err := util.ReadFile(updatedState.Filesystem, updatedState.Filesystem.Join(updatedState.Filesystem.Root(), tc.expectedPath))
 
@@ -910,7 +910,7 @@ func TestUndeployErrors(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			commitMsg, _, err, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -984,7 +984,7 @@ func TestReleaseTrainErrors(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			commitMsg, _, err, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -3426,12 +3426,12 @@ type injectErr struct {
 	err       error
 }
 
-func (i *injectErr) Transform(ctx context.Context, state *State) (string, error) {
+func (i *injectErr) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
 	original := state.Filesystem
 	state.Filesystem = i.collector.WithError(state.Filesystem, i.operation, i.filename, i.err)
-	s, err := i.Transformer.Transform(ctx, state)
+	s, err, _ := i.Transformer.Transform(ctx, state)
 	state.Filesystem = original
-	return s, err
+	return s, err, changes
 }
 
 func TestAllErrorsHandledDeleteEnvironmentLock(t *testing.T) {
@@ -3649,7 +3649,7 @@ func TestUpdateDatadogMetrics(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			_, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			_, _, err, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 
 			if err != nil {
 				t.Fatalf("Got an unexpected error: %v", err)
@@ -3803,7 +3803,7 @@ func TestDeleteEnvFromApp(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			commitMsg, _, err, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -3909,7 +3909,7 @@ func TestDeleteLocks(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			commitMsg, _, err, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -290,7 +290,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			commitMsg, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -698,7 +698,7 @@ func TestDeployApplicationVersion(t *testing.T) {
 			ctxWithTime := withTimeNow(testutil.MakeTestContext(), timeNowOld)
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			_, updatedState, err, _ := repo.ApplyTransformersInternal(ctxWithTime, tc.Transformers...)
+			_, updatedState, _, err := repo.ApplyTransformersInternal(ctxWithTime, tc.Transformers...)
 			if err != nil {
 				t.Fatalf("Expected no error when applying: %v", err)
 			}
@@ -910,7 +910,7 @@ func TestUndeployErrors(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			commitMsg, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -984,7 +984,7 @@ func TestReleaseTrainErrors(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			commitMsg, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -1205,7 +1205,7 @@ func TestTransformerChanges(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			_, _, err, actualChanges := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			_, _, actualChanges, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// we only diff the changes from the last transformer here:
 			lastChanges := actualChanges[len(actualChanges)-1]
 			// note that we only check the LAST error here:
@@ -3637,12 +3637,12 @@ type injectErr struct {
 	err       error
 }
 
-func (i *injectErr) Transform(ctx context.Context, state *State) (string, error, *TransformerResult) {
+func (i *injectErr) Transform(ctx context.Context, state *State) (string, *TransformerResult, error) {
 	original := state.Filesystem
 	state.Filesystem = i.collector.WithError(state.Filesystem, i.operation, i.filename, i.err)
-	s, err, changes := i.Transformer.Transform(ctx, state)
+	s, changes, err := i.Transformer.Transform(ctx, state)
 	state.Filesystem = original
-	return s, err, changes
+	return s, changes, err
 }
 
 func TestAllErrorsHandledDeleteEnvironmentLock(t *testing.T) {
@@ -3860,7 +3860,7 @@ func TestUpdateDatadogMetrics(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			_, _, err, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			_, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 
 			if err != nil {
 				t.Fatalf("Got an unexpected error: %v", err)
@@ -4014,7 +4014,7 @@ func TestDeleteEnvFromApp(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			commitMsg, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {
@@ -4120,7 +4120,7 @@ func TestDeleteLocks(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
-			commitMsg, _, err, _ := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			commitMsg, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
 			if tc.shouldSucceed {
 				if err != nil {

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -288,7 +288,7 @@ func TestBatchServiceWorks(t *testing.T) {
 type ErrorTransformer struct{}
 
 func (p *ErrorTransformer) Transform(ctx context.Context, state *repository.State) (string, error, *repository.TransformerResult) {
-	return "error", errors.New("i am the transformer error"), changes
+	return "error", errors.New("i am the transformer error"), nil
 }
 
 func TestBatchServiceErrors(t *testing.T) {

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -287,8 +287,8 @@ func TestBatchServiceWorks(t *testing.T) {
 
 type ErrorTransformer struct{}
 
-func (p *ErrorTransformer) Transform(ctx context.Context, state *repository.State) (string, error, *repository.TransformerResult) {
-	return "error", errors.New("i am the transformer error"), nil
+func (p *ErrorTransformer) Transform(ctx context.Context, state *repository.State) (string, *repository.TransformerResult, error) {
+	return "error", nil, errors.New("i am the transformer error")
 }
 
 func TestBatchServiceErrors(t *testing.T) {

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -287,8 +287,8 @@ func TestBatchServiceWorks(t *testing.T) {
 
 type ErrorTransformer struct{}
 
-func (p *ErrorTransformer) Transform(ctx context.Context, state *repository.State) (string, error) {
-	return "error", errors.New("i am the transformer error")
+func (p *ErrorTransformer) Transform(ctx context.Context, state *repository.State) (string, error, *repository.TransformerResult) {
+	return "error", errors.New("i am the transformer error"), changes
 }
 
 func TestBatchServiceErrors(t *testing.T) {


### PR DESCRIPTION
With this feature, kuberpult sends webhooks that imitate github webhooks to argoCd, which trigger argoCds refreshs.

This is intended to reduce load on ArgoCd. Normally, argoCd renders all manifests again whenever there is a new commit in the manifest repository. However, with Webhooks, it only checks the actually changed files that are part of the Webhook body.

Note that this does not work for all cases, like deletion of environments from apps.

So you can make the "timeout.reconciliation" in argoCd bigger (e.g. 30min instead of the default 3min) - however you should not fully disable it. See https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#argocd-application-controller

To enable this kuberpult feature, set `argocd.server` in the helm chart to a hostname that reaches argoCds "argocd-server", usually this should be `http://argocd-server.${ARGO_NAMESPACE}.svc.cluster.local`.

If the certificate for the https connection is not accepted, set `argocd.insecure: true`.
This is usually safe, under the assumption that kuberpult and argoCd run on the same cluster anyway.

This feature is intended to be used when Webhooks are not an option for you (for example due to firewall policies).

Caveat: Kuberpult only retries failed connections a very limited number of times. That means, if argoCd does not react temporarily, webhooks may get lost, and therefore argoCd does not sync until the reconciliation timeout. 
