### PR TITLE
Refactor ReleaseDialog to not use mui

### DIFF
--- a/services/frontend-service/src/assets/_variables.scss
+++ b/services/frontend-service/src/assets/_variables.scss
@@ -83,7 +83,7 @@ $environment-add-lock-button-color: var(--mdc-theme-primary);
 $environment-add-lock-button-padding-left: 1em;
 
 // Release Dialog
-$release-dialog-outer-border-radius: 15px;
+$release-dialog-outer-border-radius: 10px;
 $release-dialog-top-border-radius: $release-dialog-outer-border-radius $release-dialog-outer-border-radius 0px 0px;
 $release-dialog-bottom-border-radius: 0px 0px $release-dialog-outer-border-radius $release-dialog-outer-border-radius;
 $release-dialog-inner-border-radius: 10px;

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -69,7 +69,6 @@ Copyright 2023 freiheit.com*/
         background-color: var(--mdc-theme-surface);
         display: flex;
         flex-direction: column;
-        overflow: overlay;
         gap: 12px;
         margin: 0px;
         padding-bottom: 20px;
@@ -86,11 +85,8 @@ Copyright 2023 freiheit.com*/
             display: flex;
             flex-direction: column;
             width: 900px;
-            padding: 0px;
-            margin-top: 10px;
-            margin-bottom: 0px;
-            margin-left: 20px;
-            margin-right: 20px;
+            padding: 0 0 10px;
+            margin: 10px 20px 0;
             border-radius: $release-dialog-inner-border-radius;
             gap: 0;
 
@@ -150,6 +146,7 @@ Copyright 2023 freiheit.com*/
                 display: flex;
                 flex-direction: row;
                 gap: 20px;
+                min-width: 300px;
                 button {
                     padding: 8px 19px;
                 }

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -13,7 +13,6 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-import { Dialog } from '@material-ui/core';
 import classNames from 'classnames';
 import React, { ReactElement, useCallback } from 'react';
 import { Environment, Environment_Application, EnvironmentGroup, Lock, LockBehavior, Release } from '../../../api/api';
@@ -31,6 +30,7 @@ import { EnvironmentChip } from '../chip/EnvironmentGroupChip';
 import { FormattedDate } from '../FormattedDate/FormattedDate';
 import { ArgoAppLink, ArgoTeamLink, DisplayManifestLink, DisplaySourceLink } from '../../utils/Links';
 import { ReleaseVersion } from '../ReleaseVersion/ReleaseVersion';
+import { PlainDialog } from '../dialog/ConfirmationDialog';
 
 export type ReleaseDialogProps = {
     className?: string;
@@ -154,7 +154,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
         const deployedBy = application.deploymentMetaData?.deployAuthor ?? 'unknown';
         const deployedUNIX = application.deploymentMetaData?.deployTime ?? '';
         if (deployedUNIX === '') {
-            return ['Deployed by ' + deployedBy, <></>];
+            return ['Deployed by &nbsp;' + deployedBy, <></>];
         }
         const deployedDate = new Date(+deployedUNIX * 1000);
         const returnString = 'Deployed by ' + deployedBy + ' ';
@@ -202,7 +202,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                     {queueInfo}
                     <div className={classNames('env-card-data', className)}>
                         {getDeploymentMetadata().flatMap((metadata, i) => (
-                            <div key={i}>{metadata}</div>
+                            <div key={i}>{metadata}&nbsp;</div>
                         ))}
                     </div>
                 </div>
@@ -269,60 +269,51 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
     const team = useTeamFromApplication(app);
     const closeReleaseDialog = useCloseReleaseDialog();
 
-    const dialog: JSX.Element | '' =
-        app !== '' ? (
-            <div>
-                <Dialog
-                    className={classNames('release-dialog', className)}
-                    fullWidth={true}
-                    maxWidth="md"
-                    open={app !== ''}
-                    onClose={closeReleaseDialog}>
-                    <div className={classNames('release-dialog-app-bar', className)}>
-                        <div className={classNames('release-dialog-app-bar-data')}>
-                            <div className={classNames('release-dialog-message', className)}>
-                                <span className={classNames('release-dialog-commitMessage', className)}>
-                                    {release?.sourceMessage}
-                                </span>
-                            </div>
-                            <div className="source">
-                                <span>
-                                    {'Created '}
-                                    {release?.createdAt ? (
-                                        <FormattedDate
-                                            createdAt={release.createdAt}
-                                            className={classNames('release-dialog-createdAt', className)}
-                                        />
-                                    ) : (
-                                        'at an unknown date'
-                                    )}
-                                    {' by '}
-                                    {release?.sourceAuthor ? release?.sourceAuthor : 'an unknown author'}{' '}
-                                </span>
-                                <span className="links">
-                                    <DisplaySourceLink commitId={release.sourceCommitId} displayString={'Source'} />
-                                    &nbsp;
-                                    <DisplayManifestLink app={app} version={release.version} displayString="Manifest" />
-                                </span>
-                            </div>
-                            <div className={classNames('release-dialog-app', className)}>
-                                {'App: '}
-                                <ArgoAppLink app={app} />
-                                <ArgoTeamLink team={team} />
-                            </div>
+    const dialog: JSX.Element | '' = (
+        <PlainDialog open={app !== ''} onClose={closeReleaseDialog}>
+            <>
+                <div className={classNames('release-dialog-app-bar', className)}>
+                    <div className={classNames('release-dialog-app-bar-data')}>
+                        <div className={classNames('release-dialog-message', className)}>
+                            <span className={classNames('release-dialog-commitMessage', className)}>
+                                {release?.sourceMessage}
+                            </span>
                         </div>
-                        <Button
-                            onClick={closeReleaseDialog}
-                            className={classNames('release-dialog-close', className)}
-                            icon={<Close />}
-                        />
+                        <div className="source">
+                            <span>
+                                {'Created '}
+                                {release?.createdAt ? (
+                                    <FormattedDate
+                                        createdAt={release.createdAt}
+                                        className={classNames('release-dialog-createdAt', className)}
+                                    />
+                                ) : (
+                                    'at an unknown date'
+                                )}
+                                {' by '}
+                                {release?.sourceAuthor ? release?.sourceAuthor : 'an unknown author'}{' '}
+                            </span>
+                            <span className="links">
+                                <DisplaySourceLink commitId={release.sourceCommitId} displayString={'Source'} />
+                                &nbsp;
+                                <DisplayManifestLink app={app} version={release.version} displayString="Manifest" />
+                            </span>
+                        </div>
+                        <div className={classNames('release-dialog-app', className)}>
+                            {'App: '}
+                            <ArgoAppLink app={app} />
+                            <ArgoTeamLink team={team} />
+                        </div>
                     </div>
-                    <EnvironmentList app={app} className={className} release={release} version={version} />
-                </Dialog>
-            </div>
-        ) : (
-            ''
-        );
-
+                    <Button
+                        onClick={closeReleaseDialog}
+                        className={classNames('release-dialog-close', className)}
+                        icon={<Close />}
+                    />
+                </div>
+                <EnvironmentList app={app} className={className} release={release} version={version} />
+            </>
+        </PlainDialog>
+    );
     return <div>{dialog}</div>;
 };

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -1,1052 +1,955 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Release Dialog Renders the environment locks normal release 1`] = `
-<body
-  style="padding-right: 0px; overflow: hidden;"
->
-  <div
-    aria-hidden="true"
-  >
+<body>
+  <div>
     <div>
