### PR TITLE
Fix lock symbol size on history page

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -183,6 +183,7 @@ button.button-lock {
     min-width: unset;
     padding: unset;
     height: auto;
+    width: 20px;
 }
 
 button.mdc-button.env-card-deploy-btn {


### PR DESCRIPTION
Before:
![Screenshot from 2023-09-18 14-13-43](https://github.com/freiheit-com/kuberpult/assets/3481382/5e27626e-d2dc-470c-97a9-ddf142b5622a)

After:
![Screenshot from 2023-09-18 14-13-22](https://github.com/freiheit-com/kuberpult/assets/3481382/861b45e5-0a87-4cb0-a638-8628a42011ac)
