### PR TITLE
Notify argocd about updates

### DIFF
--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -298,6 +298,7 @@ argocd:
   token: "$token"
   server: "https://argocd-server.${ARGO_NAMESPACE}.svc.cluster.local:443"
   insecure: true
+  refreshEnabled: true
 pgp:
   keyRing: |
 $(sed -e "s/^/    /" <./kuberpult-keyring.gpg)

--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -85,6 +85,8 @@ spec:
           value: {{ .Values.argocd.server | quote }}
         - name: KUBERPULT_ARGOCD_INSECURE
           value: {{ .Values.argocd.insecure | quote }}
+        - name: KUBERPULT_ARGOCD_REFRESH_ENABLED
+          value: {{ .Values.argocd.refreshEnabled | quote }}
         - name: LOG_FORMAT
           value: {{ .Values.log.format | quote }}
         - name: LOG_LEVEL

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -103,6 +103,8 @@ argocd:
   insecure: false
   # Enable sending webhooks to argocd
   sendWebhooks: false
+  # Enable sending refresh requests to argocd
+  refreshEnabled: false
 
 datadogTracing:
   enabled: false

--- a/services/rollout-service/Makefile
+++ b/services/rollout-service/Makefile
@@ -87,3 +87,9 @@ all: test docker
 .PHONY: get-builder-image
 get-builder-image:
 	@echo "$(KUBERPULT_BUILDER)"
+
+kind-load: docker
+	kind load docker-image "$(IMAGENAME)"
+
+patch-kind: kind-load
+	kubectl set image deployment/kuberpult-rollout-service service=$(IMAGENAME)

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/freiheit-com/kuberpult/pkg/logger"
 	"github.com/freiheit-com/kuberpult/pkg/setup"
 	"github.com/freiheit-com/kuberpult/pkg/tracing"
+	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/notifier"
 	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/service"
 	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/versions"
 	"github.com/kelseyhightower/envconfig"
