### PR TITLE
Allow locking and unlocking env groups over rest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       args:
         - UID=$USER_UID
     container_name: kuberpult-cd-service
+    environment:
+      - LOG_LEVEL=INFO
     ports:
       - "8080:8080"
       - "8443:8443"
@@ -19,6 +21,7 @@ services:
     environment:
       - KUBERPULT_CDSERVER=kuberpult-cd-service:8443
       - KUBERPULT_HTTP_CD_SERVER=http://kuberpult-cd-service:8080
+      - LOG_LEVEL=INFO
     ports:
       - "8081:8081"
     depends_on:

--- a/infrastructure/scripts/create-testdata/create-env-group-lock.sh
+++ b/infrastructure/scripts/create-testdata/create-env-group-lock.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+set -x
+
+envGroup=prod
+lockId=lockIdTest${RANDOM}
+lockId=lockIdIntegration0
+url="http://localhost:8081/environment-groups/${envGroup}/locks/${lockId}"
+echo $url
+useSignature=false
+if ${useSignature}
+then
+  SIGNATURE=$(echo -n "${envGroup}""${lockId}" | gpg --keyring trustedkeys-kuberpult.gpg --local-user kuberpult-kind@example.com --detach --sign --armor)
+  json=$(jq -n --arg signature "${SIGNATURE}" --arg message "test env group lock" '$ARGS.named')
+else
+  json=$(jq -n --arg message "test env group lock" '$ARGS.named')
+fi
+
+curl -X PUT "$url" -d "${json}" -H 'Content-Type: application/json'
+echo
+echo created locks with ID "'""${lockId}""'"
+
+
+

--- a/infrastructure/scripts/create-testdata/delete-env-group-lock.sh
+++ b/infrastructure/scripts/create-testdata/delete-env-group-lock.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+set -x
+
+envGroup=prod
+
+lockId=${1}
+url="http://localhost:8081/environment-groups/${envGroup}/locks/${lockId}"
+
+curl -X DELETE "$url" -H 'Content-Type: application/json'
+
+echo
+
+
+

--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -56,13 +56,13 @@ message DeleteEnvironmentLockRequest {
 }
 
 message CreateEnvironmentGroupLockRequest {
-  string environmentGroup = 1;
+  string environment_group = 1;
   string lock_id = 2;
   string message = 3;
 }
 
 message DeleteEnvironmentGroupLockRequest {
-  string environment = 1;
+  string environment_group = 1;
   string lock_id = 2;
 }
 

--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -28,6 +28,8 @@ message BatchAction {
     CreateEnvironmentRequest create_environment = 9;
     ReleaseTrainRequest release_train = 10;
     CreateReleaseRequest create_release = 11;
+    CreateEnvironmentGroupLockRequest create_environment_group_lock = 12;
+    DeleteEnvironmentGroupLockRequest delete_environment_group_lock = 13;
   }
 }
 
@@ -52,6 +54,18 @@ message DeleteEnvironmentLockRequest {
   string environment = 1;
   string lock_id = 2;
 }