-      <div />
-    </div>
-  </div>
-  <div
-    class="MuiModal-root MuiDialog-root release-dialog css-zw3mfo-MuiModal-root-MuiDialog-root"
-    role="presentation"
-  >
-    <div
-      aria-hidden="true"
-      class="MuiBackdrop-root css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
-    />
-    <div
-      data-test="sentinelStart"
-      tabindex="0"
-    />
-    <div
-      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
-      role="presentation"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
-      tabindex="-1"
-    >
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-142erj9-MuiPaper-root-MuiDialog-paper"
-        role="dialog"
+        class="INSIDE confirmation-dialog-container confirmation-dialog-container-open"
       >
         <div
-          class="release-dialog-app-bar"
+          class="confirmation-dialog-open release-dialog"
         >
           <div
-            class="release-dialog-app-bar-data"
+            class="release-dialog-app-bar"
           >
             <div
-              class="release-dialog-message"
-            >
-              <span
-                class="release-dialog-commitMessage"
-              >
-                test1
-              </span>
-            </div>
-            <div
-              class="source"
-            >
-              <span>
-                Created 
-                <div>
-                  some formatted date
-                </div>
-                 by 
-                test
-                 
-              </span>
-              <span
-                class="links"
-              >
-                 
-              </span>
-            </div>
-            <div
-              class="release-dialog-app"
-            >
-              App: 
-              <span>
-                test1
-              </span>
-            </div>
-          </div>
-          <button
-            aria-label=""
-            class="mdc-button release-dialog-close"
-          >
-            <div
-              class="mdc-button__ripple"
-            />
-            <svg>
-              Close.svg
-            </svg>
-          </button>
-        </div>
-        <div
-          class="release-env-group-list"
-        >
-          <ul
-            class="release-env-list"
-          >
-            <li
-              class="env-card"
+              class="release-dialog-app-bar-data"
             >
               <div
-                class="env-card-header"
+                class="release-dialog-message"
               >
-                <div
-                  class="mdc-evolution-chip release-environment environment-priority-upstream"
-                  role="row"
+                <span
+                  class="release-dialog-commitMessage"
                 >
-                  <span
-                    class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
-                    role="gridcell"
-                  >
-                    <span
-                      class="mdc-evolution-chip__text-name"
-                    >
-                      <span>
-                        prod
-                      </span>
-                    </span>
-                     
-                    <span
-                      class="mdc-evolution-chip__text-numbers"
-                    />
-                    <div
-                      class="release-environment env-locks"
-                    >
-                      <div
-                        class="tooltip-container"
-                      >
-                        <a
-                          data-tooltip-delay-hide="50"
-                          data-tooltip-place="bottom"
-                          href="#"
-                          id="tooltipenv-group-chip-id-ui-envlock"
-                        >
-                          <div>
-                            <button
-                              aria-label=""
-                              class="mdc-button button-lock"
-                            >
-                              <div
-                                class="mdc-button__ripple"
-                              />
-                              <svg
-                                class="env-card-env-lock-icon fixed-size"
-                              >
-                                Locks_White.svg
-                              </svg>
-                            </button>
-                          </div>
-                        </a>
-                      </div>
-                    </div>
-                  </span>
-                </div>
-                <div
-                  class="env-card-app-locks"
-                >
-                  <div
-                    title="App Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
-                  >
-                    <button
-                      aria-label=""
-                      class="mdc-button button-lock"
-                    >
-                      <div
-                        class="mdc-button__ripple"
-                      />
-                      <svg
-                        class="env-card-app-lock"
-                      >
-                        Locks.svg
-                      </svg>
-                    </button>
-                  </div>
-                </div>
+                  test1
+                </span>
               </div>
               <div
-                class="content-area"
+                class="source"
+              >
+                <span>
+                  Created 
+                  <div>
+                    some formatted date
+                  </div>
+                   by 
+                  test
+                   
+                </span>
+                <span
+                  class="links"
+                >
+                   
+                </span>
+              </div>
+              <div
+                class="release-dialog-app"
+              >
+                App: 
+                <span>
+                  test1
+                </span>
+              </div>
+            </div>
+            <button
+              aria-label=""
+              class="mdc-button release-dialog-close"
+            >
+              <div
+                class="mdc-button__ripple"
+              />
+              <svg>
+                Close.svg
+              </svg>
+            </button>
+          </div>
+          <div
+            class="release-env-group-list"
+          >
+            <ul
+              class="release-env-list"
+            >
+              <li
+                class="env-card"
               >
                 <div
-                  class="content-left"
+                  class="env-card-header"
                 >
                   <div
-                    class="env-card-data"
-                    title="Shows the version that is currently deployed on prod. "
+                    class="mdc-evolution-chip release-environment environment-priority-upstream"
+                    role="row"
                   >
-                    <span>
+                    <span
+                      class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
+                      role="gridcell"
+                    >
                       <span
-                        class="release-version__display-version"
-                        title="commit"
+                        class="mdc-evolution-chip__text-name"
                       >
-                        2
+                        <span>
+                          prod
+                        </span>
                       </span>
