### PR TITLE
Add dedicated setup for health checking

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -85,13 +85,13 @@ spec:
             protocol: TCP
         readinessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: http
           initialDelaySeconds: {{ .Values.cd.probes.readiness.initialDelaySeconds }}
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: http
           initialDelaySeconds: {{ .Values.cd.probes.liveness.initialDelaySeconds }}
         resources:

--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -67,13 +67,13 @@ spec:
             protocol: TCP
         readinessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: http
           initialDelaySeconds: 5
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: http
         resources:
           limits:

--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -67,13 +67,13 @@ spec:
             protocol: TCP
         readinessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: http
           initialDelaySeconds: 5
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: http
         resources:
           limits:

--- a/pkg/setup/health.go
+++ b/pkg/setup/health.go
@@ -56,8 +56,12 @@ type HealthReporter struct {
 }
 
 type report struct {
-	Health  Health        `json:"health"`
-	Message string        `json:"message,omitempty"`
+	Health  Health `json:"health"`
+	Message string `json:"message,omitempty"`
+}
+
+func (r *report) isReady() bool {
+	return r.Health == HealthReady
 }
 
 func (r *HealthReporter) ReportReady(message string) {

--- a/pkg/setup/health.go
+++ b/pkg/setup/health.go
@@ -1,0 +1,139 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+// Setup implementation shared between all microservices.
+// If this file is changed it will affect _all_ microservices in the monorepo (and this
+// is deliberately so).
+package setup
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+type Health uint
+
+const (
+	HealthStarting Health = iota
+	HealthReady
+	HealthFailed
+)
+
+func (h Health) String() string {
+	switch h {
+	case HealthStarting:
+		return "starting"
+	case HealthReady:
+		return "ready"
+	case HealthFailed:
+		return "failed"
+	}
+	return "unknown"
+}
+
+func (h Health) MarshalJSON() ([]byte, error) {
+	return json.Marshal(h.String())
+}
+
+type HealthReporter struct {
+	server *HealthServer
+	name   string
+}
+
+type report struct {
+	Health  Health        `json:"health"`
+	Message string        `json:"message,omitempty"`
+}
+
+func (r *HealthReporter) ReportReady(message string) {
+	r.ReportHealth(HealthReady, message)
+}
+
+func (r *HealthReporter) ReportHealth(health Health, message string) {
+	if r == nil {
+		return
+	}
+	r.server.mx.Lock()
+	defer r.server.mx.Unlock()
+	if r.server.parts == nil {
+		r.server.parts = map[string]report{}
+	}
+	r.server.parts[r.name] = report{
+		Health:  health,
+		Message: message,
+	}
+}
+
+type HealthServer struct {
+	parts map[string]report
+	mx    sync.Mutex
+}
+
+func (h *HealthServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	reports := h.reports()
+	success := true
+	for _, r := range reports {
+		if r.Health != HealthReady {
+			success = false
+		}
+	}
+	body, err := json.Marshal(reports)
+	if err != nil {
+		panic(err)
+	}
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+	if success {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	fmt.Fprint(w, string(body))
+}
+
+func (h *HealthServer) IsReady(name string) bool {
+	h.mx.Lock()
+	defer h.mx.Unlock()
+	if h.parts == nil {
+		return false
+	}
+	report := h.parts[name]
+	return report.Health == HealthReady
+}
+
+func (h *HealthServer) reports() map[string]report {
+	h.mx.Lock()
+	defer h.mx.Unlock()
+	result := make(map[string]report, len(h.parts))
+	for k, v := range h.parts {
+		result[k] = v
+	}
+	return result
+}
+
+func (h *HealthServer) Reporter(name string) *HealthReporter {
+	r := &HealthReporter{
+		server: h,
+		name:   name,
+	}
+	r.ReportHealth(HealthStarting, "starting")
+	return r
+}
+
+var (
+	_ http.Handler = (*HealthServer)(nil)
+)

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -235,7 +235,10 @@ func TestMetrics(t *testing.T) {
 				time.After(time.Second)
 			}
 			body, _ := io.ReadAll(response.Body)
-			expectedBody := `# HELP something_total 
+			expectedBody := `# HELP background_job_ready 
+# TYPE background_job_ready gauge
+background_job_ready{name="something"} 0
+# HELP something_total 
 # TYPE something_total counter
 something_total 1
 `

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -203,7 +203,7 @@ func TestMetrics(t *testing.T) {
 				Background: []BackgroundTaskConfig{
 					{
 						Name: "something",
-						Run: func(ctx context.Context) error {
+						Run: func(ctx context.Context, hr *HealthReporter) error {
 							pv := metrics.FromContext(ctx)
 							counter, _ := pv.Meter("something").Int64Counter("something")
 							counter.Add(ctx, 1)

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -262,10 +262,7 @@ func runServer(ctx context.Context) error {
 		}
 		httpHandler.Handle(w, req)
 	}))
-	mux.Handle("/health", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.WriteHeader(200)
-		fmt.Fprintf(w, "ok\n")
-	}))
+
 	mux.Handle("/", http.FileServer(http.Dir("build")))
 	// Split HTTP REST from gRPC Web requests, as suggested in the documentation:
 	// https://pkg.go.dev/github.com/improbable-eng/grpc-web@v0.15.0/go/grpcweb

--- a/services/frontend-service/pkg/cmd/server_test.go
+++ b/services/frontend-service/pkg/cmd/server_test.go
@@ -120,7 +120,7 @@ func TestServerHeader(t *testing.T) {
 				defer wg.Done()
 				defer cancel()
 				for {
-					res, err := http.Get("http://localhost:8081/health")
+					res, err := http.Get("http://localhost:8081/healthz")
 					if err != nil {
 						t.Logf("unhealthy: %q", err)
 						<-time.After(1 * time.Second)
@@ -220,7 +220,7 @@ func TestGrpcForwardHeader(t *testing.T) {
 				defer wg.Done()
 				defer cancel()
 				for {
-					res, err := http.Get("http://localhost:8081/health")
+					res, err := http.Get("http://localhost:8081/healthz")
 					if err != nil {
 						t.Logf("unhealthy: %q", err)
 						<-time.After(1 * time.Second)

--- a/services/rollout-service/pkg/service/service_test.go
+++ b/services/rollout-service/pkg/service/service_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/versions"
+	"github.com/freiheit-com/kuberpult/pkg/setup"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -292,8 +293,8 @@ func TestArgoConection(t *testing.T) {
 				Steps: tc.Steps,
 				t:     t,
 			}
-			ready := false
-			err := ConsumeEvents(ctx, &as, &mockVersionClient{versions: tc.Versions}, &as, func() { ready = true })
+			hlth := &setup.HealthServer{}
+			err := ConsumeEvents(ctx, &as, &mockVersionClient{versions: tc.Versions}, &as, hlth.Reporter("consume"))
 			if tc.ExpectedError == "" {
 				if err != nil {
 					t.Errorf("expected no error, but got %q", err)
@@ -305,6 +306,7 @@ func TestArgoConection(t *testing.T) {
 					t.Errorf("expected error %q, but got %q", tc.ExpectedError, err)
 				}
 			}
+			ready := hlth.IsReady("consume")
 			if tc.ExpectedReady != ready {
 				t.Errorf("expected ready to be %t but got %t", tc.ExpectedReady, ready)
 			}


### PR DESCRIPTION
This MR adds a dedicated setup for health checking of background tasks. This currently the smallest possible setup but every background job has to mark itself ready to make the service report itself ready as a whole. The readiness status is currently never invalidated.