### PR TITLE
Don't show the rollout status if it's disabled

### DIFF
--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -20,6 +20,7 @@ import { PageRoutes } from './PageRoutes';
 import '../../assets/app-v2.scss';
 import * as React from 'react';
 import {
+    EnableRolloutStatus,
     FlushRolloutStatus,
     PanicOverview,
     showSnackbarWarn,
@@ -109,8 +110,13 @@ export const App: React.FC = () => {
                         UpdateRolloutStatus(result);
                     },
                     (error) => {
+                        if (error.code === 12) {
+                            // Error code 12 means "not implemented". That is what we get when the rollout service is not enabled.
+                            FlushRolloutStatus();
+                            return;
+                        }
                         PanicOverview.set({ error: JSON.stringify({ msg: 'error in rolloutstatus', error }) });
-                        FlushRolloutStatus();
+                        EnableRolloutStatus();
                     }
                 );
             return (): void => subscription.unsubscribe();

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -74,8 +74,12 @@ const rolloutStatusPriority = [
 const calculateDeploymentStatus = (
     app: string,
     deployedAt: EnvironmentGroupExtended[],
+    rolloutEnabled: boolean,
     rolloutStatus: RolloutStatusApplication
 ): [Array<StreamStatusResponse>, StreamStatusResponse?] => {
+    if (!rolloutEnabled) {
+        return [[], undefined];
+    }
     const rolloutEnvs = deployedAt.flatMap((envGroup) =>
         envGroup.environments.map((env) => {
             const status = rolloutStatus[env.name];
@@ -120,10 +124,10 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
     // the ReleaseCard only displays actual releases, so we can assume that it exists here:
     const { createdAt, sourceMessage, sourceCommitId, sourceAuthor, undeployVersion } = useReleaseOrThrow(app, version);
     const openReleaseDialog = useOpenReleaseDialog(app, version);
-    const rolloutStatus = useRolloutStatus(app);
+    const [rolloutEnabled, rolloutStatus] = useRolloutStatus(app);
     const deployedAt = useCurrentlyDeployedAtGroup(app, version);
 
-    const [rolloutEnvs, mostInteresting] = calculateDeploymentStatus(app, deployedAt, rolloutStatus);
+    const [rolloutEnvs, mostInteresting] = calculateDeploymentStatus(app, deployedAt, rolloutEnabled, rolloutStatus);
 
     const tooltipContents = (
         <div className="mdc-tooltip__title_ release__details">

--- a/services/frontend-service/src/ui/utils/store.test.tsx
+++ b/services/frontend-service/src/ui/utils/store.test.tsx
@@ -333,6 +333,7 @@ describe('Rollout Status', () => {
     type Testcase = {
         name: string;
         events: Array<StreamStatusResponse | { error: true }>;
+        expectedEnabled: boolean;
         expectedApps: Array<{
             application: string;
             environment: string;
@@ -343,6 +344,20 @@ describe('Rollout Status', () => {
 
     const testdata: Array<Testcase> = [
         {
+            name: 'not enabled if empty',
+            events: [],
+
+            expectedEnabled: false,
+            expectedApps: [
+                {
+                    application: 'app1',
+                    environment: 'env1',
+                    version: 0,
+                    rolloutStatus: RolloutStatus.RolloutStatusSuccesful,
+                },
+            ],
+        },
+        {
             name: 'updates one app',
             events: [
                 {
@@ -352,6 +367,8 @@ describe('Rollout Status', () => {
                     rolloutStatus: RolloutStatus.RolloutStatusSuccesful,
                 },
             ],
+
+            expectedEnabled: true,
             expectedApps: [
                 {
                     application: 'app1',
@@ -377,6 +394,8 @@ describe('Rollout Status', () => {
                     rolloutStatus: RolloutStatus.RolloutStatusSuccesful,
                 },
             ],
+
+            expectedEnabled: true,
             expectedApps: [
                 {
                     application: 'app1',
@@ -397,6 +416,8 @@ describe('Rollout Status', () => {
                 },
                 { error: true },
             ],
+
+            expectedEnabled: false,
             expectedApps: [
                 {
                     application: 'app1',
@@ -419,15 +440,14 @@ describe('Rollout Status', () => {
                 }
             });
             testcase.expectedApps.forEach((app) => {
-                const rollout = renderHook(() => {
-                    const status = useRolloutStatus(app.application);
-                    return status;
-                });
+                const rollout = renderHook(() => useRolloutStatus(app.application));
+                const [enabled, status] = rollout.result.current;
                 if (app.version === 0) {
-                    expect(rollout.result.current).not.toHaveProperty(app.environment, app);
+                    expect(status).not.toHaveProperty(app.environment, app);
                 } else {
-                    expect(rollout.result.current).toHaveProperty(app.environment, app);
+                    expect(status).toHaveProperty(app.environment, app);
                 }
+                expect(enabled).toEqual(testcase.expectedEnabled);
             });
         });
     });


### PR DESCRIPTION
The rollout status is currently always shown, regardles if its backend is deployed. This change makes the frontend aware of the services availability, displaying the rollout status only if the frontend service doesn't responds with "not implemented" error.