### PR TITLE
Send dora events to revolution

### DIFF
--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -132,6 +132,17 @@ spec:
             secretKeyRef:
               name: kuberpult-rollout-service
               key: KUBERPULT_ARGOCD_TOKEN
+        - name: KUBERPULT_REVOLUTION_DORA_ENABLED
+          value: {{ .Values.revolution.dora.enabled | quote }}
+        - name: KUBERPULT_REVOLUTION_DORA_URL
+          value: {{ .Values.revolution.dora.url | quote }}
+        - name: KUBERPULT_REVOLUTION_DORA_CONCURRENCY
+          value: {{ .Values.revolution.dora.concurrency | quote }}
+        - name: KUBERPULT_REVOLUTION_DORA_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: kuberpult-rollout-service
+              key: KUBERPULT_REVOLUTION_DORA_TOKEN
         volumeMounts:
         # We need to mount a writeable tmp directory for argocd connections to work correctly. https://github.com/argoproj/argo-cd/issues/14115
         - name: tmp
@@ -174,4 +185,5 @@ metadata:
 type: Opaque
 data:
   KUBERPULT_ARGOCD_TOKEN: {{ .Values.argocd.token | b64enc }}
+  KUBERPULT_REVOLUTION_DORA_TOKEN: {{ .Values.revolution.dora.token | b64enc }}
 {{- end }}

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -245,5 +245,13 @@ dex:
   #       clientSecret: $GOOGLE_CLIENT_SECRET
   #       redirectURI: http://127.0.0.1:5556/callback
   config: {}
