### PR TITLE
Kill processes earlier when stopping them locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "8443:8443"
     volumes:
       - .:/kp/kuberpult
+    stop_grace_period: 0.5s
   frontend:
     build:
       context: infrastructure/docker/frontend
@@ -28,6 +29,7 @@ services:
       - backend
     volumes:
       - .:/kp/kuberpult
+    stop_grace_period: 0.5s
   ui:
     build:
       context: infrastructure/docker/ui
@@ -40,3 +42,4 @@ services:
       - frontend
     volumes:
       - .:/kp/kuberpult
+    stop_grace_period: 0.5s


### PR DESCRIPTION
Kill processes earlier when stopping them locally

When running with docker-compose, handling signals is a hassle, because Make invocations are wrapped in shell scripts.
It's much simpler to just let docker-compose send the kill signal quicker.

This is only relevant for local development.