### PR TITLE
Fix: empty dora token break rollout service deployment

### DIFF
--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -184,6 +184,6 @@ metadata:
   name: kuberpult-rollout-service
 type: Opaque
 data:
-  KUBERPULT_ARGOCD_TOKEN: {{ .Values.argocd.token | b64enc }}
-  KUBERPULT_REVOLUTION_DORA_TOKEN: {{ .Values.revolution.dora.token | b64enc }}
+  KUBERPULT_ARGOCD_TOKEN: {{ .Values.argocd.token | b64enc | quote }}
+  KUBERPULT_REVOLUTION_DORA_TOKEN: {{ .Values.revolution.dora.token | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
When using an empty dora token ( which is totally valid if not using this optional feature ), then the key will not be rendered in the secret which breaks the rollout deployment. By quoting the value, we ensure that keys do get removed even when they are empty.