### PR TITLE
Add Release Version to the frontend SideBar

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.scss
@@ -28,9 +28,9 @@ Copyright 2023 freiheit.com*/
     width: inherit;
     margin: 10px;
     font-style: normal;
-    font-weight: 700;
-    font-size: 18px;
-    line-height: 32px;
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 24px;
     color: #4a4a4a;
 }
 

--- a/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.scss
@@ -27,10 +27,7 @@ Copyright 2023 freiheit.com*/
     height: 100%;
     width: inherit;
     margin: 10px;
-    font-style: normal;
-    font-weight: 500;
-    font-size: 14px;
-    line-height: 24px;
+    @extend .text-regular;
     color: #4a4a4a;
 }
 

--- a/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.tsx
@@ -19,6 +19,7 @@ import { useOpenReleaseDialog, useReleaseOrThrow } from '../../utils/store';
 import { EnvironmentGroupChipList } from '../chip/EnvironmentGroupChip';
 import { undeployTooltipExplanation } from '../ReleaseDialog/ReleaseDialog';
 import { FormattedDate } from '../FormattedDate/FormattedDate';
+import { ReleaseVersionLink } from '../../utils/Links';
 
 export type ReleaseCardMiniProps = {
     className?: string;
@@ -33,12 +34,20 @@ export const ReleaseCardMini: React.FC<ReleaseCardMiniProps> = (props) => {
     const openReleaseDialog = useOpenReleaseDialog(app, version);
     const displayedMessage = undeployVersion ? 'Undeploy Version' : sourceMessage;
     const displayedTitle = undeployVersion ? undeployTooltipExplanation : '';
+    const release = useReleaseOrThrow(app, version);
     return (
         <div className={classNames('release-card-mini', className)} onClick={openReleaseDialog}>
             <div className={classNames('release__details-mini', className)}>
                 <div className="release__details-header" title={displayedTitle}>
                     {displayedMessage}
                 </div>
+                <ReleaseVersionLink
+                    displayVersion={release.displayVersion}
+                    undeployVersion={undeployVersion}
+                    sourceCommitId={''}
+                    version={version}
+                    app={app}
+                />
                 <div className="release__details-msg">
                     {sourceAuthor + ' | '}
                     {!!createdAt && <FormattedDate createdAt={createdAt} className="release__metadata-mini" />}

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.scss
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.scss
@@ -62,6 +62,7 @@ Copyright 2023 freiheit.com*/
     gap: 6px;
     color: var(--mdc-theme-on-surface);
     align-items: flex-start;
+    @extend .text-regular;
 }
 
 .mdc-drawer-sidebar-list-item-text-name {

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -202,12 +202,12 @@ type SideBarListItemProps = {
 export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children: action }: SideBarListItemProps) => {
     const { environmentLocks, appLocks } = useAllLocks();
     const actionDetails = getActionDetails(action, appLocks, environmentLocks);
-    const DisplayVersion = (): string => {
+    const DisplayVersion = () => {
         try {
             const release = useReleaseOrThrow(actionDetails.application ?? '', actionDetails.version ?? 0);
             return release.displayVersion;
         } catch (error) {
-            return '' as const;
+            return '';
         }
     };
 
@@ -275,7 +275,7 @@ export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children:
                 <div className="mdc-drawer-sidebar-list-item-text-name">{actionDetails.name}</div>
                 <div className="mdc-drawer-sidebar-list-item-text-summary">{actionDetails.summary}</div>
                 <ReleaseVersionLink
-                    displayVersion={DisplayVersion.toString()}
+                    displayVersion={DisplayVersion()}
                     undeployVersion={actionDetails.type === ActionTypes.Undeploy}
                     sourceCommitId={''}
                     version={actionDetails.version ?? 0}

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -202,7 +202,7 @@ type SideBarListItemProps = {
 export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children: action }: SideBarListItemProps) => {
     const { environmentLocks, appLocks } = useAllLocks();
     const actionDetails = getActionDetails(action, appLocks, environmentLocks);
-    const DisplayVersion = () => {
+    const DisplayVersion = (): string => {
         try {
             const release = useReleaseOrThrow(actionDetails.application ?? '', actionDetails.version ?? 0);
             return release.displayVersion;

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -202,14 +202,14 @@ type SideBarListItemProps = {
 export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children: action }: SideBarListItemProps) => {
     const { environmentLocks, appLocks } = useAllLocks();
     const actionDetails = getActionDetails(action, appLocks, environmentLocks);
-    const displayVersion = ():string  => {
+    const DisplayVersion = (): string => {
         try {
             const release = useReleaseOrThrow(actionDetails.application ?? '', actionDetails.version ?? 0);
             return release.displayVersion;
         } catch (error) {
-            return '' as const
+            return '' as const;
         }
-    }
+    };
 
     const handleDelete = useCallback(() => deleteAction(action), [action]);
     const similarLocks = useLocksSimilarTo(action);
@@ -275,7 +275,7 @@ export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children:
                 <div className="mdc-drawer-sidebar-list-item-text-name">{actionDetails.name}</div>
                 <div className="mdc-drawer-sidebar-list-item-text-summary">{actionDetails.summary}</div>
                 <ReleaseVersionLink
-                    displayVersion={displayVersion.toString()}
+                    displayVersion={DisplayVersion.toString()}
                     undeployVersion={actionDetails.type === ActionTypes.Undeploy}
                     sourceCommitId={''}
                     version={actionDetails.version ?? 0}

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -202,12 +202,13 @@ type SideBarListItemProps = {
 export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children: action }: SideBarListItemProps) => {
     const { environmentLocks, appLocks } = useAllLocks();
     const actionDetails = getActionDetails(action, appLocks, environmentLocks);
-    var displayVersion = '';
-    try {
-        const release = useReleaseOrThrow(actionDetails.application ?? '', actionDetails.version ?? 0);
-        displayVersion = release.displayVersion;
-    } catch (error) {
-        // continue without displayVersion
+    const displayVersion = ():string  => {
+        try {
+            const release = useReleaseOrThrow(actionDetails.application ?? '', actionDetails.version ?? 0);
+            return release.displayVersion;
+        } catch (error) {
+            return '' as const
+        }
     }
 
     const handleDelete = useCallback(() => deleteAction(action), [action]);
@@ -274,7 +275,7 @@ export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children:
                 <div className="mdc-drawer-sidebar-list-item-text-name">{actionDetails.name}</div>
                 <div className="mdc-drawer-sidebar-list-item-text-summary">{actionDetails.summary}</div>
                 <ReleaseVersionLink
-                    displayVersion={displayVersion}
+                    displayVersion={displayVersion.toString()}
                     undeployVersion={actionDetails.type === ActionTypes.Undeploy}
                     sourceCommitId={''}
                     version={actionDetails.version ?? 0}


### PR DESCRIPTION
Example of how this would look like for a deployment
![Screenshot 2023-09-11 at 10 28 27 AM](https://github.com/freiheit-com/kuberpult/assets/47796934/38bb6f30-4487-4162-b946-710c45924613)

and 
![Screenshot 2023-09-11 at 11 53 28 AM](https://github.com/freiheit-com/kuberpult/assets/47796934/341d97e1-8268-4c2b-acdc-6137cceef77a)