-                      test1
+                       
+                      <span
+                        class="mdc-evolution-chip__text-numbers"
+                      />
+                      <div
+                        class="release-environment env-locks"
+                      >
+                        <div
+                          class="tooltip-container"
+                        >
+                          <a
+                            data-tooltip-delay-hide="50"
+                            data-tooltip-place="bottom"
+                            href="#"
+                            id="tooltipenv-group-chip-id-ui-envlock"
+                          >
+                            <div>
+                              <button
+                                aria-label=""
+                                class="mdc-button button-lock"
+                              >
+                                <div
+                                  class="mdc-button__ripple"
+                                />
+                                <svg
+                                  class="env-card-env-lock-icon fixed-size"
+                                >
+                                  Locks_White.svg
+                                </svg>
+                              </button>
+                            </div>
+                          </a>
+                        </div>
+                      </div>
                     </span>
                   </div>
                   <div
-                    class="env-card-data"
+                    class="env-card-app-locks"
                   >
-                    <div>
-                      Deployed by unknown
-                    </div>
-                    <div />
-                  </div>
-                </div>
-                <div
-                  class="content-right"
-                >
-                  <div
-                    class="env-card-buttons"
-                  >
-                    <button
-                      aria-label="Add lock"
-                      class="mdc-button env-card-add-lock-btn"
-                    >
-                      <div
-                        class="mdc-button__ripple"
-                      />
-                      <svg
-                        class="icon"
-                      >
-                        Locks.svg
-                      </svg>
-                      <span
-                        class="mdc-button__label"
-                      >
-                        Add lock
-                      </span>
-                    </button>
                     <div
-                      title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                      title="App Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
                     >
                       <button
-                        aria-label="Deploy & Lock"
-                        class="mdc-button env-card-deploy-btn mdc-button--unelevated"
-                        disabled=""
+                        aria-label=""
+                        class="mdc-button button-lock"
                       >
                         <div
                           class="mdc-button__ripple"
                         />
-                        <span
-                          class="mdc-button__label"
+                        <svg
+                          class="env-card-app-lock"
                         >
-                          Deploy & Lock
-                        </span>
+                          Locks.svg
+                        </svg>
                       </button>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-          </ul>
+                <div
+                  class="content-area"
+                >
+                  <div
+                    class="content-left"
+                  >
+                    <div
+                      class="env-card-data"
+                      title="Shows the version that is currently deployed on prod. "
+                    >
+                      <span>
+                        <span
+                          class="release-version__display-version"
+                          title="commit"
+                        >
+                          2
+                        </span>
+                        test1
+                      </span>
+                    </div>
+                    <div
+                      class="env-card-data"
+                    >
+                      <div>
+                        Deployed by &nbsp;unknown
+                         
+                      </div>
+                      <div>
+                         
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="content-right"
+                  >
+                    <div
+                      class="env-card-buttons"
+                    >
+                      <button
+                        aria-label="Add lock"
+                        class="mdc-button env-card-add-lock-btn"
+                      >
+                        <div
+                          class="mdc-button__ripple"
+                        />
+                        <svg
+                          class="icon"
+                        >
+                          Locks.svg
+                        </svg>
+                        <span
+                          class="mdc-button__label"
+                        >
+                          Add lock
+                        </span>
+                      </button>
+                      <div
+                        title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                      >
+                        <button
+                          aria-label="Deploy & Lock"
+                          class="mdc-button env-card-deploy-btn mdc-button--unelevated"
+                          disabled=""
+                        >
+                          <div
+                            class="mdc-button__ripple"
+                          />
+                          <span
+                            class="mdc-button__label"
+                          >
+                            Deploy & Lock
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
-    <div
-      data-test="sentinelEnd"
-      tabindex="0"
-    />
   </div>
 </body>
 `;
 
 exports[`Release Dialog Renders the environment locks normal release with deploymentMetadata set 1`] = `
-<body
-  style="padding-right: 0px; overflow: hidden;"
->
-  <div
-    aria-hidden="true"
-  >
+<body>
+  <div>
     <div>
-      <div />
-    </div>
-  </div>
-  <div
-    class="MuiModal-root MuiDialog-root release-dialog css-zw3mfo-MuiModal-root-MuiDialog-root"
-    role="presentation"
-  >
-    <div
-      aria-hidden="true"
-      class="MuiBackdrop-root css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
-    />
-    <div
-      data-test="sentinelStart"
-      tabindex="0"
-    />
-    <div
-      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
-      role="presentation"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
-      tabindex="-1"
-    >
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-142erj9-MuiPaper-root-MuiDialog-paper"
-        role="dialog"
+        class="INSIDE confirmation-dialog-container confirmation-dialog-container-open"
       >
         <div
-          class="release-dialog-app-bar"
+          class="confirmation-dialog-open release-dialog"
         >
           <div
-            class="release-dialog-app-bar-data"
+            class="release-dialog-app-bar"
           >
             <div
-              class="release-dialog-message"
-            >
-              <span
-                class="release-dialog-commitMessage"
-              >
-                test1
-              </span>
-            </div>
-            <div
-              class="source"
-            >
-              <span>
-                Created 
-                <div>
-                  some formatted date
-                </div>
-                 by 
-                test
-                 
-              </span>
-              <span
-                class="links"
-              >
-                 
-              </span>
-            </div>
-            <div
-              class="release-dialog-app"
-            >
-              App: 
-              <span>
-                test1
-              </span>
-            </div>
-          </div>
-          <button
-            aria-label=""
-            class="mdc-button release-dialog-close"
-          >
-            <div
-              class="mdc-button__ripple"
-            />
-            <svg>
-              Close.svg
-            </svg>
-          </button>
-        </div>
-        <div
-          class="release-env-group-list"
-        >
-          <ul
-            class="release-env-list"
-          >
-            <li
-              class="env-card"
+              class="release-dialog-app-bar-data"
             >
               <div
-                class="env-card-header"
+                class="release-dialog-message"
               >
-                <div
-                  class="mdc-evolution-chip release-environment environment-priority-upstream"
-                  role="row"
+                <span
+                  class="release-dialog-commitMessage"
                 >