+
+message CreateEnvironmentGroupLockRequest {
+  string environmentGroup = 1;
+  string lock_id = 2;
+  string message = 3;
+}
+
+message DeleteEnvironmentGroupLockRequest {
+  string environment = 1;
+  string lock_id = 2;
+}
+
 
 message CreateEnvironmentApplicationLockRequest {
   string environment = 1;

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/pkg/logger"
 	xpath "github.com/freiheit-com/kuberpult/pkg/path"
 	"log"
 	"net/http"
@@ -102,13 +101,11 @@ func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfu
 	token := req.Header.Get("authorization")
 	for _, allowedPath := range allowedPaths {
 		if req.URL.Path == allowedPath {
-			logger.FromContext(req.Context()).Info("path not allowed: " + req.URL.Path)
 			return nil
 		}
 	}
 	for _, allowedPrefix := range allowedPrefixes {
 		if strings.HasPrefix(req.URL.Path, allowedPrefix) {
-			logger.FromContext(req.Context()).Info("prefix not allowed: " + req.URL.Path)
 			return nil
 		}
 	}

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
 	xpath "github.com/freiheit-com/kuberpult/pkg/path"
 	"log"
 	"net/http"
@@ -101,11 +102,13 @@ func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfu
 	token := req.Header.Get("authorization")
 	for _, allowedPath := range allowedPaths {
 		if req.URL.Path == allowedPath {
+			logger.FromContext(req.Context()).Info("path not allowed: " + req.URL.Path)
 			return nil
 		}
 	}
 	for _, allowedPrefix := range allowedPrefixes {
 		if strings.HasPrefix(req.URL.Path, allowedPrefix) {
+			logger.FromContext(req.Context()).Info("prefix not allowed: " + req.URL.Path)
 			return nil
 		}
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -72,5 +72,6 @@ func Wrap(ctx context.Context, inner func(ctx context.Context) error) error {
 		}
 	}()
 	err = inner(WithLogger(ctx, logger))
+
 	return err
 }

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -77,12 +77,16 @@ func MakeTestContextDexEnabledUser(role string) context.Context {
 }
 
 func MakeEnvConfigLatest(argoCd *config.EnvironmentConfigArgoCd) config.EnvironmentConfig {
+	return MakeEnvConfigLatestWithGroup(argoCd, nil)
+}
+
+func MakeEnvConfigLatestWithGroup(argoCd *config.EnvironmentConfigArgoCd, envGroup *string) config.EnvironmentConfig {
 	return config.EnvironmentConfig{
 		Upstream: &config.EnvironmentConfigUpstream{
 			Latest: true,
 		},
 		ArgoCd:           argoCd,
-		EnvironmentGroup: nil,
+		EnvironmentGroup: envGroup,
 	}
 }
 

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -1345,6 +1345,26 @@ func (s *State) GetEnvironmentConfigs() (map[string]config.EnvironmentConfig, er
 	}
 }
 
