### PR TITLE
Always build all services

### DIFF
--- a/services/cd-service/Buildfile.yaml
+++ b/services/cd-service/Buildfile.yaml
@@ -8,9 +8,4 @@ metadata:
 spec:
   buildWith: infrastructure/docker/builder
   dependsOn:
-  - ../../charts/kuberpult
-  - ../../pkg
-  - ../../go.mod
-  - ../../go.sum
-  - ../../tests/integration-tests/
-# rebuild-counter: 1
+  - ../../

--- a/services/frontend-service/Buildfile.yaml
+++ b/services/frontend-service/Buildfile.yaml
@@ -3,9 +3,4 @@ metadata:
 spec:
   buildWith: infrastructure/docker/builder
   dependsOn:
-  - ../../charts/kuberpult
-  - ../../pkg
-  - ../../go.mod
-  - ../../go.sum
-  - ../../tests/integration-tests/
-# rebuild-counter: 2
+  - ../../

--- a/services/rollout-service/Buildfile.yaml
+++ b/services/rollout-service/Buildfile.yaml
@@ -4,8 +4,4 @@ metadata:
 spec:
   buildWith: infrastructure/docker/builder
   dependsOn:
-  - ../../pkg
-  - ../../go.mod
-  - ../../go.sum
-  - ../../tests/integration-tests/
-# rebuild-counter: 1
+  - ../../


### PR DESCRIPTION
This is a first step to simplify our CI.
It also fixes a bug where the integration test do not find the right docker image to test.