### PR TITLE
Use different base build images depending on host architecture

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,12 +1,19 @@
 VERSION 0.7
-FROM golang:1.21-bookworm
+FROM busybox
 ARG --global UID=1000
 ARG --global target=docker
 
 deps:
+    ARG USERARCH
     ARG BUF_VERSION=v1.26.1
     ARG BUF_BIN_PATH=/usr/local/bin
-
+    IF [ "$USERARCH" = "arm64" ]
+        FROM golang:1.21-bookworm
+        RUN apt update && apt install --auto-remove ca-certificates tzdata libgit2-dev libsqlite3-dev -y
+    ELSE
+        FROM golang:1.21-alpine3.18
+        RUN apk add --no-cache ca-certificates tzdata libgit2-dev sqlite-dev alpine-sdk
+    END
     WORKDIR /kp
 
     COPY go.mod go.sum ./

--- a/services/cd-service/Earthfile
+++ b/services/cd-service/Earthfile
@@ -3,7 +3,6 @@ ARG --global service=cd-service
 
 deps:
     FROM ../../+deps
-    RUN apt update && apt install ca-certificates tzdata libgit2-dev git libsqlite3-dev -y
     COPY ../../pkg+artifacts/* pkg/
     COPY pkg services/$service/pkg
     COPY cmd/server/* services/$service/cmd/server/
@@ -35,10 +34,10 @@ docker:
     ARG tag="local"
     ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     ENV TZ=Europe/Berlin
-    RUN useradd -m -d "/kp" --uid ${UID} kp
-    RUN chown -R kp:kp /kp
+    RUN adduser --disabled-password --home "/kp" --uid ${UID} kp
     COPY +compile/main /main
     COPY gitconfig /etc/gitconfig
+    RUN chown -R kp:kp /kp
     USER kp
     WORKDIR /kp
     ENTRYPOINT ["/main"] 

--- a/services/frontend-service/Earthfile
+++ b/services/frontend-service/Earthfile
@@ -4,7 +4,6 @@ ARG --global service=frontend-service
 deps:
     FROM ../../+deps
     ARG tag="deps"
-    RUN apt update && apt --auto-remove install ca-certificates tzdata -y
     COPY ../../pkg+artifacts/* pkg/
     BUILD ../cd-service/+artifacts --service=cd-service
     COPY (../cd-service/+artifacts/pkg --service=cd-service) services/cd-service/pkg/

--- a/services/rollout-service/Earthfile
+++ b/services/rollout-service/Earthfile
@@ -3,7 +3,6 @@ ARG --global service=rollout-service
 
 deps:
     FROM ../../+deps
-    RUN apt update && apt install ca-certificates tzdata -y
     COPY ../../pkg+artifacts/* pkg/
     COPY pkg services/$service/pkg
     COPY cmd/server/* services/$service/cmd/server/
@@ -36,7 +35,7 @@ docker:
     ARG tag="local"
     ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     ENV TZ=Europe/Berlin
-    RUN adduser -D -h "/kp" --uid ${UID} kp
+    RUN adduser --disabled-password --home "/kp" --uid ${UID} kp
     RUN chown -R kp:kp /kp
     COPY +compile/main /main
     COPY +deps/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
* For CI runs, the base golang image used would be `golang:1.21-alpine3.18` which will produce a final image size of ~360MB for the cd-service
* For local runs on M1 Macs, the produced cd-service image will be ~1GB because it uses debian based golang image.