### PR TITLE
Rollout service: dedup version notifications and notify for app deletions

### DIFF
--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -144,6 +144,8 @@ outer:
 					}
 				}
 			}
+			// Send events with version 0 for deleted applications so that we can react
+			// to apps getting deleted.
 			for k := range versions {
 				if seen[k] == 0 {
 					processor.ProcessKuberpultEvent(ctx, KuberpultEvent{


### PR DESCRIPTION
Currently the rollout service needs to obtain the shared lock for every deployed app. This is rather costly. This patch changes that, so that we do send fewer events to that store by deduplicating the notifications in the versions.go locally.

Furthermore, the versions client never cared about removed apps.  This is also handled properly now.