### PR TITLE
Show error about too many items before submit

### DIFF
--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -36,6 +36,7 @@ type BatchServer struct {
 	RBACConfig auth.RBACConfig
 }
 
+// see maxBatchActions in store.tsx
 const maxBatchActions int = 100
 
 func ValidateEnvironmentLock(

--- a/services/frontend-service/src/ui/utils/store.test.tsx
+++ b/services/frontend-service/src/ui/utils/store.test.tsx
@@ -16,15 +16,25 @@ Copyright 2023 freiheit.com*/
 import { act, renderHook } from '@testing-library/react';
 import {
     AllLocks,
+    appendAction,
     FlushRolloutStatus,
+    UpdateAction,
     updateActions,
     UpdateOverview,
     UpdateRolloutStatus,
+    UpdateSnackbar,
     useLocksSimilarTo,
     useNavigateWithSearchParams,
     useRolloutStatus,
 } from './store';
-import { BatchAction, EnvironmentGroup, Priority, RolloutStatus, StreamStatusResponse } from '../../api/api';
+import {
+    BatchAction,
+    EnvironmentGroup,
+    LockBehavior,
+    Priority,
+    RolloutStatus,
+    StreamStatusResponse,
+} from '../../api/api';
 import { makeDisplayLock, makeLock } from '../../setupTests';
 import { BrowserRouter } from 'react-router-dom';
 
@@ -449,6 +459,64 @@ describe('Rollout Status', () => {
                 }
                 expect(enabled).toEqual(testcase.expectedEnabled);
             });
+        });
+    });
+});
+
+describe('Test maxActions', () => {
+    type TestDataStore = {
+        name: string;
+        inputActionsLen: number;
+        expectedLen: number;
+        expectedShowError: boolean;
+    };
+
+    const testdata: TestDataStore[] = [
+        {
+            name: 'below limit',
+            inputActionsLen: 99,
+            expectedLen: 99,
+            expectedShowError: false,
+        },
+        {
+            name: 'at limit',
+            inputActionsLen: 100,
+            expectedLen: 100,
+            expectedShowError: false,
+        },
+        {
+            name: 'over limit',
+            inputActionsLen: 101,
+            expectedLen: 100,
+            expectedShowError: true,
+        },
+    ];
+
+    describe.each(testdata)('with', (testcase) => {
+        it(testcase.name, () => {
+            // given
+            updateActions([]);
+
+            // when
+            for (let i = 0; i < testcase.inputActionsLen; i++) {
+                appendAction([
+                    {
+                        action: {
+                            $case: 'deploy',
+                            deploy: {
+                                environment: 'foo',
+                                application: 'bread' + i,
+                                version: i,
+                                ignoreAllLocks: false,
+                                lockBehavior: LockBehavior.Ignore,
+                            },
+                        },
+                    },
+                ]);
+            }
+            // then
+            expect(UpdateSnackbar.get().show).toStrictEqual(testcase.expectedShowError);
+            expect(UpdateAction.get().actions.length).toStrictEqual(testcase.expectedLen);
         });
     });
 });


### PR DESCRIPTION
The server always allowed only 100 actions.
Now the UI also checks if there are too many items, and stops the user before adding the 101st action.

This fixes issue https://github.com/freiheit-com/kuberpult/issues/878