### PR TITLE
Fix docker-compose path to manifest repo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - "8080:8080"
       - "8443:8443"
     volumes:
-      - .:/kp/kuberpult
+      - ./services/cd-service:/kp/kuberpult
     stop_grace_period: 0.5s
   frontend-service:
     build:


### PR DESCRIPTION
The path must point to a local checked out (git clone) manifest repo.

This is now different, because the docker context for the cd-service is the git root, instead of `services/cd-service`.