### PR TITLE
Remove chart testing from CI

### DIFF
--- a/.github/workflows/execution-plan-main.yml
+++ b/.github/workflows/execution-plan-main.yml
@@ -18,11 +18,3 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       trigger: main
-
-  lint-and-test-helm-chart:
-    needs: [execution-plan]
-    uses: ./.github/workflows/test-helm-chart-release.yml
-    with:
-      trigger: main
-    secrets: inherit
-

--- a/.github/workflows/execution-plan-pr.yml
+++ b/.github/workflows/execution-plan-pr.yml
@@ -15,10 +15,3 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       trigger: pull-request
-
-  lint-and-test-helm-chart:
-    needs: [execution-plan]
-    uses: ./.github/workflows/test-helm-chart-release.yml
-    with:
-      trigger: pull-request
-    secrets: inherit

--- a/.github/workflows/execution-plan-tag.yml
+++ b/.github/workflows/execution-plan-tag.yml
@@ -11,15 +11,8 @@ jobs:
       trigger: tag
     secrets: inherit
 
-  lint-and-test-helm-chart:
-    needs: [execution-plan]
-    uses: ./.github/workflows/test-helm-chart-release.yml
-    with:
-      trigger: tag
-    secrets: inherit
-
   release:
-    needs: [execution-plan, lint-and-test-helm-chart]
+    needs: [execution-plan]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Chart testing was not working properly.
It has its own logic to decide if it needs to run, and often it just doesn't.

I suspect this has not been working for a long time.

It is not a huge loss to remove it, because we have integration tests that also install our helm chart.

Reference: SRX-WJULW1