### PR TITLE
Fix display of delete-them-all button

### DIFF
--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -258,7 +258,7 @@ export const SideBarListItem: React.FC<{ children: BatchAction }> = ({ children:
                     }>
                     There are other similar locks.
                 </div>
-                <Button onClick={handleAddAll} label={' Delete them all! '} className={'button-lock'}></Button>
+                <Button onClick={handleAddAll} label={' Delete them all! '} className={''}></Button>
             </div>
         );
     return (


### PR DESCRIPTION
it was way too small.

Now:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/55d0839d-6d63-4d7c-9fa0-433878f89c86)
