### PR TITLE
Always add /metrics endpoint

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -17,6 +17,7 @@ Copyright 2023 freiheit.com*/
 package metrics
 
 import (
+	"context"
 	"net/http"
 
 	"go.opentelemetry.io/otel/metric"
@@ -40,4 +41,16 @@ func Init() (metric.MeterProvider, http.Handler, error) {
 	)
 
 	return meterProvider, promhttp.HandlerFor(reg, promhttp.HandlerOpts{}), nil
+}
+
+type ctxKeyType struct{}
+
+var ctxKey ctxKeyType = ctxKeyType{}
+
+func FromContext(ctx context.Context) metric.MeterProvider {
+	return ctx.Value(ctxKey).(metric.MeterProvider)
+}
+
+func With(ctx context.Context, pv metric.MeterProvider) context.Context {
+	return context.WithValue(ctx, ctxKey, pv)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -51,6 +51,6 @@ func FromContext(ctx context.Context) metric.MeterProvider {
 	return ctx.Value(ctxKey).(metric.MeterProvider)
 }
 
-func With(ctx context.Context, pv metric.MeterProvider) context.Context {
+func WithProvider(ctx context.Context, pv metric.MeterProvider) context.Context {
 	return context.WithValue(ctx, ctxKey, pv)
 }

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -106,7 +106,7 @@ func Run(ctx context.Context, config ServerConfig) {
 
 	ctx, cancel := context.WithCancel(ctx)
 	pv, handler, _ := metrics.Init()
-	ctx = metrics.With(ctx, pv)
+	ctx = metrics.WithProvider(ctx, pv)
 
 	// Start the listening on each protocol
 	for _, cfg := range config.HTTP {

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/freiheit-com/kuberpult/pkg/logger"
+	"github.com/freiheit-com/kuberpult/pkg/metrics"
 	"google.golang.org/grpc"
 )
 
@@ -104,10 +105,12 @@ func Run(ctx context.Context, config ServerConfig) {
 	s := &setup{}
 
 	ctx, cancel := context.WithCancel(ctx)
+	pv, handler, _ := metrics.Init()
+	ctx = metrics.With(ctx, pv)
 
 	// Start the listening on each protocol
 	for _, cfg := range config.HTTP {
-		setupHTTP(ctx, s, cfg, cancel)
+		setupHTTP(ctx, s, cfg, cancel, handler)
 	}
 	if config.GRPC != nil {
 		setupGRPC(ctx, s, *config.GRPC, cancel)
@@ -199,10 +202,10 @@ func serveGRPC(ctx context.Context, grpcS *grpc.Server, grpcL net.Listener, canc
 	}
 }
 
-func setupHTTP(ctx context.Context, s *setup, config HTTPConfig, cancel context.CancelFunc) {
+func setupHTTP(ctx context.Context, s *setup, config HTTPConfig, cancel context.CancelFunc, metricHandler http.Handler) {
 	mux := http.NewServeMux()
 	config.Register(mux)
-
+	mux.Handle("/metrics", metricHandler)
 	runHTTPHandler(ctx, s, mux, config.Port, config.BasicAuth, config.Shutdown, cancel)
 }
 

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -86,8 +86,8 @@ func (config *Config) RevolutionConfig() (revolution.Config, error) {
 		return revolution.Config{}, fmt.Errorf("KUBERPULT_REVOLUTION_DORA_TOKEN must not be empty")
 	}
 	return revolution.Config{
-		URL:            config.RevolutionDoraUrl,
-		Token:          []byte(config.RevolutionDoraToken),
+		URL:         config.RevolutionDoraUrl,
+		Token:       []byte(config.RevolutionDoraToken),
 		Concurrency: config.RevolutionDoraConcurrency,
 	}, nil
 }
@@ -224,14 +224,10 @@ func runServer(ctx context.Context, config Config) error {
 		})
 	}
 
-	meter, handler, err := pkgmetrics.Init()
-	if err != nil {
-		return err
-	}
 	backgroundTasks = append(backgroundTasks, setup.BackgroundTaskConfig{
 		Name: "create metrics",
 		Run: func(ctx context.Context) error {
-			return metrics.Metrics(ctx, broadcast, meter, nil)
+			return metrics.Metrics(ctx, broadcast, pkgmetrics.FromContext(ctx), nil)
 		},
 	})
 
@@ -247,7 +243,6 @@ func runServer(ctx context.Context, config Config) error {
 							w.WriteHeader(500)
 						}
 					}))
-					mux.Handle("/metrics", handler)
 				},
 			},
 		},


### PR DESCRIPTION
This makes the /metrics endpoint available on all services and to all background tasks. I need to have this available in my next MR to register a metric there that is 0/1 for all background tasks depending on wether they are running.