### PR TITLE
Make it easier to run integration tests locally

### DIFF
--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -337,8 +337,8 @@ done
 
 if "$LOCAL_EXECUTION"
 then
-  echo "sleeping for 1h to allow debugging"
-  sleep 1h
+  echo "hit ctrl+c to stop"
+  read -r -d '' _ </dev/tty
 else
   echo "done. Kind cluster is up and kuberpult and argoCd are running."
 fi

--- a/tests/integration-tests/.gitignore
+++ b/tests/integration-tests/.gitignore
@@ -1,0 +1,1 @@
+.run-number

--- a/tests/integration-tests/main_test.go
+++ b/tests/integration-tests/main_test.go
@@ -1,5 +1,4 @@
-/*
-This file is part of kuberpult.
+/*This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -13,8 +12,7 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright 2023 freiheit.com
-*/
+Copyright 2023 freiheit.com*/
 package integration_tests
 
 import (

--- a/tests/integration-tests/main_test.go
+++ b/tests/integration-tests/main_test.go
@@ -1,0 +1,74 @@
+/*
+This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com
+*/
+package integration_tests
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+)
+
+
+var runNumber uint64
+// The appSuffix is a unique string consisting of only characters that are valid app names.
+// This is used to make tests repeatable.
+var appSuffix string
+
+func base26(i uint64) string {
+	result := ""
+	if i == 0 {
+		return "a"
+	}
+	for i > 0 {
+		rem := i % 26
+		i = i / 26
+		result = string(rune('a'+rem)) + result
+	}
+	return result
+}
+
+func calculateRunNumber() error {
+	content, err := os.ReadFile(".run-number")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			content = []byte("0")
+		} else {
+			return err
+		}
+	}
+	nr, err := strconv.ParseUint(string(content), 10, 64)
+	if err != nil {
+		return err
+	}
+	nextRun := nr + 1
+	os.WriteFile(".run-number", []byte(fmt.Sprintf("%d", nextRun)), 0644)
+	runNumber = nr
+	appSuffix = base26(runNumber)
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	err := calculateRunNumber()
+	if err != nil {
+		fmt.Printf("%s", err)
+		os.Exit(2)
+	}
+	os.Exit(m.Run())
+}

--- a/tests/integration-tests/main_test.go
+++ b/tests/integration-tests/main_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 
-var runNumber uint64
 // The appSuffix is a unique string consisting of only characters that are valid app names.
 // This is used to make tests repeatable.
 var appSuffix string
@@ -42,7 +41,8 @@ func base26(i uint64) string {
 	return result
 }
 
-func calculateRunNumber() error {
+// The app suffix is calculate by storing a counter in a file called .run-number.
+func calculateAppSuffix() error {
 	content, err := os.ReadFile(".run-number")
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -57,13 +57,12 @@ func calculateRunNumber() error {
 	}
 	nextRun := nr + 1
 	os.WriteFile(".run-number", []byte(fmt.Sprintf("%d", nextRun)), 0644)
-	runNumber = nr
-	appSuffix = base26(runNumber)
+	appSuffix = base26(nr)
 	return nil
 }
 
 func TestMain(m *testing.M) {
-	err := calculateRunNumber()
+	err := calculateAppSuffix()
 	if err != nil {
 		fmt.Printf("%s", err)
 		os.Exit(2)


### PR DESCRIPTION
I increased the run-kind timeout to infinity and I made the integration tests repeatable locally.