### PR TITLE
Add more error conditions to the rollout service

### DIFF
--- a/services/rollout-service/pkg/service/broadcast.go
+++ b/services/rollout-service/pkg/service/broadcast.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/gitops-engine/pkg/health"
+	"github.com/argoproj/gitops-engine/pkg/sync/common"
 )
 
 type key struct {
@@ -131,6 +132,13 @@ func rolloutStatus(ev *Event) api.RolloutStatus {
 	case health.HealthStatusProgressing, health.HealthStatusSuspended:
 		return api.RolloutStatus_RolloutStatusProgressing
 	case health.HealthStatusHealthy:
+		if ev.OperationState != nil {
+			switch ev.OperationState.Phase {
+			case common.OperationError, common.OperationFailed:
+
+				return api.RolloutStatus_RolloutStatusError
+			}
+		}
 		switch ev.SyncStatusCode {
 		case v1alpha1.SyncStatusCodeOutOfSync:
 			return api.RolloutStatus_RolloutStatusProgressing

--- a/services/rollout-service/pkg/service/broadcast_test.go
+++ b/services/rollout-service/pkg/service/broadcast_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/gitops-engine/pkg/health"
+	"github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/freiheit-com/kuberpult/pkg/api"
 	"google.golang.org/grpc"
 )
@@ -174,6 +175,44 @@ func TestBroadcast(t *testing.T) {
 					},
 
 					ExpectStatus: &RolloutStatusSuccesful,
+				},
+			},
+		},
+		{
+			Name: "rollout fails",
+			Steps: []step{
+				{
+					Event: Event{
+						Application:      "foo",
+						Environment:      "bar",
+						Version:          1,
+						SyncStatusCode:   v1alpha1.SyncStatusCodeOutOfSync,
+						HealthStatusCode: health.HealthStatusHealthy,
+						OperationState: &v1alpha1.OperationState{
+							Phase: common.OperationFailed,
+						},
+					},
+
+					ExpectStatus: &RolloutStatusError,
+				},
+			},
+		},
+		{
+			Name: "rollout errors",
+			Steps: []step{
+				{
+					Event: Event{
+						Application:      "foo",
+						Environment:      "bar",
+						Version:          1,
+						SyncStatusCode:   v1alpha1.SyncStatusCodeOutOfSync,
+						HealthStatusCode: health.HealthStatusHealthy,
+						OperationState: &v1alpha1.OperationState{
+							Phase: common.OperationError,
+						},
+					},
+
+					ExpectStatus: &RolloutStatusError,
 				},
 			},
 		},

--- a/services/rollout-service/pkg/service/service.go
+++ b/services/rollout-service/pkg/service/service.go
@@ -82,6 +82,7 @@ func ConsumeEvents(ctx context.Context, appClient SimplifiedApplicationServiceCl
 					Environment:      environment,
 					SyncStatusCode:   ev.Application.Status.Sync.Status,
 					HealthStatusCode: ev.Application.Status.Health.Status,
+					OperationState:   ev.Application.Status.OperationState,
 					Version:          version,
 				})
 			case "DELETED":
@@ -90,7 +91,9 @@ func ConsumeEvents(ctx context.Context, appClient SimplifiedApplicationServiceCl
 					Environment:      environment,
 					SyncStatusCode:   ev.Application.Status.Sync.Status,
 					HealthStatusCode: ev.Application.Status.Health.Status,
-					Version:          0,
+
+					OperationState: ev.Application.Status.OperationState,
+					Version:        0,
 				})
 				continue recv
 			case "BOOKMARK":
@@ -111,5 +114,6 @@ type Event struct {
 	Application      string
 	SyncStatusCode   v1alpha1.SyncStatusCode
 	HealthStatusCode health.HealthStatusCode
+	OperationState   *v1alpha1.OperationState
 	Version          uint64
 }


### PR DESCRIPTION
ArgoCD reports errors in one additional field. We also need to consider this field when calculating the rollout status.