-                  <span
-                    class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
-                    role="gridcell"
-                  >
-                    <span
-                      class="mdc-evolution-chip__text-name"
-                    >
-                      <span>
-                        prod
-                      </span>
-                    </span>
-                     
-                    <span
-                      class="mdc-evolution-chip__text-numbers"
-                    />
-                    <div
-                      class="release-environment env-locks"
-                    >
-                      <div
-                        class="tooltip-container"
-                      >
-                        <a
-                          data-tooltip-delay-hide="50"
-                          data-tooltip-place="bottom"
-                          href="#"
-                          id="tooltipenv-group-chip-id-ui-envlock"
-                        >
-                          <div>
-                            <button
-                              aria-label=""
-                              class="mdc-button button-lock"
-                            >
-                              <div
-                                class="mdc-button__ripple"
-                              />
-                              <svg
-                                class="env-card-env-lock-icon fixed-size"
-                              >
-                                Locks_White.svg
-                              </svg>
-                            </button>
-                          </div>
-                        </a>
-                      </div>
-                    </div>
-                  </span>
-                </div>
-                <div
-                  class="env-card-app-locks"
-                >
-                  <div
-                    title="App Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
-                  >
-                    <button
-                      aria-label=""
-                      class="mdc-button button-lock"
-                    >
-                      <div
-                        class="mdc-button__ripple"
-                      />
-                      <svg
-                        class="env-card-app-lock"
-                      >
-                        Locks.svg
-                      </svg>
-                    </button>
-                  </div>
-                </div>
+                  test1
+                </span>
               </div>
               <div
-                class="content-area"
+                class="source"
+              >
+                <span>
+                  Created 
+                  <div>
+                    some formatted date
+                  </div>
+                   by 
+                  test
+                   
+                </span>
+                <span
+                  class="links"
+                >
+                   
+                </span>
+              </div>
+              <div
+                class="release-dialog-app"
+              >
+                App: 
+                <span>
+                  test1
+                </span>
+              </div>
+            </div>
+            <button
+              aria-label=""
+              class="mdc-button release-dialog-close"
+            >
+              <div
+                class="mdc-button__ripple"
+              />
+              <svg>
+                Close.svg
+              </svg>
+            </button>
+          </div>
+          <div
+            class="release-env-group-list"
+          >
+            <ul
+              class="release-env-list"
+            >
+              <li
+                class="env-card"
               >
                 <div
-                  class="content-left"
+                  class="env-card-header"
                 >
                   <div
-                    class="env-card-data"
-                    title="Shows the version that is currently deployed on prod. "
+                    class="mdc-evolution-chip release-environment environment-priority-upstream"
+                    role="row"
                   >
-                    <span>
+                    <span
+                      class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
+                      role="gridcell"
+                    >
                       <span
-                        class="release-version__display-version"
-                        title="commit"
+                        class="mdc-evolution-chip__text-name"
                       >
-                        2
+                        <span>
+                          prod
+                        </span>
                       </span>
-                      test1
+                       
+                      <span
+                        class="mdc-evolution-chip__text-numbers"
+                      />
+                      <div
+                        class="release-environment env-locks"
+                      >
+                        <div
+                          class="tooltip-container"
+                        >
+                          <a
+                            data-tooltip-delay-hide="50"
+                            data-tooltip-place="bottom"
+                            href="#"
+                            id="tooltipenv-group-chip-id-ui-envlock"
+                          >
+                            <div>
+                              <button
+                                aria-label=""
+                                class="mdc-button button-lock"
+                              >
+                                <div
+                                  class="mdc-button__ripple"
+                                />
+                                <svg
+                                  class="env-card-env-lock-icon fixed-size"
+                                >
+                                  Locks_White.svg
+                                </svg>
+                              </button>
+                            </div>
+                          </a>
+                        </div>
+                      </div>
                     </span>
                   </div>
                   <div
-                    class="env-card-data"
+                    class="env-card-app-locks"
                   >
-                    <div>
-                      Deployed by test 
-                    </div>
-                    <div>
-                      <div>
-                        some formatted date
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="content-right"
-                >
-                  <div
-                    class="env-card-buttons"
-                  >
-                    <button
-                      aria-label="Add lock"
-                      class="mdc-button env-card-add-lock-btn"
-                    >
-                      <div
-                        class="mdc-button__ripple"
-                      />
-                      <svg
-                        class="icon"
-                      >
-                        Locks.svg
-                      </svg>
-                      <span
-                        class="mdc-button__label"
-                      >
-                        Add lock
-                      </span>
-                    </button>
                     <div
-                      title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                      title="App Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
                     >
                       <button
-                        aria-label="Deploy & Lock"
-                        class="mdc-button env-card-deploy-btn mdc-button--unelevated"
-                        disabled=""
+                        aria-label=""
+                        class="mdc-button button-lock"
                       >
                         <div
                           class="mdc-button__ripple"
                         />
-                        <span
-                          class="mdc-button__label"
+                        <svg
+                          class="env-card-app-lock"
                         >
-                          Deploy & Lock
-                        </span>
+                          Locks.svg
+                        </svg>
                       </button>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-          </ul>
+                <div
+                  class="content-area"
+                >
+                  <div
+                    class="content-left"
+                  >
+                    <div
+                      class="env-card-data"
+                      title="Shows the version that is currently deployed on prod. "
+                    >
+                      <span>
+                        <span
+                          class="release-version__display-version"
+                          title="commit"
+                        >
+                          2
+                        </span>
+                        test1
+                      </span>
+                    </div>
+                    <div
+                      class="env-card-data"
+                    >
+                      <div>
+                        Deployed by test 
+                         
+                      </div>
+                      <div>
+                        <div>
+                          some formatted date
+                        </div>
+                         
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="content-right"
+                  >
+                    <div
+                      class="env-card-buttons"
+                    >
+                      <button
+                        aria-label="Add lock"
+                        class="mdc-button env-card-add-lock-btn"
+                      >
+                        <div
+                          class="mdc-button__ripple"
+                        />
+                        <svg
+                          class="icon"
+                        >
+                          Locks.svg
+                        </svg>
+                        <span
+                          class="mdc-button__label"
+                        >
+                          Add lock
+                        </span>
+                      </button>
+                      <div
+                        title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                      >
+                        <button
+                          aria-label="Deploy & Lock"
+                          class="mdc-button env-card-deploy-btn mdc-button--unelevated"
+                          disabled=""
+                        >
+                          <div
+                            class="mdc-button__ripple"
+                          />
+                          <span
+                            class="mdc-button__label"
+                          >
+                            Deploy & Lock
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
-    <div
-      data-test="sentinelEnd"
-      tabindex="0"
-    />
   </div>
 </body>
 `;
 
 exports[`Release Dialog Renders the environment locks two envs release 1`] = `
