### PR TITLE
UI: Show warning before deploying over a lock

### DIFF
--- a/services/frontend-service/src/setupTests.ts
+++ b/services/frontend-service/src/setupTests.ts
@@ -82,8 +82,8 @@ export const makeLock = (input: Partial<Lock>): Lock => ({
     message: 'lock msg 1',
     createdAt: date,
     createdBy: {
-        name: 'Betty',
-        email: 'betty@example.com',
+        name: 'default',
+        email: 'default@example.com',
     },
     ...input,
 });

--- a/services/frontend-service/src/ui/components/EnvironmentLockDisplay/EnvironmentLockDisplay.tsx
+++ b/services/frontend-service/src/ui/components/EnvironmentLockDisplay/EnvironmentLockDisplay.tsx
@@ -26,7 +26,7 @@ export const DisplayLockInlineRenderer: React.FC<{ lock: DisplayLock }> = (props
 
     const description = lock.application ? (
         <span>
-            App <b>{lock.application}</b> locked by <b>{author}</b> on environment <b>{lock.environment}</b>
+            Application <b>{lock.application}</b> locked by <b>{author}</b> on environment <b>{lock.environment}</b>
         </span>
     ) : (
         <span>

--- a/services/frontend-service/src/ui/components/EnvironmentLockDisplay/EnvironmentLockDisplay.tsx
+++ b/services/frontend-service/src/ui/components/EnvironmentLockDisplay/EnvironmentLockDisplay.tsx
@@ -19,6 +19,22 @@ import { Tooltip } from '../tooltip/tooltip';
 import { Locks, LocksWhite } from '../../../images';
 import { Button } from '../button';
 
+export const DisplayLockInlineRenderer: React.FC<{ lock: DisplayLock }> = (props) => {
+    const { lock } = props;
+    const hasAuthor = lock.authorEmail || lock.authorName;
+    const author = hasAuthor ? lock.authorName + '<' + lock.authorEmail + '>' : 'unknown';
+    return (
+        <span title={lock.lockId}>
+            <span>
+                locked by <b>{author}</b>
+            </span>
+            <span>
+                {' '}
+                with message: <b>{lock.message}</b>{' '}
+            </span>
+        </span>
+    );
+};
 export const DisplayLockRenderer: React.FC<{ lock: DisplayLock }> = (props) => {
     const { lock } = props;
     const hasAuthor = lock.authorEmail || lock.authorName;

--- a/services/frontend-service/src/ui/components/EnvironmentLockDisplay/EnvironmentLockDisplay.tsx
+++ b/services/frontend-service/src/ui/components/EnvironmentLockDisplay/EnvironmentLockDisplay.tsx
@@ -23,14 +23,22 @@ export const DisplayLockInlineRenderer: React.FC<{ lock: DisplayLock }> = (props
     const { lock } = props;
     const hasAuthor = lock.authorEmail || lock.authorName;
     const author = hasAuthor ? lock.authorName + '<' + lock.authorEmail + '>' : 'unknown';
+
+    const description = lock.application ? (
+        <span>
+            App <b>{lock.application}</b> locked by <b>{author}</b> on environment <b>{lock.environment}</b>
+        </span>
+    ) : (
+        <span>
+            Environment <b>{lock.environment}</b> locked by <b>{author}</b>
+        </span>
+    );
     return (
         <span title={lock.lockId}>
-            <span>
-                locked by <b>{author}</b>
-            </span>
+            {description}
             <span>
                 {' '}
-                with message: <b>{lock.message}</b>{' '}
+                with message: <b>'{lock.message}'</b>{' '}
             </span>
         </span>
     );

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -185,18 +185,19 @@ button.mdc-button.env-card-deploy-btn {
 
 .confirmation-dialog-container {
     display: flex;
+}
 
-    &.confirmation-dialog-container-open {
-        &::before {
-            content: "";
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            z-index: 999;
-            background-color: #00000050;
-        }
+.confirmation-dialog-container-open {
+    &::before {
+        // this is to make everything behind the dialog grey and not clickable:
+        content: "";
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 999;
+        background-color: #00000050;
     }
 }
 

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -213,26 +213,24 @@ button.mdc-button.env-card-deploy-btn {
     transform: translate(-50%, -50%);
 
     z-index: 1000;
-    //border: 2px solid var(--mdc-theme-primary);
-    //border-radius: 5px;
-    //border-width: 2px;
     border-radius: 10px;
-    box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 5px -3px, rgba(0, 0, 0, 0.14) 0px 8px 10px 1px,
+    box-shadow: rgba(0, 0, 0, 0.2) 0 5px 5px -3px, rgba(0, 0, 0, 0.14) 0px 8px 10px 1px,
     rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
 
 
     .confirmation-dialog-header {
         @extend .headline1;
-        padding: 2rem 2rem 0 2rem;
+        padding: 2rem 2rem 1rem 2rem;
     }
     .confirmation-dialog-content {
         font-weight: 500;
         overflow:auto;
-        padding: 0 2rem 0 2rem;
+        padding: 1rem 2rem 0 2rem;
     }
     .confirmation-dialog-footer {
         display: flex;
-        justify-content: space-around;
+        justify-content: flex-end;
+        gap: 1rem;
         padding: 1rem 2rem 1rem 2rem;
 
         .item:not(:first-child) {
@@ -243,9 +241,13 @@ button.mdc-button.env-card-deploy-btn {
             list-style-type: none;
             padding: 0;
         }
+        button {
+            border-radius: 10px;
+
+        }
     }
     hr {
-        width: 100%;
         color: grey;
+        margin: 0 2rem 0 2rem;
     }
 }

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -185,35 +185,55 @@ button.mdc-button.env-card-deploy-btn {
 
 .confirmation-dialog-container {
     display: flex;
+
+    &.confirmation-dialog-container-open {
+        &::before {
+            content: "";
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            z-index: 999;
+            background-color: #00000050;
+        }
+    }
 }
 
 .confirmation-dialog-open {
-    background: #ffffff;
-    position: absolute;
+    max-height: 80vh;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    background: white;
+    color: black;
+    position: fixed;
     float: left;
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
 
     z-index: 1000;
-    border: 5px solid var(--mdc-theme-primary);
-    border-radius: 5px;
+    //border: 2px solid var(--mdc-theme-primary);
+    //border-radius: 5px;
+    //border-width: 2px;
+    border-radius: 10px;
     box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 5px -3px, rgba(0, 0, 0, 0.14) 0px 8px 10px 1px,
     rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
 
-    .confirmation-dialog-header {
-        margin: 16px;
-        @extend .headline1;
 
+    .confirmation-dialog-header {
+        @extend .headline1;
+        padding: 2rem 2rem 0 2rem;
     }
     .confirmation-dialog-content {
-        margin: 16px;
+        font-weight: 500;
+        overflow:auto;
+        padding: 0 2rem 0 2rem;
     }
-    .list {
+    .confirmation-dialog-footer {
         display: flex;
         justify-content: space-around;
-        margin-top: 8px;
-        margin-bottom: 8px;
+        padding: 1rem 2rem 1rem 2rem;
 
         .item:not(:first-child) {
             border-top: 1px solid;
@@ -221,7 +241,11 @@ button.mdc-button.env-card-deploy-btn {
         }
         .item {
             list-style-type: none;
-            padding: 0px;
+            padding: 0;
         }
+    }
+    hr {
+        width: 100%;
+        color: grey;
     }
 }

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -181,8 +181,6 @@ button.mdc-button.env-card-deploy-btn {
     @extend .text-bold;
 }
 
-
-
 .confirmation-dialog-container {
     display: flex;
 }
@@ -190,7 +188,7 @@ button.mdc-button.env-card-deploy-btn {
 .confirmation-dialog-container-open {
     &::before {
         // this is to make everything behind the dialog grey and not clickable:
-        content: "";
+        content: '';
         position: fixed;
         top: 0;
         left: 0;
@@ -216,8 +214,7 @@ button.mdc-button.env-card-deploy-btn {
     z-index: 1000;
     border-radius: 10px;
     box-shadow: rgba(0, 0, 0, 0.2) 0 5px 5px -3px, rgba(0, 0, 0, 0.14) 0px 8px 10px 1px,
-    rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
-
+        rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
 
     .confirmation-dialog-header {
         @extend .headline1;
@@ -225,7 +222,7 @@ button.mdc-button.env-card-deploy-btn {
     }
     .confirmation-dialog-content {
         font-weight: 500;
-        overflow:auto;
+        overflow: auto;
         padding: 1rem 2rem 1rem 2rem;
     }
     .confirmation-dialog-footer {
@@ -244,7 +241,6 @@ button.mdc-button.env-card-deploy-btn {
         }
         button {
             border-radius: 10px;
-
         }
     }
     hr {

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -226,7 +226,7 @@ button.mdc-button.env-card-deploy-btn {
     .confirmation-dialog-content {
         font-weight: 500;
         overflow:auto;
-        padding: 1rem 2rem 0 2rem;
+        padding: 1rem 2rem 1rem 2rem;
     }
     .confirmation-dialog-footer {
         display: flex;

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -180,3 +180,48 @@ button.mdc-button.env-card-deploy-btn {
     color: white;
     @extend .text-bold;
 }
+
+
+
+.confirmation-dialog-container {
+    display: flex;
+}
+
+.confirmation-dialog-open {
+    background: #ffffff;
+    position: absolute;
+    float: left;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+
+    z-index: 1000;
+    border: 5px solid var(--mdc-theme-primary);
+    border-radius: 5px;
+    box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 5px -3px, rgba(0, 0, 0, 0.14) 0px 8px 10px 1px,
+    rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
+
+    .confirmation-dialog-header {
+        margin: 16px;
+        @extend .headline1;
+
+    }
+    .confirmation-dialog-content {
+        margin: 16px;
+    }
+    .list {
+        display: flex;
+        justify-content: space-around;
+        margin-top: 8px;
+        margin-bottom: 8px;
+
+        .item:not(:first-child) {
+            border-top: 1px solid;
+            border-color: white;
+        }
+        .item {
+            list-style-type: none;
+            padding: 0px;
+        }
+    }
+}

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -50,12 +50,10 @@ describe('Release Dialog', () => {
         expect_queues: number;
         data_length: number;
         teamName: string;
-        expectExtraClick: boolean;
     }
     const dataLocks: dataTLocks[] = [
         {
             name: 'without locks',
-            expectExtraClick: false,
             props: {
                 app: 'test1',
                 version: 2,
@@ -76,47 +74,6 @@ describe('Release Dialog', () => {
                 {
                     name: 'prod',
                     locks: {},
-                    applications: {
-                        test1: {
-                            name: 'test1',
-                            version: 2,
-                            locks: {},
-                            queuedVersion: 0,
-                            undeployVersion: false,
-                        },
-                    },
-                    distanceToUpstream: 0,
-                    priority: Priority.UPSTREAM,
-                },
-            ],
-            expect_message: true,
-            expect_queues: 0,
-            data_length: 2,
-            teamName: '',
-        },
-        {
-            name: 'with locks',
-            expectExtraClick: true,
-            props: {
-                app: 'test1',
-                version: 2,
-            },
-            rels: [
-                {
-                    version: 2,
-                    sourceMessage: 'test1',
-                    sourceAuthor: 'test',
-                    sourceCommitId: 'commit',
-                    createdAt: new Date(2002),
-                    undeployVersion: false,
-                    prNumber: '#1337',
-                    displayVersion: '2',
-                },
-            ],
-            envs: [
-                {
-                    name: 'prod',
-                    locks: { envLock: { message: 'envLock', lockId: 'ui-envlock' } },
                     applications: {
                         test1: {
                             name: 'test1',
@@ -418,15 +375,6 @@ describe('Release Dialog', () => {
                 );
                 const result = querySelectorSafe('.env-card-deploy-btn');
                 fireEvent.click(result);
-                if (testcase.expectExtraClick) {
-                    // when there is a lock, a confirmation dialog pops up, so we have to click another button:
-                    expect(UpdateSidebar.get().shown).toBeFalsy();
-                    const confirm = querySelectorSafe('.button-confirm');
-                    expect(confirm.attributes.getNamedItem('aria-label')?.value).toBe('Yes I really want to deploy');
-                    fireEvent.click(confirm);
-                } else {
-                    // because there is no lock, we do not need an extra click:
-                }
                 expect(UpdateSidebar.get().shown).toBeTruthy();
                 expect(UpdateAction.get().actions).toEqual([
                     {

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -112,26 +112,23 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
             },
         });
     }, [app, env.name]);
-    const onConfirm = useCallback((): void => {
-        addAction({
-            action: {
-                $case: 'deploy',
-                deploy: {
-                    environment: env.name,
-                    application: app,
-                    version: release.version,
-                    ignoreAllLocks: false,
-                    lockBehavior: LockBehavior.Ignore,
-                },
-            },
-        });
-        createAppLock();
-    }, [app, env.name, release.version, createAppLock]);
-    const deployClick = useCallback(() => {
+    const deployAndLockClick = useCallback(() => {
         if (release.version) {
-            onConfirm();
+            addAction({
+                action: {
+                    $case: 'deploy',
+                    deploy: {
+                        environment: env.name,
+                        application: app,
+                        version: release.version,
+                        ignoreAllLocks: false,
+                        lockBehavior: LockBehavior.Ignore,
+                    },
+                },
+            });
+            createAppLock();
         }
-    }, [release.version, onConfirm]);
+    }, [release.version, app, env.name, createAppLock]);
 
     const queueInfo =
         queuedVersion === 0 ? null : (
@@ -227,7 +224,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                             <Button
                                 disabled={application && application.version === release.version}
                                 className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
-                                onClick={deployClick}
+                                onClick={deployAndLockClick}
                                 label="Deploy & Lock"
                             />
                         </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -23,7 +23,7 @@ import {
     useCloseReleaseDialog,
     useEnvironmentGroups,
     useEnvLocks,
-    useFilteredApplicationLocks,
+    useFilteredApplicationLocksForEnv,
     useReleaseOptional,
     useReleaseOrThrow,
     useTeamFromApplication,
@@ -105,14 +105,12 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
 }) => {
     type ConfirmDialog = {
         showConfirmationDialog: boolean;
-        // environment: string | null;
     };
 
     const initial: ConfirmDialog = {
         showConfirmationDialog: false,
-        // environment: 'staging',
     };
-    const appLocks = useFilteredApplicationLocks(app);
+    const appLocks = useFilteredApplicationLocksForEnv(app, env.name);
     const envLocks = useEnvLocks(env.name);
     const hasLocks = appLocks.length > 0 || envLocks.length > 0;
 

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -15,12 +15,15 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright 2023 freiheit.com*/
 import { Dialog } from '@material-ui/core';
 import classNames from 'classnames';
-import React, { ReactElement, useCallback } from 'react';
+import React, { ReactElement, useCallback, useState } from 'react';
 import { Environment, Environment_Application, EnvironmentGroup, Lock, LockBehavior, Release } from '../../../api/api';
 import {
     addAction,
+    DisplayLock,
     useCloseReleaseDialog,
     useEnvironmentGroups,
+    useEnvLocks,
+    useFilteredApplicationLocks,
     useReleaseOptional,
     useReleaseOrThrow,
     useTeamFromApplication,
@@ -31,6 +34,7 @@ import { EnvironmentChip } from '../chip/EnvironmentGroupChip';
 import { FormattedDate } from '../FormattedDate/FormattedDate';
 import { ArgoAppLink, ArgoTeamLink, DisplayManifestLink, DisplaySourceLink } from '../../utils/Links';
 import { ReleaseVersion } from '../ReleaseVersion/ReleaseVersion';
+import { DisplayLockInlineRenderer } from '../EnvironmentLockDisplay/EnvironmentLockDisplay';
 
 export type ReleaseDialogProps = {
     className?: string;
@@ -99,6 +103,23 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
     queuedVersion,
     className,
 }) => {
+    type ConfirmDialog = {
+        showConfirmationDialog: boolean;
+        // environment: string | null;
+    };
+
+    const initial: ConfirmDialog = {
+        showConfirmationDialog: false,
+        // environment: 'staging',
+    };
+    const appLocks = useFilteredApplicationLocks(app);
+    const envLocks = useEnvLocks(env.name);
+    const hasLocks = appLocks.length > 0 || envLocks.length > 0;
+
+    const [dialogState, setDialogState] = useState(initial);
+    const cancelConfirmation = useCallback((): void => {
+        setDialogState({ showConfirmationDialog: false });
+    }, []);
     const createAppLock = useCallback(() => {
         addAction({
             action: {
@@ -112,23 +133,78 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
             },
         });
     }, [app, env.name]);
-    const deploy = useCallback(() => {
-        if (release.version) {
-            addAction({
-                action: {
-                    $case: 'deploy',
-                    deploy: {
-                        environment: env.name,
-                        application: app,
-                        version: release.version,
-                        ignoreAllLocks: false,
-                        lockBehavior: LockBehavior.Ignore,
-                    },
+    const onConfirm = useCallback((): void => {
+        addAction({
+            action: {
+                $case: 'deploy',
+                deploy: {
+                    environment: env.name,
+                    application: app,
+                    version: release.version,
+                    ignoreAllLocks: false,
+                    lockBehavior: LockBehavior.Ignore,
                 },
-            });
-        }
+            },
+        });
+        setDialogState({ showConfirmationDialog: false });
         createAppLock();
     }, [app, env.name, release.version, createAppLock]);
+    const appLocksRendered =
+        appLocks.length === 0 ? undefined : (
+            <>
+                <h4>App locks:</h4>
+                <ul>
+                    {appLocks.map((appLock: DisplayLock) => (
+                        <li>
+                            <DisplayLockInlineRenderer lock={appLock} key={appLock.lockId + '-' + app} />
+                        </li>
+                    ))}
+                </ul>
+            </>
+        );
+    const envLocksRendered =
+        envLocks.length === 0 ? undefined : (
+            <>
+                <h4>Environment locks:</h4>
+                <ul>
+                    {envLocks.map((envLock: DisplayLock) => (
+                        <li>
+                            <DisplayLockInlineRenderer lock={envLock} key={envLock.lockId + '-' + env.name} />
+                        </li>
+                    ))}
+                </ul>
+            </>
+        );
+    const confirmationDialog: JSX.Element = (
+        <div className={'confirmation-dialog-container'}>
+            <ConfirmationDialog
+                onConfirm={onConfirm}
+                confirmLabel={'Yes I really want to deploy'}
+                onCancel={cancelConfirmation}
+                open={dialogState.showConfirmationDialog}>
+                <div>
+                    You are attempting to deploy the app <b>{app}</b> in version <b>{release.version}</b> to environment{' '}
+                    <b>{env.name}</b> even though <b>it is locked</b>. Please check the locks and be sure you really
+                    want to ignore them:
+                    <div className={'locks'}>
+                        {appLocksRendered}
+                        {envLocksRendered}
+                    </div>
+                </div>
+            </ConfirmationDialog>
+        </div>
+    );
+
+    const deployClick = useCallback(() => {
+        if (hasLocks) {
+            if (release.version) {
+                setDialogState({ showConfirmationDialog: true });
+            }
+        } else {
+            onConfirm();
+        }
+    }, [release.version, onConfirm, hasLocks]);
+
     const queueInfo =
         queuedVersion === 0 ? null : (
             <div
@@ -168,6 +244,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
     };
     return (
         <li key={env.name} className={classNames('env-card', className)}>
+            {confirmationDialog}
             <div className="env-card-header">
                 <EnvironmentChip
                     env={env}
@@ -223,7 +300,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                             <Button
                                 disabled={application && application.version === release.version}
                                 className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
-                                onClick={deploy}
+                                onClick={deployClick}
                                 label="Deploy & Lock"
                             />
                         </div>
@@ -264,13 +341,51 @@ export const EnvironmentList: React.FC<{
 export const undeployTooltipExplanation =
     'This is the "undeploy" version. It is essentially an empty manifest. Deploying this means removing all kubernetes entities like deployments from the given environment. You must deploy this to all environments before kuberpult allows to delete the app entirely.';
 
+export type ConfirmationDialogProps = {
+    onConfirm: () => void;
+    onCancel: () => void;
+    open: boolean;
+    children: JSX.Element;
+    confirmLabel: string;
+};
+
+export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => {
+    if (!props.open) {
+        return <div className={'confirmation-dialog-hidden'}></div>;
+    }
+
+    return (
+        <div className={'confirmation-dialog-open'}>
+            <div className={'confirmation-dialog-header'}>Please Confirm</div>
+            <div className={'confirmation-dialog-content'}>{props.children}</div>
+            <div className={'list'}>
+                <div className={'item'} key={'button-menu-cancel'}>
+                    <Button
+                        className="mdc-button--unelevated button-cancel"
+                        label={'Cancel'}
+                        onClick={props.onCancel}
+                    />
+                </div>
+                <div className={'item'} key={'button-menu-confirm'}>
+                    <Button
+                        className="mdc-button--unelevated button-confirm"
+                        label={props.confirmLabel}
+                        onClick={props.onConfirm}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};
+
 export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
     const { app, className, version } = props;
     // the ReleaseDialog is only opened when there is a release, so we can assume that it exists here:
     const release = useReleaseOrThrow(app, version);
     const team = useTeamFromApplication(app);
     const closeReleaseDialog = useCloseReleaseDialog();
-    const dialog =
+
+    const dialog: JSX.Element | '' =
         app !== '' ? (
             <div>
                 <Dialog
@@ -282,7 +397,6 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                     <div className={classNames('release-dialog-app-bar', className)}>
                         <div className={classNames('release-dialog-app-bar-data')}>
                             <div className={classNames('release-dialog-message', className)}>
-                                <ReleaseVersion release={release} />
                                 <span className={classNames('release-dialog-commitMessage', className)}>
                                     {release?.sourceMessage}
                                 </span>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -103,18 +103,13 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
     queuedVersion,
     className,
 }) => {
-    type ConfirmDialog = {
-        showConfirmationDialog: boolean;
-    };
-
-    const initial: ConfirmDialog = {
-        showConfirmationDialog: false,
-    };
     const appLocks = useFilteredApplicationLocksForEnv(app, env.name);
     const envLocks = useEnvLocks(env.name);
     const hasLocks = appLocks.length > 0 || envLocks.length > 0;
 
-    const [dialogState, setDialogState] = useState(initial);
+    const [dialogState, setDialogState] = useState({
+        showConfirmationDialog: false,
+    });
     const cancelConfirmation = useCallback((): void => {
         setDialogState({ showConfirmationDialog: false });
     }, []);
@@ -174,7 +169,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
             </>
         );
     const confirmationDialog: JSX.Element = (
-        <div className={'confirmation-dialog-container'}>
+        <div className={'confirmation-dialog-container OLD_OUTDATED'}>
             <ConfirmationDialog
                 onConfirm={onConfirm}
                 confirmLabel={'Yes I really want to deploy'}
@@ -354,15 +349,16 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => 
 
     return (
         <div className={'confirmation-dialog-open'}>
-            <div className={'confirmation-dialog-header'}>Please Confirm</div>
-            <div className={'confirmation-dialog-content'}>{props.children}</div>
-            <div className={'list'}>
+            <div className={'confirmation-dialog-header'}>
+                Please Confirm the Deployment <hr />
+            </div>
+            <div className={'confirmation-dialog-content'}>
+                {props.children}
+                <hr />
+            </div>
+            <div className={'confirmation-dialog-footer'}>
                 <div className={'item'} key={'button-menu-cancel'}>
-                    <Button
-                        className="mdc-button--unelevated button-cancel"
-                        label={'Cancel'}
-                        onClick={props.onCancel}
-                    />
+                    <Button className="mdc-button--ripple button-cancel" label={'Cancel'} onClick={props.onCancel} />
                 </div>
                 <div className={'item'} key={'button-menu-confirm'}>
                     <Button

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -346,16 +346,12 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => 
     if (!props.open) {
         return <div className={'confirmation-dialog-hidden'}></div>;
     }
-
     return (
         <div className={'confirmation-dialog-open'}>
-            <div className={'confirmation-dialog-header'}>
-                Please Confirm the Deployment <hr />
-            </div>
-            <div className={'confirmation-dialog-content'}>
-                {props.children}
-                <hr />
-            </div>
+            <div className={'confirmation-dialog-header'}>Please Confirm the Deployment over Locks</div>
+            <hr />
+            <div className={'confirmation-dialog-content'}>{props.children}</div>
+            <hr />
             <div className={'confirmation-dialog-footer'}>
                 <div className={'item'} key={'button-menu-cancel'}>
                     <Button className="mdc-button--ripple button-cancel" label={'Cancel'} onClick={props.onCancel} />

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -273,6 +273,7 @@ export type ConfirmationDialogProps = {
     onCancel: () => void;
     open: boolean;
     children: JSX.Element;
+    headerLabel: string;
     confirmLabel: string;
 };
 
@@ -282,7 +283,7 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => 
     }
     return (
         <div className={'confirmation-dialog-open'}>
-            <div className={'confirmation-dialog-header'}>Please Confirm the Deployment over Locks</div>
+            <div className={'confirmation-dialog-header'}>{props.headerLabel}</div>
             <hr />
             <div className={'confirmation-dialog-content'}>{props.children}</div>
             <hr />

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -104,6 +104,13 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
               class="env-card"
             >
               <div
+                class="confirmation-dialog-container"
+              >
+                <div
+                  class="confirmation-dialog-hidden"
+                />
+              </div>
+              <div
                 class="env-card-header"
               >
                 <div
@@ -369,6 +376,13 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
             <li
               class="env-card"
             >
+              <div
+                class="confirmation-dialog-container"
+              >
+                <div
+                  class="confirmation-dialog-hidden"
+                />
+              </div>
               <div
                 class="env-card-header"
               >
@@ -643,6 +657,13 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
               class="env-card"
             >
               <div
+                class="confirmation-dialog-container"
+              >
+                <div
+                  class="confirmation-dialog-hidden"
+                />
+              </div>
+              <div
                 class="env-card-header"
               >
                 <div
@@ -796,6 +817,13 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
             <li
               class="env-card"
             >
+              <div
+                class="confirmation-dialog-container"
+              >
+                <div
+                  class="confirmation-dialog-hidden"
+                />
+              </div>
               <div
                 class="env-card-header"
               >

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -44,12 +44,6 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
               class="release-dialog-message"
             >
               <span
-                class="release-version__display-version"
-                title="commit"
-              >
-                2
-              </span>
-              <span
                 class="release-dialog-commitMessage"
               >
                 test1
@@ -103,13 +97,6 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
             <li
               class="env-card"
             >
-              <div
-                class="confirmation-dialog-container"
-              >
-                <div
-                  class="confirmation-dialog-hidden"
-                />
-              </div>
               <div
                 class="env-card-header"
               >
@@ -317,12 +304,6 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
               class="release-dialog-message"
             >
               <span
-                class="release-version__display-version"
-                title="commit"
-              >
-                2
-              </span>
-              <span
                 class="release-dialog-commitMessage"
               >
                 test1
@@ -376,13 +357,6 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
             <li
               class="env-card"
             >
-              <div
-                class="confirmation-dialog-container"
-              >
-                <div
-                  class="confirmation-dialog-hidden"
-                />
-              </div>
               <div
                 class="env-card-header"
               >
@@ -594,12 +568,6 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
               class="release-dialog-message"
             >
               <span
-                class="release-version__display-version"
-                title="cafe"
-              >
-                2
-              </span>
-              <span
                 class="release-dialog-commitMessage"
               >
                 the other commit message 2
@@ -656,13 +624,6 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
             <li
               class="env-card"
             >
-              <div
-                class="confirmation-dialog-container"
-              >
-                <div
-                  class="confirmation-dialog-hidden"
-                />
-              </div>
               <div
                 class="env-card-header"
               >
@@ -817,13 +778,6 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
             <li
               class="env-card"
             >
-              <div
-                class="confirmation-dialog-container"
-              >
-                <div
-                  class="confirmation-dialog-hidden"
-                />
-              </div>
               <div
                 class="env-card-header"
               >
@@ -1035,12 +989,6 @@ exports[`Release Dialog Renders the environment locks undeploy version release 1
             <div
               class="release-dialog-message"
             >
-              <span
-                class="release-version__undeploy-version"
-                title="Remove"
-              >
-                undeploy
-              </span>
               <span
                 class="release-dialog-commitMessage"
               />

--- a/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.tsx
@@ -32,9 +32,9 @@ export const DotsMenu: React.FC<DotsMenuProps> = (props) => {
     const openMenu = React.useCallback(() => {
         setOpen(true);
     }, []);
-    const closeMenu = React.useCallback(() => {
-        setOpen(false);
-    }, []);
+    // const closeMenu = React.useCallback(() => {
+    //     setOpen(false);
+    // }, []);
     const memoizedOnClick = React.useCallback(
         (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
             const index = e.currentTarget.id;
@@ -53,7 +53,7 @@ export const DotsMenu: React.FC<DotsMenuProps> = (props) => {
     }
 
     return (
-        <div className={'dots-menu dots-menu-open'} onMouseLeave={closeMenu}>
+        <div className={'dots-menu dots-menu-open'}>
             <ul className={'list'}>
                 {props.buttons.map((button, index) => (
                     <li className={'item'} key={'button-menu-' + String(index)}>

--- a/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/DotsMenu.tsx
@@ -32,9 +32,9 @@ export const DotsMenu: React.FC<DotsMenuProps> = (props) => {
     const openMenu = React.useCallback(() => {
         setOpen(true);
     }, []);
-    // const closeMenu = React.useCallback(() => {
-    //     setOpen(false);
-    // }, []);
+    const closeMenu = React.useCallback(() => {
+        setOpen(false);
+    }, []);
     const memoizedOnClick = React.useCallback(
         (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
             const index = e.currentTarget.id;
@@ -53,7 +53,7 @@ export const DotsMenu: React.FC<DotsMenuProps> = (props) => {
     }
 
     return (
-        <div className={'dots-menu dots-menu-open'}>
+        <div className={'dots-menu dots-menu-open'} onMouseLeave={closeMenu}>
             <ul className={'list'}>
                 {props.buttons.map((button, index) => (
                     <li className={'item'} key={'button-menu-' + String(index)}>

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -205,7 +205,7 @@ export const ServiceLane: React.FC<{ application: Application }> = (props) => {
     );
 
     return (
-        <div className="service-lane_">
+        <div className="service-lane">
             {dialog}
             <div className="service-lane__header">
                 <div className="service__name">

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -205,7 +205,7 @@ export const ServiceLane: React.FC<{ application: Application }> = (props) => {
     );
 
     return (
-        <div className="service-lane">
+        <div className="service-lane_">
             {dialog}
             <div className="service-lane__header">
                 <div className="service__name">
@@ -216,7 +216,7 @@ export const ServiceLane: React.FC<{ application: Application }> = (props) => {
                         </div>
                     )}
                 </div>
-                <div className="service__actions">{dotsMenu}</div>
+                <div className="service__actions__">{dotsMenu}</div>
             </div>
             <div className="service__warnings">
                 <WarningBoxes application={application} />

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -300,11 +300,8 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
     const actions = useActions();
     const [lockMessage, setLockMessage] = useState('');
     const api = useApi;
-    // const [open, setOpen] = useState(false);
     const { authHeader, authReady } = useAzureAuthSub((auth) => auth);
 
-    // const handleClose = useCallback(() => setOpen(false), []);
-    // const handleOpen = useCallback(() => setOpen(true), []);
     let title = 'Planned Actions';
     const numActions = useNumberOfActions();
     if (numActions > 0) {
@@ -374,13 +371,9 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
         }
     }, [actions, api, authHeader, authReady, lockCreationList, lockMessage]);
 
-    const applyActionsOrDialog = useCallback(() => {
-        if (hasLocks) {
-            setDialogState({ showConfirmationDialog: true });
-        } else {
-            applyActions();
-        }
-    }, [applyActions, hasLocks]);
+    const showDialog = useCallback(() => {
+        setDialogState({ showConfirmationDialog: true });
+    }, [applyActions]);
 
     const newLockExists = useMemo(() => lockCreationList.length !== 0, [lockCreationList.length]);
 
@@ -424,13 +417,14 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                 </ul>
             </>
         );
-    const confirmationDialog: JSX.Element = (
+    const confirmationDialog: JSX.Element = hasLocks ? (
         <div
             className={
                 'confirmation-dialog-container ' +
                 (dialogState.showConfirmationDialog ? 'confirmation-dialog-container-open' : '')
             }>
             <ConfirmationDialog
+                headerLabel={'Please Confirm the Deployment over Locks'}
                 onConfirm={applyActions}
                 confirmLabel={'Confirm Deployment'}
                 onCancel={cancelConfirmation}
@@ -443,6 +437,21 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                         {envLocksRendered}
                     </div>
                 </div>
+            </ConfirmationDialog>
+        </div>
+    ) : (
+        <div
+            className={
+                'confirmation-dialog-container ' +
+                (dialogState.showConfirmationDialog ? 'confirmation-dialog-container-open' : '')
+            }>
+            <ConfirmationDialog
+                headerLabel={'Please Confirm the Deployment over Locks'}
+                onConfirm={applyActions}
+                confirmLabel={'Confirm Submit'}
+                onCancel={cancelConfirmation}
+                open={dialogState.showConfirmationDialog}>
+                <div>Are you sure you want to apply all planned actions?'</div>
             </ConfirmationDialog>
         </div>
     );
@@ -482,19 +491,10 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                         )}
                         label={'Apply'}
                         disabled={!canApply}
-                        onClick={applyActionsOrDialog}
+                        onClick={showDialog}
                     />
                     {showSpinner && <Spinner message="Submitting changes" />}
                     {confirmationDialog}
-                    {/*<Dialog open={open} onClose={handleClose}>*/}
-                    {/*    <DialogTitle id="alert-dialog-title">*/}
-                    {/*        {'Are you sure you want to apply all planned actions?'}*/}
-                    {/*    </DialogTitle>*/}
-                    {/*    <DialogActions>*/}
-                    {/*        <Button label="Cancel" onClick={handleClose} />*/}
-                    {/*        <Button label="Confirm" onClick={applyActionsOrDialog} />*/}
-                    {/*    </DialogActions>*/}
-                    {/*</Dialog>*/}
                 </div>
             </nav>
         </aside>

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -433,8 +433,8 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                     You are attempting to deploy apps, although there are locks present. Please check the locks and be
                     sure you really want to ignore them.
                     <div className={'locks'}>
-                        {appLocksRendered}
                         {envLocksRendered}
+                        {appLocksRendered}
                     </div>
                 </div>
             </ConfirmationDialog>

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -374,12 +374,6 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
         }
     }, [actions, api, authHeader, authReady, lockCreationList, lockMessage]);
 
-    // const useHasLocks = (): boolean => {
-    //     const appLocks = useFilteredApplicationLocksForEnv(app, env.name);
-    //     const envLocks = useEnvLocks(env.name);
-    //     return appLocks.length > 0 || envLocks.length > 0;
-    // };
-
     const applyActionsOrDialog = useCallback(() => {
         if (hasLocks) {
             setDialogState({ showConfirmationDialog: true });
@@ -433,9 +427,8 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
     const confirmationDialog: JSX.Element = (
         <div
             className={
-                'confirmation-dialog-container ' + dialogState.showConfirmationDialog
-                    ? 'confirmation-dialog-container-open'
-                    : ''
+                'confirmation-dialog-container ' +
+                (dialogState.showConfirmationDialog ? 'confirmation-dialog-container-open' : '')
             }>
             <ConfirmationDialog
                 onConfirm={applyActions}
@@ -445,24 +438,9 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                 <div>
                     You are attempting to deploy apps, although there are locks present. Please check the locks and be
                     sure you really want to ignore them.
-                    {/*You are attempting to deploy the app <b>{app}</b> in version <b>{release.version}</b> to environment{' '}*/}
-                    {/*<b>{env.name}</b> even though <b>it is locked</b>. Please check the locks and be sure you really*/}
-                    {/*want to ignore them:*/}
                     <div className={'locks'}>
-                        {/*{appLocksRendered}*/}
-                        {/*{appLocksRendered}*/}
-                        {/*{appLocksRendered}*/}
-                        {/*{envLocksRendered}*/}
                         {appLocksRendered}
                         {envLocksRendered}
-                        {/*{appLocksRendered}*/}
-                        {/*{envLocksRendered}*/}
-                        {/*{appLocksRendered}*/}
-                        {/*{envLocksRendered}*/}
-                        {/*{appLocksRendered}*/}
-                        {/*{envLocksRendered}*/}
-                        {/*{appLocksRendered}*/}
-                        {/*{envLocksRendered}*/}
                     </div>
                 </div>
             </ConfirmationDialog>

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -29,14 +29,17 @@ import {
     addAction,
     useLocksSimilarTo,
     useRelease,
+    useLocksConflictingWithActions,
 } from '../../utils/store';
 import React, { ChangeEvent, useCallback, useMemo, useState } from 'react';
 import { useApi } from '../../utils/GrpcApi';
-import { TextField, Dialog, DialogTitle, DialogActions } from '@material-ui/core';
+import { TextField } from '@material-ui/core';
 import classNames from 'classnames';
 import { useAzureAuthSub } from '../../utils/AzureAuthProvider';
 import { Spinner } from '../Spinner/Spinner';
 import { ReleaseVersionWithLinks } from '../ReleaseVersion/ReleaseVersion';
+import { ConfirmationDialog } from '../ReleaseDialog/ReleaseDialog';
+import { DisplayLockInlineRenderer } from '../EnvironmentLockDisplay/EnvironmentLockDisplay';
 
 export enum ActionTypes {
     Deploy,
@@ -297,11 +300,11 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
     const actions = useActions();
     const [lockMessage, setLockMessage] = useState('');
     const api = useApi;
-    const [open, setOpen] = useState(false);
+    // const [open, setOpen] = useState(false);
     const { authHeader, authReady } = useAzureAuthSub((auth) => auth);
 
-    const handleClose = useCallback(() => setOpen(false), []);
-    const handleOpen = useCallback(() => setOpen(true), []);
+    // const handleClose = useCallback(() => setOpen(false), []);
+    // const handleOpen = useCallback(() => setOpen(true), []);
     let title = 'Planned Actions';
     const numActions = useNumberOfActions();
     if (numActions > 0) {
@@ -315,6 +318,15 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
             action.action?.$case === 'createEnvironmentApplicationLock'
     );
     const [showSpinner, setShowSpinner] = useState(false);
+    const [dialogState, setDialogState] = useState({
+        showConfirmationDialog: false,
+    });
+    const cancelConfirmation = useCallback((): void => {
+        setDialogState({ showConfirmationDialog: false });
+    }, []);
+
+    const conflictingLocks = useLocksConflictingWithActions();
+    const hasLocks = conflictingLocks.environmentLocks.length > 0 || conflictingLocks.appLocks.length > 0;
 
     const applyActions = useCallback(() => {
         if (lockMessage) {
@@ -358,9 +370,23 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                 .finally(() => {
                     setShowSpinner(false);
                 });
-            handleClose();
+            setDialogState({ showConfirmationDialog: false });
         }
-    }, [actions, api, handleClose, lockCreationList, lockMessage, authHeader, authReady]);
+    }, [actions, api, authHeader, authReady, lockCreationList, lockMessage]);
+
+    // const useHasLocks = (): boolean => {
+    //     const appLocks = useFilteredApplicationLocksForEnv(app, env.name);
+    //     const envLocks = useEnvLocks(env.name);
+    //     return appLocks.length > 0 || envLocks.length > 0;
+    // };
+
+    const applyActionsOrDialog = useCallback(() => {
+        if (hasLocks) {
+            setDialogState({ showConfirmationDialog: true });
+        } else {
+            applyActions();
+        }
+    }, [applyActions, hasLocks]);
 
     const newLockExists = useMemo(() => lockCreationList.length !== 0, [lockCreationList.length]);
 
@@ -371,6 +397,76 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
     const canApply = useMemo(
         () => actions.length > 0 && (!newLockExists || lockMessage),
         [actions.length, lockMessage, newLockExists]
+    );
+    const appLocksRendered =
+        conflictingLocks.appLocks.length === 0 ? undefined : (
+            <>
+                <h4>Conflicting App Locks:</h4>
+                <ul>
+                    {conflictingLocks.appLocks.map((appLock: DisplayLock) => (
+                        <li>
+                            <DisplayLockInlineRenderer
+                                lock={appLock}
+                                key={appLock.lockId + '-' + appLock.application + '-' + appLock.environment}
+                            />
+                        </li>
+                    ))}
+                </ul>
+            </>
+        );
+    const envLocksRendered =
+        conflictingLocks.environmentLocks.length === 0 ? undefined : (
+            <>
+                <h4>Conflicting Environment Locks:</h4>
+                <ul>
+                    {conflictingLocks.environmentLocks.map((envLock: DisplayLock) => (
+                        <li>
+                            <DisplayLockInlineRenderer
+                                lock={envLock}
+                                key={envLock.lockId + '-' + envLock.environment}
+                            />
+                        </li>
+                    ))}
+                </ul>
+            </>
+        );
+    const confirmationDialog: JSX.Element = (
+        <div
+            className={
+                'confirmation-dialog-container ' + dialogState.showConfirmationDialog
+                    ? 'confirmation-dialog-container-open'
+                    : ''
+            }>
+            <ConfirmationDialog
+                onConfirm={applyActions}
+                confirmLabel={'Confirm Deployment'}
+                onCancel={cancelConfirmation}
+                open={dialogState.showConfirmationDialog}>
+                <div>
+                    You are attempting to deploy apps, although there are locks present. Please check the locks and be
+                    sure you really want to ignore them.
+                    {/*You are attempting to deploy the app <b>{app}</b> in version <b>{release.version}</b> to environment{' '}*/}
+                    {/*<b>{env.name}</b> even though <b>it is locked</b>. Please check the locks and be sure you really*/}
+                    {/*want to ignore them:*/}
+                    <div className={'locks'}>
+                        {/*{appLocksRendered}*/}
+                        {/*{appLocksRendered}*/}
+                        {/*{appLocksRendered}*/}
+                        {/*{envLocksRendered}*/}
+                        {appLocksRendered}
+                        {envLocksRendered}
+                        {/*{appLocksRendered}*/}
+                        {/*{envLocksRendered}*/}
+                        {/*{appLocksRendered}*/}
+                        {/*{envLocksRendered}*/}
+                        {/*{appLocksRendered}*/}
+                        {/*{envLocksRendered}*/}
+                        {/*{appLocksRendered}*/}
+                        {/*{envLocksRendered}*/}
+                    </div>
+                </div>
+            </ConfirmationDialog>
+        </div>
     );
 
     return (
@@ -408,18 +504,19 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                         )}
                         label={'Apply'}
                         disabled={!canApply}
-                        onClick={handleOpen}
+                        onClick={applyActionsOrDialog}
                     />
                     {showSpinner && <Spinner message="Submitting changes" />}
-                    <Dialog open={open} onClose={handleClose}>
-                        <DialogTitle id="alert-dialog-title">
-                            {'Are you sure you want to apply all planned actions?'}
-                        </DialogTitle>
-                        <DialogActions>
-                            <Button label="Cancel" onClick={handleClose} />
-                            <Button label="Confirm" onClick={applyActions} />
-                        </DialogActions>
-                    </Dialog>
+                    {confirmationDialog}
+                    {/*<Dialog open={open} onClose={handleClose}>*/}
+                    {/*    <DialogTitle id="alert-dialog-title">*/}
+                    {/*        {'Are you sure you want to apply all planned actions?'}*/}
+                    {/*    </DialogTitle>*/}
+                    {/*    <DialogActions>*/}
+                    {/*        <Button label="Cancel" onClick={handleClose} />*/}
+                    {/*        <Button label="Confirm" onClick={applyActionsOrDialog} />*/}
+                    {/*    </DialogActions>*/}
+                    {/*</Dialog>*/}
                 </div>
             </nav>
         </aside>

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -373,7 +373,7 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
 
     const showDialog = useCallback(() => {
         setDialogState({ showConfirmationDialog: true });
-    }, [applyActions]);
+    }, []);
 
     const newLockExists = useMemo(() => lockCreationList.length !== 0, [lockCreationList.length]);
 
@@ -446,12 +446,12 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                 (dialogState.showConfirmationDialog ? 'confirmation-dialog-container-open' : '')
             }>
             <ConfirmationDialog
-                headerLabel={'Please Confirm the Deployment over Locks'}
+                headerLabel={'Please Confirm the Planned Actions'}
                 onConfirm={applyActions}
-                confirmLabel={'Confirm Submit'}
+                confirmLabel={'Confirm Planned Actions'}
                 onCancel={cancelConfirmation}
                 open={dialogState.showConfirmationDialog}>
-                <div>Are you sure you want to apply all planned actions?'</div>
+                <div>Are you sure you want to apply all planned actions?</div>
             </ConfirmationDialog>
         </div>
     );

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -322,7 +322,6 @@ export const useLocksConflictingWithActions = (): AllLocks => {
         environmentLocks: locks.environmentLocks.filter((envLock: DisplayLock) => {
             const actions = allActions.filter((action) => {
                 if (action.action?.$case === 'deploy') {
-                    // const app = action.action.deploy.application;
                     const env = action.action.deploy.environment;
                     if (envLock.environment === env) {
                         // found an env lock that matches
@@ -393,28 +392,6 @@ export const searchCustomFilter = (queryContent: string | null, val: string | un
 export type AllLocks = {
     environmentLocks: DisplayLock[];
     appLocks: DisplayLock[];
-};
-
-export const useEnvLocks = (thisEnv: string): DisplayLock[] => {
-    const envs = useEnvironments();
-    const environmentLocks: DisplayLock[] = [];
-    envs.forEach((env: Environment) => {
-        for (const locksKey in env.locks) {
-            const lock = env.locks[locksKey];
-            const displayLock: DisplayLock = {
-                lockId: lock.lockId,
-                date: lock.createdAt,
-                environment: env.name,
-                message: lock.message,
-                authorName: lock.createdBy?.name,
-                authorEmail: lock.createdBy?.email,
-            };
-            if (thisEnv === displayLock.environment) {
-                environmentLocks.push(displayLock);
-            }
-        }
-    });
-    return environmentLocks;
 };
 
 export const useAllLocks = (): AllLocks => {

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -315,6 +315,11 @@ export const useFilteredApplicationLocks = (appNameParam: string | null): Displa
     return sortLocks(filteredLocks, 'newestToOldest');
 };
 
+export const useFilteredApplicationLocksForEnv = (appNameParam: string, env: string): DisplayLock[] => {
+    const finalLocks: DisplayLock[] = useFilteredApplicationLocks(appNameParam);
+    return finalLocks.filter((val) => env === val.environment);
+};
+
 // return env lock IDs from given env
 export const useFilteredEnvironmentLockIDs = (envName: string): string[] =>
     useEnvironments()
@@ -358,6 +363,28 @@ export const searchCustomFilter = (queryContent: string | null, val: string | un
 export type AllLocks = {
     environmentLocks: DisplayLock[];
     appLocks: DisplayLock[];
+};
+
+export const useEnvLocks = (thisEnv: string): DisplayLock[] => {
+    const envs = useEnvironments();
+    const environmentLocks: DisplayLock[] = [];
+    envs.forEach((env: Environment) => {
+        for (const locksKey in env.locks) {
+            const lock = env.locks[locksKey];
+            const displayLock: DisplayLock = {
+                lockId: lock.lockId,
+                date: lock.createdAt,
+                environment: env.name,
+                message: lock.message,
+                authorName: lock.createdBy?.name,
+                authorEmail: lock.createdBy?.email,
+            };
+            if (thisEnv === displayLock.environment) {
+                environmentLocks.push(displayLock);
+            }
+        }
+    });
+    return environmentLocks;
 };
 
 export const useAllLocks = (): AllLocks => {

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -315,11 +315,6 @@ export const useFilteredApplicationLocks = (appNameParam: string | null): Displa
     return sortLocks(filteredLocks, 'newestToOldest');
 };
 
-export const useFilteredApplicationLocksForEnv = (appNameParam: string, env: string): DisplayLock[] => {
-    const finalLocks: DisplayLock[] = useFilteredApplicationLocks(appNameParam);
-    return finalLocks.filter((val) => env === val.environment);
-};
-
 export const useLocksConflictingWithActions = (): AllLocks => {
     const allActions = useActions();
     const locks = useAllLocks();


### PR DESCRIPTION
If the user wants to deploy an app that has a lock, or if the user wants to deploy to an environment that has a lock, we now show a warning (when submitting the actions), because generally locks should not be ignored.

The dialog shows which locks are the "offenders".

The user can still choose to ignore this, but now they have been warned.

New Dialog with offending locks:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/dc176fb2-9ccf-4aa4-8d31-3a18b378366a)

New Dialog without offending locks:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/cdfcf594-6390-47a7-aa23-bf9527159d38)

