### PR TITLE
Add pod annotations to the rollout pod

### DIFF
--- a/charts/kuberpult/templates/_helpers.tpl
+++ b/charts/kuberpult/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "rollout-podAnnotations" }}
+{{- if .Values.datadogTracing.enabled }}
+apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-rollout-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ .Values.rollout.tag }}"}'
+{{- end }}
+{{- end }}

--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -21,6 +21,7 @@
 {{- if not (eq .Values.argocd.refreshEnabled nil) }}
 {{ fail "argocd.refreshEnabled is removed in favour of argocd.refresh.enabled"}}
 {{- end -}}
+{{- $podAnnotations := mustMergeOverwrite (dict) (include "rollout-podAnnotations" . | fromYaml ) .Values.rollout.podAnnotations -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -46,9 +47,9 @@ spec:
         tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
         tags.datadoghq.com/service: kuberpult-rollout-service
         tags.datadoghq.com/version: {{ .Values.rollout.tag }}
-      annotations:
-        apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-rollout-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ .Values.rollout.tag }}"}'
 {{- end }}
+      annotations:
+{{ $podAnnotations | toYaml | indent 8}}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -89,6 +89,7 @@ rollout:
     requests:
       cpu: 500m
       memory: 250Mi
+  podAnnotations: {}
 
 ingress:
   # The simplest setup involves an ingress, to make kuberpult available outside the cluster.

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -89,6 +89,7 @@ rollout:
     requests:
       cpu: 500m
       memory: 250Mi
+  # annotations given here will take precedence over the defaults defined in _helpers.tpl
   podAnnotations: {}
 
 ingress:


### PR DESCRIPTION
This adds a new option to the rollout service to add annotations to the pod directly. The current annotations will be used as a default and will be merge with the specified ones.