### PR TITLE
User get notified of permission errors on the frontend

### DIFF
--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -202,7 +202,7 @@ func ReadRbacPolicy(dexEnabled bool) (policy map[string]*Permission, err error) 
 }
 
 // Checks user permissions on the RBAC policy.
-func CheckUserPermissions(rbacConfig RBACConfig, user *User, env, envGroup, application, action string) error {
+func CheckUserPermissions(rbacConfig RBACConfig, user *User, env, team, envGroup, application, action string) error {
 	// If the action is environment independent, the env format is <ENVIRONMENT_GROUP>:*
 	if isEnvironmentIndependent(action) {
 		env = "*"
@@ -221,8 +221,7 @@ func CheckUserPermissions(rbacConfig RBACConfig, user *User, env, envGroup, appl
 		}
 	}
 	// The permission is not found. Return an error.
-	p := fmt.Sprintf(PermissionTemplate, user.DexAuthContext.Role, action, envGroup, env, application)
-	return status.Errorf(codes.PermissionDenied, fmt.Sprintf("user does not have permissions for: %s", p))
+	return status.Errorf(codes.PermissionDenied, fmt.Sprintf("The user %s with role %s is not allowed to perform the action %s on environment %s for team %s", user.Name, user.DexAuthContext.Role, action, env, team))
 }
 
 // Helper function to parse the scopes

--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -221,7 +221,7 @@ func CheckUserPermissions(rbacConfig RBACConfig, user *User, env, team, envGroup
 		}
 	}
 	// The permission is not found. Return an error.
-	return status.Errorf(codes.PermissionDenied, fmt.Sprintf("The user %s with role %s is not allowed to perform the action %s on environment %s for team %s", user.Name, user.DexAuthContext.Role, action, env, team))
+	return status.Errorf(codes.PermissionDenied, fmt.Sprintf("%s: The user '%s' with role '%s' is not allowed to perform the action '%s' on environment '%s' for team '%s'", codes.PermissionDenied.String(), user.Name, user.DexAuthContext.Role, action, env, team))
 }
 
 // Helper function to parse the scopes