-<body
-  style="padding-right: 0px; overflow: hidden;"
->
-  <div
-    aria-hidden="true"
-  >
+<body>
+  <div>
     <div>
-      <div />
-    </div>
-  </div>
-  <div
-    class="MuiModal-root MuiDialog-root release-dialog css-zw3mfo-MuiModal-root-MuiDialog-root"
-    role="presentation"
-  >
-    <div
-      aria-hidden="true"
-      class="MuiBackdrop-root css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
-    />
-    <div
-      data-test="sentinelStart"
-      tabindex="0"
-    />
-    <div
-      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
-      role="presentation"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
-      tabindex="-1"
-    >
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-142erj9-MuiPaper-root-MuiDialog-paper"
-        role="dialog"
+        class="INSIDE confirmation-dialog-container confirmation-dialog-container-open"
       >
         <div
-          class="release-dialog-app-bar"
+          class="confirmation-dialog-open release-dialog"
         >
           <div
-            class="release-dialog-app-bar-data"
+            class="release-dialog-app-bar"
           >
             <div
-              class="release-dialog-message"
+              class="release-dialog-app-bar-data"
             >
-              <span
-                class="release-dialog-commitMessage"
+              <div
+                class="release-dialog-message"
               >
-                the other commit message 2
-              </span>
-            </div>
-            <div
-              class="source"
-            >
-              <span>
-                Created 
-                <div>
-                  some formatted date
-                </div>
-                 by 
-                nobody
-                 
-              </span>
-              <span
-                class="links"
+                <span
+                  class="release-dialog-commitMessage"
+                >
+                  the other commit message 2
+                </span>
+              </div>
+              <div
+                class="source"
               >
-                 
-              </span>
+                <span>
+                  Created 
+                  <div>
+                    some formatted date
+                  </div>
+                   by 
+                  nobody
+                   
+                </span>
+                <span
+                  class="links"
+                >
+                   
+                </span>
+              </div>
+              <div
+                class="release-dialog-app"
+              >
+                App: 
+                <span>
+                  test1
+                </span>
+                <span>
+                  test me team
+                </span>
+              </div>
             </div>
-            <div
-              class="release-dialog-app"
+            <button
+              aria-label=""
+              class="mdc-button release-dialog-close"
             >
-              App: 
-              <span>
-                test1
-              </span>
-              <span>
-                test me team
-              </span>
-            </div>
+              <div
+                class="mdc-button__ripple"
+              />
+              <svg>
+                Close.svg
+              </svg>
+            </button>
           </div>
-          <button
-            aria-label=""
-            class="mdc-button release-dialog-close"
+          <div
+            class="release-env-group-list"
           >
-            <div
-              class="mdc-button__ripple"
-            />
-            <svg>
-              Close.svg
-            </svg>
-          </button>
-        </div>
-        <div
-          class="release-env-group-list"
-        >
-          <ul
-            class="release-env-list"
-          >
-            <li
-              class="env-card"
+            <ul
+              class="release-env-list"
             >
-              <div
-                class="env-card-header"
+              <li
+                class="env-card"
               >
                 <div
-                  class="mdc-evolution-chip release-environment environment-priority-upstream"
-                  role="row"
+                  class="env-card-header"
                 >
-                  <span
-                    class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
-                    role="gridcell"
+                  <div
+                    class="mdc-evolution-chip release-environment environment-priority-upstream"
+                    role="row"
                   >
                     <span
-                      class="mdc-evolution-chip__text-name"
+                      class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
+                      role="gridcell"
                     >
-                      <span>
-                        prod
-                      </span>
-                    </span>
-                     
-                    <span
-                      class="mdc-evolution-chip__text-numbers"
-                    />
-                    <div
-                      class="release-environment env-locks"
-                    >
-                      <div
-                        class="tooltip-container"
+                      <span
+                        class="mdc-evolution-chip__text-name"
                       >
-                        <a
-                          data-tooltip-delay-hide="50"
-                          data-tooltip-place="bottom"
-                          href="#"
-                          id="tooltipenv-group-chip-id-ui-envlock"
+                        <span>
+                          prod
+                        </span>
+                      </span>
+                       
+                      <span
+                        class="mdc-evolution-chip__text-numbers"
+                      />
+                      <div
+                        class="release-environment env-locks"
+                      >
+                        <div
+                          class="tooltip-container"
                         >
-                          <div>
-                            <button
-                              aria-label=""
-                              class="mdc-button button-lock"
-                            >
-                              <div
-                                class="mdc-button__ripple"
-                              />
-                              <svg
-                                class="env-card-env-lock-icon fixed-size"
+                          <a
+                            data-tooltip-delay-hide="50"
+                            data-tooltip-place="bottom"
+                            href="#"
+                            id="tooltipenv-group-chip-id-ui-envlock"
+                          >
+                            <div>
+                              <button
+                                aria-label=""
+                                class="mdc-button button-lock"
                               >
-                                Locks_White.svg
-                              </svg>
-                            </button>
-                          </div>
-                        </a>
+                                <div
+                                  class="mdc-button__ripple"
+                                />
+                                <svg
+                                  class="env-card-env-lock-icon fixed-size"
+                                >
+                                  Locks_White.svg
+                                </svg>
+                              </button>
+                            </div>
+                          </a>
+                        </div>
                       </div>
-                    </div>
-                  </span>
-                </div>
-                <div
-                  class="env-card-app-locks"
-                >
-                  <div
-                    title="App Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
-                  >
-                    <button
-                      aria-label=""
-                      class="mdc-button button-lock"
-                    >
-                      <div
-                        class="mdc-button__ripple"
-                      />
-                      <svg
-                        class="env-card-app-lock"
-                      >
-                        Locks.svg
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="content-area"
-              >
-                <div
-                  class="content-left"
-                >
-                  <div
-                    class="env-card-data"
-                    title="Shows the version that is currently deployed on prod. "
-                  >
-                    <span>
-                      <span
-                        class="release-version__display-version"
-                        title="cafe"
-                      >
-                        2
-                      </span>
-                      the other commit message 2
                     </span>
                   </div>
                   <div
-                    class="env-card-data"
+                    class="env-card-app-locks"
                   >
