### PR TITLE
Fix: segfault in rollout service

### DIFF
--- a/services/rollout-service/pkg/service/broadcast.go
+++ b/services/rollout-service/pkg/service/broadcast.go
@@ -211,10 +211,14 @@ type BroadcastEvent struct {
 }
 
 func streamStatus(b *BroadcastEvent) *api.StreamStatusResponse {
+	version := uint64(0)
+	if b.ArgocdVersion != nil {
+		version = b.ArgocdVersion.Version
+	}
 	return &api.StreamStatusResponse{
 		Environment:   b.Environment,
 		Application:   b.Application,
-		Version:       b.ArgocdVersion.Version,
+		Version:       version,
 		RolloutStatus: b.RolloutStatus,
 	}
 }

--- a/services/rollout-service/pkg/service/broadcast_test.go
+++ b/services/rollout-service/pkg/service/broadcast_test.go
@@ -65,6 +65,7 @@ func TestBroadcast(t *testing.T) {
 		RolloutStatusSuccesful   = api.RolloutStatus_RolloutStatusSuccesful
 		RolloutStatusProgressing = api.RolloutStatus_RolloutStatusProgressing
 		RolloutStatusError       = api.RolloutStatus_RolloutStatusError
+		RolloutStatusUnknown     = api.RolloutStatus_RolloutStatusUnknown
 	)
 	type step struct {
 		ArgoEvent    *ArgoEvent
@@ -106,7 +107,20 @@ func TestBroadcast(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "missing argo app",
+			Steps: []step{
+				{
+					VersionEvent: &versions.KuberpultEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     &versions.VersionInfo{Version: 2},
+					},
 
+					ExpectStatus: &RolloutStatusUnknown,
+				},
+			},
+		},
 		{
 			Name: "app syncing and becomming healthy",
 			Steps: []step{


### PR DESCRIPTION
In case the argocd app has not been created, the rollout service currently segfaults.