-
-
+# Configuration for revolution dora metrics. If you are not using revolution you can safely ignore this.
+revolution:
+  dora:
+    enabled: false
+    # The default url in revolution is https://revolution.dev/api/dora/kuberpult?companyID=myCompany&productID=myProductID&projectID=myProductId
+    url: ""
+    # The token can be obtained from revolution.
+    token: ""
+    # Maximum number of requests send in parallel.
+    concurrency: 20

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/go-cmp v0.6.0
+	github.com/google/uuid v1.4.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -156,7 +157,6 @@ require (
 	github.com/google/go-jsonnet v0.20.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
-	github.com/google/uuid v1.4.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.1 // indirect

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -55,6 +55,10 @@ type Config struct {
 	ArgocdToken              string `split_words:"true"`
 	ArgocdRefreshEnabled     bool   `split_words:"true"`
 	ArgocdRefreshConcurrency int    `default:"50" split_words:"true"`
+
+	RevolutionDoraEnabled bool   `split_words:"true"`
+	RevolutionDoraUrl     string `split_words:"true"`
+	RevolutionDoraToken   string `split_words:"true"`
 }
 
 func (config *Config) ClientConfig() (apiclient.ClientOptions, error) {

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/freiheit-com/kuberpult/pkg/tracing"
 	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/metrics"
 	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/notifier"
+	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/revolution"
 	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/service"
 	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/versions"
 	"github.com/kelseyhightower/envconfig"
@@ -56,9 +57,10 @@ type Config struct {
 	ArgocdRefreshEnabled     bool   `split_words:"true"`
 	ArgocdRefreshConcurrency int    `default:"50" split_words:"true"`
 
-	RevolutionDoraEnabled bool   `split_words:"true"`
-	RevolutionDoraUrl     string `split_words:"true"`
-	RevolutionDoraToken   string `split_words:"true"`
+	RevolutionDoraEnabled     bool   `split_words:"true"`
+	RevolutionDoraUrl         string `split_words:"true" default:""`
+	RevolutionDoraToken       string `split_words:"true" default:""`
+	RevolutionDoraConcurrency int    `default:"10" split_words:"true"`
 }
 
 func (config *Config) ClientConfig() (apiclient.ClientOptions, error) {
@@ -74,6 +76,20 @@ func (config *Config) ClientConfig() (apiclient.ClientOptions, error) {
 	opts.Insecure = config.ArgocdInsecure
 	opts.AuthToken = config.ArgocdToken
 	return opts, nil
+}
+
+func (config *Config) RevolutionConfig() (revolution.Config, error) {
+	if config.RevolutionDoraUrl == "" {
+		return revolution.Config{}, fmt.Errorf("KUBERPULT_REVOLUTION_DORA_URL must be a valid url")
+	}
+	if config.RevolutionDoraToken == "" {
+		return revolution.Config{}, fmt.Errorf("KUBERPULT_REVOLUTION_DORA_TOKEN must not be empty")
+	}
+	return revolution.Config{
+		URL:            config.RevolutionDoraUrl,
+		Token:          []byte(config.RevolutionDoraToken),
+		Concurrency: config.RevolutionDoraConcurrency,
+	}, nil
 }
 
 func RunServer() {
@@ -190,6 +206,20 @@ func runServer(ctx context.Context, config Config) error {
 			Run: func(ctx context.Context) error {
 				notify := notifier.New(appClient, config.ArgocdRefreshConcurrency)
 				return notifier.Subscribe(ctx, notify, broadcast)
+			},
+		})
+	}
+
+	if config.RevolutionDoraEnabled {
+		revolutionConfig, err := config.RevolutionConfig()
+		if err != nil {
+			return err
+		}
+		revolutionDora := revolution.New(revolutionConfig)
+		backgroundTasks = append(backgroundTasks, setup.BackgroundTaskConfig{
+			Name: "revolution dora",
+			Run: func(ctx context.Context) error {
+				return revolutionDora.Subscribe(ctx, broadcast)
 			},
 		})
 	}

--- a/services/rollout-service/pkg/revolution/revolution.go
+++ b/services/rollout-service/pkg/revolution/revolution.go
@@ -101,7 +101,7 @@ type kuberpultEvent struct {
 	CommitHash string `json:"commitHash"`
 	EventTime  string `json:"eventTime"`
 	// optimally in RFC3339 format
-	URL string `json:"url"`
+	URL string `json:"url,omitempty"`
 	// where to see the logs/status of the deployment
 	ServiceName string `json:"serviceName"`
 }

--- a/services/rollout-service/pkg/revolution/revolution.go
+++ b/services/rollout-service/pkg/revolution/revolution.go
@@ -1,0 +1,138 @@
+/*
+This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com
+*/
+package revolution
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/service"
+	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
+)
+
+type Config struct {
+	URL                string
+	Token              []byte
+	MaximumConcurrency int
+}
+
+func New(config Config) *Subscriber {
+	sub := &Subscriber{
+		group: errgroup.Group{},
+	}
+	sub.group.SetLimit(config.MaximumConcurrency)
+	return sub
+}
+
+type Subscriber struct {
+	group errgroup.Group
+	token []byte
+	url   string
+}
+
+func (s *Subscriber) Subscribe(ctx context.Context, b *service.Broadcast) error {
+	event, ch, unsub := b.Start()
+	defer unsub()
+	state := map[service.Key]*service.BroadcastEvent{}
+	for _, ev := range event {
+		if ev.IsProduction != nil && *ev.IsProduction {
+			state[ev.Key] = ev
+		}
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return s.group.Wait()
+		case ev, ok := <-ch:
+			if !ok {
+				return s.group.Wait()
+			}
+			if ev.IsProduction == nil || !*ev.IsProduction {
+				continue
+			}
+			if shouldNotify(state[ev.Key], ev) {
+				s.group.Go(s.notify(ctx, ev))
+			}
+			state[ev.Key] = ev
+		}
+	}
+}
+
+func shouldNotify(old *service.BroadcastEvent, nu *service.BroadcastEvent) bool {
+	if old == nil {
+		return true
+	}
+	return false
+}
+
+type kuberpultEvent struct {
+	Id string `json:"id"`
+	// Id/UUID to de-duplicate events
+	CommitHash string `json:"commitHash"`
+	EventTime  string `json:"eventTime"`
+	// optimally in RFC3339 format
+	URL string `json:"url"`
+	// where to see the logs/status of the deployment
+	ServiceName string `json:"serviceName"`
+}
+
+func (s *Subscriber) notify(ctx context.Context, ev *service.BroadcastEvent) func() error {
+	event := kuberpultEvent{
+		Id:          uuidFor(ev.Application, ev.ArgocdVersion.SourceCommitId, ev.ArgocdVersion.DeployedAt.String()),
+		CommitHash:  ev.ArgocdVersion.SourceCommitId,
+		EventTime:   ev.ArgocdVersion.DeployedAt.Format(time.RFC3339),
+		ServiceName: ev.Application,
+	}
+	return func() error {
+		body, err := json.Marshal(event)
+		h := hmac.New(sha256.New, s.token)
+		h.Write([]byte(body))
+		sha := "sha256=" + hex.EncodeToString(h.Sum(nil))
+		r, err := http.NewRequest("POST", s.url, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("creating http request: %w", err)
+		}
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set("X-Hub-Signature-256", sha)
+		s, err := http.DefaultClient.Do(r)
+		if err != nil {
+			return fmt.Errorf("sending req: %w", err)
+		}
+		defer s.Body.Close()
+		content, _ := io.ReadAll(s.Body)
+		if s.StatusCode > 299 {
+			return fmt.Errorf("http status (%d): %s", s.StatusCode, content)
+		}
+		return nil
+	}
+}
+
+var kuberpultUuid uuid.UUID = uuid.NewSHA1(uuid.MustParse("00000000-0000-0000-0000-000000000000"), []byte("kuberpult"))
+
+func uuidFor(application, commitHash, deployedAt string) string {
+	return uuid.NewSHA1(kuberpultUuid, []byte(fmt.Sprintf("%s\n%s\n%s", application, commitHash, deployedAt))).String()
+}

