### PR TITLE
Add a feature flag to disable sending webhooks

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -109,8 +109,13 @@ spec:
           value: {{ .Values.log.format | quote }}
         - name: LOG_LEVEL
           value: {{ .Values.log.level | quote }}
+{{- if .Values.argocd.sendWebhook }}
         - name: KUBERPULT_ARGO_CD_SERVER
           value: {{ .Values.argocd.server | quote }}
+{{- else }}
+        - name: KUBERPULT_ARGO_CD_SERVER
+          value: ""
+{{- end }}
         - name: KUBERPULT_ARGO_CD_INSECURE
           value: {{ .Values.argocd.insecure | quote }}
         - name: KUBERPULT_GIT_WEB_URL

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -101,6 +101,8 @@ argocd:
   server: ""
   # Disables tls verification. This is useful when running in the same cluster as argocd and using a self-signed certificate.
   insecure: false
+  # Enable sending webhooks to argocd
+  sendWebhooks: false
 
 datadogTracing:
   enabled: false


### PR DESCRIPTION
I did this now as a helm-only thing to unblock the next kuberpult release. We will clean this up soon.