### PR TITLE
Allow renovate to run at any time

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,6 @@
     "gomodTidy"
   ],
   "schedule": [
-    "before 10am"
+    "at any time"
   ]
 }


### PR DESCRIPTION
Note that the schedule configuration is to limit renovate, not to enable it.

Docs: https://docs.renovatebot.com/configuration-options/#schedule