### PR TITLE
Distinguish more rollout states

### DIFF
--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -369,9 +369,11 @@ Error = error
 */
 enum RolloutStatus {
   RolloutStatusUnknown = 0; // argocd didn't report anything for this app
-  RolloutStatusSuccesful = 1; // sync healthy
-  RolloutStatusProgressing = 2; // out-of-sync || 
-  RolloutStatusError = 3; // error in argocd
+  RolloutStatusSuccesful = 1; // sync succesful
+  RolloutStatusProgressing = 2; // argocd picked up the change but didn't apply it yet
+  RolloutStatusError = 3; // argocd applied the change but failed
+  RolloutStatusPending = 4; // argocd hasn't yet picked up the change
+  RolloutStatusUnhealthy = 5; // argocd applied the change succesfully, but the app is unhealthy
 }
 
 message StreamStatusResponse {

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
@@ -83,7 +83,7 @@ Copyright 2023 freiheit.com*/
     right: $release-card-inner-padding;
 }
 
-.rollout__icon_error {
+.rollout__icon_error, .rollout__icon_unhealthy {
     color: var(--mdc-theme-error);
 }
 
@@ -91,7 +91,7 @@ Copyright 2023 freiheit.com*/
     color: var(--mdc-theme-on-surface);
 }
 
-.rollout__icon_progressing {
+.rollout__icon_progressing, .rollout__icon_pending {
     color: var(--mdc-theme-secondary);
 }
 
@@ -119,14 +119,14 @@ Copyright 2023 freiheit.com*/
     border-color: var(--mdc-theme-on-secondary);
 }
 
-.rollout__description_error {
+.rollout__description_error, .rollout__description_unhealthy {
     @extend .rollout__description;
     background-color: var(--mdc-theme-error);
     color: var(--mdc-theme-on-secondary);
     border-color: var(--mdc-theme-on-secondary);
 }
 
-.rollout__description_progressing {
+.rollout__description_progressing, .rollout__description_pending {
     @extend .rollout__description;
     background-color: var(--mdc-theme-secondary);
     color: var(--mdc-theme-on-secondary);

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.scss
@@ -83,7 +83,8 @@ Copyright 2023 freiheit.com*/
     right: $release-card-inner-padding;
 }
 
-.rollout__icon_error, .rollout__icon_unhealthy {
+.rollout__icon_error,
+.rollout__icon_unhealthy {
     color: var(--mdc-theme-error);
 }
 
@@ -91,7 +92,8 @@ Copyright 2023 freiheit.com*/
     color: var(--mdc-theme-on-surface);
 }
 
-.rollout__icon_progressing, .rollout__icon_pending {
+.rollout__icon_progressing,
+.rollout__icon_pending {
     color: var(--mdc-theme-secondary);
 }
 
@@ -119,14 +121,16 @@ Copyright 2023 freiheit.com*/
     border-color: var(--mdc-theme-on-secondary);
 }
 
-.rollout__description_error, .rollout__description_unhealthy {
+.rollout__description_error,
+.rollout__description_unhealthy {
     @extend .rollout__description;
     background-color: var(--mdc-theme-error);
     color: var(--mdc-theme-on-secondary);
     border-color: var(--mdc-theme-on-secondary);
 }
 
-.rollout__description_progressing, .rollout__description_pending {
+.rollout__description_progressing,
+.rollout__description_pending {
     @extend .rollout__description;
     background-color: var(--mdc-theme-secondary);
     color: var(--mdc-theme-on-secondary);

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -108,7 +108,7 @@ const calculateDeploymentStatus = (
             ) {
                 // The rollout service might be sligthly behind the UI.
                 // In that case the
-                return { ...status, rolloutStatus: RolloutStatus.RolloutStatusProgressing };
+                return { ...status, rolloutStatus: RolloutStatus.RolloutStatusPending };
             }
             return status;
         })

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -42,8 +42,12 @@ const RolloutStatusIcon: React.FC<{ status: RolloutStatus }> = (props) => {
             return <span className="rollout__icon_successful">✓</span>;
         case RolloutStatus.RolloutStatusProgressing:
             return <span className="rollout__icon_progressing">↻</span>;
+        case RolloutStatus.RolloutStatusPending:
+            return <span className="rollout__icon_pending">⧖</span>;
         case RolloutStatus.RolloutStatusError:
             return <span className="rollout__icon_error">!</span>;
+        case RolloutStatus.RolloutStatusUnhealthy:
+            return <span className="rollout__icon_unhealthy">⚠</span>;
     }
     return <span className="rollout__icon_unknown">?</span>;
 };
@@ -55,8 +59,12 @@ const RolloutStatusDescription: React.FC<{ status: RolloutStatus }> = (props) =>
             return <span className="rollout__description_successful">✓ Done</span>;
         case RolloutStatus.RolloutStatusProgressing:
             return <span className="rollout__description_progressing">↻ In progress</span>;
+        case RolloutStatus.RolloutStatusPending:
+            return <span className="rollout__description_pending">⧖ Pending</span>;
         case RolloutStatus.RolloutStatusError:
             return <span className="rollout__description_error">! Failed</span>;
+        case RolloutStatus.RolloutStatusUnhealthy:
+            return <span className="rollout__description_unhealthy">⚠ Unhealthy</span>;
     }
     return <span className="rollout__description_unknown">? Unkwown</span>;
 };