--- a/services/rollout-service/pkg/revolution/revolution.go
+++ b/services/rollout-service/pkg/revolution/revolution.go
@@ -89,7 +89,14 @@ func (s *Subscriber) Subscribe(ctx context.Context, b *service.Broadcast) error 
 }
 
 func shouldNotify(old *service.BroadcastEvent, nu *service.BroadcastEvent) bool {
-	if old == nil {
+	// check for fields that must be present to generate the request
+	if nu.ArgocdVersion == nil || nu.IsProduction == nil || nu.ArgocdVersion.SourceCommitId == "" {
+		return false
+	}
+	if old == nil || old.ArgocdVersion == nil || old.IsProduction == nil {
+		return true
+	}
+	if old.ArgocdVersion.SourceCommitId != nu.ArgocdVersion.SourceCommitId || old.ArgocdVersion.DeployedAt != nu.ArgocdVersion.DeployedAt {
 		return true
 	}
 	return false

--- a/services/rollout-service/pkg/revolution/revolution.go
+++ b/services/rollout-service/pkg/revolution/revolution.go
@@ -37,14 +37,14 @@ import (
 type Config struct {
 	URL                string
 	Token              []byte
-	MaximumConcurrency int
+	Concurrency int
 }
 
 func New(config Config) *Subscriber {
 	sub := &Subscriber{
 		group: errgroup.Group{},
 	}
-	sub.group.SetLimit(config.MaximumConcurrency)
+	sub.group.SetLimit(config.Concurrency)
 	sub.url = config.URL
 	sub.token = config.Token
 	sub.ready = func() {}

--- a/services/rollout-service/pkg/revolution/revolution_test.go
+++ b/services/rollout-service/pkg/revolution/revolution_test.go
@@ -1,3 +1,18 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
 /*
 This file is part of kuberpult.
 

--- a/services/rollout-service/pkg/revolution/revolution_test.go
+++ b/services/rollout-service/pkg/revolution/revolution_test.go
@@ -1,0 +1,59 @@
+/*
+This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com
+*/
+package revolution
+
+import (
+	"context"
+	"testing"
+
+	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/service"
+)
+
+func TestSubscriber(t *testing.T) {
+	type step struct {
+	}
+	tcs := []struct {
+		Name  string
+		Steps []step
+	}{
+		{
+			Name:  "works",
+			Steps: []step{},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			bc := service.New()
+			errCh := make(chan error, 1)
+			cs := New(Config{})
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				errCh <- cs.Subscribe(ctx, bc)
+			}()
+      for i, s := range tc.Steps {
+
+      }
+			cancel()
+			err := <-errCh
+			if err != nil {
+				t.Errorf("expected no error but got %q", err)
+			}
+		})
+	}
+}

--- a/services/rollout-service/pkg/revolution/revolution_test.go
+++ b/services/rollout-service/pkg/revolution/revolution_test.go
@@ -74,7 +74,7 @@ func TestRevolution(t *testing.T) {
 						Version: &versions.VersionInfo{
 							Version:        1,
 							SourceCommitId: "123456",
-							DeployedAt:     time.Unix(123456789, 0),
+							DeployedAt:     time.Unix(123456789, 0).UTC(),
 						},
 					},
 					KuberpultEvent: &versions.KuberpultEvent{
@@ -84,7 +84,7 @@ func TestRevolution(t *testing.T) {
 						Version: &versions.VersionInfo{
 							Version:        1,
 							SourceCommitId: "123456",
-							DeployedAt:     time.Unix(123456789, 0),
+							DeployedAt:     time.Unix(123456789, 0).UTC(),
 						},
 					},
 
@@ -93,9 +93,9 @@ func TestRevolution(t *testing.T) {
 						Header: http.Header{
 							"Content-Type":        []string{"application/json"},
 							"User-Agent":          []string{"kuberpult"},
-							"X-Hub-Signature-256": []string{"sha256=6226a9b12f3de5b35cf7bef299be1bc21fdb0bcab4e5e71e3977881e251c06a7"},
+							"X-Hub-Signature-256": []string{"sha256=c227a4f702ce00368a15bd00c3678dd20c76ed7275d82c5a2d48009beb78b5ee"},
 						},
-						Body: `{"id":"743b08b4-a5a5-5931-8207-fb22128d180c","commitHash":"123456","eventTime":"1973-11-29T22:33:09+01:00","serviceName":"bar"}`,
+						Body: `{"id":"0ee3e568-0f9d-5be9-b75c-caa9025599c2","commitHash":"123456","eventTime":"1973-11-29T21:33:09Z","serviceName":"bar"}`,
 					},
 				},
 				{
@@ -107,7 +107,7 @@ func TestRevolution(t *testing.T) {
 						Version: &versions.VersionInfo{
 							Version:        1,
 							SourceCommitId: "123456",
-							DeployedAt:     time.Unix(123456789, 0),
+							DeployedAt:     time.Unix(123456789, 0).UTC(),
 						},
 					},
 

--- a/services/rollout-service/pkg/revolution/revolution_test.go
+++ b/services/rollout-service/pkg/revolution/revolution_test.go
@@ -78,9 +78,9 @@ func TestRevolution(t *testing.T) {
 						Header: http.Header{
 							"Content-Type":        []string{"application/json"},
 							"User-Agent":          []string{"kuberpult"},
-							"X-Hub-Signature-256": []string{"sha256=76903a105ca442d285d7eb3968b7d980f4f0b9aac309080ba7397ac8e5cbdde4"},
+							"X-Hub-Signature-256": []string{"sha256=6226a9b12f3de5b35cf7bef299be1bc21fdb0bcab4e5e71e3977881e251c06a7"},
 						},
-						Body: `{"id":"743b08b4-a5a5-5931-8207-fb22128d180c","commitHash":"123456","eventTime":"1973-11-29T22:33:09+01:00","url":"","serviceName":"bar"}`,
+						Body: `{"id":"743b08b4-a5a5-5931-8207-fb22128d180c","commitHash":"123456","eventTime":"1973-11-29T22:33:09+01:00","serviceName":"bar"}`,
 					},
 				},
 			},

--- a/services/rollout-service/pkg/revolution/revolution_test.go
+++ b/services/rollout-service/pkg/revolution/revolution_test.go
@@ -48,7 +48,7 @@ func TestRevolution(t *testing.T) {
 		Steps []step
 	}{
 		{
-			Name: "send out deployment events with timestamp",
+			Name: "send out deployment events with timestamp once",
 			Steps: []step{
 				{
 					ArgoEvent: &service.ArgoEvent{
@@ -82,6 +82,21 @@ func TestRevolution(t *testing.T) {
 						},
 						Body: `{"id":"743b08b4-a5a5-5931-8207-fb22128d180c","commitHash":"123456","eventTime":"1973-11-29T22:33:09+01:00","serviceName":"bar"}`,
 					},
+				},
+				{
+					ArgoEvent: &service.ArgoEvent{
+						Environment:      "foo",
+						Application:      "bar",
+						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
+						HealthStatusCode: health.HealthStatusDegraded,
+						Version: &versions.VersionInfo{
+							Version:        1,
+							SourceCommitId: "123456",
+							DeployedAt:     time.Unix(123456789, 0),
+						},
+					},
+
+					ExpectedRequest: nil,
 				},
 			},
 		},
@@ -134,6 +149,12 @@ func TestRevolution(t *testing.T) {
 						}
 					}
 
+				} else {
+					select {
+					case req := <-reqCh:
+						t.Errorf("unexpected requests in step %d: %#v", i, req)
+					default:
+					}
 				}
 			}
 			cancel()

