### PR TITLE
Submit user data via grpc message instead of header

### DIFF
--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -11,8 +11,14 @@ service BatchService {
   rpc ProcessBatch (BatchRequest) returns (BatchResponse) {}
 }
 
+message User {
+  string username = 1;
+  string email = 2;
+}
+
 message BatchRequest {
   repeated BatchAction actions = 1;
+  User currentUser = 2;
 }
 
 message BatchAction {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -39,6 +39,17 @@ func TestToFromContext(t *testing.T) {
 			},
 		},
 		{
+			Name: "User has special chars",
+			Author: User{
+				Email: "tur@test.com",
+				Name:  "Tür",
+			},
+			ExpectedUser: User{
+				Email: "tur@test.com",
+				Name:  "Tür",
+			},
+		},
+		{
 			Name: "Name is not specified",
 			Author: User{
 				Email: "new@test.com",

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -15,7 +15,7 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright 2023 freiheit.com*/
 import { Button } from '../button';
 import { DeleteGray, HideBarWhite } from '../../../images';
-import { BatchAction } from '../../../api/api';
+import { BatchAction, User } from '../../../api/api';
 import {
     deleteAction,
     useActions,
@@ -292,7 +292,7 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
     const [lockMessage, setLockMessage] = useState('');
     const api = useApi;
     const [open, setOpen] = useState(false);
-    const { authHeader, authReady } = useAzureAuthSub((auth) => auth);
+    const { authHeader, authReady, userData } = useAzureAuthSub((auth) => auth);
 
     const handleClose = useCallback(() => setOpen(false), []);
     const handleOpen = useCallback(() => setOpen(true), []);
@@ -310,6 +310,10 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
     );
 
     const applyActions = useCallback(() => {
+        const currentUser: User = {
+            username: userData.username,
+            email: userData.email,
+        };
         if (lockMessage) {
             lockCreationList.forEach((action) => {
                 if (action.action?.$case === 'createEnvironmentLock') {
@@ -332,7 +336,7 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                 }
             }
             api.batchService()
-                .ProcessBatch({ actions }, authHeader)
+                .ProcessBatch({ actions, currentUser }, authHeader)
                 .then((result) => {
                     deleteAllActions();
                     showSnackbarSuccess('Actions were applied successfully');
@@ -344,7 +348,7 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                 });
             handleClose();
         }
-    }, [actions, api, handleClose, lockCreationList, lockMessage, authHeader, authReady]);
+    }, [actions, api, handleClose, lockCreationList, lockMessage, authHeader, authReady, userData]);
 
     const newLockExists = useMemo(() => lockCreationList.length !== 0, [lockCreationList.length]);
 

--- a/services/frontend-service/src/ui/utils/AzureAuthProvider.test.tsx
+++ b/services/frontend-service/src/ui/utils/AzureAuthProvider.test.tsx
@@ -108,7 +108,7 @@ describe('AuthProvider', () => {
     });
 
     describe('AcquireToken', () => {
-        it('Get id token and store it in authHeader with acquireTokenSilent method', async () => {
+        it('Get id token with acquireTokenSilent method', async () => {
             // given
             jest.spyOn(pca, 'getAllAccounts').mockImplementation(() => [testAccount]);
             const acquireTokenSilentSpy = jest
@@ -131,11 +131,9 @@ describe('AuthProvider', () => {
             expect(screen.queryByText('Token Acquired')).toBeInTheDocument();
             await waitFor(async () => expect(acquireTokenSilentSpy).toHaveBeenCalledTimes(1));
             await waitFor(() => expect(AzureAuthSub.get().authHeader.get('authorization')).toContain('unique-token'));
-            await waitFor(() => expect(AzureAuthSub.get().authHeader.get('email')).toContain('mail@example.com'));
-            await waitFor(() => expect(AzureAuthSub.get().authHeader.get('username')).toContain('test person'));
         });
 
-        it('Get id token and store it in authHeader with acquireTokenPopup method', async () => {
+        it('Get id token with acquireTokenPopup method', async () => {
             // given
             jest.spyOn(pca, 'getAllAccounts').mockImplementation(() => [testAccount]);
             const acquireTokenSilentSpy = jest
@@ -162,8 +160,6 @@ describe('AuthProvider', () => {
             await waitFor(async () => expect(acquireTokenSilentSpy).toHaveBeenCalledTimes(1));
             await waitFor(async () => expect(acquireTokenPopup).toHaveBeenCalledTimes(1));
             await waitFor(() => expect(AzureAuthSub.get().authHeader.get('authorization')).toContain('unique-token-2'));
-            await waitFor(() => expect(AzureAuthSub.get().authHeader.get('email')).toContain('mail@example.com'));
-            await waitFor(() => expect(AzureAuthSub.get().authHeader.get('username')).toContain('test person'));
         });
         it('Get id token both method failed', async () => {
             // given

--- a/services/frontend-service/src/ui/utils/AzureAuthProvider.tsx
+++ b/services/frontend-service/src/ui/utils/AzureAuthProvider.tsx
@@ -34,12 +34,20 @@ type AzureAuthSubType = {
     authHeader: grpc.Metadata & {
         Authorization?: String;
     };
+    userData: {
+        email: string;
+        username: string;
+    };
     authReady: boolean;
 };
 
 export const [useAzureAuthSub, AzureAuthSub] = createStore<AzureAuthSubType>({
     authHeader: new BrowserHeaders({}),
     authReady: false,
+    userData: {
+        email: '',
+        username: '',
+    },
 });
 
 const getMsalConfig = (configs: GetFrontendConfigResponse): Configuration => ({
@@ -80,9 +88,11 @@ export const AcquireToken: React.FC<{ children: React.ReactNode }> = ({ children
                 AzureAuthSub.set({
                     authHeader: new BrowserHeaders({
                         Authorization: response.idToken,
-                        email: email, // use same key here as in server.go function getRequestAuthorFromAzure: r.Header.Get("email")
-                        username: username, // use same key here too
                     }),
+                    userData: {
+                        email: email,
+                        username: username,
+                    },
                     authReady: true,
                 });
             })
@@ -93,9 +103,11 @@ export const AcquireToken: React.FC<{ children: React.ReactNode }> = ({ children
                         AzureAuthSub.set({
                             authHeader: new BrowserHeaders({
                                 Authorization: response.idToken,
-                                email: email, // use same key here as in server.go function getRequestAuthorFromAzure: r.Header.Get("email")
-                                username: username, // use same key here too
                             }),
+                            userData: {
+                                email: email,
+                                username: username,
+                            },
                             authReady: true,
                         });
                     })


### PR DESCRIPTION
Headers are genereally not safe with special characters. Instead of encoding the header with base64, we move the data to a normal grpc message (ProcessBatch), because this is the only request where we have this userdata anyway.

This should fix the bug https://github.com/freiheit-com/kuberpult/issues/874 that happened on azure when users have non-ascii usernames - but it is hard to verify this.