-                    <div>
-                      Deployed by unknown
-                    </div>
-                    <div />
-                  </div>
-                </div>
-                <div
-                  class="content-right"
-                >
-                  <div
-                    class="env-card-buttons"
-                  >
-                    <button
-                      aria-label="Add lock"
-                      class="mdc-button env-card-add-lock-btn"
-                    >
-                      <div
-                        class="mdc-button__ripple"
-                      />
-                      <svg
-                        class="icon"
-                      >
-                        Locks.svg
-                      </svg>
-                      <span
-                        class="mdc-button__label"
-                      >
-                        Add lock
-                      </span>
-                    </button>
                     <div
-                      title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                      title="App Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
                     >
                       <button
-                        aria-label="Deploy & Lock"
-                        class="mdc-button env-card-deploy-btn mdc-button--unelevated"
-                        disabled=""
+                        aria-label=""
+                        class="mdc-button button-lock"
                       >
                         <div
                           class="mdc-button__ripple"
                         />
-                        <span
-                          class="mdc-button__label"
+                        <svg
+                          class="env-card-app-lock"
                         >
-                          Deploy & Lock
-                        </span>
+                          Locks.svg
+                        </svg>
                       </button>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              class="env-card"
-            >
-              <div
-                class="env-card-header"
-              >
                 <div
-                  class="mdc-evolution-chip release-environment environment-priority-upstream"
-                  role="row"
+                  class="content-area"
                 >
-                  <span
-                    class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
-                    role="gridcell"
+                  <div
+                    class="content-left"
                   >
-                    <span
-                      class="mdc-evolution-chip__text-name"
+                    <div
+                      class="env-card-data"
+                      title="Shows the version that is currently deployed on prod. "
                     >
                       <span>
-                        dev
-                      </span>
-                    </span>
-                     
-                    <span
-                      class="mdc-evolution-chip__text-numbers"
-                    />
-                    <div
-                      class="release-environment env-locks"
-                    >
-                      <div
-                        class="tooltip-container"
-                      >
-                        <a
-                          data-tooltip-delay-hide="50"
-                          data-tooltip-place="bottom"
-                          href="#"
-                          id="tooltipenv-group-chip-id-ui-envlock"
+                        <span
+                          class="release-version__display-version"
+                          title="cafe"
                         >
-                          <div>
-                            <button
-                              aria-label=""
-                              class="mdc-button button-lock"
-                            >
-                              <div
-                                class="mdc-button__ripple"
-                              />
-                              <svg
-                                class="env-card-env-lock-icon fixed-size"
-                              >
-                                Locks_White.svg
-                              </svg>
-                            </button>
-                          </div>
-                        </a>
+                          2
+                        </span>
+                        the other commit message 2
+                      </span>
+                    </div>
+                    <div
+                      class="env-card-data"
+                    >
+                      <div>
+                        Deployed by &nbsp;unknown
+                         
+                      </div>
+                      <div>
+                         
                       </div>
                     </div>
-                  </span>
-                </div>
-                <div
-                  class="env-card-app-locks"
-                >
-                  <div
-                    title="App Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
-                  >
-                    <button
-                      aria-label=""
-                      class="mdc-button button-lock"
-                    >
-                      <div
-                        class="mdc-button__ripple"
-                      />
-                      <svg
-                        class="env-card-app-lock"
-                      >
-                        Locks.svg
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="content-area"
-              >
-                <div
-                  class="content-left"
-                >
-                  <div
-                    class="env-card-data"
-                    title="Shows the version that is currently deployed on dev. "
-                  >
-                    <span>
-                      <span
-                        class="release-version__display-version"
-                        title="cafe"
-                      >
-                        3
-                      </span>
-                      the other commit message 3
-                    </span>
                   </div>
                   <div
-                    class="env-card-data env-card-data-queue"
-                    title="An attempt was made to deploy version 666 either by a release train, or when a new version was created. However, there was a lock present at the time, so kuberpult did not deploy this version. "
+                    class="content-right"
                   >
-                    Version 
-                    666
-                     was not deployed, because of a lock.
-                  </div>
-                  <div
-                    class="env-card-data"
-                  >
-                    <div>
-                      Deployed by unknown
-                    </div>
-                    <div />
-                  </div>
-                </div>
-                <div
-                  class="content-right"
-                >
-                  <div
-                    class="env-card-buttons"
-                  >
-                    <button
-                      aria-label="Add lock"
-                      class="mdc-button env-card-add-lock-btn"
-                    >
-                      <div
-                        class="mdc-button__ripple"
-                      />
-                      <svg
-                        class="icon"
-                      >
-                        Locks.svg
-                      </svg>
-                      <span
-                        class="mdc-button__label"
-                      >
-                        Add lock
-                      </span>
-                    </button>
                     <div
-                      title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                      class="env-card-buttons"
                     >
                       <button
-                        aria-label="Deploy & Lock"
-                        class="mdc-button env-card-deploy-btn mdc-button--unelevated"
+                        aria-label="Add lock"
+                        class="mdc-button env-card-add-lock-btn"
                       >
                         <div
                           class="mdc-button__ripple"
                         />
+                        <svg
+                          class="icon"
+                        >
+                          Locks.svg
+                        </svg>
                         <span
                           class="mdc-button__label"
                         >
-                          Deploy & Lock
+                          Add lock
                         </span>
