### PR TITLE
Fix server_test in frontend-service

### DIFF
--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -77,16 +77,21 @@ func RunServer() {
 
 func runServer(ctx context.Context) error {
 	err := envconfig.Process("kuberpult", &c)
+
 	if err != nil {
-		logger.FromContext(ctx).Fatal("config.parse", zap.Error(err))
+		logger.FromContext(ctx).Error("config.parse", zap.Error(err))
 		return err
 	}
 	logger.FromContext(ctx).Warn(fmt.Sprintf("config: \n%v", c))
 	if c.GitAuthorEmail == "" {
-		logger.FromContext(ctx).Fatal("DefaultGitAuthorEmail must not be empty")
+		msg := "DefaultGitAuthorEmail must not be empty"
+		logger.FromContext(ctx).Error(msg)
+		return fmt.Errorf(msg)
 	}
 	if c.GitAuthorName == "" {
-		logger.FromContext(ctx).Fatal("DefaultGitAuthorName must not be empty")
+		msg := "DefaultGitAuthorName must not be empty"
+		logger.FromContext(ctx).Error(msg)
+		return fmt.Errorf(msg)
 	}
 
 	var jwks *keyfunc.JWKS = nil


### PR DESCRIPTION
The function runServer used the Fatal function of the zap logger. This has really unfortunate results in tests: You cannot see any details, except the name of the test and that it failed Instead we should always log with "Error" and then return the error (or only return the error).