### PR TITLE
Fix readyness reporting for the kuberpult event consumer

### DIFF
--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -146,14 +146,15 @@ type key struct {
 
 func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEventProcessor, hr *setup.HealthReporter) error {
 	ctx = auth.WriteUserToGrpcContext(ctx, RolloutServiceUser)
+	versions := map[key]uint64{}
+	environmentGroups := map[key]string{}
+	teams := map[key]string{}
 	return hr.Retry(ctx, func() error {
 		client, err := v.client.StreamOverview(ctx, &api.GetOverviewRequest{})
 		if err != nil {
 			return fmt.Errorf("overview.connect: %w", err)
 		}
-		versions := map[key]uint64{}
-		environmentGroups := map[key]string{}
-		teams := map[key]string{}
+		hr.ReportReady("consuming")
 		for {
 			select {
 			case <-ctx.Done():

--- a/services/rollout-service/pkg/versions/versions_test.go
+++ b/services/rollout-service/pkg/versions/versions_test.go
@@ -482,6 +482,44 @@ func TestVersionClientStream(t *testing.T) {
 			},
 		},
 		{
+			Name: "Notify for apps that are deleted across reconnects",
+			Steps: []step{
+				{
+					Overview: testOverview,
+				},
+				{
+					RecvErr: fmt.Errorf("no"),
+				},
+				{
+					Overview: emptyTestOverview,
+				},
+				{
+					RecvErr:       status.Error(codes.Canceled, "context cancelled"),
+					CancelContext: true,
+				},
+			},
+			ExpectedEvents: []KuberpultEvent{
+				{
+					Environment:      "staging",
+					Application:      "foo",
+					EnvironmentGroup: "staging-group",
+					Team:             "footeam",
+					Version: &VersionInfo{
+						Version:        1,
+						SourceCommitId: "00001",
+						DeployedAt:     time.Unix(123456789, 0).UTC(),
+					},
+				},
+				{
+					Environment:      "staging",
+					Application:      "foo",
+					EnvironmentGroup: "staging-group",
+					Team:             "footeam",
+					Version:          &VersionInfo{},
+				},
+			},
+		},
+		{
 			Name: "Updates environment groups",
 			Steps: []step{
 				{


### PR DESCRIPTION
I noticed that this line was missing:

```
hr.ReportReady("consuming")
```

However, writing a good test with the current setup turned out to be tricky, so I improved that and also found another bug that can happen in very rare edge cases ( app gets deleted between two reconnects ).