### PR TITLE
Add webUrl as separate option for argo webhooks

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -113,6 +113,8 @@ spec:
           value: {{ .Values.argocd.server | quote }}
         - name: KUBERPULT_ARGO_CD_INSECURE
           value: {{ .Values.argocd.insecure | quote }}
+        - name: KUBERPULT_GIT_WEB_URL
+          value: {{ .Values.git.webUrl | quote }}
 {{- if .Values.datadogTracing.enabled }}
         - name: DD_AGENT_HOST
           valueFrom:

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -4,6 +4,7 @@
 
 git:
   url:  # git@github.com/.../...
+  webUrl:  # only necessary for webhooks to argoCd, e.g. https://github.com/freiheit-com/kuberpult
   branch: "master"
   sourceRepoUrl: ""
   author:

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -62,6 +62,7 @@ type Config struct {
 	DexMockRole       string `default:"Developer" split_words:"true"`
 	ArgoCdServer      string `default:"" split_words:"true"`
 	ArgoCdInsecure    bool   `default:"false" split_words:"true"`
+	GitWebUrl         string `default:"" split_words:"true"`
 }
 
 func (c *Config) storageBackend() repository.StorageBackend {
@@ -161,6 +162,7 @@ func RunServer() {
 			StorageBackend:         c.storageBackend(),
 			ArgoInsecure:           c.ArgoCdInsecure,
 			ArgoWebhookUrl:         c.ArgoCdServer,
+			WebURL:                 c.GitWebUrl,
 		})
 		if err != nil {
 			logger.FromContext(ctx).Fatal("repository.new.error", zap.Error(err), zap.String("git.url", c.GitUrl), zap.String("git.branch", c.GitBranch))

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -110,6 +110,7 @@ type repository struct {
 
 type RepositoryConfig struct {
 	// Mandatory Config
+	// the URL used for git checkout, (ssh protocol)
 	URL  string
 	Path string
 	// Optional Config
@@ -130,6 +131,8 @@ type RepositoryConfig struct {
 	ArgoInsecure           bool
 	// if set, kuberpult will generate push events to argoCd whenever it writes to the manifest repo:
 	ArgoWebhookUrl string
+	// the url to the git repo, like the browser requires it (https protocol)
+	WebURL string
 }
 
 func openOrCreate(path string, storageBackend StorageBackend) (*git.Repository, error) {
@@ -460,7 +463,7 @@ func (r *repository) sendWebhookToArgoCd(ctx context.Context, logger *zap.Logger
 	}
 
 	argoResult := ArgoWebhookData{
-		htmlUrl:  r.config.URL, // if this does not match, argo will completely ignore the request and return 200
+		htmlUrl:  r.config.WebURL, // if this does not match, argo will completely ignore the request and return 200
 		revision: "refs/heads/" + r.config.Branch,
 		change: changeInfo{
 			payloadAfter: changes.Commits.Current.String(),


### PR DESCRIPTION
It's different from the url to clone a repo.
WebUrl has https protocol.
Url to clone a repo uses ssh protocol.
ArgoCd requires this url to have https protocol, otherwise it fails to parse the url and webhooks do not work.