+func (s *State) GetEnvironmentConfigsForGroup(envGroup string) ([]string, error) {
+	allEnvConfigs, err := s.GetEnvironmentConfigs()
+	if err != nil {
+		return nil, err
+	}
+	groupEnvNames := []string{}
+	for env := range allEnvConfigs {
+		envConfig := allEnvConfigs[env]
+		g := envConfig.EnvironmentGroup
+		if g != nil && *g == envGroup {
+			groupEnvNames = append(groupEnvNames, env)
+		}
+	}
+	if len(groupEnvNames) == 0 {
+		return nil, errors.New(fmt.Sprintf("No environment found with given group '%s'", envGroup))
+	}
+	sort.Strings(groupEnvNames)
+	return groupEnvNames, nil
+}
+
 func (s *State) GetEnvironmentApplications(environment string) ([]string, error) {
 	appDir := s.Filesystem.Join("environments", environment, "applications")
 	return names(s.Filesystem, appDir)

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -4143,3 +4143,171 @@ func TestDeleteLocks(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvironmentGroupLocks(t *testing.T) {
+	group := ptr.FromString("prod")
+	tcs := []struct {
+		Name              string
+		Transformers      []Transformer
+		expectedError     string
+		expectedCommitMsg string
+		shouldSucceed     bool
+	}{
+		{
+			Name: "Success create env group lock",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "prod-ca",
+					Config:      testutil.MakeEnvConfigLatestWithGroup(nil, group),
+				},
+				&CreateEnvironment{
+					Environment: "prod-de",
+					Config:      testutil.MakeEnvConfigLatestWithGroup(nil, group),
+				},
+				&CreateEnvironment{
+					Environment: "staging",
+					Config:      testutil.MakeEnvConfigLatestWithGroup(nil, ptr.FromString("another-group")),
+				},
+				&CreateEnvironmentGroupLock{
+					Authentication:   Authentication{},
+					EnvironmentGroup: *group,
+					LockId:           "my-lock",
+					Message:          "my-message",
+				},
+			},
+			expectedError:     "",
+			expectedCommitMsg: "Creating locks 'my-lock' for environment group 'prod':\nCreated lock \"my-lock\" on environment \"prod-ca\"\nCreated lock \"my-lock\" on environment \"prod-de\"",
+			shouldSucceed:     true,
+		},
+		{
+			Name: "Success delete env group lock",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "prod-ca",
+					Config:      testutil.MakeEnvConfigLatestWithGroup(nil, group),
+				},
+				&CreateEnvironment{
+					Environment: "prod-de",
+					Config:      testutil.MakeEnvConfigLatestWithGroup(nil, group),
+				},
+				&CreateEnvironment{
+					Environment: "staging",
+					Config:      testutil.MakeEnvConfigLatestWithGroup(nil, ptr.FromString("another-group")),
+				},
+				&CreateEnvironmentGroupLock{
+					Authentication:   Authentication{},
+					EnvironmentGroup: *group,
+					LockId:           "my-lock",
+					Message:          "my-message",
+				},
+				&DeleteEnvironmentGroupLock{
+					Authentication:   Authentication{},
+					EnvironmentGroup: *group,
+					LockId:           "my-lock",
+				},
+			},
+			expectedError:     "",
+			expectedCommitMsg: "Deleting locks 'my-lock' for environment group 'prod':\nDeleted lock \"my-lock\" on environment \"prod-ca\"\nDeleted lock \"my-lock\" on environment \"prod-de\"",
+			shouldSucceed:     true,
+		},
+		{
+			Name: "Success delete env group that was created as env lock",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "prod-ca",
+					Config:      testutil.MakeEnvConfigLatestWithGroup(nil, group),
+				},
+				&CreateEnvironmentLock{
+					Authentication: Authentication{},
+					Environment:    "prod-ca",
+					LockId:         "my-lock",
+					Message:        "my-message",
+				},
+				&DeleteEnvironmentGroupLock{
+					Authentication:   Authentication{},
+					EnvironmentGroup: *group,
+					LockId:           "my-lock",
+				},
+			},
+			expectedError:     "",
+			expectedCommitMsg: "Deleting locks 'my-lock' for environment group 'prod':\nDeleted lock \"my-lock\" on environment \"prod-ca\"",
+			shouldSucceed:     true,
+		},
+		{
+			Name: "Success delete env lock that was created as env group lock",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "prod-ca",
+					Config:      testutil.MakeEnvConfigLatestWithGroup(nil, group),
+				},
+				&CreateEnvironmentGroupLock{
+					Authentication:   Authentication{},
+					EnvironmentGroup: *group,
+					LockId:           "my-lock",
+					Message:          "my-message",
+				},
+				&DeleteEnvironmentLock{
+					Authentication: Authentication{},
+					Environment:    "prod-ca",
+					LockId:         "my-lock",
+				},
+			},
+			expectedError:     "",
+			expectedCommitMsg: "Deleted lock \"my-lock\" on environment \"prod-ca\"",
+			shouldSucceed:     true,
+		},
+		{
+			Name: "Failure create env group lock - no envs found",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "prod-ca",
+					Config:      testutil.MakeEnvConfigLatestWithGroup(nil, group),
+				},
+				&CreateEnvironment{
+					Environment: "prod-de",
+					Config:      testutil.MakeEnvConfigLatestWithGroup(nil, group),
+				},
+				&CreateEnvironment{
+					Environment: "staging",
+					Config:      testutil.MakeEnvConfigLatestWithGroup(nil, ptr.FromString("another-group")),
+				},
+				&CreateEnvironmentGroupLock{
+					Authentication:   Authentication{},
+					EnvironmentGroup: "dev",
+					LockId:           "my-lock",
+					Message:          "my-message",
+				},
+			},
+			expectedError:     "rpc error: code = InvalidArgument desc = error: No environment found with given group 'dev'",
+			expectedCommitMsg: "",
+			shouldSucceed:     false,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			repo := setupRepositoryTest(t)
+			commitMsg, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
+			// note that we only check the LAST error here:
+			if tc.shouldSucceed {
+				if err != nil {
+					t.Fatalf("Expected no error: %v", err)
+				}
+				actualMsg := commitMsg[len(commitMsg)-1]
+				if diff := cmp.Diff(actualMsg, tc.expectedCommitMsg); diff != "" {
+					t.Errorf("got %v, want %v, diff (-want +got) %s", actualMsg, tc.expectedCommitMsg, diff)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("Expected an error but got none")
+				} else {
+					actualMsg := err.Error()
+					if actualMsg != tc.expectedError {
+						t.Fatalf("expected a different error.\nExpected: %q\nGot %q", tc.expectedError, actualMsg)
+					}
+				}
+			}
+		})
+	}
+}

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -248,6 +248,21 @@ func (d *BatchServer) processAction(
 			Authentication: repository.Authentication{RBACConfig: d.RBACConfig},
 		}
 		return transformer, nil, nil
