### PR TITLE
Increase nginx timeout to 300s

### DIFF
--- a/charts/kuberpult/templates/ingress.yaml
+++ b/charts/kuberpult/templates/ingress.yaml
@@ -57,7 +57,7 @@ metadata:
     cert-manager.io/acme-challenge-type: dns01
     cert-manager.io/cluster-issuer: letsencrypt
 {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value }}
+    {{ $key | quote}}: {{ $value | quote}}
 {{- end }}
   name: kuberpult
 spec:

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -64,7 +64,8 @@ rollout:
 
 ingress:
   create: true
-  annotations: {}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: 300
   domainName: null
   iap:
     enabled: false


### PR DESCRIPTION
The publish endpoint takes a minute to reply if pushing to git takes a minute. This is not an error but nginx times out the reply after thirty seconds so that the caller has the impression that something went wrong. The timeout should be much higher. We will start with 5 minutes.