+                      </button>
+                      <div
+                        title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                      >
+                        <button
+                          aria-label="Deploy & Lock"
+                          class="mdc-button env-card-deploy-btn mdc-button--unelevated"
+                          disabled=""
+                        >
+                          <div
+                            class="mdc-button__ripple"
+                          />
+                          <span
+                            class="mdc-button__label"
+                          >
+                            Deploy & Lock
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li
+                class="env-card"
+              >
+                <div
+                  class="env-card-header"
+                >
+                  <div
+                    class="mdc-evolution-chip release-environment environment-priority-upstream"
+                    role="row"
+                  >
+                    <span
+                      class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary mdc-evolution-chip__action--primary"
+                      role="gridcell"
+                    >
+                      <span
+                        class="mdc-evolution-chip__text-name"
+                      >
+                        <span>
+                          dev
+                        </span>
+                      </span>
+                       
+                      <span
+                        class="mdc-evolution-chip__text-numbers"
+                      />
+                      <div
+                        class="release-environment env-locks"
+                      >
+                        <div
+                          class="tooltip-container"
+                        >
+                          <a
+                            data-tooltip-delay-hide="50"
+                            data-tooltip-place="bottom"
+                            href="#"
+                            id="tooltipenv-group-chip-id-ui-envlock"
+                          >
+                            <div>
+                              <button
+                                aria-label=""
+                                class="mdc-button button-lock"
+                              >
+                                <div
+                                  class="mdc-button__ripple"
+                                />
+                                <svg
+                                  class="env-card-env-lock-icon fixed-size"
+                                >
+                                  Locks_White.svg
+                                </svg>
+                              </button>
+                            </div>
+                          </a>
+                        </div>
+                      </div>
+                    </span>
+                  </div>
+                  <div
+                    class="env-card-app-locks"
+                  >
+                    <div
+                      title="App Lock Message: \\"appLock\\" | ID: \\"ui-applock\\"  | Click to unlock. "
+                    >
+                      <button
+                        aria-label=""
+                        class="mdc-button button-lock"
+                      >
+                        <div
+                          class="mdc-button__ripple"
+                        />
+                        <svg
+                          class="env-card-app-lock"
+                        >
+                          Locks.svg
+                        </svg>
                       </button>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-          </ul>
+                <div
+                  class="content-area"
+                >
+                  <div
+                    class="content-left"
+                  >
+                    <div
+                      class="env-card-data"
+                      title="Shows the version that is currently deployed on dev. "
+                    >
+                      <span>
+                        <span
+                          class="release-version__display-version"
+                          title="cafe"
+                        >
+                          3
+                        </span>
+                        the other commit message 3
+                      </span>
+                    </div>
+                    <div
+                      class="env-card-data env-card-data-queue"
+                      title="An attempt was made to deploy version 666 either by a release train, or when a new version was created. However, there was a lock present at the time, so kuberpult did not deploy this version. "
+                    >
+                      Version 
+                      666
+                       was not deployed, because of a lock.
+                    </div>
+                    <div
+                      class="env-card-data"
+                    >
+                      <div>
+                        Deployed by &nbsp;unknown
+                         
+                      </div>
+                      <div>
+                         
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="content-right"
+                  >
+                    <div
+                      class="env-card-buttons"
+                    >
+                      <button
+                        aria-label="Add lock"
+                        class="mdc-button env-card-add-lock-btn"
+                      >
+                        <div
+                          class="mdc-button__ripple"
+                        />
+                        <svg
+                          class="icon"
+                        >
+                          Locks.svg
+                        </svg>
+                        <span
+                          class="mdc-button__label"
+                        >
+                          Add lock
+                        </span>
+                      </button>
+                      <div
+                        title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                      >
+                        <button
+                          aria-label="Deploy & Lock"
+                          class="mdc-button env-card-deploy-btn mdc-button--unelevated"
+                        >
+                          <div
+                            class="mdc-button__ripple"
+                          />
+                          <span
+                            class="mdc-button__label"
+                          >
+                            Deploy & Lock
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
-    <div
-      data-test="sentinelEnd"
-      tabindex="0"
-    />
   </div>
 </body>
 `;
 
 exports[`Release Dialog Renders the environment locks undeploy version release 1`] = `
-<body
-  style="padding-right: 0px; overflow: hidden;"
->
-  <div
-    aria-hidden="true"
-  >
+<body>
+  <div>
     <div>
-      <div />
-    </div>
-  </div>
-  <div
-    class="MuiModal-root MuiDialog-root release-dialog css-zw3mfo-MuiModal-root-MuiDialog-root"
-    role="presentation"
-  >
-    <div
-      aria-hidden="true"
-      class="MuiBackdrop-root css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
-    />
-    <div
-      data-test="sentinelStart"
-      tabindex="0"
-    />
-    <div
-      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
-      role="presentation"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
-      tabindex="-1"
-    >
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-142erj9-MuiPaper-root-MuiDialog-paper"
-        role="dialog"
+        class="INSIDE confirmation-dialog-container confirmation-dialog-container-open"
       >
         <div
-          class="release-dialog-app-bar"
+          class="confirmation-dialog-open release-dialog"
         >
           <div
-            class="release-dialog-app-bar-data"
+            class="release-dialog-app-bar"
           >
             <div
-              class="release-dialog-message"
+              class="release-dialog-app-bar-data"
             >
-              <span
-                class="release-dialog-commitMessage"
-              />
-            </div>
-            <div
-              class="source"
-            >
-              <span>
-                Created 
-                <div>
-                  some formatted date
-                </div>
-                 by 
-                test1
-                 
-              </span>
-              <span
-                class="links"
+              <div
+                class="release-dialog-message"
               >
-                 
-              </span>
+                <span
+                  class="release-dialog-commitMessage"
+                />
+              </div>
+              <div
+                class="source"
+              >
+                <span>
+                  Created 
+                  <div>
+                    some formatted date
+                  </div>
+                   by 
+                  test1
+                   
+                </span>
+                <span
+                  class="links"
+                >
+                   
+                </span>
+              </div>
+              <div
+                class="release-dialog-app"
+              >
+                App: 
+                <span>
+                  test1
+                </span>
+              </div>
             </div>
-            <div
-              class="release-dialog-app"
+            <button
+              aria-label=""
+              class="mdc-button release-dialog-close"
             >
-              App: 
-              <span>
-                test1
-              </span>
-            </div>
+              <div
+                class="mdc-button__ripple"
+              />
+              <svg>
+                Close.svg
+              </svg>
+            </button>
           </div>
-          <button
-            aria-label=""
-            class="mdc-button release-dialog-close"
+          <div
+            class="release-env-group-list"
           >
-            <div
-              class="mdc-button__ripple"
+            <ul
+              class="release-env-list"
             />
-            <svg>
-              Close.svg
-            </svg>
-          </button>
-        </div>
-        <div
-          class="release-env-group-list"
-        >
-          <ul
-            class="release-env-list"
-          />
+          </div>
         </div>
       </div>
     </div>
