### PR TITLE
Added the first two endpoints for the repository service

### DIFF
--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -191,6 +191,10 @@ $(sed -e "s/^/        /" <../../services/cd-service/known_hosts)
   cm:
     accounts.kuberpult: apiKey
     timeout.reconciliation: 0s
+  params:
+    controller.repo.server.plaintext: "true"
+    server.repo.server.plaintext: "true"
+    repo.server: kuberpult-cd-service:8443
   rbac:
     policy.csv: |
       p, role:kuberpult, applications, get, */*, allow

--- a/go.mod
+++ b/go.mod
@@ -134,6 +134,7 @@ require (
 	github.com/DataDog/go-tuf v1.0.2-0.5.2 // indirect
 	github.com/DataDog/sketches-go v1.4.2 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -152,6 +153,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-github/v53 v53.0.0 // indirect
+	github.com/google/go-jsonnet v0.20.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/uuid v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d h1:WtAMR0fPCOfK7TPGZ8ZpLLY18HRvL7XJ3xcs0wnREgo=
+github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d/go.mod h1:WML6KOYjeU8N6YyusMjj2qRvaPNUEvrQvaxuFcMRFJY=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ=
 github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
@@ -493,6 +495,8 @@ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v53 v53.0.0 h1:T1RyHbSnpHYnoF0ZYKiIPSgPtuJ8G6vgc0MKodXsQDQ=
 github.com/google/go-github/v53 v53.0.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
+github.com/google/go-jsonnet v0.20.0 h1:WG4TTSARuV7bSm4PMB4ohjxe33IHT5WVTrJSU33uT4g=
+github.com/google/go-jsonnet v0.20.0/go.mod h1:VbgWF9JX7ztlv770x/TolZNGGFfiHEVx9G6ca2eUmeA=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -701,6 +705,7 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/malexdev/utfutil v0.0.0-20180510171754-00c8d4a8e7a8 h1:A6SLdFpRzUUF5v9F/7T1fu3DERmOCgTwwP6x54eyFfU=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/services/cd-service/Makefile
+++ b/services/cd-service/Makefile
@@ -130,3 +130,9 @@ publish: release
 .PHONY: get-builder-image
 get-builder-image:
 	@echo "$(KUBERPULT_BUILDER)"
+
+kind-load: docker
+	kind load docker-image "$(IMAGENAME)"
+
+patch-kind: kind-load
+	kubectl set image deployment/kuberpult-cd-service service=$(IMAGENAME)

--- a/services/cd-service/pkg/argocd/reposerver/reposerver.go
+++ b/services/cd-service/pkg/argocd/reposerver/reposerver.go
@@ -1,0 +1,179 @@
+package reposerver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	argorepo "github.com/argoproj/argo-cd/v2/reposerver/apiclient"
+	"github.com/argoproj/argo-cd/v2/util/argo"
+	"github.com/argoproj/gitops-engine/pkg/utils/kube"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
+	"github.com/go-git/go-billy/v5/util"
+	git "github.com/libgit2/git2go/v34"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type reposerver struct {
+	repo   repository.Repository
+	config repository.RepositoryConfig
+}
+
+var resourceTracking argo.ResourceTracking = argo.NewResourceTracking()
+var notImplemented error = status.Error(codes.Unimplemented, "not implemented")
+
+// GenerateManifest implements apiclient.RepoServerServiceServer.
+func (r *reposerver) GenerateManifest(ctx context.Context, req *argorepo.ManifestRequest) (*argorepo.ManifestResponse, error) {
+	state, _, err := r.resolve(req.Revision)
+	if err != nil {
+		return nil, err
+	}
+	bfs := state.Filesystem
+	path := req.ApplicationSource.Path
+	mn := []string{}
+	err = util.Walk(bfs, path, func(file string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			m, err := util.ReadFile(bfs, file)
+			if err != nil {
+				return fmt.Errorf("reading %s: %w", file, err)
+			}
+			parts, err := kube.SplitYAML(m)
+			if err != nil {
+				return err
+			}
+			for _, obj := range parts {
+				if req.AppLabelKey != "" && req.AppName != "" && !kube.IsCRD(obj) {
+					err = resourceTracking.SetAppInstance(obj, req.AppLabelKey, req.AppName, req.Namespace, v1alpha1.TrackingMethod(req.TrackingMethod))
+					if err != nil {
+						return err
+					}
+				}
+				jsonData, err := json.Marshal(obj.Object)
+				if err != nil {
+					return err
+				}
+				mn = append(mn, string(jsonData))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	resp := &argorepo.ManifestResponse{
+		Manifests:  mn,
+		Revision:   state.Commit.Id().String(),
+		SourceType: "Directory",
+	}
+	return resp, nil
+}
+
+// GenerateManifestWithFiles implements apiclient.RepoServerServiceServer.
+func (*reposerver) GenerateManifestWithFiles(argorepo.RepoServerService_GenerateManifestWithFilesServer) error {
+	return notImplemented
+}
+
+// GetAppDetails implements apiclient.RepoServerServiceServer.
+func (*reposerver) GetAppDetails(context.Context, *argorepo.RepoServerAppDetailsQuery) (*argorepo.RepoAppDetailsResponse, error) {
+	return nil, notImplemented
+}
+
+// GetHelmCharts implements apiclient.RepoServerServiceServer.
+func (*reposerver) GetHelmCharts(context.Context, *argorepo.HelmChartsRequest) (*argorepo.HelmChartsResponse, error) {
+	return nil, notImplemented
+}
+
+// GetRevisionMetadata implements apiclient.RepoServerServiceServer.
+func (*reposerver) GetRevisionMetadata(context.Context, *argorepo.RepoServerRevisionMetadataRequest) (*v1alpha1.RevisionMetadata, error) {
+	return nil, notImplemented
+}
+
+// ListApps implements apiclient.RepoServerServiceServer.
+func (*reposerver) ListApps(context.Context, *argorepo.ListAppsRequest) (*argorepo.AppList, error) {
+	return nil, notImplemented
+}
+
+// ListPlugins implements apiclient.RepoServerServiceServer.
+func (*reposerver) ListPlugins(context.Context, *emptypb.Empty) (*argorepo.PluginList, error) {
+	return nil, notImplemented
+}
+
+// ListRefs implements apiclient.RepoServerServiceServer.
+func (*reposerver) ListRefs(context.Context, *argorepo.ListRefsRequest) (*argorepo.Refs, error) {
+	return nil, notImplemented
+}
+
+// ResolveRevision implements apiclient.RepoServerServiceServer.
+func (r *reposerver) ResolveRevision(ctx context.Context, req *argorepo.ResolveRevisionRequest) (*argorepo.ResolveRevisionResponse, error) {
+	state, oid, err := r.resolve(req.AmbiguousRevision)
+	if err != nil {
+		// This looks a bit strange but argocd actually responds with a succes response if the ambiguous ref can be parsed as a git commit id even if that commit does not exists at all.
+		if serr, ok := status.FromError(err); ok && serr.Code() == codes.NotFound && oid != nil {
+			return &argorepo.ResolveRevisionResponse{
+				Revision:          oid.String(),
+				AmbiguousRevision: fmt.Sprintf("%s (%s)", req.AmbiguousRevision, oid),
+			}, nil
+		}
+		return nil, err
+	}
+	resp := argorepo.ResolveRevisionResponse{
+		Revision:          state.Commit.Id().String(),
+		AmbiguousRevision: fmt.Sprintf("%s (%s)", req.AmbiguousRevision, state.Commit.Id()),
+	}
+	return &resp, nil
+}
+
+func (r *reposerver) resolve(rev string) (*repository.State, *git.Oid, error) {
+	var oid *git.Oid
+	if o, err := git.NewOid(rev); err == nil {
+		oid = o
+	} else if rev != "HEAD" && rev != r.config.Branch {
+		return nil, nil, status.Error(codes.NotFound, fmt.Sprintf("unknown revision %q, I only know \"HEAD\", %q and commit hashes", rev, r.config.Branch))
+	}
+	state, err := r.repo.StateAt(oid)
+	if err != nil {
+		var gerr *git.GitError
+		if errors.As(err, &gerr) {
+			if gerr.Code == git.ErrorCodeNotFound {
+
+				return nil, oid, status.Error(codes.NotFound, fmt.Sprintf("unknown revision %q, I only know \"HEAD\", %q and commit hashes", rev, r.config.Branch))
+			}
+		}
+		return nil, oid, status.Error(codes.Internal, fmt.Sprintf("internal error: %s", err))
+	}
+	return state, oid, nil
+}
+
+// TestRepository implements apiclient.RepoServerServiceServer.
+func (*reposerver) TestRepository(context.Context, *argorepo.TestRepositoryRequest) (*argorepo.TestRepositoryResponse, error) {
+	return nil, notImplemented
+}
+
+func (*reposerver) GetGitDirectories(context.Context, *argorepo.GitDirectoriesRequest) (*argorepo.GitDirectoriesResponse, error) {
+	return nil, notImplemented
+}
+
+func (*reposerver) GetGitFiles(context.Context, *argorepo.GitFilesRequest) (*argorepo.GitFilesResponse, error) {
+	return nil, notImplemented
+}
+
+func (*reposerver) GetRevisionChartDetails(context.Context, *argorepo.RepoServerRevisionChartDetailsRequest) (*v1alpha1.ChartDetails, error) {
+	return nil, notImplemented
+}
+
+func New(repo repository.Repository, config repository.RepositoryConfig) argorepo.RepoServerServiceServer {
+	return &reposerver{repo, config}
+}
+
+func Register(s *grpc.Server, repo repository.Repository, config repository.RepositoryConfig) {
+	argorepo.RegisterRepoServerServiceServer(s, New(repo, config))
+}

--- a/services/cd-service/pkg/argocd/reposerver/reposerver.go
+++ b/services/cd-service/pkg/argocd/reposerver/reposerver.go
@@ -1,3 +1,19 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
 package reposerver
 
 import (

--- a/services/cd-service/pkg/argocd/reposerver/reposerver_test.go
+++ b/services/cd-service/pkg/argocd/reposerver/reposerver_test.go
@@ -227,7 +227,7 @@ func TestGenerateManifest(t *testing.T) {
 				}
 			} else {
 				if err.Error() != tc.ExpectedArgoError {
-					t.Fatalf("got wrong error, expected %q but got %q", tc.ExpectedArgoError, err)
+					t.Fatalf("got wrong error, expected %q but got %q, diff: %s", tc.ExpectedArgoError, err, cmp.Diff(tc.ExpectedArgoError, err.Error()))
 				}
 			}
 		})

--- a/services/cd-service/pkg/argocd/reposerver/reposerver_test.go
+++ b/services/cd-service/pkg/argocd/reposerver/reposerver_test.go
@@ -1,0 +1,398 @@
+package reposerver
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+
+	v1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	argorepo "github.com/argoproj/argo-cd/v2/reposerver/apiclient"
+	"github.com/argoproj/argo-cd/v2/reposerver/cache"
+	"github.com/argoproj/argo-cd/v2/reposerver/metrics"
+	argosrv "github.com/argoproj/argo-cd/v2/reposerver/repository"
+	"github.com/argoproj/argo-cd/v2/util/argo"
+	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
+	"github.com/argoproj/argo-cd/v2/util/git"
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/config"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+var createOneAppInDevelopment []repository.Transformer = []repository.Transformer{
+	&repository.CreateEnvironment{
+		Environment: "development",
+		Config: config.EnvironmentConfig{
+			Upstream: &config.EnvironmentConfigUpstream{
+				Latest: true,
+			},
+		},
+	},
+	&repository.CreateApplicationVersion{
+		Application: "app",
+		Manifests: map[string]string{
+			"development": `
+api: v1
+kind: ConfigMap
+metadata:
+  name: something
+  namespace: something
+data:
+  key: value
+---
+api: v1
+kind: ConfigMap
+metadata:
+  name: somethingelse
+  namespace: somethingelse
+data:
+  key: value
+`,
+		},
+	},
+}
+
+func TestGenerateManifest(t *testing.T) {
+	tcs := []struct {
+		Name              string
+		Setup             []repository.Transformer
+		Request           *argorepo.ManifestRequest
+		ExpectedResponse  *argorepo.ManifestResponse
+		ExpectedError     string
+		ExpectedArgoError string
+	}{
+		{
+			Name:  "generates a manifest for HEAD",
+			Setup: createOneAppInDevelopment,
+			Request: &argorepo.ManifestRequest{
+				Revision: "HEAD",
+				Repo: &v1alpha1.Repository{
+					Repo: "<the-repo-url>",
+				},
+				ApplicationSource: &v1alpha1.ApplicationSource{
+					Path: "environments/development/applications/app/manifests",
+				},
+			},
+
+			ExpectedResponse: &argorepo.ManifestResponse{
+				Manifests: []string{
+					`{"api":"v1","data":{"key":"value"},"kind":"ConfigMap","metadata":{"name":"something","namespace":"something"}}`,
+					`{"api":"v1","data":{"key":"value"},"kind":"ConfigMap","metadata":{"name":"somethingelse","namespace":"somethingelse"}}`,
+				},
+				SourceType: "Directory",
+			},
+		},
+		{
+			Name:  "generates a manifest for the branch itself",
+			Setup: createOneAppInDevelopment,
+			Request: &argorepo.ManifestRequest{
+				Revision: "master",
+				Repo: &v1alpha1.Repository{
+					Repo: "<the-repo-url>",
+				},
+				ApplicationSource: &v1alpha1.ApplicationSource{
+					Path: "environments/development/applications/app/manifests",
+				},
+			},
+
+			ExpectedResponse: &argorepo.ManifestResponse{
+				Manifests: []string{
+					`{"api":"v1","data":{"key":"value"},"kind":"ConfigMap","metadata":{"name":"something","namespace":"something"}}`,
+					`{"api":"v1","data":{"key":"value"},"kind":"ConfigMap","metadata":{"name":"somethingelse","namespace":"somethingelse"}}`,
+				},
+				SourceType: "Directory",
+			},
+		},
+		{
+			Name:  "generates a manifest for a fixed commit id",
+			Setup: createOneAppInDevelopment,
+			Request: &argorepo.ManifestRequest{
+				Revision: "<last-commit-id>",
+				Repo: &v1alpha1.Repository{
+					Repo: "<the-repo-url>",
+				},
+				ApplicationSource: &v1alpha1.ApplicationSource{
+					Path: "environments/development/applications/app/manifests",
+				},
+			},
+
+			ExpectedResponse: &argorepo.ManifestResponse{
+				Manifests: []string{
+					`{"api":"v1","data":{"key":"value"},"kind":"ConfigMap","metadata":{"name":"something","namespace":"something"}}`,
+					`{"api":"v1","data":{"key":"value"},"kind":"ConfigMap","metadata":{"name":"somethingelse","namespace":"somethingelse"}}`,
+				},
+				SourceType: "Directory",
+			},
+		},
+		{
+			Name:  "rejectes unknown refs",
+			Setup: createOneAppInDevelopment,
+			Request: &argorepo.ManifestRequest{
+				Revision: "not-our-branch",
+				Repo: &v1alpha1.Repository{
+					Repo: "<the-repo-url>",
+				},
+				ApplicationSource: &v1alpha1.ApplicationSource{
+					Path: "environments/development/applications/app/manifests",
+				},
+			},
+
+			ExpectedArgoError: "Unable to resolve 'not-our-branch' to a commit SHA",
+			ExpectedError:     "rpc error: code = NotFound desc = unknown revision \"not-our-branch\", I only know \"HEAD\", \"master\" and commit hashes",
+		},
+		{
+			Name:  "rejectes unknown commit ids",
+			Setup: createOneAppInDevelopment,
+			Request: &argorepo.ManifestRequest{
+				Revision: "b551320bc327abfabf9df32ee5a830f8ccb1e88d",
+				Repo: &v1alpha1.Repository{
+					Repo: "<the-repo-url>",
+				},
+				ApplicationSource: &v1alpha1.ApplicationSource{
+					Path: "environments/development/applications/app/manifests",
+				},
+			},
+
+			ExpectedArgoError: "rpc error: code = Internal desc = Failed to checkout revision b551320bc327abfabf9df32ee5a830f8ccb1e88d: `git fetch origin b551320bc327abfabf9df32ee5a830f8ccb1e88d --tags --force --prune` failed exit status 128: fatal: git upload-pack: not our ref b551320bc327abfabf9df32ee5a830f8ccb1e88d\nfatal: remote error: upload-pack: not our ref b551320bc327abfabf9df32ee5a830f8ccb1e88d",
+			ExpectedError:     "rpc error: code = NotFound desc = unknown revision \"b551320bc327abfabf9df32ee5a830f8ccb1e88d\", I only know \"HEAD\", \"master\" and commit hashes",
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			repo, cfg := testRepository(t)
+			err := repo.Apply(testutil.MakeTestContext(), tc.Setup...)
+			if err != nil {
+				t.Fatalf("failed setup: %s", err)
+			}
+			// These two values change every run:
+			if tc.Request.Repo.Repo == "<the-repo-url>" {
+				tc.Request.Repo.Repo = cfg.URL
+			}
+			if tc.Request.Revision == "<last-commit-id>" {
+
+				tc.Request.Revision = repo.State().Commit.Id().String()
+			}
+			if tc.ExpectedResponse != nil {
+				tc.ExpectedResponse.Revision = repo.State().Commit.Id().String()
+			}
+
+			srv := New(repo, cfg)
+			resp, err := srv.GenerateManifest(context.Background(), tc.Request)
+			if tc.ExpectedError == "" {
+				if err != nil {
+					t.Fatalf("expected no error, but got %q", err)
+				}
+
+				d := cmp.Diff(resp, tc.ExpectedResponse, protocmp.Transform())
+				if d != "" {
+					t.Errorf("unexpected response: %s", d)
+				}
+			} else {
+				if err.Error() != tc.ExpectedError {
+					t.Errorf("got wrong error, expected %q but got %q", tc.ExpectedError, err.Error())
+				}
+			}
+			asrv := testArgoServer(t)
+			aresp, err := asrv.GenerateManifest(context.Background(), tc.Request)
+			if tc.ExpectedError == "" {
+				if err != nil {
+					t.Fatalf("expected no error, but got %q", err)
+				}
+
+				d := cmp.Diff(aresp, tc.ExpectedResponse, protocmp.Transform())
+				if d != "" {
+					t.Errorf("unexpected response: %s", d)
+				}
+			} else {
+				if err.Error() != tc.ExpectedArgoError {
+					t.Fatalf("got wrong error, expected %q but got %q", tc.ExpectedArgoError, err)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveRevision(t *testing.T) {
+	tcs := []struct {
+		Name              string
+		Setup             []repository.Transformer
+		Request           *argorepo.ResolveRevisionRequest
+		ExpectedError     string
+		ExpectedArgoError string
+	}{
+		{
+			Name:  "resolves HEAD",
+			Setup: createOneAppInDevelopment,
+			Request: &argorepo.ResolveRevisionRequest{
+				App: &v1alpha1.Application{
+					Spec: v1alpha1.ApplicationSpec{},
+				},
+				Repo: &v1alpha1.Repository{
+					Repo: "<the-repo-url>",
+				},
+				AmbiguousRevision: "HEAD",
+			},
+		},
+		{
+			Name:  "resolves master",
+			Setup: createOneAppInDevelopment,
+			Request: &argorepo.ResolveRevisionRequest{
+				App: &v1alpha1.Application{
+					Spec: v1alpha1.ApplicationSpec{},
+				},
+				Repo: &v1alpha1.Repository{
+					Repo: "<the-repo-url>",
+				},
+				AmbiguousRevision: "master",
+			},
+		},
+		{
+			Name:  "resolves a commit id",
+			Setup: createOneAppInDevelopment,
+			Request: &argorepo.ResolveRevisionRequest{
+				App: &v1alpha1.Application{
+					Spec: v1alpha1.ApplicationSpec{},
+				},
+				Repo: &v1alpha1.Repository{
+					Repo: "<the-repo-url>",
+				},
+				AmbiguousRevision: "<last-commit-id>",
+			},
+		},
+		{
+			Name:  "rejects an unknown branch",
+			Setup: createOneAppInDevelopment,
+			Request: &argorepo.ResolveRevisionRequest{
+				App: &v1alpha1.Application{
+					Spec: v1alpha1.ApplicationSpec{},
+				},
+				Repo: &v1alpha1.Repository{
+					Repo: "<the-repo-url>",
+				},
+				AmbiguousRevision: "not-our-branch",
+			},
+
+			ExpectedError: "rpc error: code = NotFound desc = unknown revision \"not-our-branch\", I only know \"HEAD\", \"master\" and commit hashes",
+
+			ExpectedArgoError: "Unable to resolve 'not-our-branch' to a commit SHA",
+		},
+		{
+			Name:  "accepts unknown commit ids",
+			Setup: createOneAppInDevelopment,
+			Request: &argorepo.ResolveRevisionRequest{
+				App: &v1alpha1.Application{
+					Spec: v1alpha1.ApplicationSpec{},
+				},
+				Repo: &v1alpha1.Repository{
+					Repo: "<the-repo-url>",
+				},
+				AmbiguousRevision: "b551320bc327abfabf9df32ee5a830f8ccb1e88d",
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			repo, cfg := testRepository(t)
+			err := repo.Apply(testutil.MakeTestContext(), tc.Setup...)
+			if err != nil {
+				t.Fatalf("failed setup: %s", err)
+			}
+			// These two values change every run:
+			if tc.Request.Repo.Repo == "<the-repo-url>" {
+				tc.Request.Repo.Repo = cfg.URL
+			}
+			if tc.Request.AmbiguousRevision == "<last-commit-id>" {
+				tc.Request.AmbiguousRevision = repo.State().Commit.Id().String()
+			}
+			asrv := testArgoServer(t)
+			aresp, err := asrv.ResolveRevision(context.Background(), tc.Request)
+			if tc.ExpectedError == "" {
+				if err != nil {
+					t.Fatalf("expected no error, but got %q", err)
+				}
+			} else {
+				if err == nil {
+
+					t.Fatalf("expected error %q but got response %#v", tc.ExpectedArgoError, aresp)
+				}
+				if err.Error() != tc.ExpectedArgoError {
+					t.Fatalf("got wrong error, expected %q but got %q", tc.ExpectedArgoError, err)
+				}
+			}
+
+			srv := New(repo, cfg)
+			resp, err := srv.ResolveRevision(context.Background(), tc.Request)
+			if tc.ExpectedError == "" {
+				if err != nil {
+					t.Fatalf("expected no error, but got %q", err)
+				}
+				// We only need to check here if both are the same
+				d := cmp.Diff(resp, aresp, protocmp.Transform())
+				if d != "" {
+					t.Errorf("unexpected response: %s", d)
+				}
+			} else {
+				if err.Error() != tc.ExpectedError {
+					t.Errorf("got wrong error, expected %q but got %q", tc.ExpectedError, err.Error())
+				}
+			}
+
+		})
+	}
+}
+
+func testRepository(t *testing.T) (repository.Repository, repository.RepositoryConfig) {
+	dir := t.TempDir()
+	remoteDir := path.Join(dir, "remote")
+	localDir := path.Join(dir, "local")
+	cmd := exec.Command("git", "init", "--bare", remoteDir)
+	cmd.Run()
+	cfg := repository.RepositoryConfig{
+		URL:    "file://" + remoteDir,
+		Path:   localDir,
+		Branch: "master",
+	}
+	repo, err := repository.New(
+		testutil.MakeTestContext(),
+		cfg,
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got '%e'", err)
+	}
+	return repo, cfg
+}
+
+func testArgoServer(t *testing.T) argorepo.RepoServerServiceServer {
+	argoRoot := t.TempDir()
+	t.Cleanup(
+		func() {
+			// argocd chmods all its directories in such a way that they can't be listed.
+			// this makes a lot of sense until you actually want to remove them cleanly.
+			os.Chmod(argoRoot, 0700)
+			dirs, _ := os.ReadDir(argoRoot)
+			for _, dir := range dirs {
+				os.Chmod(filepath.Join(argoRoot, dir.Name()), 0700)
+			}
+		})
+	asrv := argosrv.NewService(
+		metrics.NewMetricsServer(),
+		cache.NewCache(cacheutil.NewCache(cacheutil.NewInMemoryCache(time.Hour)), time.Hour, time.Hour),
+		argosrv.RepoServerInitConstants{},
+		argo.NewResourceTracking(),
+		&git.NoopCredsStore{},
+		argoRoot,
+	)
+	err := asrv.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return asrv
+
+}

--- a/services/cd-service/pkg/argocd/reposerver/reposerver_test.go
+++ b/services/cd-service/pkg/argocd/reposerver/reposerver_test.go
@@ -1,3 +1,19 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
 package reposerver
 
 import (

--- a/services/cd-service/pkg/fs/fs.go
+++ b/services/cd-service/pkg/fs/fs.go
@@ -484,7 +484,7 @@ func (t *TreeBuilderFS) MkdirAll(dir string, perm os.FileMode) error {
 }
 
 func (t *TreeBuilderFS) Lstat(path string) (os.FileInfo, error) {
-	// TODO(HVG): implement this to support actual symlinks
+	// TODO(HVG): implement this to support actual symlinkk (https://github.com/freiheit-com/kuberpult/issues/1046)
 	return t.Stat(path)
 }
 

--- a/services/cd-service/pkg/fs/fs.go
+++ b/services/cd-service/pkg/fs/fs.go
@@ -484,7 +484,8 @@ func (t *TreeBuilderFS) MkdirAll(dir string, perm os.FileMode) error {
 }
 
 func (t *TreeBuilderFS) Lstat(path string) (os.FileInfo, error) {
-	return nil, billy.ErrNotSupported
+	// TODO(HVG): implement this to support actual symlinks
+	return t.Stat(path)
 }
 
 func (t *TreeBuilderFS) Readlink(path string) (string, error) {

--- a/services/cd-service/pkg/grpc/errors.go
+++ b/services/cd-service/pkg/grpc/errors.go
@@ -18,6 +18,7 @@ package grpc
 
 import (
 	"context"
+
 	"github.com/freiheit-com/kuberpult/pkg/logger"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"

--- a/services/cd-service/pkg/interceptors/interceptors.go
+++ b/services/cd-service/pkg/interceptors/interceptors.go
@@ -18,7 +18,6 @@ package interceptors
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/freiheit-com/kuberpult/pkg/auth"
@@ -35,7 +34,6 @@ func UnaryUserContextInterceptor(ctx context.Context,
 	reader auth.GrpcContextReader) (interface{}, error) {
 
 	if strings.HasPrefix(info.FullMethod, "/repository.RepoServerService/") {
-		fmt.Printf("%s(%#v)\n", info.FullMethod, req)
 		return handler(ctx, req)
 	}
 	user, err := reader.ReadUserFromGrpcContext(ctx)

--- a/services/cd-service/pkg/interceptors/interceptors.go
+++ b/services/cd-service/pkg/interceptors/interceptors.go
@@ -18,6 +18,8 @@ package interceptors
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/freiheit-com/kuberpult/pkg/auth"
 	"google.golang.org/grpc"
@@ -32,6 +34,10 @@ func UnaryUserContextInterceptor(ctx context.Context,
 	handler grpc.UnaryHandler,
 	reader auth.GrpcContextReader) (interface{}, error) {
 
+	if strings.HasPrefix(info.FullMethod, "/repository.RepoServerService/") {
+		fmt.Printf("%s(%#v)\n", info.FullMethod, req)
+		return handler(ctx, req)
+	}
 	user, err := reader.ReadUserFromGrpcContext(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The first two endpoints `GenerateManifest` and `ResolveRevision` are the absolute minimum that is  needed to make  the integration test  work. I have made sure  that our implementation is correct by starting the argocd repo server in the unit tests and tested that they give the  same responses.