### PR TITLE
Add networking timeouts to git pushes

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -169,6 +169,8 @@ spec:
 {{- end }}
         - name: KUBERPULT_ENABLE_SQLITE
           value: "{{ .Values.cd.enableSqlite }}"
+        - name: KUBERPULT_GIT_NETWORK_TIMEOUT
+          value: "{{ .Values.git.networkTimeout }}"
         volumeMounts:
         - name: repository
           mountPath: /repository

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -15,6 +15,8 @@ git:
   author:
     name: local.user@example.com
     email: defaultUser
+  # Timeout used for network operations
+  networkTimeout: 1m
 
 hub: europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/kylelemons/godebug v1.1.0
 	github.com/lestrrat-go/jwx v1.2.26
 	github.com/libgit2/git2go/v34 v34.0.0
+	github.com/mattn/go-shellwords v1.0.12
+	github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a
 	go.uber.org/zap v1.25.0
 	golang.org/x/crypto v0.12.0
 	golang.org/x/oauth2 v0.11.0
@@ -103,7 +105,7 @@ require (
 	go.opentelemetry.io/otel v1.16.0 // indirect
 	go.opentelemetry.io/otel/trace v1.16.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
-	golang.org/x/sync v0.3.0 // indirect
+	golang.org/x/sync v0.3.0
 	golang.org/x/term v0.11.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -706,9 +706,13 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a h1:eU8j/ClY2Ty3qdHnn0TyW3ivFoPC/0F1gQZz8yTxbbE=
+github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a/go.mod h1:v8eSC2SMp9/7FTKUncp7fH9IwPfw+ysMObcEz5FWheQ=
 github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.58/go.mod h1:NUDy4A4oXPq1l2yK6LTSvCEzAMeIcoz9lcj5dbzSrRE=
@@ -1678,6 +1682,7 @@ gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
+gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.1/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/interceptors"
 
@@ -43,26 +44,27 @@ import (
 
 type Config struct {
 	// these will be mapped to "KUBERPULT_GIT_URL", etc.
-	GitUrl            string `required:"true" split_words:"true"`
-	GitBranch         string `default:"master" split_words:"true"`
-	BootstrapMode     bool   `default:"false" split_words:"true"`
-	GitCommitterEmail string `default:"kuberpult@freiheit.com" split_words:"true"`
-	GitCommitterName  string `default:"kuberpult" split_words:"true"`
-	GitSshKey         string `default:"/etc/ssh/identity" split_words:"true"`
-	GitSshKnownHosts  string `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
-	PgpKeyRing        string `split_words:"true"`
-	AzureEnableAuth   bool   `default:"false" split_words:"true"`
-	DexEnabled        bool   `default:"false" split_words:"true"`
-	DexRbacPolicy     string `split_words:"true"`
-	EnableTracing     bool   `default:"false" split_words:"true"`
-	EnableMetrics     bool   `default:"false" split_words:"true"`
-	DogstatsdAddr     string `default:"127.0.0.1:8125" split_words:"true"`
-	EnableSqlite      bool   `default:"true" split_words:"true"`
-	DexMock           bool   `default:"false" split_words:"true"`
-	DexMockRole       string `default:"Developer" split_words:"true"`
-	ArgoCdServer      string `default:"" split_words:"true"`
-	ArgoCdInsecure    bool   `default:"false" split_words:"true"`
-	GitWebUrl         string `default:"" split_words:"true"`
+	GitUrl            string        `required:"true" split_words:"true"`
+	GitBranch         string        `default:"master" split_words:"true"`
+	BootstrapMode     bool          `default:"false" split_words:"true"`
+	GitCommitterEmail string        `default:"kuberpult@freiheit.com" split_words:"true"`
+	GitCommitterName  string        `default:"kuberpult" split_words:"true"`
+	GitSshKey         string        `default:"/etc/ssh/identity" split_words:"true"`
+	GitSshKnownHosts  string        `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
+	GitNetworkTimeout time.Duration `default:"1m" split_words:"true"`
+	PgpKeyRing        string        `split_words:"true"`
+	AzureEnableAuth   bool          `default:"false" split_words:"true"`
+	DexEnabled        bool          `default:"false" split_words:"true"`
+	DexRbacPolicy     string        `split_words:"true"`
+	EnableTracing     bool          `default:"false" split_words:"true"`
+	EnableMetrics     bool          `default:"false" split_words:"true"`
+	DogstatsdAddr     string        `default:"127.0.0.1:8125" split_words:"true"`
+	EnableSqlite      bool          `default:"true" split_words:"true"`
+	DexMock           bool          `default:"false" split_words:"true"`
+	DexMockRole       string        `default:"Developer" split_words:"true"`
+	ArgoCdServer      string        `default:"" split_words:"true"`
+	ArgoCdInsecure    bool          `default:"false" split_words:"true"`
+	GitWebUrl         string        `default:"" split_words:"true"`
 }
 
 func (c *Config) storageBackend() repository.StorageBackend {
@@ -163,6 +165,7 @@ func RunServer() {
 			ArgoInsecure:           c.ArgoCdInsecure,
 			ArgoWebhookUrl:         c.ArgoCdServer,
 			WebURL:                 c.GitWebUrl,
+			NetworkTimeout:         c.GitNetworkTimeout,
 		})
 		if err != nil {
 			logger.FromContext(ctx).Fatal("repository.new.error", zap.Error(err), zap.String("git.url", c.GitUrl), zap.String("git.branch", c.GitBranch))

--- a/services/cd-service/pkg/grpc/errors.go
+++ b/services/cd-service/pkg/grpc/errors.go
@@ -36,6 +36,10 @@ func PublicError(ctx context.Context, err error) error {
 	return status.Error(codes.InvalidArgument, "error: "+err.Error())
 }
 
+func CanceledError(ctx context.Context, err error) error {
+	return status.Error(codes.Canceled, err.Error())
+}
+
 func AuthError(ctx context.Context, err error) error {
 	return status.Error(codes.Unauthenticated, "error: "+err.Error())
 }

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -93,7 +93,6 @@ type repository struct {
 	writeLock    sync.Mutex
 	writesDone   uint
 	queue        queue
-	remote       *git.Remote
 	config       *RepositoryConfig
 	credentials  *credentialsStore
 	certificates *certificateStore
@@ -120,6 +119,8 @@ type RepositoryConfig struct {
 	CommitterName  string
 	// default branch is master
 	Branch string
+	// network timeout
+	NetworkTimeout time.Duration
 	//
 	GcFrequency    uint
 	StorageBackend StorageBackend
@@ -193,6 +194,9 @@ func New(ctx context.Context, cfg RepositoryConfig) (Repository, error) {
 	if cfg.StorageBackend == DefaultBackend {
 		cfg.StorageBackend = SqliteBackend
 	}
+	if cfg.NetworkTimeout == 0 {
+		cfg.NetworkTimeout = time.Minute
+	}
 	var credentials *credentialsStore
 	var certificates *certificateStore
 	var err error
@@ -217,7 +221,6 @@ func New(ctx context.Context, cfg RepositoryConfig) (Repository, error) {
 			return nil, err
 		} else {
 			result := &repository{
-				remote:          remote,
 				config:          &cfg,
 				credentials:     credentials,
 				certificates:    certificates,
@@ -326,6 +329,23 @@ func (r *repository) applyElements(elements []element, allowFetchAndReset bool) 
 
 var panicError = errors.New("Panic")
 
+func (r *repository) useRemote(ctx context.Context, callback func(*git.Remote) error) error {
+	remote, _ := r.repository.Remotes.CreateAnonymous(r.config.URL)
+	defer remote.Disconnect()
+	ctx, cancel := context.WithTimeout(context.Background(), r.config.NetworkTimeout)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- callback(remote)
+	}()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	}
+}
+
 func (r *repository) drainQueue() []element {
 	elements := []element{}
 	for {
@@ -344,7 +364,6 @@ func (r *repository) drainQueue() []element {
 	}
 }
 
-// defaultPushUpdate is public for testing reasons only.
 // It returns always nil
 // success is set to true if the push was successful
 func defaultPushUpdate(branch string, success *bool) git.PushUpdateReferenceCallback {
@@ -362,7 +381,9 @@ type PushActionCallbackFunc func(git.PushOptions, *repository) PushActionFunc
 // DefaultPushActionCallback is public for testing reasons only.
 func DefaultPushActionCallback(pushOptions git.PushOptions, r *repository) PushActionFunc {
 	return func() error {
-		return r.remote.Push([]string{fmt.Sprintf("refs/heads/%s:refs/heads/%s", r.config.Branch, r.config.Branch)}, &pushOptions)
+		return r.useRemote(context.Background(), func(remote *git.Remote) error {
+			return remote.Push([]string{fmt.Sprintf("refs/heads/%s:refs/heads/%s", r.config.Branch, r.config.Branch)}, &pushOptions)
+		})
 	}
 }
 
@@ -410,9 +431,9 @@ func (r *repository) ProcessQueueOnce(ctx context.Context, e element, callback P
 	// Try pushing once
 	err = r.Push(e.ctx, pushAction(pushOptions, r))
 	if err != nil {
-		gerr := err.(*git.GitError)
+		gerr, ok := err.(*git.GitError)
 		// If it doesn't work because the branch diverged, try reset and apply again.
-		if gerr.Code == git.ErrorCodeNonFastForward {
+		if ok && gerr.Code == git.ErrorCodeNonFastForward {
 			err = r.FetchAndReset(e.ctx)
 			if err != nil {
 				return
@@ -425,6 +446,8 @@ func (r *repository) ProcessQueueOnce(ctx context.Context, e element, callback P
 			if pushErr := r.Push(e.ctx, pushAction(pushOptions, r)); pushErr != nil {
 				err = &InternalError{inner: pushErr}
 			}
+		} else if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			err = grpc.CanceledError(ctx, err)
 		} else {
 			logger.Error(fmt.Sprintf("error while pushing: %s", err))
 			err = grpc.PublicError(ctx, errors.New(fmt.Sprintf("could not push to manifest repository '%s' on branch '%s' - this indicates that the ssh key does not have write access", r.config.URL, r.config.Branch)))
@@ -735,6 +758,7 @@ func (r *repository) ApplyTransformers(ctx context.Context, transformers ...Tran
 	}
 
 	user, err := auth.ReadUserFromContext(ctx)
+
 	if err != nil {
 		return nil, err
 	}
@@ -790,7 +814,9 @@ func (r *repository) FetchAndReset(ctx context.Context) error {
 			CertificateCheckCallback: r.certificates.CertificateCheckCallback(ctx),
 		},
 	}
-	err := r.remote.Fetch([]string{fetchSpec}, &fetchOptions, "fetching")
+	err := r.useRemote(ctx, func(remote *git.Remote) error {
+		return remote.Fetch([]string{fetchSpec}, &fetchOptions, "fetching")
+	})
 	if err != nil {
 		return &InternalError{inner: err}
 	}
@@ -856,8 +882,8 @@ func (r *repository) Push(ctx context.Context, pushAction func() error) error {
 			defer span.Finish()
 			err := pushAction()
 			if err != nil {
-				gerr := err.(*git.GitError)
-				if gerr.Code == git.ErrorCodeNonFastForward {
+				gerr, ok := err.(*git.GitError)
+				if ok && gerr.Code == git.ErrorCodeNonFastForward {
 					return backoff.Permanent(err)
 				}
 			}
@@ -1402,7 +1428,7 @@ type Release struct {
 	SourceCommitId  string
 	SourceMessage   string
 	CreatedAt       time.Time
-	DisplayVersion  string 
+	DisplayVersion  string
 }
 
 func (s *State) IsUndeployVersion(application string, version uint64) (bool, error) {
@@ -1452,7 +1478,7 @@ func (s *State) GetApplicationRelease(application string, version uint64) (*Rele
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
-		release.DisplayVersion = "";
+		release.DisplayVersion = ""
 	} else {
 		release.DisplayVersion = string(displayVersion)
 	}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -330,7 +330,10 @@ func (r *repository) applyElements(elements []element, allowFetchAndReset bool) 
 var panicError = errors.New("Panic")
 
 func (r *repository) useRemote(ctx context.Context, callback func(*git.Remote) error) error {
-	remote, _ := r.repository.Remotes.CreateAnonymous(r.config.URL)
+	remote, err := r.repository.Remotes.CreateAnonymous(r.config.URL)
+	if err != nil {
+		return fmt.Errorf("opening remote %q: %w", r.config.URL, err)
+	}
 	defer remote.Disconnect()
 	ctx, cancel := context.WithTimeout(context.Background(), r.config.NetworkTimeout)
 	defer cancel()

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -292,7 +292,7 @@ func (r *repository) ProcessQueue(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case e := <-r.queue.elements:
-			r.ProcessQueueOnce(ctx, e, DefaultPushUpdate, DefaultPushActionCallback)
+			r.ProcessQueueOnce(ctx, e, defaultPushUpdate, DefaultPushActionCallback)
 		}
 	}
 }
@@ -344,10 +344,10 @@ func (r *repository) drainQueue() []element {
 	}
 }
 
-// DefaultPushUpdate is public for testing reasons only.
+// defaultPushUpdate is public for testing reasons only.
 // It returns always nil
 // success is set to true if the push was successful
-func DefaultPushUpdate(branch string, success *bool) git.PushUpdateReferenceCallback {
+func defaultPushUpdate(branch string, success *bool) git.PushUpdateReferenceCallback {
 	return func(refName string, status string) error {
 		var expectedRefName = fmt.Sprintf("refs/heads/%s", branch)
 		// if we were successful the status is empty and the ref contains our branch:

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -1400,7 +1400,7 @@ func TestPushUpdate(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			var success = false
-			actualError := DefaultPushUpdate(tc.InputBranch, &success)(tc.InputRefName, tc.InputStatus)
+			actualError := defaultPushUpdate(tc.InputBranch, &success)(tc.InputRefName, tc.InputStatus)
 			if success != tc.ExpectedSuccess {
 				t.Fatal(fmt.Sprintf("expected sucess=%t but got %t", tc.ExpectedSuccess, success))
 			}
@@ -1421,7 +1421,7 @@ func TestProcessQueueOnce(t *testing.T) {
 	}{
 		{
 			Name:           "success",
-			PushUpdateFunc: DefaultPushUpdate,
+			PushUpdateFunc: defaultPushUpdate,
 			PushActionFunc: DefaultPushActionCallback,
 			Element: element{
 				ctx: testutil.MakeTestContext(),

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -1572,7 +1572,7 @@ func TestGitPushDoesntGetStuck(t *testing.T) {
 			if status.Code(err) != codes.Canceled {
 				t.Errorf("expected status code cancelled, but got %q", status.Code(err))
 			}
-			// This will prevent the next push from working
+			// This will make the next push work
 			ts.DelayExecs(0 * time.Second)
 			err = repo.Apply(testutil.MakeTestContext(),
 				&CreateEnvironment{Environment: "stg"},

--- a/services/cd-service/pkg/repository/testssh/README.md
+++ b/services/cd-service/pkg/repository/testssh/README.md
@@ -1,0 +1,4 @@
+testssh
+=========
+
+`testssh` implements an ssh server that can be instructed to delay commands. It is used to test misbehaving git servers.

--- a/services/cd-service/pkg/repository/testssh/server.go
+++ b/services/cd-service/pkg/repository/testssh/server.go
@@ -1,0 +1,169 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package testssh
+
+import (
+	"crypto/ed25519"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/mattn/go-shellwords"
+	"github.com/mikesmitty/edkey"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+type TestServer struct {
+	Port       int
+	KnownHosts string
+	ClientKey  string
+	Url        string
+	l          net.Listener
+	execDelay  time.Duration
+}
+
+type envReq struct {
+	Env   string
+	Value string
+}
+
+type execReq struct {
+	Command string
+}
+
+type exitReq struct {
+	Status uint32
+}
+
+func New(workdir string) *TestServer {
+	ts := TestServer{}
+	// Allocate a new listening port
+	ts.l, _ = net.ListenTCP("tcp", &net.TCPAddr{})
+	ts.Port = ts.l.Addr().(*net.TCPAddr).Port
+
+	// Setup a private key for the server and write a known hosts file
+	_, servPriv, _ := ed25519.GenerateKey(nil)
+	ps, _ := ssh.NewSignerFromSigner(servPriv)
+	kh := knownhosts.Line([]string{fmt.Sprintf("127.0.0.1")}, ps.PublicKey())
+	ts.KnownHosts = filepath.Join(workdir, "known_hosts")
+	os.WriteFile(ts.KnownHosts, []byte(kh), 0644)
+	sc := &ssh.ServerConfig{
+		PublicKeyCallback: func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			return &ssh.Permissions{}, nil
+		},
+	}
+	sc.AddHostKey(ps)
+
+	// Setup a private key for the client and write it to an openssh compatible file
+	_, clientPriv, _ := ed25519.GenerateKey(nil)
+	ts.ClientKey = filepath.Join(workdir, "id_ed25519")
+	key := pem.EncodeToMemory(&pem.Block{
+		Type:  "OPENSSH PRIVATE KEY",
+		Bytes: edkey.MarshalED25519PrivateKey(clientPriv),
+	})
+	os.WriteFile(ts.ClientKey, key, 0600)
+
+	ts.Url = fmt.Sprintf("ssh://git@127.0.0.1:%d/.", ts.Port)
+	
+	go func() {
+		for {
+			con, err := ts.l.Accept()
+			if err != nil {
+				fmt.Printf("testssh: err %q\n", err)
+				return
+			}
+			go ts.handleConn(con, workdir, sc)
+		}
+	}()
+	return &ts
+}
+
+func (ts *TestServer) handleConn(con net.Conn, workdir string, sc *ssh.ServerConfig) {
+	defer con.Close()
+	sCon, chans, reqs, err := ssh.NewServerConn(con, sc)
+	if err != nil {
+		fmt.Printf("testssh: err %q\n", err)
+		return
+	}
+	defer sCon.Close()
+	go ssh.DiscardRequests(reqs)
+	for newch := range chans {
+		if newch.ChannelType() != "session" {
+			newch.Reject(ssh.UnknownChannelType, "only channel type session is allowed")
+		}
+		ch, reqs, err := newch.Accept()
+		if err != nil {
+			fmt.Printf("testssh: accept err %q\n", err)
+			return
+		}
+		env := []string{}
+		for req := range reqs {
+			switch req.Type {
+			case "env":
+				var payload envReq
+				ssh.Unmarshal(req.Payload, &payload)
+				env = append(env, fmt.Sprintf("%s=%s", payload.Env, payload.Value))
+			case "exec":
+				var payload execReq
+				ssh.Unmarshal(req.Payload, &payload)
+				args, _ := shellwords.Parse(payload.Command)
+				if args[0] != "git-upload-pack" && args[0] != "git-receive-pack" {
+					fmt.Printf("testssh: illegal command: %q\n", args[0])
+					req.Reply(false, nil)
+					ch.Close()
+					return
+				}
+				args[1] = filepath.Join(workdir, args[1])
+				cmd := exec.Command(args[0], args[1:len(args)]...)
+				cmd.Env = env
+				stdin, _ := cmd.StdinPipe()
+				stdout, _ := cmd.StdoutPipe()
+				stderr, _ := cmd.StderrPipe()
+				go io.Copy(stdin, ch)
+				time.Sleep(ts.execDelay)
+				cmd.Start()
+				req.Reply(true, nil)
+				_, _ = io.Copy(ch, stdout)
+				_, _ = io.Copy(ch.Stderr(), stderr)
+				err = cmd.Wait()
+				if err != nil {
+					fmt.Printf("testssh: run err %q\n", err)
+				}
+				ch.SendRequest("exit-status", false, ssh.Marshal(&exitReq{Status: uint32(cmd.ProcessState.ExitCode())}))
+				ch.Close()
+			default:
+				fmt.Printf("testssh: illegal req: %q\n", req.Type)
+				ch.Close()
+			}
+
+		}
+	}
+}
+
+func (ts *TestServer) DelayExecs(dr time.Duration) {
+	ts.execDelay = dr
+}
+
+func (ts *TestServer) Close() {
+	ts.l.Close()
+}


### PR DESCRIPTION
The solution take is highly unelegant but kinda unavoidable given the options available. Basically, libgit as most c based libs doesn't allow cancelling anything. The only thing we can do is to run the push operation in a seperate go routine and return our own timeout after some time while throwing a cancellation at the lib to stop. This is now done in the `useRemote` function. The network timeout is now 1 minute which is probably good enough for most consumers.