### PR TITLE
Release 1.11.0

### DIFF
--- a/services/frontend-service/Buildfile.yaml
+++ b/services/frontend-service/Buildfile.yaml
@@ -8,3 +8,4 @@ spec:
   - ../../go.mod
   - ../../go.sum
   - ../../tests/integration-tests/
+# rebuild-counter: 1


### PR DESCRIPTION
re-release, since the previous release had issues with the dex helm chart.

The rebuild-counter is necessary for the integration tests (otherwise they pick the wrong image, which leads to the wrong thing being tested).