### PR TITLE
Submit refreshes to argocd in parallel

### DIFF
--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -298,7 +298,8 @@ argocd:
   token: "$token"
   server: "https://argocd-server.${ARGO_NAMESPACE}.svc.cluster.local:443"
   insecure: true
-  refreshEnabled: true
+  refresh:
+    enabled: true
 pgp:
   keyRing: |
 $(sed -e "s/^/    /" <./kuberpult-keyring.gpg)

--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -18,6 +18,9 @@
 {{- if not (regexMatch "^https?://[^:]+:[0-9]+$" .Values.argocd.server) -}}
 {{ fail "argocd.server must be a valid http/https url including the port"}}
 {{- end -}}
+{{- if not (eq .Values.argocd.refreshEnabled nil) }}
+{{ fail "argocd.refreshEnabled is removed in favour of argocd.refresh.enabled"}}
+{{- end -}}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -86,7 +86,9 @@ spec:
         - name: KUBERPULT_ARGOCD_INSECURE
           value: {{ .Values.argocd.insecure | quote }}
         - name: KUBERPULT_ARGOCD_REFRESH_ENABLED
-          value: {{ .Values.argocd.refreshEnabled | quote }}
+          value: {{ .Values.argocd.refresh.enabled | quote }}
+        - name: KUBERPULT_ARGOCD_REFRESH_CONCURRENCY
+          value: {{ .Values.argocd.refresh.concurrency | quote }}
         - name: LOG_FORMAT
           value: {{ .Values.log.format | quote }}
         - name: LOG_LEVEL

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -103,8 +103,13 @@ argocd:
   insecure: false
   # Enable sending webhooks to argocd
   sendWebhooks: false
-  # Enable sending refresh requests to argocd
-  refreshEnabled: false
+
+  refresh:
+    # Enable sending refresh requests to argocd
+    enabled: false
+    # Send up to that many parallel refresh requests to argocd.
+    # The number is determined by the power of the deployed argocd.
+    concurrency: 50
 
 datadogTracing:
   enabled: false

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -48,10 +48,11 @@ type Config struct {
 	CdServer      string `default:"kuberpult-cd-service:8443"`
 	EnableTracing bool   `default:"false" split_words:"true"`
 
-	ArgocdServer         string `split_words:"true"`
-	ArgocdInsecure       bool   `default:"false" split_words:"true"`
-	ArgocdToken          string `split_words:"true"`
-	ArgocdRefreshEnabled bool   `split_words:"true"`
+	ArgocdServer             string `split_words:"true"`
+	ArgocdInsecure           bool   `default:"false" split_words:"true"`
+	ArgocdToken              string `split_words:"true"`
+	ArgocdRefreshEnabled     bool   `split_words:"true"`
+	ArgocdRefreshConcurrency int    `default:"50" split_words:"true"`
 }
 
 func (config *Config) ClientConfig() (apiclient.ClientOptions, error) {
@@ -177,10 +178,11 @@ func runServer(ctx context.Context, config Config) error {
 	}
 
 	if config.ArgocdRefreshEnabled {
-		notify := notifier.New(appClient)
+
 		backgroundTasks = append(backgroundTasks, setup.BackgroundTaskConfig{
 			Name: "refresh argocd",
 			Run: func(ctx context.Context) error {
+				notify := notifier.New(appClient, config.ArgocdRefreshConcurrency)
 				return notifier.Subscribe(ctx, notify, broadcast)
 			},
 		})

--- a/services/rollout-service/pkg/notifier/notifier_test.go
+++ b/services/rollout-service/pkg/notifier/notifier_test.go
@@ -1,0 +1,73 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package notifier
+
+import (
+	"context"
+	"testing"
+
+	argoapplication "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+
+	"google.golang.org/grpc"
+)
+
+type mockApplicationClient struct {
+	requests chan *argoapplication.ApplicationQuery
+}
+
+func (m *mockApplicationClient) Get(ctx context.Context, in *argoapplication.ApplicationQuery, opts ...grpc.CallOption) (*argoappv1.Application, error) {
+	m.requests <- in
+	return nil, nil
+}
+
+func TestNotifier(t *testing.T) {
+	tcs := []struct {
+		Name             string
+		ConcurrencyLimit int
+	}{
+		{
+			Name:             "sends requests in parallel",
+			ConcurrencyLimit: 10,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := context.Background()
+			// chan without capacity will block all requests
+			ch := make(chan *argoapplication.ApplicationQuery)
+			ma := &mockApplicationClient{ch}
+			nf := New(ma, tc.ConcurrencyLimit)
+			for i := 0; i < tc.ConcurrencyLimit; i = i + 1 {
+				nf.NotifyArgoCd(ctx, "foo", "bar")
+			}
+
+			for i := 0; i < tc.ConcurrencyLimit; i = i + 1 {
+				in := <-ch
+				if *in.Name != "foo-bar" {
+					t.Errorf("expected application %q, but got %q", "foo-bar", *in.Name)
+				}
+				if *in.Refresh != "normal" {
+					t.Errorf("expected referesh type %q, but got %q", "normal", *in.Refresh)
+				}
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
There is a new option on the helm chart `argocd.refresh.concurrency` that allows for configuring the number of parallel requests to argocd. Also the timeout for argocd is bumped from 5s to 60s.