@@ -67,6 +75,8 @@ const RolloutStatusDescription: React.FC<{ status: RolloutStatus }> = (props) =>
 const rolloutStatusPriority = [
     RolloutStatus.RolloutStatusError,
     RolloutStatus.RolloutStatusProgressing,
+    RolloutStatus.RolloutStatusUnhealthy,
+    RolloutStatus.RolloutStatusPending,
     RolloutStatus.RolloutStatusUnknown,
     RolloutStatus.RolloutStatusSuccesful,
 ];

--- a/services/rollout-service/pkg/metrics/metrics.go
+++ b/services/rollout-service/pkg/metrics/metrics.go
@@ -124,7 +124,7 @@ func (a *appState) update(ev *service.BroadcastEvent) *appState {
 		// We also need to know that something is in argocd
 		return nil
 	}
-	sc := ev.RolloutStatus == api.RolloutStatus_RolloutStatusSuccesful
+	sc := (ev.RolloutStatus == api.RolloutStatus_RolloutStatusSuccesful || ev.RolloutStatus == api.RolloutStatus_RolloutStatusUnhealthy)
 	// The environment group is the only thing that can change
 	as := a.attributes(ev)
 	return &appState{

--- a/services/rollout-service/pkg/metrics/metrics_test.go
+++ b/services/rollout-service/pkg/metrics/metrics_test.go
@@ -137,6 +137,35 @@ rollout_lag_seconds{kuberpult_application="foo",kuberpult_environment="bar",kube
 			},
 		},
 		{
+			Name: "reports no lag if the application is just unhealthy",
+			Steps: []step{
+				{
+					VersionsEvent: &versions.KuberpultEvent{
+						Application:      "foo",
+						Environment:      "bar",
+						EnvironmentGroup: "buz",
+						Version: &versions.VersionInfo{
+							Version:    2,
+							DeployedAt: time.Unix(1000, 0),
+						},
+					},
+					ArgoEvent: &service.ArgoEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version: &versions.VersionInfo{
+							Version: 2,
+						},
+						HealthStatusCode: health.HealthStatusDegraded,
+						SyncStatusCode:   v1alpha1.SyncStatusCodeUnknown,
+					},
+					ExpectedBody: `# HELP rollout_lag_seconds 
+# TYPE rollout_lag_seconds gauge
+rollout_lag_seconds{kuberpult_application="foo",kuberpult_environment="bar",kuberpult_environment_group="buz"} 0
+`,
+				},
+			},
+		},
+		{
 			Name: "removes metrics when app is removed",
 			Steps: []step{
 				{

--- a/services/rollout-service/pkg/service/broadcast_test.go
+++ b/services/rollout-service/pkg/service/broadcast_test.go
@@ -66,6 +66,8 @@ func TestBroadcast(t *testing.T) {
 		RolloutStatusProgressing = api.RolloutStatus_RolloutStatusProgressing
 		RolloutStatusError       = api.RolloutStatus_RolloutStatusError
 		RolloutStatusUnknown     = api.RolloutStatus_RolloutStatusUnknown
+		RolloutStatusUnhealthy   = api.RolloutStatus_RolloutStatusUnhealthy
+		RolloutStatusPending     = api.RolloutStatus_RolloutStatusPending
 	)
 	type step struct {
 		ArgoEvent    *ArgoEvent
@@ -193,7 +195,7 @@ func TestBroadcast(t *testing.T) {
 						HealthStatusCode: health.HealthStatusDegraded,
 					},
 
-					ExpectStatus: &RolloutStatusError,
+					ExpectStatus: &RolloutStatusUnhealthy,
 				},
 				{
 					ArgoEvent: &ArgoEvent{
@@ -247,7 +249,7 @@ func TestBroadcast(t *testing.T) {
 			},
 		},
 		{
-			Name: "healthy app switches to progressing when a new version in kuberpult is deployed",
+			Name: "healthy app switches to pending when a new version in kuberpult is deployed",
 			Steps: []step{
 				{
 					ArgoEvent: &ArgoEvent{
@@ -267,7 +269,7 @@ func TestBroadcast(t *testing.T) {
 						Version:     &versions.VersionInfo{Version: 2},
 					},
 
-					ExpectStatus: &RolloutStatusProgressing,
+					ExpectStatus: &RolloutStatusPending,
 				},
 				{
 					ArgoEvent: &ArgoEvent{

--- a/services/rollout-service/pkg/versions/versions_test.go
+++ b/services/rollout-service/pkg/versions/versions_test.go
@@ -331,10 +331,10 @@ func TestVersionClientStream(t *testing.T) {
 			},
 			ExpectedEvents: []KuberpultEvent{
 				{
-					Environment: "staging",
-					Application: "foo",
+					Environment:      "staging",
+					Application:      "foo",
 					EnvironmentGroup: "staging-group",
-					Version:     &VersionInfo{Version: 1, DeployedAt: time.Unix(123456789, 0).UTC()},
+					Version:          &VersionInfo{Version: 1, DeployedAt: time.Unix(123456789, 0).UTC()},
 				},
 			},
 		},
@@ -353,16 +353,16 @@ func TestVersionClientStream(t *testing.T) {
 			},
 			ExpectedEvents: []KuberpultEvent{
 				{
-					Environment: "staging",
-					Application: "foo",
+					Environment:      "staging",
+					Application:      "foo",
 					EnvironmentGroup: "staging-group",
-					Version:     &VersionInfo{Version: 1, DeployedAt: time.Unix(123456789, 0).UTC()},
+					Version:          &VersionInfo{Version: 1, DeployedAt: time.Unix(123456789, 0).UTC()},
 				},
 				{
-					Environment: "staging",
-					Application: "foo",
+					Environment:      "staging",
+					Application:      "foo",
 					EnvironmentGroup: "staging-group",
-					Version:     &VersionInfo{},
+					Version:          &VersionInfo{},
 				},
 			},
 		},
@@ -381,16 +381,16 @@ func TestVersionClientStream(t *testing.T) {
 			},
 			ExpectedEvents: []KuberpultEvent{
 				{
-					Environment: "staging",
-					Application: "foo",
+					Environment:      "staging",
+					Application:      "foo",
 					EnvironmentGroup: "staging-group",
-					Version:     &VersionInfo{Version: 1, DeployedAt: time.Unix(123456789, 0).UTC()},
+					Version:          &VersionInfo{Version: 1, DeployedAt: time.Unix(123456789, 0).UTC()},
 				},
-		  		{
-					Environment: "staging",
-					Application: "foo",
+				{
+					Environment:      "staging",
+					Application:      "foo",
 					EnvironmentGroup: "not-staging-group",
-					Version:     &VersionInfo{Version: 2, DeployedAt: time.Unix(123456789, 0).UTC()},
+					Version:          &VersionInfo{Version: 2, DeployedAt: time.Unix(123456789, 0).UTC()},
 				},
 			},
 		},


### PR DESCRIPTION
When looking at the rollout_lag metrics, I noticed that they sometimes jump from zero to several days and back to zero. I inspected this and it turned out that these apps are just becoming unhealthy and recover. In that case the rollout_lag should not go up again. In order to solve this, I added two more intermediate states to the rollout states.

- `progressing` ( = change not applied yet ) is split up into `progressing` ( = argocd is working on it ) and `pending` ( = argocd has not picked it up yet )
- `error` ( = something failed ) is split up into `error` ( = sync failed ) and `unhealthy` ( = health is degraded )