+	case *api.BatchAction_CreateEnvironmentGroupLock:
+		act := action.CreateEnvironmentGroupLock
+		return &repository.CreateEnvironmentGroupLock{
+			EnvironmentGroup: act.EnvironmentGroup,
+			LockId:           act.LockId,
+			Message:          act.Message,
+			Authentication:   repository.Authentication{RBACConfig: d.RBACConfig},
+		}, nil, nil
+	case *api.BatchAction_DeleteEnvironmentGroupLock:
+		act := action.DeleteEnvironmentGroupLock
+		return &repository.DeleteEnvironmentGroupLock{
+			EnvironmentGroup: act.EnvironmentGroup,
+			LockId:           act.LockId,
+			Authentication:   repository.Authentication{RBACConfig: d.RBACConfig},
+		}, nil, nil
 	}
 	return nil, nil, status.Error(codes.InvalidArgument, "processAction: cannot process action: invalid action type")
 }

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -236,6 +236,13 @@ func runServer(ctx context.Context) error {
 		}
 		httpHandler.Handle(w, req)
 	}))
+	mux.Handle("/environment-groups/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		defer readAllAndClose(req.Body, 1024)
+		if c.DexEnabled {
+			interceptors.DexLoginInterceptor(w, req, httpHandler, c.DexClientId, c.DexClientSecret)
+		}
+		httpHandler.Handle(w, req)
+	}))
 	mux.Handle("/release", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer readAllAndClose(req.Body, 1024)
 		if c.DexEnabled {

--- a/services/frontend-service/pkg/handler/handle.go
+++ b/services/frontend-service/pkg/handler/handle.go
@@ -38,6 +38,8 @@ func (s Server) Handle(w http.ResponseWriter, req *http.Request) {
 	switch group {
 	case "environments":
 		s.HandleEnvironments(w, req, tail)
+	case "environment-group":
+		s.HandleEnvironmentGroups(w, req, tail)
 	case "release":
 		s.HandleRelease(w, req, tail)
 	default:

--- a/services/frontend-service/pkg/handler/handle.go
+++ b/services/frontend-service/pkg/handler/handle.go
@@ -38,7 +38,7 @@ func (s Server) Handle(w http.ResponseWriter, req *http.Request) {
 	switch group {
 	case "environments":
 		s.HandleEnvironments(w, req, tail)
-	case "environment-group":
+	case "environment-groups":
 		s.HandleEnvironmentGroups(w, req, tail)
 	case "release":
 		s.HandleRelease(w, req, tail)

--- a/services/frontend-service/pkg/handler/handleEnvironments.go
+++ b/services/frontend-service/pkg/handler/handleEnvironments.go
@@ -23,6 +23,23 @@ import (
 	xpath "github.com/freiheit-com/kuberpult/pkg/path"
 )
 
+func (s Server) HandleEnvironmentGroups(w http.ResponseWriter, req *http.Request, tail string) {
+	envGroup, tail := xpath.Shift(tail)
+	if envGroup == "" {
+		http.Error(w, "missing group ID", http.StatusNotFound)
+		return
+	}
+
+	function, tail := xpath.Shift(tail)
+
+	switch function {
+	case "locks":
+		s.handleEnvironmentLocks(w, req, envGroup, tail)
+	default:
+		http.Error(w, fmt.Sprintf("unknown function '%s'", function), http.StatusNotFound)
+	}
+}
+
 func (s Server) HandleEnvironments(w http.ResponseWriter, req *http.Request, tail string) {
 	environment, tail := xpath.Shift(tail)
 	if environment == "" {

--- a/services/frontend-service/pkg/handler/handleEnvironments.go
+++ b/services/frontend-service/pkg/handler/handleEnvironments.go
@@ -34,7 +34,7 @@ func (s Server) HandleEnvironmentGroups(w http.ResponseWriter, req *http.Request
 
 	switch function {
 	case "locks":
-		s.handleEnvironmentLocks(w, req, envGroup, tail)
+		s.handleEnvironmentGroupLocks(w, req, envGroup, tail)
 	default:
 		http.Error(w, fmt.Sprintf("unknown function '%s'", function), http.StatusNotFound)
 	}

--- a/services/frontend-service/pkg/handler/handle_test.go
+++ b/services/frontend-service/pkg/handler/handle_test.go
@@ -561,7 +561,7 @@ func TestServer_Handle(t *testing.T) {
 			expectedResp: &http.Response{
 				StatusCode: http.StatusNotFound,
 			},
-			expectedBody: "missing lock ID\n",
+			expectedBody: "missing ID for env lock\n",
 		},
 		{
 			name: "lock env but additional path params",
@@ -574,7 +574,7 @@ func TestServer_Handle(t *testing.T) {
 			expectedResp: &http.Response{
 				StatusCode: http.StatusNotFound,
 			},
-			expectedBody: "locks does not accept additional path arguments after the lock ID, got: '/junk'\n",
+			expectedBody: "env locks does not accept additional path arguments after the lock ID, got: '/junk'\n",
 		},
 		{
 			name: "lock env but wrong content type",
@@ -676,7 +676,7 @@ func TestServer_Handle(t *testing.T) {
 			expectedResp: &http.Response{
 				StatusCode: http.StatusNotFound,
 			},
-			expectedBody: "missing lock ID\n",
+			expectedBody: "missing ID for env lock\n",
 		},
 		{
 			name: "unlock env but additional path params",
@@ -689,7 +689,7 @@ func TestServer_Handle(t *testing.T) {
 			expectedResp: &http.Response{
 				StatusCode: http.StatusNotFound,
 			},
-			expectedBody: "locks does not accept additional path arguments after the lock ID, got: '/junk'\n",
+			expectedBody: "env locks does not accept additional path arguments after the lock ID, got: '/junk'\n",
 		},
 		{
 			name: "lock env but wrong method",
@@ -874,7 +874,9 @@ func TestServer_Handle(t *testing.T) {
 				t.Errorf("error reading response body: %s", err)
 			}
 			if d := cmp.Diff(tt.expectedBody, string(body)); d != "" {
-				t.Errorf("response body mismatch: %s", d)
+				//t.Errorf("response body mismatch: %s", d)
+				t.Errorf("response body mismatch:\ngot:  %s\nwant: %s\ndiff: \n%s", string(body), tt.expectedBody, d)
+
 			}
 			if d := cmp.Diff(tt.expectedBatchRequest, batchClient.batchRequest, protocmp.Transform()); d != "" {
 				t.Errorf("create batch request mismatch: %s", d)

--- a/services/frontend-service/pkg/handler/handle_test.go
+++ b/services/frontend-service/pkg/handler/handle_test.go
@@ -904,7 +904,7 @@ func TestServer_Handle(t *testing.T) {
 			expectedResp: &http.Response{
 				StatusCode: http.StatusNotFound,
 			},
-			expectedBody: "locks does not accept additional path arguments after the lock ID, got: /garbage\n",
+			expectedBody: "group locks does not accept additional path arguments after the lock ID, got: '/garbage'\n",
 		},
 		{
 			name: "lock env group but wrong method",

--- a/services/frontend-service/pkg/handler/handle_test.go
+++ b/services/frontend-service/pkg/handler/handle_test.go
@@ -852,6 +852,73 @@ func TestServer_Handle(t *testing.T) {
 			},
 			expectedBody: "unsupported method 'GET'\n",
 		},
+		{
+			name: "unlock env group",
+			req: &http.Request{
+				Method: http.MethodDelete,
+				URL: &url.URL{
+					Path: "/environment-groups/development/locks/test",
+				},
+			},
+			batchResponse: &api.BatchResponse{Results: []*api.BatchResult{
+				{},
+			}},
+			expectedResp: &http.Response{
+				StatusCode: http.StatusOK,
+			},
+			expectedBody: "{\"Result\":null}",
+			expectedBatchRequest: &api.BatchRequest{
+				Actions: []*api.BatchAction{
+					{
+						Action: &api.BatchAction_DeleteEnvironmentGroupLock{
+							DeleteEnvironmentGroupLock: &api.DeleteEnvironmentGroupLockRequest{
+								EnvironmentGroup: "development",
+								LockId:           "test",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "unlock env group but missing lock ID",
+			req: &http.Request{
+				Method: http.MethodDelete,
+				URL: &url.URL{
+					Path: "/environment-groups/development/locks",
+				},
+			},
+			expectedResp: &http.Response{
+				StatusCode: http.StatusNotFound,
+			},
+			expectedBody: "missing ID for env group lock\n",
+		},
+		{
+			name: "unlock env group but additional path params",
+			req: &http.Request{
+				Method: http.MethodDelete,
+				URL: &url.URL{
+					Path: "/environment-groups/development/locks/test/garbage",
+				},
+			},
+			expectedResp: &http.Response{
+				StatusCode: http.StatusNotFound,
+			},
+			expectedBody: "locks does not accept additional path arguments after the lock ID, got: /garbage\n",
+		},
+		{
+			name: "lock env group but wrong method",
+			req: &http.Request{
+				Method: http.MethodGet,
+				URL: &url.URL{
+					Path: "/environment-groups/development/locks/test-lock",
+				},
+			},
+			expectedResp: &http.Response{
+				StatusCode: http.StatusMethodNotAllowed,
+			},
+			expectedBody: "unsupported method 'GET'\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/services/frontend-service/pkg/handler/locks.go
+++ b/services/frontend-service/pkg/handler/locks.go
@@ -244,7 +244,7 @@ func (s Server) handlePutEnvironmentGroupLock(w http.ResponseWriter, req *http.R
 	if err != nil {
 		return
 	}
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusCreated)
 	w.Write(jsonResponse)
 }
 

--- a/services/frontend-service/pkg/handler/locks.go
+++ b/services/frontend-service/pkg/handler/locks.go
@@ -30,14 +30,35 @@ import (
 	"strings"
 )
 
-func (s Server) handleEnvironmentLocks(w http.ResponseWriter, req *http.Request, environment, tail string) {
+func (s Server) handleEnvironmentGroupLocks(w http.ResponseWriter, req *http.Request, environmentGroup, tail string) {
 	lockID, tail := xpath.Shift(tail)
 	if lockID == "" {
-		http.Error(w, "missing lock ID", http.StatusNotFound)
+		http.Error(w, "missing ID for env group lock", http.StatusNotFound)
 		return
 	}
 	if tail != "/" {
-		http.Error(w, fmt.Sprintf("locks does not accept additional path arguments after the lock ID, got: '%s'", tail), http.StatusNotFound)
+		http.Error(w, fmt.Sprintf("group locks does not accept additional path arguments after the lock ID, got: '%s'", tail), http.StatusNotFound)
+		return
+	}
+
+	switch req.Method {
+	case http.MethodPut:
+		s.handlePutEnvironmentLock(w, req, environmentGroup, lockID)
+	case http.MethodDelete:
+		s.handleDeleteEnvironmentLock(w, req, environmentGroup, lockID)
+	default:
+		http.Error(w, fmt.Sprintf("unsupported method '%s'", req.Method), http.StatusMethodNotAllowed)
+	}
+}
+
+func (s Server) handleEnvironmentLocks(w http.ResponseWriter, req *http.Request, environment, tail string) {
+	lockID, tail := xpath.Shift(tail)
+	if lockID == "" {
+		http.Error(w, "missing ID for env lock", http.StatusNotFound)
+		return
+	}
+	if tail != "/" {
+		http.Error(w, fmt.Sprintf("env locks does not accept additional path arguments after the lock ID, got: '%s'", tail), http.StatusNotFound)
 		return
 	}
 

--- a/services/frontend-service/pkg/handler/locks.go
+++ b/services/frontend-service/pkg/handler/locks.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	pgperrors "github.com/ProtonMail/go-crypto/openpgp/errors"
 	"github.com/freiheit-com/kuberpult/pkg/api"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
 	xpath "github.com/freiheit-com/kuberpult/pkg/path"
 	"io"
 	"net/http"
@@ -43,9 +44,9 @@ func (s Server) handleEnvironmentGroupLocks(w http.ResponseWriter, req *http.Req
 
 	switch req.Method {
 	case http.MethodPut:
-		s.handlePutEnvironmentLock(w, req, environmentGroup, lockID)
+		s.handlePutEnvironmentGroupLock(w, req, environmentGroup, lockID)
 	case http.MethodDelete:
-		s.handleDeleteEnvironmentLock(w, req, environmentGroup, lockID)
+		s.handleDeleteEnvironmentGroupLock(w, req, environmentGroup, lockID)
 	default:
 		http.Error(w, fmt.Sprintf("unsupported method '%s'", req.Method), http.StatusMethodNotAllowed)
 	}
@@ -73,9 +74,7 @@ func (s Server) handleEnvironmentLocks(w http.ResponseWriter, req *http.Request,
 }
 
 func (s Server) handlePutEnvironmentLock(w http.ResponseWriter, req *http.Request, environment, lockID string) {
-	contentType := req.Header.Get("Content-Type")
-	if contentType != "application/json" {
-		http.Error(w, fmt.Sprintf("body must be application/json, got: '%s'", contentType), http.StatusUnsupportedMediaType)
+	if s.checkContentType(w, req) {
 		return
 	}
 
@@ -179,4 +178,142 @@ func (s Server) handleDeleteEnvironmentLock(w http.ResponseWriter, req *http.Req
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+func (s Server) handlePutEnvironmentGroupLock(w http.ResponseWriter, req *http.Request, environmentGroup, lockID string) {
+	if s.checkContentType(w, req) {
+		return
+	}
+
+	var body putLockRequest
+	invalidMessage := "Please provide lock message in body"
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		decodeError := err.Error()
+		if errors.Is(err, io.EOF) {
+			decodeError = invalidMessage
+		}
+		http.Error(w, decodeError, http.StatusBadRequest)
+		return
+	}
+
+	if len(body.Message) == 0 {
+		http.Error(w, invalidMessage, http.StatusBadRequest)
+		return
+	}
+
+	signature := body.Signature
+	if len(signature) == 0 && s.AzureAuth {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Missing signature in request body - this is required with AzureAuth enabled"))
+		return
+	}
+
+	if len(signature) > 0 {
+		if s.KeyRing == nil {
+			http.Error(w, "key ring is not configured", http.StatusNotFound)
+			return
+		}
+		if _, err := openpgp.CheckArmoredDetachedSignature(s.KeyRing, strings.NewReader(environmentGroup+lockID), strings.NewReader(signature), nil); err != nil {
+			if err != pgperrors.ErrUnknownIssuer {
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprintf(w, "Internal: Invalid Signature: %s", err)
+				return
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprintf(w, "Invalid signature")
+			return
+		}
+	}
+
+	response, err := s.BatchClient.ProcessBatch(req.Context(), &api.BatchRequest{Actions: []*api.BatchAction{
+		{Action: &api.BatchAction_CreateEnvironmentGroupLock{
+			CreateEnvironmentGroupLock: &api.CreateEnvironmentGroupLockRequest{
+				EnvironmentGroup: environmentGroup,
+				LockId:           lockID,
+				Message:          body.Message,
+			},
+		}},
+	}})
+
+	if err != nil {
+		handleGRPCError(req.Context(), w, err)
+		return
+	}
+
+	jsonResponse, err := json.Marshal(response.Results[0])
+	if err != nil {
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(jsonResponse)
+}
+
+func (s Server) checkContentType(w http.ResponseWriter, req *http.Request) bool {
+	contentType := req.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		http.Error(w, fmt.Sprintf("body must be application/json, got: '%s'", contentType), http.StatusUnsupportedMediaType)
+		return true
+	}
+	return false
+}
+
+func (s Server) handleDeleteEnvironmentGroupLock(w http.ResponseWriter, req *http.Request, environmentGroup, lockID string) {
+	if req.Body == nil && s.AzureAuth {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "missing request body")
+		return
+	}
+	if req.Body != nil {
+		if s.checkContentType(w, req) {
+			return
+		}
+		signature, err := io.ReadAll(req.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, "Can't read request body %s", err)
+			return
+		}
+		if len(signature) == 0 && s.AzureAuth {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("Missing signature in request body"))
+			return
+		}
+		if len(signature) > 0 {
+			if s.KeyRing == nil {
+				logger.FromContext(req.Context()).Warn("NO KEYRING. signature: " + string(signature))
+				http.Error(w, "key ring is not configured", http.StatusNotFound)
+				return
+			}
+			if _, err := openpgp.CheckArmoredDetachedSignature(s.KeyRing, strings.NewReader(environmentGroup+lockID), bytes.NewReader(signature), nil); err != nil {
+				if err != pgperrors.ErrUnknownIssuer {
+					w.WriteHeader(500)
+					fmt.Fprintf(w, "Internal: Invalid Signature: %s", err)
+					return
+				}
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprintf(w, "Invalid signature")
+				return
+			}
+		}
+	}
+	response, err := s.BatchClient.ProcessBatch(req.Context(), &api.BatchRequest{Actions: []*api.BatchAction{
+		{Action: &api.BatchAction_DeleteEnvironmentGroupLock{
+			DeleteEnvironmentGroupLock: &api.DeleteEnvironmentGroupLockRequest{
+				EnvironmentGroup: environmentGroup,
+				LockId:           lockID,
+			},
+		}},
+	}})
+
+	if err != nil {
+		handleGRPCError(req.Context(), w, err)
+		return
+	}
+
+	jsonResponse, err := json.Marshal(response.Results[0])
+	if err != nil {
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(jsonResponse)
 }

--- a/services/frontend-service/pkg/handler/locks.go
+++ b/services/frontend-service/pkg/handler/locks.go
@@ -310,6 +310,11 @@ func (s Server) handleDeleteEnvironmentGroupLock(w http.ResponseWriter, req *htt
 		return
 	}
 
+	if response == nil || len(response.Results) == 0 {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("cd-service did not return a result"))
+		return
+	}
 	jsonResponse, err := json.Marshal(response.Results[0])
 	if err != nil {
 		return

--- a/tests/integration-tests/release_test.go
+++ b/tests/integration-tests/release_test.go
@@ -293,11 +293,11 @@ func TestGroupLock(t *testing.T) {
 	testCases := []struct {
 		name               string
 		inputEnvGroup      string
-		inputLockId        string
 		expectedStatusCode int
 	}{
 		{
 			name:               "Simple invocation of group lock endpoint",
+			inputEnvGroup:      "prod",
 			expectedStatusCode: 201,
 		},
 	}
@@ -306,12 +306,12 @@ func TestGroupLock(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			lockId := fmt.Sprintf("lockIdIntegration%d", index)
-			inputSignature := CalcSignature(t, tc.inputEnvGroup+tc.inputLockId)
+			inputSignature := CalcSignature(t, lockId)
 			requestBody := &putLockRequest{
 				Message:   "hello world",
 				Signature: inputSignature,
 			}
-			actualStatusCode, respBody, err := callCreateGroupLock(t, "prod", lockId, requestBody)
+			actualStatusCode, respBody, err := callCreateGroupLock(t, tc.inputEnvGroup, lockId, requestBody)
 			if err != nil {
 				log.Fatalf("callRelease failed: %s", err.Error())
 			}

--- a/tests/integration-tests/release_test.go
+++ b/tests/integration-tests/release_test.go
@@ -306,7 +306,7 @@ func TestGroupLock(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			lockId := fmt.Sprintf("lockIdIntegration%d", index)
-			inputSignature := CalcSignature(t, lockId)
+			inputSignature := CalcSignature(t, tc.inputEnvGroup+lockId)
 			requestBody := &putLockRequest{
 				Message:   "hello world",
 				Signature: inputSignature,


### PR DESCRIPTION
This makes it's possible to lock/unlock all environments in one group with one rest call.
The endpoint is `/environment-groups/<envGroup>/locks/<lockId>`, see `infrastructure/scripts/create-testdata/create-env-group-lock.sh` and `infrastructure/scripts/create-testdata/delete-env-group-lock.sh` for details.
Note that this will create multiple *environment locks*.
That means if you create an env lock with id "x" you can then delete it for one environment by calling `/environments/<env>/locks/x" - even though it was created with the `environment-groups` endpoint.

So there are still only 2 kinds of locks: environment locks and app locks.