### PR TITLE
Also emit deploy time in version events

### DIFF
--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -151,8 +151,9 @@ outer:
 			for _, envGroup := range overview.EnvironmentGroups {
 				for _, env := range envGroup.Environments {
 					for _, app := range env.Applications {
+						dt := deployedAt(app)
 
-						l.Info("version.process", zap.String("application", app.Name), zap.String("environment", env.Name), zap.Uint64("version", app.Version))
+						l.Info("version.process", zap.String("application", app.Name), zap.String("environment", env.Name), zap.Uint64("version", app.Version), zap.Time("deployedAt", dt))
 						k := key{env.Name, app.Name}
 						seen[k] = app.Version
 						if versions[k] == app.Version {
@@ -162,7 +163,8 @@ outer:
 							Application: app.Name,
 							Environment: env.Name,
 							Version: &VersionInfo{
-								Version: app.Version,
+								Version:    app.Version,
+								DeployedAt: dt,
 							},
 						})
 					}

--- a/services/rollout-service/pkg/versions/versions_test.go
+++ b/services/rollout-service/pkg/versions/versions_test.go
@@ -227,6 +227,9 @@ func TestVersionClientStream(t *testing.T) {
 							"foo": {
 								Name:    "foo",
 								Version: 1,
+								DeploymentMetaData: &api.Environment_Application_DeploymentMetaData{
+									DeployTime: "123456789",
+								},
 							},
 						},
 					},
@@ -276,13 +279,14 @@ func TestVersionClientStream(t *testing.T) {
 					Environment:     "staging",
 					Application:     "foo",
 					DeployedVersion: 1,
+					DeployTime:      time.Unix(123456789, 0).UTC(),
 				},
 			},
 			ExpectedEvents: []KuberpultEvent{
 				{
 					Environment: "staging",
 					Application: "foo",
-					Version:     &VersionInfo{Version: 1},
+					Version:     &VersionInfo{Version: 1, DeployedAt: time.Unix(123456789, 0).UTC()},
 				},
 			},
 		},
@@ -303,7 +307,7 @@ func TestVersionClientStream(t *testing.T) {
 				{
 					Environment: "staging",
 					Application: "foo",
-					Version:     &VersionInfo{Version: 1},
+					Version:     &VersionInfo{Version: 1, DeployedAt: time.Unix(123456789, 0).UTC()},
 				},
 			},
 		},
@@ -324,7 +328,7 @@ func TestVersionClientStream(t *testing.T) {
 				{
 					Environment: "staging",
 					Application: "foo",
-					Version:     &VersionInfo{Version: 1},
+					Version:     &VersionInfo{Version: 1, DeployedAt: time.Unix(123456789, 0).UTC()},
 				},
 				{
 					Environment: "staging",


### PR DESCRIPTION
This is a follow up of #960 . The deploy time was added there, but only in one method.