### PR TITLE
Track DeployTime of applications in the rollout service

### DIFF
--- a/services/rollout-service/pkg/notifier/subscriber.go
+++ b/services/rollout-service/pkg/notifier/subscriber.go
@@ -94,7 +94,7 @@ func (s *subscriber) subscribeOnce(ctx context.Context, broadcast *service.Broad
 
 func (s *subscriber) maybeSend(ctx context.Context, ev *service.BroadcastEvent) {
 	// skip cases where we don't know the kuberpult version
-	if ev.KuberpultVersion == 0 {
+	if ev.KuberpultVersion == nil {
 		return
 	}
 	// also don't notify when the version in argocd is already the right one
@@ -104,11 +104,11 @@ func (s *subscriber) maybeSend(ctx context.Context, ev *service.BroadcastEvent) 
 	// also don't send events for the same version again
 	k := key{ev.Environment, ev.Application}
 	ns := s.notifyStatus[k]
-	if ns != nil && ns.targetVersion == ev.KuberpultVersion {
+	if ns != nil && ns.targetVersion == ev.KuberpultVersion.Version {
 		return
 	}
 	s.notifyStatus[k] = &notifyStatus{
-		targetVersion: ev.KuberpultVersion,
+		targetVersion: ev.KuberpultVersion.Version,
 	}
 	// finally send the request
 	s.notifier.NotifyArgoCd(ctx, ev.Environment, ev.Application)

--- a/services/rollout-service/pkg/notifier/subscriber_test.go
+++ b/services/rollout-service/pkg/notifier/subscriber_test.go
@@ -62,14 +62,14 @@ func TestSubscribe(t *testing.T) {
 					ArgoEvent: &service.ArgoEvent{
 						Application: "foo",
 						Environment: "bar",
-						Version:     1,
+						Version:     &versions.VersionInfo{Version: 1},
 					},
 				},
 				{
 					VersionEvent: &versions.KuberpultEvent{
 						Application: "foo",
 						Environment: "bar",
-						Version:     2,
+						Version:     &versions.VersionInfo{Version: 2},
 					},
 					ExpectedNotification: &expectedNotification{
 						Application: "foo",
@@ -85,14 +85,14 @@ func TestSubscribe(t *testing.T) {
 					ArgoEvent: &service.ArgoEvent{
 						Application: "foo",
 						Environment: "bar",
-						Version:     1,
+						Version:     &versions.VersionInfo{Version: 1},
 					},
 				},
 				{
 					VersionEvent: &versions.KuberpultEvent{
 						Application: "foo",
 						Environment: "bar",
-						Version:     2,
+						Version:     &versions.VersionInfo{Version: 2},
 					},
 					ExpectedNotification: &expectedNotification{
 						Application: "foo",
@@ -103,7 +103,7 @@ func TestSubscribe(t *testing.T) {
 					VersionEvent: &versions.KuberpultEvent{
 						Application: "foo",
 						Environment: "bar",
-						Version:     2,
+						Version:     &versions.VersionInfo{Version: 2},
 					},
 				},
 			},
@@ -115,14 +115,14 @@ func TestSubscribe(t *testing.T) {
 					ArgoEvent: &service.ArgoEvent{
 						Application: "foo",
 						Environment: "bar",
-						Version:     1,
+						Version:     &versions.VersionInfo{Version: 1},
 					},
 				},
 				{
 					VersionEvent: &versions.KuberpultEvent{
 						Application: "foo",
 						Environment: "bar",
-						Version:     2,
+						Version:     &versions.VersionInfo{Version: 2},
 					},
 					ExpectedNotification: &expectedNotification{
 						Application: "foo",
@@ -133,7 +133,7 @@ func TestSubscribe(t *testing.T) {
 					VersionEvent: &versions.KuberpultEvent{
 						Application: "foo",
 						Environment: "bar",
-						Version:     3,
+						Version:     &versions.VersionInfo{Version: 3},
 					},
 					ExpectedNotification: &expectedNotification{
 						Application: "foo",
@@ -185,7 +185,7 @@ func TestSubscribe(t *testing.T) {
 }
 
 type mockBackoff struct {
-	called   uint
+	called uint
 }
 
 func (b *mockBackoff) NextBackOff() time.Duration {
@@ -206,8 +206,8 @@ func TestSubscriberHandlesReconnects(t *testing.T) {
 		return bo
 	}
 	tcs := []struct {
-		Name          string
-		Disconnects   uint
+		Name        string
+		Disconnects uint
 	}{
 		{
 			Name:        "reconnects are handled",
@@ -231,7 +231,7 @@ func TestSubscriberHandlesReconnects(t *testing.T) {
 				bc.ProcessKuberpultEvent(ctx, versions.KuberpultEvent{
 					Application: "app",
 					Environment: "env",
-					Version:     i,
+					Version:     &versions.VersionInfo{Version: i},
 				})
 				<-notifications
 				bc.DisconnectAll()

--- a/services/rollout-service/pkg/service/broadcast_test.go
+++ b/services/rollout-service/pkg/service/broadcast_test.go
@@ -97,7 +97,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          1,
+						Version:          &versions.VersionInfo{Version: 1},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
 						HealthStatusCode: health.HealthStatusHealthy,
 					},
@@ -114,7 +114,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          1,
+						Version:          &versions.VersionInfo{Version: 1},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
 						HealthStatusCode: health.HealthStatusHealthy,
 					},
@@ -125,7 +125,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          1,
+						Version:          &versions.VersionInfo{Version: 1},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeOutOfSync,
 						HealthStatusCode: health.HealthStatusHealthy,
 					},
@@ -136,7 +136,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          1,
+						Version:          &versions.VersionInfo{Version: 1},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeOutOfSync,
 						HealthStatusCode: health.HealthStatusProgressing,
 					},
@@ -147,7 +147,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          2,
+						Version:          &versions.VersionInfo{Version: 2},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
 						HealthStatusCode: health.HealthStatusHealthy,
 					},
@@ -163,7 +163,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          1,
+						Version:          &versions.VersionInfo{Version: 1},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
 						HealthStatusCode: health.HealthStatusHealthy,
 					},
@@ -174,7 +174,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          1,
+						Version:          &versions.VersionInfo{Version: 1},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
 						HealthStatusCode: health.HealthStatusDegraded,
 					},
@@ -185,7 +185,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          1,
+						Version:          &versions.VersionInfo{Version: 1},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
 						HealthStatusCode: health.HealthStatusHealthy,
 					},
@@ -201,7 +201,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          1,
+						Version:          &versions.VersionInfo{Version: 1},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeOutOfSync,
 						HealthStatusCode: health.HealthStatusHealthy,
 						OperationState: &v1alpha1.OperationState{
@@ -220,7 +220,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          1,
+						Version:          &versions.VersionInfo{Version: 1},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeOutOfSync,
 						HealthStatusCode: health.HealthStatusHealthy,
 						OperationState: &v1alpha1.OperationState{
@@ -239,7 +239,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          1,
+						Version:          &versions.VersionInfo{Version: 1},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
 						HealthStatusCode: health.HealthStatusHealthy,
 					},
@@ -250,7 +250,7 @@ func TestBroadcast(t *testing.T) {
 					VersionEvent: &versions.KuberpultEvent{
 						Application: "foo",
 						Environment: "bar",
-						Version:     2,
+						Version:     &versions.VersionInfo{Version: 2},
 					},
 
 					ExpectStatus: &RolloutStatusProgressing,
@@ -259,7 +259,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          2,
+						Version:          &versions.VersionInfo{Version: 2},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
 						HealthStatusCode: health.HealthStatusHealthy,
 					},
@@ -385,7 +385,7 @@ func TestBroadcastDoesntGetStuck(t *testing.T) {
 					Environment:      "doesntmatter",
 					HealthStatusCode: health.HealthStatusHealthy,
 					SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
-					Version:          1,
+					Version:          &versions.VersionInfo{Version: 1},
 				})
 				select {
 				case resp := <-ch2:

--- a/services/rollout-service/pkg/service/service.go
+++ b/services/rollout-service/pkg/service/service.go
@@ -93,7 +93,7 @@ func ConsumeEvents(ctx context.Context, appClient SimplifiedApplicationServiceCl
 					HealthStatusCode: ev.Application.Status.Health.Status,
 
 					OperationState: ev.Application.Status.OperationState,
-					Version:        0,
+					Version:        &versions.VersionInfo{Version: 0},
 				})
 				continue recv
 			case "BOOKMARK":
@@ -115,6 +115,5 @@ type ArgoEvent struct {
 	SyncStatusCode   v1alpha1.SyncStatusCode
 	HealthStatusCode health.HealthStatusCode
 	OperationState   *v1alpha1.OperationState
-	Version          uint64
+	Version          *versions.VersionInfo
 }
-

--- a/services/rollout-service/pkg/service/service_test.go
+++ b/services/rollout-service/pkg/service/service_test.go
@@ -100,16 +100,16 @@ type mockVersionClient struct {
 }
 
 // GetVersion implements versions.VersionClient
-func (m *mockVersionClient) GetVersion(ctx context.Context, revision string, environment string, application string) (uint64, error) {
+func (m *mockVersionClient) GetVersion(ctx context.Context, revision string, environment string, application string) (*versions.VersionInfo, error) {
 	for _, v := range m.versions {
 		if v.Revision == revision && v.Environment == environment && v.Application == application {
-			return v.DeployedVersion, v.Error
+			return &versions.VersionInfo{Version: v.DeployedVersion}, v.Error
 		}
 	}
-	return 0, nil
+	return nil, nil
 }
 
-func (m *mockVersionClient) ConsumeEvents(ctx context.Context, pc versions.VersionEventProcessor ) error {
+func (m *mockVersionClient) ConsumeEvents(ctx context.Context, pc versions.VersionEventProcessor) error {
 	panic("not implemented")
 }
 
@@ -230,7 +230,7 @@ func TestArgoConection(t *testing.T) {
 					ExpectedEvent: &ArgoEvent{
 						Application: "bar",
 						Environment: "foo",
-						Version:     42,
+						Version:     &versions.VersionInfo{Version: 42},
 					},
 				},
 				{
@@ -240,7 +240,7 @@ func TestArgoConection(t *testing.T) {
 			ExpectedReady: true,
 		},
 		{
-			Name: "doesnt generate events for deleted ",
+			Name: "doesnt generate events for deleted",
 			Versions: []version{
 				{
 					Revision:        "1234",
@@ -273,7 +273,7 @@ func TestArgoConection(t *testing.T) {
 					ExpectedEvent: &ArgoEvent{
 						Application: "bar",
 						Environment: "foo",
-						Version:     0,
+						Version:     &versions.VersionInfo{Version: 0},
 					},
 				},
 				{

--- a/services/rollout-service/pkg/versions/versions_test.go
+++ b/services/rollout-service/pkg/versions/versions_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/freiheit-com/kuberpult/pkg/api"
 	"github.com/google/go-cmp/cmp"
@@ -41,6 +42,7 @@ type expectedVersion struct {
 	Environment     string
 	Application     string
 	DeployedVersion uint64
+	DeployTime      time.Time
 	Metadata        metadata.MD
 }
 
@@ -136,6 +138,9 @@ func TestVersionClient(t *testing.T) {
 							Applications: map[string]*api.Environment_Application{
 								"bar": {
 									Version: 2,
+									DeploymentMetaData: &api.Environment_Application_DeploymentMetaData{
+										DeployTime: "123456789",
+									},
 								},
 							},
 						},
@@ -173,6 +178,7 @@ func TestVersionClient(t *testing.T) {
 					Environment:     "staging",
 					Application:     "bar",
 					DeployedVersion: 2,
+					DeployTime:      time.Unix(123456789, 0).UTC(),
 					Metadata:        defaultMetadata,
 				},
 			},
@@ -231,7 +237,7 @@ func TestVersionClientStream(t *testing.T) {
 	}
 	emptyTestOverview := &api.GetOverviewResponse{
 		EnvironmentGroups: []*api.EnvironmentGroup{},
-		GitRevision: "000",
+		GitRevision:       "000",
 	}
 
 	tcs := []struct {
@@ -276,7 +282,7 @@ func TestVersionClientStream(t *testing.T) {
 				{
 					Environment: "staging",
 					Application: "foo",
-					Version:     1,
+					Version:     &VersionInfo{Version: 1},
 				},
 			},
 		},
@@ -297,7 +303,7 @@ func TestVersionClientStream(t *testing.T) {
 				{
 					Environment: "staging",
 					Application: "foo",
-					Version:     1,
+					Version:     &VersionInfo{Version: 1},
 				},
 			},
 		},
@@ -318,12 +324,12 @@ func TestVersionClientStream(t *testing.T) {
 				{
 					Environment: "staging",
 					Application: "foo",
-					Version:     1,
+					Version:     &VersionInfo{Version: 1},
 				},
 				{
 					Environment: "staging",
 					Application: "foo",
-					Version:     0,
+					Version:     &VersionInfo{},
 				},
 			},
 		},
@@ -355,8 +361,11 @@ func assertExpectedVersions(t *testing.T, expectedVersions []expectedVersion, vc
 			t.Errorf("expected no error for %s/%s@%s, but got %q", ev.Environment, ev.Application, ev.Revision, err)
 			continue
 		}
-		if version != ev.DeployedVersion {
-			t.Errorf("expected version %d to be deployed for %s/%s@%s but got %d", ev.DeployedVersion, ev.Environment, ev.Application, ev.Revision, version)
+		if version.Version != ev.DeployedVersion {
+			t.Errorf("expected version %d to be deployed for %s/%s@%s but got %d", ev.DeployedVersion, ev.Environment, ev.Application, ev.Revision, version.Version)
+		}
+		if version.DeployedAt != ev.DeployTime {
+			t.Errorf("expected deploy time to be %q for %s/%s@%s but got %q", ev.DeployTime, ev.Environment, ev.Application, ev.Revision, version.DeployedAt)
 		}
 		if !cmp.Equal(mc.LastMetadata, ev.Metadata) {
 			t.Errorf("mismachted metadata %s", cmp.Diff(mc.LastMetadata, ev.Metadata))


### PR DESCRIPTION
I need to have the time when something is deployed to calculate how much argocd is behind kuberpult. The deploy time is available in `DeploymentMetaData.DeployTime`