### PR TITLE
Maintenance: handle ts-proto warning

### DIFF
--- a/services/frontend-service/buf.gen.yaml
+++ b/services/frontend-service/buf.gen.yaml
@@ -22,6 +22,6 @@ plugins:
     opt:
     #  - paths=source_relative
       - oneof=unions
-      - useOptionals=true
+      - useOptionals=messages
       - esModuleInterop=true
       - outputClientImpl=grpc-web


### PR DESCRIPTION
Warning from ts-proto was: "Passing useOptionals as a boolean option is deprecated and will be removed in a future version. Please pass the string messages instead of true."