--- a/services/rollout-service/pkg/revolution/revolution_test.go
+++ b/services/rollout-service/pkg/revolution/revolution_test.go
@@ -123,7 +123,7 @@ func TestRevolution(t *testing.T) {
 			cs := New(Config{
 				URL:                revolution.URL,
 				Token:              []byte("revolution"),
-				MaximumConcurrency: 100,
+				Concurrency: 100,
 			})
 			cs.ready = func() { readyCh <- struct{}{} }
 			ctx, cancel := context.WithCancel(context.Background())

--- a/services/rollout-service/pkg/service/broadcast.go
+++ b/services/rollout-service/pkg/service/broadcast.go
@@ -54,7 +54,7 @@ func (a *appState) applyArgoEvent(ev *ArgoEvent) *BroadcastEvent {
 }
 
 func (a *appState) applyKuberpultEvent(ev *versions.KuberpultEvent) *BroadcastEvent {
-	if a.kuberpultVersion == nil || a.kuberpultVersion.Version != ev.Version.Version {
+	if a.kuberpultVersion == nil || a.kuberpultVersion.Version != ev.Version.Version || a.isProduction == nil || *a.isProduction != ev.IsProduction {
 		a.kuberpultVersion = ev.Version
 		a.environmentGroup = ev.EnvironmentGroup
 		a.isProduction = ptr.Bool(ev.IsProduction)

--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -78,7 +78,11 @@ func (v *versionClient) GetVersion(ctx context.Context, revision, environment, a
 				if app == nil {
 					return &VersionInfo{}, nil
 				}
-				return &VersionInfo{Version: app.Version, SourceCommitId: sourceCommitId(overview, app), DeployedAt: deployedAt(app)}, nil
+				return &VersionInfo{
+					Version:        app.Version,
+					SourceCommitId: sourceCommitId(overview, app),
+					DeployedAt:     deployedAt(app),
+				}, nil
 			}
 		}
 	}
@@ -117,6 +121,7 @@ type KuberpultEvent struct {
 	Environment      string
 	Application      string
 	EnvironmentGroup string
+	IsProduction     bool
 	Version          *VersionInfo
 }
 
@@ -182,10 +187,12 @@ outer:
 							Application:      app.Name,
 							Environment:      env.Name,
 							EnvironmentGroup: envGroup.EnvironmentGroupName,
+							IsProduction:   env.Priority == api.Priority_PROD,
 							Version: &VersionInfo{
 								Version:        app.Version,
 								SourceCommitId: sc,
 								DeployedAt:     dt,
+
 							},
 						})
 					}


### PR DESCRIPTION
This adds a new subservice to the rollout service that sends out deployment events to revolution.