### PR TITLE
Fix teams dropdown overflow

### DIFF
--- a/services/frontend-service/src/ui/components/dropdown/dropdown.scss
+++ b/services/frontend-service/src/ui/components/dropdown/dropdown.scss
@@ -45,6 +45,7 @@ div.mdc-select {
 }
 
 .dropdown {
+    overflow-y: auto;
     min-width: 220px;
     left: 0;
     top: -5px;


### PR DESCRIPTION
This fixing a missing scrollbar in the filter for teams on the homepage.

Now:
(note that I duplicated the teams just for testing. Usually each team appears once)
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/1a8a1994-5ad9-4b72-a61d-3ceffaf9f35a)

Before:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/2a6d6bb3-bd1d-4d8f-bbe1-0e70d5367a03)