@@ -47,9 +48,10 @@ type Config struct {
 	CdServer      string `default:"kuberpult-cd-service:8443"`
 	EnableTracing bool   `default:"false" split_words:"true"`
 
-	ArgocdServer   string `split_words:"true"`
-	ArgocdInsecure bool   `default:"false" split_words:"true"`
-	ArgocdToken    string `split_words:"true"`
+	ArgocdServer         string `split_words:"true"`
+	ArgocdInsecure       bool   `default:"false" split_words:"true"`
+	ArgocdToken          string `split_words:"true"`
+	ArgocdRefreshEnabled bool   `split_words:"true"`
 }
 
 func (config *Config) ClientConfig() (apiclient.ClientOptions, error) {
@@ -157,6 +159,33 @@ func runServer(ctx context.Context, config Config) error {
 	broadcast := service.New()
 	shutdownCh := make(chan struct{})
 	ready := false
+	versionC := versions.New(overview)
+
+	backgroundTasks := []setup.BackgroundTaskConfig{
+		{
+			Name: "consume argocd events",
+			Run: func(ctx context.Context) error {
+				return service.ConsumeEvents(ctx, appClient, versionC, broadcast, func() { ready = true })
+			},
+		},
+		{
+			Name: "consume kuberpult events",
+			Run: func(ctx context.Context) error {
+				return versionC.Subscribe(ctx, broadcast)
+			},
+		},
+	}
+
+	if config.ArgocdRefreshEnabled {
+		notify := notifier.New(appClient)
+		backgroundTasks = append(backgroundTasks, setup.BackgroundTaskConfig{
+			Name: "refresh argocd",
+			Run: func(ctx context.Context) error {
+				return notifier.Subscribe(ctx, notify, broadcast)
+			},
+		})
+	}
+
 	setup.Run(ctx, setup.ServerConfig{
 		HTTP: []setup.HTTPConfig{
 			{
@@ -172,13 +201,7 @@ func runServer(ctx context.Context, config Config) error {
 				},
 			},
 		},
-		Background: []setup.BackgroundTaskConfig{
-			{
-				Name: "consume events",
-				Run: func(ctx context.Context) error {
-					return service.ConsumeEvents(ctx, appClient, versions.New(overview), broadcast, func() { ready = true })
-				},
-			}},
+		Background: backgroundTasks,
 		GRPC: &setup.GRPCConfig{
 			Port: "8443",
 			Opts: []grpc.ServerOption{

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -171,7 +171,7 @@ func runServer(ctx context.Context, config Config) error {
 		{
 			Name: "consume kuberpult events",
 			Run: func(ctx context.Context) error {
-				return versionC.Subscribe(ctx, broadcast)
+				return versionC.ConsumeEvents(ctx, broadcast)
 			},
 		},
 	}

--- a/services/rollout-service/pkg/notifier/notifier.go
+++ b/services/rollout-service/pkg/notifier/notifier.go
@@ -1,0 +1,66 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package notifier
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	argoapplication "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
+	"github.com/freiheit-com/kuberpult/pkg/ptr"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+type SimplifiedApplicationInterface interface {
+	Get(ctx context.Context, in *argoapplication.ApplicationQuery, opts ...grpc.CallOption) (*argoappv1.Application, error)
+}
+
+type Notifier interface {
+	NotifyArgoCd(ctx context.Context, environment, application string)
+}
+
+func New(client SimplifiedApplicationInterface) Notifier {
+	return &notifier{client}
+}
+
+type notifier struct {
+	client SimplifiedApplicationInterface
+}
+
+func (n *notifier) NotifyArgoCd(ctx context.Context, environment, application string) {
+        var err error
+	span, ctx := tracer.StartSpanFromContext(ctx, "argocd.refresh")
+	span.SetTag("environment", environment)
+	span.SetTag("application", application)
+	defer span.Finish(tracer.WithError(err))
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	l := logger.FromContext(ctx).With(zap.String("environment", environment), zap.String("application", application))
+
+	_, err = n.client.Get(ctx, &argoapplication.ApplicationQuery{
+		Name:    ptr.FromString(fmt.Sprintf("%s-%s", environment, application)),
+		Refresh: ptr.FromString(string(argoappv1.RefreshTypeNormal)),
+	})
+	if err != nil {
+		l.Error("argocd.refresh", zap.Error(err))
+	}
+}

--- a/services/rollout-service/pkg/notifier/subscriber.go
+++ b/services/rollout-service/pkg/notifier/subscriber.go
@@ -1,0 +1,76 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package notifier
+
+import (
+	"context"
+
+	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/service"
+)
+
+func Subscribe(ctx context.Context, notifier Notifier, broadcast *service.Broadcast) error {
+	s := subscriber{notifier: notifier, notifyStatus: map[key]*notifyStatus{}}
+	initial, ch, unsubscribe := broadcast.Start()
+	defer unsubscribe()
+	for _, ev := range initial {
+		s.maybeSend(ctx, ev)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev := <-ch:
+			s.maybeSend(ctx, ev)
+		}
+	}
+}
+
+type key struct {
+	environment string
+	application string
+}
+
+type notifyStatus struct {
+	targetVersion uint64
+}
+
+type subscriber struct {
+	notifier     Notifier
+	notifyStatus map[key]*notifyStatus
+}
+
+func (s *subscriber) maybeSend(ctx context.Context, ev *service.BroadcastEvent) {
+	// skip cases where we don't know the kuberpult version
+	if ev.KuberpultVersion == 0 {
+		return
+	}
+	// also don't notify when the version in argocd is already the right one
+	if ev.ArgocdVersion == ev.KuberpultVersion {
+	  return
+	}
+	// also don't send events for the same version again
+	k := key{ev.Environment, ev.Application}
+	ns := s.notifyStatus[k]
+	if ns != nil && ns.targetVersion == ev.KuberpultVersion {
+		return
+	}
+	s.notifyStatus[k] = &notifyStatus{
+		targetVersion: ev.KuberpultVersion,
+	}
+	// finally send the request
+	s.notifier.NotifyArgoCd(ctx, ev.Environment, ev.Application)
+}

--- a/services/rollout-service/pkg/notifier/subscriber.go
+++ b/services/rollout-service/pkg/notifier/subscriber.go
@@ -60,7 +60,7 @@ func (s *subscriber) maybeSend(ctx context.Context, ev *service.BroadcastEvent) 
 	}
 	// also don't notify when the version in argocd is already the right one
 	if ev.ArgocdVersion == ev.KuberpultVersion {
-	  return
+		return
 	}
 	// also don't send events for the same version again
 	k := key{ev.Environment, ev.Application}

--- a/services/rollout-service/pkg/notifier/subscriber_test.go
+++ b/services/rollout-service/pkg/notifier/subscriber_test.go
@@ -1,0 +1,182 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package notifier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/service"
+	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/versions"
+	"github.com/google/go-cmp/cmp"
+)
+
+type expectedNotification struct {
+	Application string
+	Environment string
+}
+
+type mockArgocdNotifier struct {
+	ch chan<- expectedNotification
+}
+
+func (m *mockArgocdNotifier) NotifyArgoCd(ctx context.Context, environment, application string) {
+	m.ch <- expectedNotification{application, environment}
+}
+
+func TestSubscribe(t *testing.T) {
+	type step struct {
+		ArgoEvent    *service.ArgoEvent
+		VersionEvent *versions.KuberpultEvent
+
+		ExpectedNotification *expectedNotification
+	}
+	tcs := []struct {
+		Name  string
+		Steps []step
+	}{
+		{
+			Name: "shuts down correctly",
+		},
+		{
+			Name: "notifies when the kuberpult version differs",
+			Steps: []step{
+				{
+					ArgoEvent: &service.ArgoEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     1,
+					},
+				},
+				{
+					VersionEvent: &versions.KuberpultEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     2,
+					},
+					ExpectedNotification: &expectedNotification{
+						Application: "foo",
+						Environment: "bar",
+					},
+				},
+			},
+		},
+		{
+			Name: "doesnt notify for the same version again",
+			Steps: []step{
+				{
+					ArgoEvent: &service.ArgoEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     1,
+					},
+				},
+				{
+					VersionEvent: &versions.KuberpultEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     2,
+					},
+					ExpectedNotification: &expectedNotification{
+						Application: "foo",
+						Environment: "bar",
+					},
+				},
+				{
+					VersionEvent: &versions.KuberpultEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     2,
+					},
+				},
+			},
+		},
+		{
+			Name: "does notify for each version",
+			Steps: []step{
+				{
+					ArgoEvent: &service.ArgoEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     1,
+					},
+				},
+				{
+					VersionEvent: &versions.KuberpultEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     2,
+					},
+					ExpectedNotification: &expectedNotification{
+						Application: "foo",
+						Environment: "bar",
+					},
+				},
+				{
+					VersionEvent: &versions.KuberpultEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     3,
+					},
+					ExpectedNotification: &expectedNotification{
+						Application: "foo",
+						Environment: "bar",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := context.Background()
+			notifications := make(chan expectedNotification, len(tc.Steps))
+			mn := &mockArgocdNotifier{notifications}
+			bc := service.New()
+			ctx, cancel := context.WithCancel(ctx)
+			eCh := make(chan error, 1)
+			go func() {
+				eCh <- Subscribe(ctx, mn, bc)
+			}()
+
+			for _, s := range tc.Steps {
+				if s.ArgoEvent != nil {
+					bc.ProcessArgoEvent(ctx, *s.ArgoEvent)
+				} else {
+					bc.ProcessKuberpultEvent(ctx, *s.VersionEvent)
+				}
+				if s.ExpectedNotification != nil {
+					notification := <-notifications
+					if !cmp.Equal(notification, *s.ExpectedNotification) {
+						t.Errorf("expected notification %v, but got %v", s.ExpectedNotification, notification)
+					}
+				} else {
+					select {
+					case notification := <-notifications:
+						t.Errorf("exptected no notification, but got %v", notification)
+					default:
+					}
+				}
+			}
+			cancel()
+			err := <-eCh
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+		})
+	}
+}

