### PR TITLE
Add a unified retry mechanism for background tasks

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -362,7 +362,6 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,7 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -203,9 +203,8 @@ func runServer(ctx context.Context, config Config) error {
 		backgroundTasks = append(backgroundTasks, setup.BackgroundTaskConfig{
 			Name: "refresh argocd",
 			Run: func(ctx context.Context, health *setup.HealthReporter) error {
-				health.ReportReady("refreshing")
 				notify := notifier.New(appClient, config.ArgocdRefreshConcurrency)
-				return notifier.Subscribe(ctx, notify, broadcast)
+				return notifier.Subscribe(ctx, notify, broadcast, health)
 			},
 		})
 	}

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -192,8 +192,7 @@ func runServer(ctx context.Context, config Config) error {
 		{
 			Name: "consume kuberpult events",
 			Run: func(ctx context.Context, health *setup.HealthReporter) error {
-				health.ReportReady("consuming")
-				return versionC.ConsumeEvents(ctx, broadcast)
+				return versionC.ConsumeEvents(ctx, broadcast, health)
 			},
 		},
 	}

--- a/services/rollout-service/pkg/service/service_test.go
+++ b/services/rollout-service/pkg/service/service_test.go
@@ -119,7 +119,7 @@ func (m *mockVersionClient) GetVersion(ctx context.Context, revision string, env
 	return nil, nil
 }
 
-func (m *mockVersionClient) ConsumeEvents(ctx context.Context, pc versions.VersionEventProcessor) error {
+func (m *mockVersionClient) ConsumeEvents(ctx context.Context, pc versions.VersionEventProcessor, hr *setup.HealthReporter) error {
 	panic("not implemented")
 }
 

--- a/services/rollout-service/pkg/service/service_test.go
+++ b/services/rollout-service/pkg/service/service_test.go
@@ -24,8 +24,9 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/versions"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/freiheit-com/kuberpult/pkg/setup"
+	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/versions"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -34,9 +35,10 @@ import (
 )
 
 type step struct {
-	Event    *v1alpha1.ApplicationWatchEvent
-	WatchErr error
-	RecvErr  error
+	Event         *v1alpha1.ApplicationWatchEvent
+	WatchErr      error
+	RecvErr       error
+	CancelContext bool
 
 	ExpectedEvent *ArgoEvent
 }
@@ -53,6 +55,9 @@ func (m *mockApplicationServiceClient) Recv() (*v1alpha1.ApplicationWatchEvent, 
 	}
 	m.lastEvent = nil
 	reply := m.Steps[m.current]
+	if reply.CancelContext {
+		m.cancel()
+	}
 	m.current = m.current + 1
 	return reply.Event, reply.RecvErr
 }
@@ -62,15 +67,19 @@ type mockApplicationServiceClient struct {
 	current   int
 	t         *testing.T
 	lastEvent *ArgoEvent
+	cancel    context.CancelFunc
 	grpc.ClientStream
 }
 
 func (m *mockApplicationServiceClient) Watch(ctx context.Context, qry *application.ApplicationQuery, opts ...grpc.CallOption) (application.ApplicationService_WatchClient, error) {
 	if m.current >= len(m.Steps) {
-		return nil, fmt.Errorf("exhausted: %w", io.EOF)
+		return nil, setup.Permanent(fmt.Errorf("exhausted: %w", io.EOF))
 	}
 	reply := m.Steps[m.current]
 	if reply.WatchErr != nil {
+		if reply.CancelContext {
+			m.cancel()
+		}
 		m.current = m.current + 1
 		return nil, reply.WatchErr
 	}
@@ -129,28 +138,32 @@ func TestArgoConection(t *testing.T) {
 			Name: "stops without error when ctx is closed on Recv call",
 			Steps: []step{
 				{
-					WatchErr: status.Error(codes.Canceled, "context cancelled"),
+					WatchErr:      status.Error(codes.Canceled, "context cancelled"),
+					CancelContext: true,
 				},
 			},
 			ExpectedReady: false,
 		},
 		{
-			Name: "stops with error on other watch errors",
+			Name: "does not stop for watch errors",
 			Steps: []step{
 				{
 					WatchErr: fmt.Errorf("no"),
 				},
+				{
+					WatchErr:      status.Error(codes.Canceled, "context cancelled"),
+					CancelContext: true,
+				},
 			},
 
-			ExpectedError: "watching applications: no",
 			ExpectedReady: false,
 		},
-
 		{
 			Name: "stops when ctx closes in the watch call",
 			Steps: []step{
 				{
 					RecvErr: status.Error(codes.Canceled, "context cancelled"),
+					CancelContext: true,
 				},
 			},
 			ExpectedReady: true,
@@ -162,7 +175,8 @@ func TestArgoConection(t *testing.T) {
 					RecvErr: fmt.Errorf("no"),
 				},
 				{
-					RecvErr: status.Error(codes.Canceled, "context cancelled"),
+					RecvErr:       status.Error(codes.Canceled, "context cancelled"),
+					CancelContext: true,
 				},
 			},
 			ExpectedReady: true,
@@ -192,7 +206,8 @@ func TestArgoConection(t *testing.T) {
 					ExpectedEvent: nil,
 				},
 				{
-					RecvErr: status.Error(codes.Canceled, "context cancelled"),
+					RecvErr:       status.Error(codes.Canceled, "context cancelled"),
+					CancelContext: true,
 				},
 			},
 			ExpectedReady: true,
@@ -235,7 +250,8 @@ func TestArgoConection(t *testing.T) {
 					},
 				},
 				{
-					RecvErr: status.Error(codes.Canceled, "context cancelled"),
+					RecvErr:       status.Error(codes.Canceled, "context cancelled"),
+					CancelContext: true,
 				},
 			},
 			ExpectedReady: true,
@@ -278,7 +294,8 @@ func TestArgoConection(t *testing.T) {
 					},
 				},
 				{
-					RecvErr: status.Error(codes.Canceled, "context cancelled"),
+					RecvErr:       status.Error(codes.Canceled, "context cancelled"),
+					CancelContext: true,
 				},
 			},
 			ExpectedReady: true,
@@ -288,12 +305,14 @@ func TestArgoConection(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
 			as := mockApplicationServiceClient{
-				Steps: tc.Steps,
-				t:     t,
+				Steps:  tc.Steps,
+				cancel: cancel,
+				t:      t,
 			}
 			hlth := &setup.HealthServer{}
+			hlth.BackOffFactory = func() backoff.BackOff { return backoff.NewConstantBackOff(0) }
 			err := ConsumeEvents(ctx, &as, &mockVersionClient{versions: tc.Versions}, &as, hlth.Reporter("consume"))
 			if tc.ExpectedError == "" {
 				if err != nil {


### PR DESCRIPTION
The new retry mechanism is implemented in the HealthReporter.Retry function. This function retries the function a few times with randomized backoff until the context is cancelled or the number of retries is exhausted. This is necessary because the grpc stream sometimes disconnect when their pods get restarted. Before this change the reconnect logic was reinplemented in multiple places and not consistent. This change adds a consistent method for that and introduces it to various jobs. This also gets rid of several warning logs.