--- a/pkg/auth/rbac_test.go
+++ b/pkg/auth/rbac_test.go
@@ -132,7 +132,7 @@ func TestCheckUserPermissions(t *testing.T) {
 			action:      PermissionCreateLock,
 			rbacConfig:  RBACConfig{DexEnabled: true, Policy: map[string]*Permission{"Developer,CreateLock,production:production,app1,allow": {Role: "Developer"}}},
 			team:        "random-team",
-			WantError:   status.Errorf(codes.PermissionDenied, fmt.Sprintf("The user  with role Developer is not allowed to perform the action CreateLock on environment production for team random-team")),
+			WantError:   status.Errorf(codes.PermissionDenied, fmt.Sprintf("PermissionDenied: The user '' with role 'Developer' is not allowed to perform the action 'CreateLock' on environment 'production' for team 'random-team'")),
 		},
 		{
 			Name:        "User does not have permission: wrong app",
@@ -143,7 +143,7 @@ func TestCheckUserPermissions(t *testing.T) {
 			action:      PermissionCreateLock,
 			team:        "other-team",
 			rbacConfig:  RBACConfig{DexEnabled: true, Policy: map[string]*Permission{"Developer,CreateLock,production:production,app1,allow": {Role: "Developer"}}},
-			WantError:   status.Errorf(codes.PermissionDenied, fmt.Sprintf("The user  with role Developer is not allowed to perform the action CreateLock on environment production for team other-team")),
+			WantError:   status.Errorf(codes.PermissionDenied, fmt.Sprintf("PermissionDenied: The user '' with role 'Developer' is not allowed to perform the action 'CreateLock' on environment 'production' for team 'other-team'")),
 		},
 	}
 

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1464,7 +1464,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					}}},
 				},
 			},
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeployUndeploy on environment * for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'DeployUndeploy' on environment '*' for team ''",
 		},
 		{
 			Name: "able to create environment with permissions policy",
@@ -1494,7 +1494,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Config:         config.EnvironmentConfig{EnvironmentGroup: &envGroupProduction},
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}}},
 			},
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action CreateEnvironment on environment * for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'CreateEnvironment' on environment '*' for team",
 		},
 		{
 			Name: "able to create undeploy with permissions policy",
@@ -1556,7 +1556,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					}}},
 				},
 			},
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeployRelease on environment staging for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'DeployRelease' on environment 'staging' for team",
 		},
 		{
 			Name: "unable to create undeploy without permissions policy: Missing CreateUndeploy permission",
@@ -1586,7 +1586,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					}}},
 				},
 			},
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action CreateUndeploy on environment * for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'CreateUndeploy' on environment '*' for team",
 		},
 		{
 			Name: "able to create release train with permissions policy",
@@ -1614,7 +1614,7 @@ func TestRbacTransformerTest(t *testing.T) {
 				Target:         envProduction,
 				Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 			}),
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeployReleaseTrain on environment production for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'DeployReleaseTrain' on environment 'production' for team",
 		},
 		{
 			Name: "able to create application version with permissions policy",
@@ -1654,7 +1654,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					}}},
 				},
 			},
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeployRelease on environment acceptance for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'DeployRelease' on environment 'acceptance' for team",
 		},
 		{
 			Name: "unable to create application version without permissions policy",
@@ -1672,7 +1672,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action CreateRelease on environment * for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'CreateRelease' on environment '*' for team",
 		},
 		{
 			Name: "able to deploy application with permissions policy",
@@ -1722,7 +1722,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeployRelease on environment acceptance for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'DeployRelease' on environment 'acceptance' for team",
 		},
 		{
 			Name: "able to create environment lock with permissions policy",
@@ -1771,7 +1771,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action CreateLock on environment production for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'CreateLock' on environment 'production' for team",
 		},
 		{
 			Name: "unable to delete environment lock without permissions policy",
@@ -1793,7 +1793,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeleteLock on environment production for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'DeleteLock' on environment 'production' for team",
 		},
 		{
 			Name: "able to delete environment lock with permissions policy",
@@ -1841,7 +1841,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action CreateLock on environment production for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'CreateLock' on environment 'production' for team",
 		},
 		{
 			Name: "able to create environment application lock with correct permissions policy",
@@ -1896,7 +1896,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeleteLock on environment production for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'DeleteLock' on environment 'production' for team",
 		},
 		{
 			Name: "able to delete environment application lock without permissions policy",
@@ -1959,7 +1959,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeleteEnvironmentApplication on environment production for team",
+			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'DeleteEnvironmentApplication' on environment 'production' for team",
 		},
 		{
 			Name: "able to delete environment application without permission policy",

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1464,7 +1464,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,DeployUndeploy,staging:*,app1,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeployUndeploy on environment * for team",
 		},
 		{
 			Name: "able to create environment with permissions policy",
@@ -1494,7 +1494,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Config:         config.EnvironmentConfig{EnvironmentGroup: &envGroupProduction},
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}}},
 			},
-			ExpectedError: "user does not have permissions for: developer,CreateEnvironment,production:*,*,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action CreateEnvironment on environment * for team",
 		},
 		{
 			Name: "able to create undeploy with permissions policy",
@@ -1556,7 +1556,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,DeployRelease,staging:staging,app1,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeployRelease on environment staging for team",
 		},
 		{
 			Name: "unable to create undeploy without permissions policy: Missing CreateUndeploy permission",
@@ -1586,7 +1586,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,CreateUndeploy,staging:*,app1,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action CreateUndeploy on environment * for team",
 		},
 		{
 			Name: "able to create release train with permissions policy",
@@ -1614,7 +1614,7 @@ func TestRbacTransformerTest(t *testing.T) {
 				Target:         envProduction,
 				Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 			}),
