### PR TITLE
Fix race condition in rollout-service metrics

### DIFF
--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -227,7 +227,7 @@ func runServer(ctx context.Context, config Config) error {
 		Name: "create metrics",
 		Run: func(ctx context.Context, health *setup.HealthReporter) error {
 			health.ReportReady("reporting")
-			return metrics.Metrics(ctx, broadcast, pkgmetrics.FromContext(ctx), nil)
+			return metrics.Metrics(ctx, broadcast, pkgmetrics.FromContext(ctx), nil, func() {})
 		},
 	})
 


### PR DESCRIPTION
The rollout service processes metrics async. That means, if the check happens too fast we get the wrong result. This MR adds a `done` function that syncs the testing with the processing.