### PR TITLE
Show error about too many items before submit

### DIFF
--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -36,6 +36,7 @@ type BatchServer struct {
 	RBACConfig auth.RBACConfig
 }
 
+// see maxBatchActions in store.tsx
 const maxBatchActions int = 100
 
 func ValidateEnvironmentLock(


### PR DESCRIPTION
The server always allowed only 100 actions.
Now the UI also checks if there are too many items, and stops the user before adding the 101st action.