--- a/services/rollout-service/pkg/service/broadcast.go
+++ b/services/rollout-service/pkg/service/broadcast.go
@@ -142,6 +142,16 @@ func (b *Broadcast) ProcessKuberpultEvent(ctx context.Context, ev versions.Kuber
 	}
 }
 
+// Disconnects all listeners. This is used in tests to check wheter subscribers handle reconnects
+func (b *Broadcast) DisconnectAll() {
+	b.mx.Lock()
+	defer b.mx.Unlock()
+	for l := range b.listener {
+		close(l)
+	}
+	b.listener = make(map[chan *BroadcastEvent]struct{})
+}
+
 func (b *Broadcast) StreamStatus(req *api.StreamStatusRequest, svc api.RolloutService_StreamStatusServer) error {
 	resp, ch, unsubscribe := b.Start()
 	defer unsubscribe()

--- a/services/rollout-service/pkg/service/broadcast.go
+++ b/services/rollout-service/pkg/service/broadcast.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/freiheit-com/kuberpult/pkg/api"
+	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/versions"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/gitops-engine/pkg/health"
@@ -33,38 +34,101 @@ type key struct {
 	Environment string
 }
 
+type appState struct {
+	argocdVersion    uint64
+	kuberpultVersion uint64
+	rolloutStatus    api.RolloutStatus
+}
+
+func (a *appState) applyArgoEvent(ev *ArgoEvent) *BroadcastEvent {
+	status := rolloutStatus(ev)
+	if a.rolloutStatus != status || a.argocdVersion != ev.Version {
+		a.rolloutStatus = status
+		a.argocdVersion = ev.Version
+		return a.getEvent(ev.Application, ev.Environment)
+	}
+	return nil
+}
+
+func (a *appState) applyKuberpultEvent(ev *versions.KuberpultEvent) *BroadcastEvent {
+	if a.kuberpultVersion != ev.Version {
+		a.kuberpultVersion = ev.Version
+		return a.getEvent(ev.Application, ev.Environment)
+	}
+	return nil
+}
+
+func (a *appState) getEvent(application, environment string) *BroadcastEvent {
+	rs := a.rolloutStatus
+	if a.kuberpultVersion != 0 && a.kuberpultVersion != a.argocdVersion {
+		rs = api.RolloutStatus_RolloutStatusProgressing
+	}
+	return &BroadcastEvent{
+		Environment:      environment,
+		Application:      application,
+		ArgocdVersion:    a.argocdVersion,
+		RolloutStatus:    rs,
+		KuberpultVersion: a.kuberpultVersion,
+	}
+}
+
 type Broadcast struct {
-	state    map[key]Event
+	state    map[key]*appState
 	mx       sync.Mutex
-	listener map[chan *api.StreamStatusResponse]struct{}
+	listener map[chan *BroadcastEvent]struct{}
 }
 
 func New() *Broadcast {
 	return &Broadcast{
-		state:    map[key]Event{},
-		listener: map[chan *api.StreamStatusResponse]struct{}{},
+		state:    map[key]*appState{},
+		listener: map[chan *BroadcastEvent]struct{}{},
 	}
 }
 
-// Process implements service.EventProcessor
-func (b *Broadcast) Process(ctx context.Context, ev Event) {
+// ProcessArgoEvent implements service.EventProcessor
+func (b *Broadcast) ProcessArgoEvent(ctx context.Context, ev ArgoEvent) {
 	b.mx.Lock()
 	defer b.mx.Unlock()
 	k := key{
 		Application: ev.Application,
 		Environment: ev.Environment,
 	}
-	if b.state[k] == ev {
+	if b.state[k] == nil {
+		b.state[k] = &appState{}
+	}
+	msg := b.state[k].applyArgoEvent(&ev)
+	if msg == nil {
 		return
 	}
-	msg := &api.StreamStatusResponse{
-		Environment:   ev.Environment,
-		Application:   ev.Application,
-		Version:       ev.Version,
-		RolloutStatus: rolloutStatus(&ev),
+	desub := []chan *BroadcastEvent{}
+	for l := range b.listener {
+		select {
+		case l <- msg:
+		default:
+			close(l)
+			desub = append(desub, l)
+		}
 	}
-	b.state[k] = ev
-	desub := []chan *api.StreamStatusResponse{}
+	for _, l := range desub {
+		delete(b.listener, l)
+	}
+}
+
+func (b *Broadcast) ProcessKuberpultEvent(ctx context.Context, ev versions.KuberpultEvent) {
+	b.mx.Lock()
+	defer b.mx.Unlock()
+	k := key{
+		Application: ev.Application,
+		Environment: ev.Environment,
+	}
+	if b.state[k] == nil {
+		b.state[k] = &appState{}
+	}
+	msg := b.state[k].applyKuberpultEvent(&ev)
+	if msg == nil {
+		return
+	}
+	desub := []chan *BroadcastEvent{}
 	for l := range b.listener {
 		select {
 		case l <- msg:
@@ -79,15 +143,15 @@ func (b *Broadcast) Process(ctx context.Context, ev Event) {
 }
 
 func (b *Broadcast) StreamStatus(req *api.StreamStatusRequest, svc api.RolloutService_StreamStatusServer) error {
-	resp, ch, unsubscribe := b.start()
+	resp, ch, unsubscribe := b.Start()
 	defer unsubscribe()
 	for _, r := range resp {
-		svc.Send(r)
+		svc.Send(streamStatus(r))
 	}
 	for {
 		select {
 		case r := <-ch:
-			err := svc.Send(r)
+			err := svc.Send(streamStatus(r))
 			if err != nil {
 				return err
 			}
@@ -103,20 +167,14 @@ func (b *Broadcast) StreamStatus(req *api.StreamStatusRequest, svc api.RolloutSe
 
 type unsubscribe func()
 
-func (b *Broadcast) start() ([]*api.StreamStatusResponse, <-chan *api.StreamStatusResponse, unsubscribe) {
+func (b *Broadcast) Start() ([]*BroadcastEvent, <-chan *BroadcastEvent, unsubscribe) {
 	b.mx.Lock()
 	defer b.mx.Unlock()
-	result := make([]*api.StreamStatusResponse, 0, len(b.state))
-	for _, ev := range b.state {
-		msg := &api.StreamStatusResponse{
-			Environment:   ev.Environment,
-			Application:   ev.Application,
-			Version:       ev.Version,
-			RolloutStatus: rolloutStatus(&ev),
-		}
-		result = append(result, msg)
+	result := make([]*BroadcastEvent, 0, len(b.state))
+	for key, app := range b.state {
+		result = append(result, app.getEvent(key.Application, key.Environment))
 	}
-	ch := make(chan *api.StreamStatusResponse, 100)
+	ch := make(chan *BroadcastEvent, 100)
 	b.listener[ch] = struct{}{}
 	return result, ch, func() {
 		b.mx.Lock()
@@ -125,7 +183,24 @@ func (b *Broadcast) start() ([]*api.StreamStatusResponse, <-chan *api.StreamStat
 	}
 }
 
-func rolloutStatus(ev *Event) api.RolloutStatus {
+type BroadcastEvent struct {
+	Environment      string
+	Application      string
+	ArgocdVersion    uint64
+	KuberpultVersion uint64
+	RolloutStatus    api.RolloutStatus
+}
+
+func streamStatus(b *BroadcastEvent) *api.StreamStatusResponse {
+	return &api.StreamStatusResponse{
+		Environment:   b.Environment,
+		Application:   b.Application,
+		Version:       b.ArgocdVersion,
+		RolloutStatus: b.RolloutStatus,
+	}
+}
+
+func rolloutStatus(ev *ArgoEvent) api.RolloutStatus {
 	switch ev.HealthStatusCode {
 	case health.HealthStatusDegraded, health.HealthStatusMissing:
 		return api.RolloutStatus_RolloutStatusError
@@ -148,5 +223,5 @@ func rolloutStatus(ev *Event) api.RolloutStatus {
 	return api.RolloutStatus_RolloutStatusUnknown
 }
 
-var _ EventProcessor = (*Broadcast)(nil)
+var _ ArgoEventProcessor = (*Broadcast)(nil)
 var _ api.RolloutServiceServer = (*Broadcast)(nil)

--- a/services/rollout-service/pkg/service/service_test.go
+++ b/services/rollout-service/pkg/service/service_test.go
@@ -109,7 +109,7 @@ func (m *mockVersionClient) GetVersion(ctx context.Context, revision string, env
 	return 0, nil
 }
 
-func (m *mockVersionClient) Subscribe(ctx context.Context, pc versions.VersionEventProcessor ) error {
+func (m *mockVersionClient) ConsumeEvents(ctx context.Context, pc versions.VersionEventProcessor ) error {
 	panic("not implemented")
 }
 

--- a/services/rollout-service/pkg/service/service_test.go
+++ b/services/rollout-service/pkg/service/service_test.go
@@ -37,7 +37,7 @@ type step struct {
 	WatchErr error
 	RecvErr  error
 
-	ExpectedEvent *Event
+	ExpectedEvent *ArgoEvent
 }
 
 func (m *mockApplicationServiceClient) Recv() (*v1alpha1.ApplicationWatchEvent, error) {
@@ -60,7 +60,7 @@ type mockApplicationServiceClient struct {
 	Steps     []step
 	current   int
 	t         *testing.T
-	lastEvent *Event
+	lastEvent *ArgoEvent
 	grpc.ClientStream
 }
 
@@ -83,7 +83,7 @@ func (m *mockApplicationServiceClient) testAllConsumed(t *testing.T) {
 }
 
 // Process implements service.EventProcessor
-func (m *mockApplicationServiceClient) Process(ctx context.Context, ev Event) {
+func (m *mockApplicationServiceClient) ProcessArgoEvent(ctx context.Context, ev ArgoEvent) {
 	m.lastEvent = &ev
 }
 
@@ -107,6 +107,10 @@ func (m *mockVersionClient) GetVersion(ctx context.Context, revision string, env
 		}
 	}
 	return 0, nil
+}
+
+func (m *mockVersionClient) Subscribe(ctx context.Context, pc versions.VersionEventProcessor ) error {
+	panic("not implemented")
 }
 
 var _ versions.VersionClient = (*mockVersionClient)(nil)
@@ -223,7 +227,7 @@ func TestArgoConection(t *testing.T) {
 							},
 						},
 					},
-					ExpectedEvent: &Event{
+					ExpectedEvent: &ArgoEvent{
 						Application: "bar",
 						Environment: "foo",
 						Version:     42,
@@ -266,7 +270,7 @@ func TestArgoConection(t *testing.T) {
 							},
 						},
 					},
-					ExpectedEvent: &Event{
+					ExpectedEvent: &ArgoEvent{
 						Application: "bar",
 						Environment: "foo",
 						Version:     0,

--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -20,8 +20,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/argoproj/argo-cd/v2/util/grpc"
 	"github.com/freiheit-com/kuberpult/pkg/api"
 	"github.com/freiheit-com/kuberpult/pkg/auth"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
 	"k8s.io/utils/lru"
 )
 
@@ -34,6 +38,7 @@ var RolloutServiceUser auth.User = auth.User{
 
 type VersionClient interface {
 	GetVersion(ctx context.Context, revision, environment, application string) (uint64, error)
+	Subscribe(ctx context.Context, processor VersionEventProcessor) error
 }
 
 type versionClient struct {
@@ -70,6 +75,67 @@ func (v *versionClient) GetVersion(ctx context.Context, revision, environment, a
 		}
 	}
 	return 0, nil
+}
+
+type KuberpultEvent struct {
+	Environment string
+	Application string
+	Version     uint64
+}
+
+type VersionEventProcessor interface {
+	ProcessKuberpultEvent(ctx context.Context, ev KuberpultEvent)
+}
+
+func (v *versionClient) Subscribe(ctx context.Context, processor VersionEventProcessor) error {
+	ctx = auth.WriteUserToGrpcContext(ctx, RolloutServiceUser)
+outer:
+	for {
+		client, err := v.client.StreamOverview(ctx, &api.GetOverviewRequest{})
+		if err != nil {
+			logger.FromContext(ctx).Warn("overview.connect", zap.Error(err))
+			continue outer
+		}
+	inner:
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+			}
+			overview, err := client.Recv()
+			if err != nil {
+				grpcErr := grpc.UnwrapGRPCStatus(err)
+				if grpcErr != nil {
+					if grpcErr.Code() == codes.Canceled {
+						return nil
+					}
+
+					logger.FromContext(ctx).Warn("overview.stream", zap.Error(err), zap.String("grpc.code", grpcErr.Code().String()), zap.String("grpc.message", grpcErr.Message()))
+				} else {
+					logger.FromContext(ctx).Warn("overview.stream", zap.Error(err))
+				}
+				continue inner
+			}
+			l := logger.FromContext(ctx).With(zap.String("git.revision", overview.GitRevision))
+			v.cache.Add(overview.GitRevision, overview)
+			l.Info("overview.get")
+			for _, envGroup := range overview.EnvironmentGroups {
+				for _, env := range envGroup.Environments {
+					for _, app := range env.Applications {
+
+						l.Info("version.process", zap.String("application", app.Name), zap.String("environment", env.Name), zap.Uint64("version", app.Version))
+						processor.ProcessKuberpultEvent(ctx, KuberpultEvent{
+							Application: app.Name,
+							Environment: env.Name,
+							Version:     app.Version,
+						})
+					}
+				}
+			}
+		}
+	}
+
 }
 
 func New(client api.OverviewServiceClient) VersionClient {

--- a/services/rollout-service/pkg/versions/versions_test.go
+++ b/services/rollout-service/pkg/versions/versions_test.go
@@ -202,7 +202,7 @@ func TestVersionClient(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			mc := &mockOverviewClient{Responses: tc.Responses}
 			vc := New(mc)
-			testExpectedVersions(t, tc.ExpectedVersions, vc, mc)
+			assertExpectedVersions(t, tc.ExpectedVersions, vc, mc)
 		})
 	}
 
@@ -279,12 +279,12 @@ func TestVersionClientStream(t *testing.T) {
 				t.Errorf("expected no error, but received %q", err)
 			}
 			mc.testAllConsumed(t)
-			testExpectedVersions(t, tc.ExpectedVersions, vc, mc)
+			assertExpectedVersions(t, tc.ExpectedVersions, vc, mc)
 		})
 	}
 }
 
-func testExpectedVersions(t *testing.T, expectedVersions []expectedVersion, vc VersionClient, mc *mockOverviewClient) {
+func assertExpectedVersions(t *testing.T, expectedVersions []expectedVersion, vc VersionClient, mc *mockOverviewClient) {
 	for _, ev := range expectedVersions {
 		version, err := vc.GetVersion(context.Background(), ev.Revision, ev.Environment, ev.Application)
 		if err != nil {

--- a/services/rollout-service/pkg/versions/versions_test.go
+++ b/services/rollout-service/pkg/versions/versions_test.go
@@ -18,6 +18,8 @@ package versions
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"testing"
 
 	"github.com/freiheit-com/kuberpult/pkg/api"
@@ -28,6 +30,12 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type step struct {
+	Overview   *api.GetOverviewResponse
+	ConnectErr error
+	RecvErr    error
+}
+
 type expectedVersion struct {
 	Revision        string
 	Environment     string
@@ -36,9 +44,24 @@ type expectedVersion struct {
 	Metadata        metadata.MD
 }
 
+type mockOverviewStreamMessage struct {
+	Overview     *api.GetOverviewResponse
+	Error        error
+	ConnectError error
+}
+
 type mockOverviewClient struct {
+	grpc.ClientStream
 	Responses    map[string]*api.GetOverviewResponse
 	LastMetadata metadata.MD
+	Steps        []step
+	current      int
+}
+
+func (m *mockOverviewClient) testAllConsumed(t *testing.T) {
+	if m.current < len(m.Steps) {
+		t.Errorf("expected to consume all %d replies, only consumed %d", len(m.Steps), m.current)
+	}
 }
 
 // GetOverview implements api.OverviewServiceClient
@@ -51,11 +74,35 @@ func (m *mockOverviewClient) GetOverview(ctx context.Context, in *api.GetOvervie
 }
 
 // StreamOverview implements api.OverviewServiceClient
-func (*mockOverviewClient) StreamOverview(ctx context.Context, in *api.GetOverviewRequest, opts ...grpc.CallOption) (api.OverviewService_StreamOverviewClient, error) {
-	panic("unimplemented")
+func (m *mockOverviewClient) StreamOverview(ctx context.Context, in *api.GetOverviewRequest, opts ...grpc.CallOption) (api.OverviewService_StreamOverviewClient, error) {
+	if m.current >= len(m.Steps) {
+		return nil, fmt.Errorf("exhausted: %w", io.EOF)
+	}
+	reply := m.Steps[m.current]
+	if reply.ConnectErr != nil {
+		m.current = m.current + 1
+		return nil, reply.ConnectErr
+	}
+	return m, nil
+}
+
+func (m *mockOverviewClient) Recv() (*api.GetOverviewResponse, error) {
+	if m.current >= len(m.Steps) {
+		return nil, fmt.Errorf("exhausted: %w", io.EOF)
+	}
+	reply := m.Steps[m.current]
+	m.current = m.current + 1
+	return reply.Overview, reply.RecvErr
 }
 
 var _ api.OverviewServiceClient = (*mockOverviewClient)(nil)
+
+type mockVersionEventProcessor struct {
+}
+
+func (m *mockVersionEventProcessor) ProcessKuberpultEvent(ctx context.Context, ev KuberpultEvent) {
+
+}
 
 func TestVersionClient(t *testing.T) {
 	t.Parallel()
@@ -155,20 +202,100 @@ func TestVersionClient(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			mc := &mockOverviewClient{Responses: tc.Responses}
 			vc := New(mc)
-			for _, ev := range tc.ExpectedVersions {
-				version, err := vc.GetVersion(context.Background(), ev.Revision, ev.Environment, ev.Application)
-				if err != nil {
-					t.Errorf("expected no error for %s/%s@%s, but got %q", ev.Environment, ev.Application, ev.Revision, err)
-					continue
-				}
-				if version != ev.DeployedVersion {
-					t.Errorf("expected version %d to be deployed for %s/%s@%s but got %d", ev.DeployedVersion, ev.Environment, ev.Application, ev.Revision, version)
-				}
-				if !cmp.Equal(mc.LastMetadata, ev.Metadata) {
-					t.Errorf("mismachted metadata %s", cmp.Diff(mc.LastMetadata, ev.Metadata))
-				}
-			}
+			testExpectedVersions(t, tc.ExpectedVersions, vc, mc)
 		})
 	}
 
+}
+
+func TestVersionClientStream(t *testing.T) {
+	t.Parallel()
+	testOverview := &api.GetOverviewResponse{
+		EnvironmentGroups: []*api.EnvironmentGroup{
+			{
+				Environments: []*api.Environment{
+					{
+						Name: "staging",
+						Applications: map[string]*api.Environment_Application{
+							"foo": {
+								Version: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+		GitRevision: "1234",
+	}
+
+	tcs := []struct {
+		Name             string
+		Steps            []step
+		ExpectedVersions []expectedVersion
+	}{
+		{
+			Name: "Retries connections and finishes",
+			Steps: []step{
+				{
+					ConnectErr: fmt.Errorf("no"),
+				},
+				{
+					RecvErr: fmt.Errorf("no"),
+				},
+				{
+					RecvErr: status.Error(codes.Canceled, "context cancelled"),
+				},
+			},
+		},
+		{
+			Name: "Puts received overviews in the cache",
+			Steps: []step{
+				{
+					Overview: testOverview,
+				},
+				{
+					RecvErr: status.Error(codes.Canceled, "context cancelled"),
+				},
+			},
+			ExpectedVersions: []expectedVersion{
+				{
+					Revision:        "1234",
+					Environment:     "staging",
+					Application:     "foo",
+					DeployedVersion: 1,
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := context.Background()
+			vp := &mockVersionEventProcessor{}
+			mc := &mockOverviewClient{Steps: tc.Steps}
+			vc := New(mc)
+			err := vc.Subscribe(ctx, vp)
+			if err != nil {
+				t.Errorf("expected no error, but received %q", err)
+			}
+			mc.testAllConsumed(t)
+			testExpectedVersions(t, tc.ExpectedVersions, vc, mc)
+		})
+	}
+}
+
+func testExpectedVersions(t *testing.T, expectedVersions []expectedVersion, vc VersionClient, mc *mockOverviewClient) {
+	for _, ev := range expectedVersions {
+		version, err := vc.GetVersion(context.Background(), ev.Revision, ev.Environment, ev.Application)
+		if err != nil {
+			t.Errorf("expected no error for %s/%s@%s, but got %q", ev.Environment, ev.Application, ev.Revision, err)
+			continue
+		}
+		if version != ev.DeployedVersion {
+			t.Errorf("expected version %d to be deployed for %s/%s@%s but got %d", ev.DeployedVersion, ev.Environment, ev.Application, ev.Revision, version)
+		}
+		if !cmp.Equal(mc.LastMetadata, ev.Metadata) {
+			t.Errorf("mismachted metadata %s", cmp.Diff(mc.LastMetadata, ev.Metadata))
+		}
+	}
 }

--- a/services/rollout-service/pkg/versions/versions_test.go
+++ b/services/rollout-service/pkg/versions/versions_test.go
@@ -274,7 +274,7 @@ func TestVersionClientStream(t *testing.T) {
 			vp := &mockVersionEventProcessor{}
 			mc := &mockOverviewClient{Steps: tc.Steps}
 			vc := New(mc)
-			err := vc.Subscribe(ctx, vp)
+			err := vc.ConsumeEvents(ctx, vp)
 			if err != nil {
 				t.Errorf("expected no error, but received %q", err)
 			}


### PR DESCRIPTION
This change adds sending refresh notifications to argocd when applications in kuberpult changes. Notifications are send by the rollout service so that they do not slow down the cd service in any way. The current implementation is rather simple at the moment. The rollout service now listens to the cd service for changes, compares the versions with argocd and issues refresh requests if the version differs.

The feature must be explicitly enabled in the helm chart using `argocd.refreshEnabled`