-			ExpectedError: "user does not have permissions for: developer,DeployReleaseTrain,production:production,*,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeployReleaseTrain on environment production for team",
 		},
 		{
 			Name: "able to create application version with permissions policy",
@@ -1654,7 +1654,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,DeployRelease,acceptance:acceptance,app1-testing,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeployRelease on environment acceptance for team",
 		},
 		{
 			Name: "unable to create application version without permissions policy",
@@ -1672,7 +1672,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,CreateRelease,acceptance:*,app1,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action CreateRelease on environment * for team",
 		},
 		{
 			Name: "able to deploy application with permissions policy",
@@ -1722,7 +1722,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,DeployRelease,acceptance:acceptance,app1,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeployRelease on environment acceptance for team",
 		},
 		{
 			Name: "able to create environment lock with permissions policy",
@@ -1771,7 +1771,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,CreateLock,production:production,*,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action CreateLock on environment production for team",
 		},
 		{
 			Name: "unable to delete environment lock without permissions policy",
@@ -1793,7 +1793,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,DeleteLock,production:production,*,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeleteLock on environment production for team",
 		},
 		{
 			Name: "able to delete environment lock with permissions policy",
@@ -1841,7 +1841,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,CreateLock,production:production,test,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action CreateLock on environment production for team",
 		},
 		{
 			Name: "able to create environment application lock with correct permissions policy",
@@ -1896,7 +1896,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,DeleteLock,production:production,test,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeleteLock on environment production for team",
 		},
 		{
 			Name: "able to delete environment application lock without permissions policy",
@@ -1959,7 +1959,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
 				},
 			},
-			ExpectedError: "user does not have permissions for: developer,DeleteEnvironmentApplication,production:production,app1,allow",
+			ExpectedError: "The user test tester with role developer is not allowed to perform the action DeleteEnvironmentApplication on environment production for team",
 		},
 		{
 			Name: "able to delete environment application without permission policy",

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -169,7 +169,7 @@ func TestBatchServiceWorks(t *testing.T) {
 			Batch:         getBatchActions(),
 			context:       testutil.MakeTestContextDexEnabled(),
 			svc:           &BatchServer{},
-			expectedError: status.Errorf(codes.PermissionDenied, "user does not have permissions for: developer,CreateLock,production:production,*,allow").Error(),
+			expectedError: status.Errorf(codes.PermissionDenied, "The user test tester with role developer is not allowed to perform the action CreateLock on environment production for team ").Error(),
 		},
 		{
 			Name: "testing Dex setup with permissions",

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -169,7 +169,7 @@ func TestBatchServiceWorks(t *testing.T) {
 			Batch:         getBatchActions(),
 			context:       testutil.MakeTestContextDexEnabled(),
 			svc:           &BatchServer{},
-			expectedError: status.Errorf(codes.PermissionDenied, "The user test tester with role developer is not allowed to perform the action CreateLock on environment production for team ").Error(),
+			expectedError: status.Errorf(codes.PermissionDenied, "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'CreateLock' on environment 'production' for team ''").Error(),
 		},
 		{
 			Name: "testing Dex setup with permissions",

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -343,7 +343,7 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                 .catch((e) => {
                     // eslint-disable-next-line no-console
                     console.error('error in batch request: ', e);
-                    if (e.message.includes('not allowed to perform the action')) {
+                    if (e.message.includes('PermissionDenied')) {
                         showSnackbarError(e.message);
                     } else {
                         showSnackbarError('Actions were not applied. Please try again');

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -343,7 +343,11 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                 .catch((e) => {
                     // eslint-disable-next-line no-console
                     console.error('error in batch request: ', e);
-                    showSnackbarError('Actions were not applied. Please try again');
+                    if (e.message.includes('not allowed to perform the action')) {
+                        showSnackbarError(e.message);
+                    } else {
+                        showSnackbarError('Actions were not applied. Please try again');
+                    }
                 })
                 .finally(() => {
                     setShowSpinner(false);

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -343,7 +343,8 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                 .catch((e) => {
                     // eslint-disable-next-line no-console
                     console.error('error in batch request: ', e);
-                    if (e.message.includes('PermissionDenied')) {
+                    const GrpcErrorPermissionDenied = 7;
+                    if (e.code === GrpcErrorPermissionDenied) {
                         showSnackbarError(e.message);
                     } else {
                         showSnackbarError('Actions were not applied. Please try again');


### PR DESCRIPTION
Message has format of "The user [example@example.com](mailto:example@example.com) with role <role> is not allow to perform the action <action> on environment <env> for team <team>"

Error toast looks like this: 
![Screenshot 2023-09-07 at 7 12 00 PM](https://github.com/freiheit-com/kuberpult/assets/47796934/3a64eaf0-bf4f-4bf8-91df-407c473a7877)