-    <div
-      data-test="sentinelEnd"
-      tabindex="0"
-    />
   </div>
 </body>
 `;

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -407,7 +407,7 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                 <h4>Conflicting Environment Locks:</h4>
                 <ul>
                     {conflictingLocks.environmentLocks.map((envLock: DisplayLock) => (
-                        <li>
+                        <li key={envLock.lockId + '-' + envLock.environment + '-envlock'}>
                             <DisplayLockInlineRenderer
                                 lock={envLock}
                                 key={envLock.lockId + '-' + envLock.environment}
@@ -418,42 +418,30 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
             </>
         );
     const confirmationDialog: JSX.Element = hasLocks ? (
-        <div
-            className={
-                'confirmation-dialog-container ' +
-                (dialogState.showConfirmationDialog ? 'confirmation-dialog-container-open' : '')
-            }>
-            <ConfirmationDialog
-                headerLabel={'Please Confirm the Deployment over Locks'}
-                onConfirm={applyActions}
-                confirmLabel={'Confirm Deployment'}
-                onCancel={cancelConfirmation}
-                open={dialogState.showConfirmationDialog}>
-                <div>
-                    You are attempting to deploy apps, although there are locks present. Please check the locks and be
-                    sure you really want to ignore them.
-                    <div className={'locks'}>
-                        {envLocksRendered}
-                        {appLocksRendered}
-                    </div>
+        <ConfirmationDialog
+            headerLabel={'Please Confirm the Deployment over Locks'}
+            onConfirm={applyActions}
+            confirmLabel={'Confirm Deployment'}
+            onCancel={cancelConfirmation}
+            open={dialogState.showConfirmationDialog}>
+            <div>
+                You are attempting to deploy apps, although there are locks present. Please check the locks and be sure
+                you really want to ignore them.
+                <div className={'locks'}>
+                    {envLocksRendered}
+                    {appLocksRendered}
                 </div>
-            </ConfirmationDialog>
-        </div>
+            </div>
+        </ConfirmationDialog>
     ) : (
-        <div
-            className={
-                'confirmation-dialog-container ' +
-                (dialogState.showConfirmationDialog ? 'confirmation-dialog-container-open' : '')
-            }>
-            <ConfirmationDialog
-                headerLabel={'Please Confirm the Planned Actions'}
-                onConfirm={applyActions}
-                confirmLabel={'Confirm Planned Actions'}
-                onCancel={cancelConfirmation}
-                open={dialogState.showConfirmationDialog}>
-                <div>Are you sure you want to apply all planned actions?</div>
-            </ConfirmationDialog>
-        </div>
+        <ConfirmationDialog
+            headerLabel={'Please Confirm the Planned Actions'}
+            onConfirm={applyActions}
+            confirmLabel={'Confirm Planned Actions'}
+            onCancel={cancelConfirmation}
+            open={dialogState.showConfirmationDialog}>
+            <div>Are you sure you want to apply all planned actions?</div>
+        </ConfirmationDialog>
     );
 
     return (

--- a/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.scss
+++ b/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.scss
@@ -20,7 +20,7 @@ Copyright 2023 freiheit.com*/
 
 .confirmation-dialog-container-open {
     &::before {
-        // this is to make everything behind the dialog grey and not clickable:
+         // this is to make everything behind the dialog grey and not clickable:
         content: '';
         position: fixed;
         top: 0;
@@ -45,7 +45,8 @@ Copyright 2023 freiheit.com*/
     transform: translate(-50%, -50%);
 
     z-index: 1000;
-    border-radius: 10px;
+    // the border radius has to align with the border radius of the release dialog:
+    border-radius: $release-dialog-outer-border-radius;
     box-shadow: rgba(0, 0, 0, 0.2) 0 5px 5px -3px, rgba(0, 0, 0, 0.14) 0px 8px 10px 1px,
         rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
 

--- a/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.scss
+++ b/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.scss
@@ -20,7 +20,7 @@ Copyright 2023 freiheit.com*/
 
 .confirmation-dialog-container-open {
     &::before {
-         // this is to make everything behind the dialog grey and not clickable:
+        // this is to make everything behind the dialog grey and not clickable:
         content: '';
         position: fixed;
         top: 0;

--- a/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.tsx
+++ b/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.tsx
@@ -13,6 +13,7 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
+
 import React from 'react';
 import { Button } from '../button';
 
@@ -28,18 +29,15 @@ export type ConfirmationDialogProps = {
 /**
  * A dialog that is used to confirm a question with either yes or no.
  */
-export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => {
-    if (!props.open) {
-        return <div className={'confirmation-dialog-hidden'}></div>;
-    }
-    return (
-        <div className={'confirmation-dialog-open'}>
+export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => (
+    <PlainDialog open={props.open} onClose={props.onCancel}>
+        <>
             <div className={'confirmation-dialog-header'}>{props.headerLabel}</div>
             <hr />
             <div className={'confirmation-dialog-content'}>{props.children}</div>
             <hr />
             <div className={'confirmation-dialog-footer'}>
-                <div className={'item'} key={'button-menu-cancel'}>
+                <div className={'item'} key={'button-menu-cancel'} title={'ESC also closes the dialog'}>
                     <Button
                         className="mdc-button--ripple button-cancel test-button-cancel"
                         label={'Cancel'}
@@ -54,6 +52,38 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => 
                     />
                 </div>
             </div>
+        </>
+    </PlainDialog>
+);
+
+export type PlainDialogProps = {
+    open: boolean;
+    onClose: () => void;
+    children: JSX.Element;
+};
+
+/**
+ * A dialog that just renders its children. Invoker must take care of all buttons.
+ */
+export const PlainDialog: React.FC<PlainDialogProps> = (props) => {
+    const { onClose, open, children } = props;
+    React.useEffect(() => {
+        window.addEventListener('keyup', (event) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        });
+    }, [onClose]);
+
+    if (!open) {
+        return <div className={'confirmation-dialog-hidden'}></div>;
+    }
+    return (
+        <div
+            className={
+                'INSIDE confirmation-dialog-container ' + (props.open ? 'confirmation-dialog-container-open' : '')
+            }>
+            <div className={'confirmation-dialog-open release-dialog'}>{children}</div>
         </div>
     );
 };


### PR DESCRIPTION
The layout has been adopted slightly.

Now:
![Screenshot from 2023-09-29 16-46-29](https://github.com/freiheit-com/kuberpult/assets/3481382/4484aad0-8bbf-4cc5-a43a-0e064f3ec11f)

Before:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/20b05862-dacf-4f0a-8ddc-9c8b63542dae)
