### PR TITLE
Fix: Allow locks for groups with azure enabled

### DIFF
--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -113,7 +113,8 @@ func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfu
 	// Skip azure authentication with ID for `/` (POST: createEnv), `/release`, `/releasetrain` and `/locks`  endpoints. The requests will be validated with pgp signature
 	// usage in requests from outside the cluster (e.g. by GitHub Actions and the publish.sh script).
 	group, tail := xpath.Shift(req.URL.Path)
-	if group == "environments" {
+
+	if group == "environments" || group == "environment-groups" {
 		envName, tail := xpath.Shift(tail)
 		if envName != "" { // We shouldn't receive an empty env, added just as a second layer of validation
 			function, tail := xpath.Shift(tail)

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -99,7 +99,7 @@ func ValidateToken(jwtB64 string, jwks *keyfunc.JWKS, clientId string, tenantId 
 
 func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfunc.JWKS, clientId string, tenantId string, allowedPaths []string, allowedPrefixes []string) error {
 	token := req.Header.Get("authorization")
-	if ShouldAllowRequest(allowedPaths, req.URL.Path, req.Method, allowedPrefixes) {
+	if AllowBypassingAzureAuth(allowedPaths, req.URL.Path, req.Method, allowedPrefixes) {
 		return nil
 	}
 	claims, err := ValidateToken(token, jwks, clientId, tenantId)
@@ -114,7 +114,7 @@ func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfu
 	return err
 }
 
-func ShouldAllowRequest(allowedPaths []string, requestUrlPath string, requestMethod string, allowedPrefixes []string) bool {
+func AllowBypassingAzureAuth(allowedPaths []string, requestUrlPath string, requestMethod string, allowedPrefixes []string) bool {
 	for _, allowedPath := range allowedPaths {
 		if requestUrlPath == allowedPath {
 			return true
@@ -130,7 +130,6 @@ func ShouldAllowRequest(allowedPaths []string, requestUrlPath string, requestMet
 	// usage in requests from outside the cluster (e.g. by GitHub Actions and the publish.sh script).
 	group, tail := xpath.Shift(requestUrlPath)
 
-	//if group == "environments" {
 	if group == "environments" || group == "environment-groups" {
 		envName, tail := xpath.Shift(tail)
 		if envName != "" { // We shouldn't receive an empty env, added just as a second layer of validation

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -99,36 +99,8 @@ func ValidateToken(jwtB64 string, jwks *keyfunc.JWKS, clientId string, tenantId 
 
 func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfunc.JWKS, clientId string, tenantId string, allowedPaths []string, allowedPrefixes []string) error {
 	token := req.Header.Get("authorization")
-	for _, allowedPath := range allowedPaths {
-		if req.URL.Path == allowedPath {
-			return nil
-		}
-	}
-	for _, allowedPrefix := range allowedPrefixes {
-		if strings.HasPrefix(req.URL.Path, allowedPrefix) {
-			return nil
-		}
-	}
-
-	// Skip azure authentication with ID for `/` (POST: createEnv), `/release`, `/releasetrain` and `/locks`  endpoints. The requests will be validated with pgp signature
-	// usage in requests from outside the cluster (e.g. by GitHub Actions and the publish.sh script).
-	group, tail := xpath.Shift(req.URL.Path)
-
-	if group == "environments" || group == "environment-groups" {
-		envName, tail := xpath.Shift(tail)
-		if envName != "" { // We shouldn't receive an empty env, added just as a second layer of validation
-			function, tail := xpath.Shift(tail)
-			switch function {
-			case "locks":
-				return nil
-			case "releasetrain":
-				return nil
-			case "": // create environment
-				if tail == "/" && req.Method == http.MethodPost {
-					return nil
-				}
-			}
-		}
+	if ShouldAllowRequest(allowedPaths, req.URL.Path, req.Method, allowedPrefixes) {
+		return nil
 	}
 	claims, err := ValidateToken(token, jwks, clientId, tenantId)
 	if _, ok := claims["aud"]; ok && claims["aud"] == clientId {
@@ -140,4 +112,40 @@ func HttpAuthMiddleWare(resp http.ResponseWriter, req *http.Request, jwks *keyfu
 		resp.Write([]byte("Invalid authorization header provided"))
 	}
 	return err
+}
+
+func ShouldAllowRequest(allowedPaths []string, requestUrlPath string, requestMethod string, allowedPrefixes []string) bool {
+	for _, allowedPath := range allowedPaths {
+		if requestUrlPath == allowedPath {
+			return true
+		}
+	}
+	for _, allowedPrefix := range allowedPrefixes {
+		if strings.HasPrefix(requestUrlPath, allowedPrefix) {
+			return true
+		}
+	}
+
+	// Skip azure authentication with ID for `/` (POST: createEnv), `/release`, `/releasetrain` and `/locks`  endpoints. The requests will be validated with pgp signature
+	// usage in requests from outside the cluster (e.g. by GitHub Actions and the publish.sh script).
+	group, tail := xpath.Shift(requestUrlPath)
+
+	//if group == "environments" {
+	if group == "environments" || group == "environment-groups" {
+		envName, tail := xpath.Shift(tail)
+		if envName != "" { // We shouldn't receive an empty env, added just as a second layer of validation
+			function, tail := xpath.Shift(tail)
+			switch function {
+			case "locks":
+				return true
+			case "releasetrain":
+				return true
+			case "": // create environment
+				if tail == "/" && requestMethod == http.MethodPost {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/pkg/auth/azure_test.go
+++ b/pkg/auth/azure_test.go
@@ -398,3 +398,74 @@ func TestHttpMiddleware(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldAllowRequest(t *testing.T) {
+	tcs := []struct {
+		Name            string
+		allowedPaths    []string
+		requestUrlPath  string
+		requestMethod   string
+		allowedPrefixes []string
+		expectedResult  bool
+	}{
+		{
+			Name:            "Bugfix env group locks",
+			allowedPaths:    nil,
+			requestUrlPath:  "environment-groups/dev/locks/mylock123",
+			requestMethod:   "POST",
+			allowedPrefixes: nil,
+			expectedResult:  true,
+		},
+		{
+			Name:            "env locks",
+			allowedPaths:    nil,
+			requestUrlPath:  "environments/dev/locks/mylock123",
+			requestMethod:   "POST",
+			allowedPrefixes: nil,
+			expectedResult:  true,
+		},
+		{
+			Name:            "allowed path succeeds",
+			allowedPaths:    []string{"foo/bar"},
+			requestUrlPath:  "foo/bar",
+			requestMethod:   "POST",
+			allowedPrefixes: nil,
+			expectedResult:  true,
+		},
+		{
+			Name:            "allowed path fails",
+			allowedPaths:    []string{"bar/foo"},
+			requestUrlPath:  "foo/bar",
+			requestMethod:   "POST",
+			allowedPrefixes: nil,
+			expectedResult:  false,
+		},
+		{
+			Name:            "allowed prefix succeeds",
+			allowedPaths:    nil,
+			requestUrlPath:  "foo/bar",
+			requestMethod:   "POST",
+			allowedPrefixes: []string{"foo"},
+			expectedResult:  true,
+		},
+		{
+			Name:            "allowed prefix fails",
+			allowedPaths:    nil,
+			requestUrlPath:  "foo/bar",
+			requestMethod:   "POST",
+			allowedPrefixes: []string{"bar"},
+			expectedResult:  false,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			actualResult := ShouldAllowRequest(tc.allowedPaths, tc.requestUrlPath, tc.requestMethod, tc.allowedPrefixes)
+			if actualResult != tc.expectedResult {
+				t.Errorf("Expected %v but got %v", tc.expectedResult, actualResult)
+			}
+		})
+	}
+}

--- a/pkg/auth/azure_test.go
+++ b/pkg/auth/azure_test.go
@@ -399,7 +399,7 @@ func TestHttpMiddleware(t *testing.T) {
 	}
 }
 
-func TestShouldAllowRequest(t *testing.T) {
+func TestAllowBypassingAzureAuth(t *testing.T) {
 	tcs := []struct {
 		Name            string
 		allowedPaths    []string
@@ -462,7 +462,7 @@ func TestShouldAllowRequest(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			actualResult := ShouldAllowRequest(tc.allowedPaths, tc.requestUrlPath, tc.requestMethod, tc.allowedPrefixes)
+			actualResult := AllowBypassingAzureAuth(tc.allowedPaths, tc.requestUrlPath, tc.requestMethod, tc.allowedPrefixes)
 			if actualResult != tc.expectedResult {
 				t.Errorf("Expected %v but got %v", tc.expectedResult, actualResult)
 			}


### PR DESCRIPTION
When azure was enabled in the helm chart, it was not possible to make REST calls to create locks for environment groups.
This was fixed. The REST call for locks to environments were not effected.
