### PR TITLE
Refactor EnvSelection to not use mui

### DIFF
--- a/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.tsx
@@ -60,7 +60,7 @@ export const EnvSelectionDialog: React.FC<EnvSelectionDialogProps> = (props) => 
             onCancel={onCancel}
             open={props.open}
             headerLabel={'Select all environments to be removed:'}
-            confirmLabel={'Remove environments from app'}>
+            confirmLabel={'Remove app from environments'}>
             <div className="envs-dropdown-select">
                 {props.environments.map((env: string, index: number) => {
                     const enabled = selectedEnvs.includes(env);

--- a/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.tsx
@@ -13,11 +13,10 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-import { Dialog, DialogActions, DialogTitle } from '@material-ui/core';
 import * as React from 'react';
-import { Button } from '../button';
 import { useState } from 'react';
 import { Checkbox } from '../dropdown/checkbox';
+import { ConfirmationDialog } from '../dialog/ConfirmationDialog';
 
 export type EnvSelectionDialogProps = {
     environments: string[];
@@ -56,8 +55,12 @@ export const EnvSelectionDialog: React.FC<EnvSelectionDialogProps> = (props) => 
     );
 
     return (
-        <Dialog open={props.open}>
-            <DialogTitle id="alert-dialog-title">{'Select all environments to be removed:'}</DialogTitle>
+        <ConfirmationDialog
+            onConfirm={onConfirm}
+            onCancel={onCancel}
+            open={props.open}
+            headerLabel={'Select all environments to be removed:'}
+            confirmLabel={'Remove environments from app'}>
             <div className="envs-dropdown-select">
                 {props.environments.map((env: string, index: number) => {
                     const enabled = selectedEnvs.includes(env);
@@ -74,11 +77,6 @@ export const EnvSelectionDialog: React.FC<EnvSelectionDialogProps> = (props) => 
                     );
                 })}
             </div>
-
-            <DialogActions>
-                <Button label="Cancel" onClick={onCancel} className={'test-button-cancel'} />
-                <Button label="Confirm" onClick={onConfirm} className={'test-button-confirm'} />
-            </DialogActions>
-        </Dialog>
+        </ConfirmationDialog>
     );
 };

--- a/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.tsx
+++ b/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.tsx
@@ -40,11 +40,15 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => 
             <hr />
             <div className={'confirmation-dialog-footer'}>
                 <div className={'item'} key={'button-menu-cancel'}>
-                    <Button className="mdc-button--ripple button-cancel" label={'Cancel'} onClick={props.onCancel} />
+                    <Button
+                        className="mdc-button--ripple button-cancel test-button-cancel"
+                        label={'Cancel'}
+                        onClick={props.onCancel}
+                    />
                 </div>
                 <div className={'item'} key={'button-menu-confirm'}>
                     <Button
-                        className="mdc-button--unelevated button-confirm"
+                        className="mdc-button--unelevated button-confirm test-button-confirm"
                         label={props.confirmLabel}
                         onClick={props.onConfirm}
                     />


### PR DESCRIPTION
Before: 
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/9a86dd77-5e94-45ee-b0c4-d27ec2ec9abb)

Now:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/fc473029-553a-4209-843b-42984eb203c1)
