### PR TITLE
Fix: ReleaseDialog renders many environments

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -14,6 +14,8 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 .release-dialog {
+    min-width: 960px;
+
     a {
         color: white;
     }
@@ -66,6 +68,7 @@ Copyright 2023 freiheit.com*/
     }
 
     .release-env-group-list {
+        overflow-y: scroll;
         background-color: var(--mdc-theme-surface);
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
Now:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/0290e5d0-3a51-4106-bce6-609860d647a0)

Before:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/04a6b460-db46-41b9-83e9-72d874adc3f1)

This fixes https://github.com/freiheit-com/kuberpult/issues/987
