### PR TITLE
UI: Lock without deploying

### DIFF
--- a/services/frontend-service/src/setupTests.ts
+++ b/services/frontend-service/src/setupTests.ts
@@ -41,11 +41,11 @@ export const documentQuerySelectorSafe = (selectors: string): HTMLElement => {
 export const elementQuerySelectorSafe = (element: HTMLElement, selectors: string): HTMLElement => {
     const result = element.querySelector(selectors);
     if (!result) {
-        throw new Error('elementQuerySelectorSafe: did not find in selector in element ' + selectors);
+        throw new Error('elementQuerySelectorSafe: did not find in selector in element "' + selectors + '"');
     }
     if (!(result instanceof HTMLElement)) {
         throw new Error(
-            'elementQuerySelectorSafe: did find element in selector but it is not an html element: ' + selectors
+            'elementQuerySelectorSafe: did find element in selector but it is not an html element: "' + selectors + '"'
         );
     }
     return result;
@@ -54,7 +54,7 @@ export const elementQuerySelectorSafe = (element: HTMLElement, selectors: string
 export const getElementsByClassNameSafe = (element: HTMLElement, selectors: string): HTMLCollectionOf<Element> => {
     const result = element.getElementsByClassName(selectors);
     if (!result || result.length === 0) {
-        throw new Error('getElementsByClassNameSafe: did not find in selector in element ' + selectors);
+        throw new Error('getElementsByClassNameSafe: did not find in selector in element "' + selectors + '"');
     }
     return result;
 };

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -29,13 +29,12 @@ Copyright 2023 freiheit.com*/
         display: flex;
     }
     .content-right {
-        max-width: 45%;
-        margin-right: 20px;
+        max-width: 40%;
         margin-left: auto;
         display: flex;
     }
     .content-left {
-        max-width: 55%;
+        max-width: 60%;
     }
 
     .release-dialog-app-bar {
@@ -85,6 +84,10 @@ Copyright 2023 freiheit.com*/
         .release-env-list {
             padding-left: 0;
             margin-bottom: 0;
+        }
+
+        button {
+            padding: 8px 19px;
         }
 
         .env-card {
@@ -154,9 +157,6 @@ Copyright 2023 freiheit.com*/
                 flex-direction: row;
                 gap: 20px;
                 min-width: 300px;
-                button {
-                    padding: 8px 19px;
-                }
 
                 .env-card-add-lock-btn {
                     border: 1px solid var(--mdc-theme-primary);

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -29,9 +29,13 @@ Copyright 2023 freiheit.com*/
         display: flex;
     }
     .content-right {
+        max-width: 45%;
         margin-right: 20px;
         margin-left: auto;
         display: flex;
+    }
+    .content-left {
+        max-width: 55%;
     }
 
     .release-dialog-app-bar {

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -172,6 +172,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
 
         return [returnString, time];
     };
+    const sven = false;
     return (
         <li key={env.name} className={classNames('env-card', className)}>
             <div className="env-card-header">
@@ -226,23 +227,29 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                             title={
                                 'When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the "planned actions".'
                             }>
-                            <ExpandButton onClickSubmit={deployAndLockClick} />
-                            <div>-----</div>
-                            <div className={'dropdown-arrow-container'}>
-                                <Button
-                                    disabled={application && application.version === release.version}
-                                    className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
-                                    onClick={deployAndLockClick}
-                                    label="Deploy & Lock"
-                                />
-                                <Button
-                                    disabled={application && application.version === release.version}
-                                    className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
-                                    onClick={toggleAddLock}
-                                    icon={<div className={'dropdown-arrow'}>⌄</div>}
-                                    label=""
-                                />
-                            </div>
+                            <ExpandButton
+                                onClickSubmit={deployAndLockClick}
+                                defaultButtonLabel={'lock & deploy'}
+                                defaultButtonIcon={<></>}
+                            />
+                            {/*<div>-----</div>*/}
+                            {sven && (
+                                <div className={'dropdown-arrow-container'}>
+                                    <Button
+                                        disabled={application && application.version === release.version}
+                                        className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
+                                        onClick={deployAndLockClick}
+                                        label="Deploy & Lock"
+                                    />
+                                    <Button
+                                        disabled={application && application.version === release.version}
+                                        className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
+                                        onClick={toggleAddLock}
+                                        icon={<div className={'dropdown-arrow'}>⌄</div>}
+                                        label=""
+                                    />
+                                </div>
+                            )}
                             {/*<Checkbox*/}
                             {/*    id={*/}
                             {/*        'lock-' +*/}
@@ -299,7 +306,12 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
     const closeReleaseDialog = useCloseReleaseDialog();
 
     const dialog: JSX.Element | '' = (
-        <PlainDialog open={app !== ''} onClose={closeReleaseDialog} classNames={'release-dialog'}>
+        <PlainDialog
+            open={app !== ''}
+            onClose={closeReleaseDialog}
+            classNames={'release-dialog'}
+            disableBackground={true}
+            center={true}>
             <>
                 <div className={classNames('release-dialog-app-bar', className)}>
                     <div className={classNames('release-dialog-app-bar-data')}>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -31,6 +31,7 @@ import { FormattedDate } from '../FormattedDate/FormattedDate';
 import { ArgoAppLink, ArgoTeamLink, DisplayManifestLink, DisplaySourceLink } from '../../utils/Links';
 import { ReleaseVersion } from '../ReleaseVersion/ReleaseVersion';
 import { PlainDialog } from '../dialog/ConfirmationDialog';
+import { ExpandButton } from '../button/ExpandButton';
 // import { Checkbox } from '../dropdown/checkbox';
 
 export type ReleaseDialogProps = {
@@ -225,6 +226,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                             title={
                                 'When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the "planned actions".'
                             }>
+                            <ExpandButton onClick={todo} />
                             <div className={'dropdown-arrow-container'}>
                                 <Button
                                     disabled={application && application.version === release.version}

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -224,11 +224,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                             title={
                                 'When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, click the arrow.'
                             }>
-                            <ExpandButton
-                                onClickSubmit={deployAndLockClick}
-                                defaultButtonLabel={'lock & deploy'}
-                                defaultButtonIcon={<></>}
-                            />
+                            <ExpandButton onClickSubmit={deployAndLockClick} defaultButtonLabel={'lock & deploy'} />
                         </div>
                     </div>
                 </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -14,7 +14,7 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 import classNames from 'classnames';
-import React, { ReactElement, useCallback, useState } from 'react';
+import React, { ReactElement, useCallback } from 'react';
 import { Environment, Environment_Application, EnvironmentGroup, Lock, LockBehavior, Release } from '../../../api/api';
 import {
     addAction,
@@ -114,29 +114,34 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
             },
         });
     }, [app, env.name]);
-    const deployAndLockClick = useCallback(() => {
-        if (release.version) {
-            addAction({
-                action: {
-                    $case: 'deploy',
-                    deploy: {
-                        environment: env.name,
-                        application: app,
-                        version: release.version,
-                        ignoreAllLocks: false,
-                        lockBehavior: LockBehavior.Ignore,
+    const deployAndLockClick = useCallback(
+        (shouldLockToo: boolean) => {
+            if (release.version) {
+                addAction({
+                    action: {
+                        $case: 'deploy',
+                        deploy: {
+                            environment: env.name,
+                            application: app,
+                            version: release.version,
+                            ignoreAllLocks: false,
+                            lockBehavior: LockBehavior.Ignore,
+                        },
                     },
-                },
-            });
-            createAppLock();
-        }
-    }, [release.version, app, env.name, createAppLock]);
+                });
+                if (shouldLockToo) {
+                    createAppLock();
+                }
+            }
+        },
+        [release.version, app, env.name, createAppLock]
+    );
 
-    const [shouldLockToo, setShouldLockToo] = useState(true);
+    // const [shouldLockToo, setShouldLockToo] = useState(true);
 
-    const toggleAddLock = useCallback(() => {
-        setShouldLockToo(!shouldLockToo);
-    }, [shouldLockToo, setShouldLockToo]);
+    // const toggleAddLock = useCallback(() => {
+    //     setShouldLockToo(!shouldLockToo);
+    // }, [shouldLockToo, setShouldLockToo]);
 
     const queueInfo =
         queuedVersion === 0 ? null : (
@@ -225,7 +230,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                         />
                         <div
                             title={
-                                'When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the "planned actions".'
+                                'When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, click the arrow.'
                             }>
                             <ExpandButton
                                 onClickSubmit={deployAndLockClick}
@@ -238,13 +243,13 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                                     <Button
                                         disabled={application && application.version === release.version}
                                         className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
-                                        onClick={deployAndLockClick}
+                                        // onClick={() => {}}
                                         label="Deploy & Lock"
                                     />
                                     <Button
                                         disabled={application && application.version === release.version}
                                         className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
-                                        onClick={toggleAddLock}
+                                        // onClick={toggleAddLock}
                                         icon={<div className={'dropdown-arrow'}>⌄</div>}
                                         label=""
                                     />

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -226,7 +226,8 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                             title={
                                 'When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the "planned actions".'
                             }>
-                            <ExpandButton onClick={todo} />
+                            <ExpandButton onClickSubmit={deployAndLockClick} />
+                            <div>-----</div>
                             <div className={'dropdown-arrow-container'}>
                                 <Button
                                     disabled={application && application.version === release.version}

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -31,6 +31,7 @@ import { FormattedDate } from '../FormattedDate/FormattedDate';
 import { ArgoAppLink, ArgoTeamLink, DisplayManifestLink, DisplaySourceLink } from '../../utils/Links';
 import { ReleaseVersion } from '../ReleaseVersion/ReleaseVersion';
 import { PlainDialog } from '../dialog/ConfirmationDialog';
+// import { Checkbox } from '../dropdown/checkbox';
 
 export type ReleaseDialogProps = {
     className?: string;
@@ -224,6 +225,16 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                                 onClick={deployAndLockClick}
                                 label="Deploy & Lock"
                             />
+                            {/*<Checkbox*/}
+                            {/*    id={*/}
+                            {/*        'lock-' +*/}
+                            {/*        ((application && application.name) || 'no-app') +*/}
+                            {/*        '-' +*/}
+                            {/*        ((env && env.name) || 'no-env')*/}
+                            {/*    }*/}
+                            {/*    enabled={true}*/}
+                            {/*    label={'also lock'}*/}
+                            {/*/>*/}
                         </div>
                     </div>
                 </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -255,16 +255,6 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                                     />
                                 </div>
                             )}
-                            {/*<Checkbox*/}
-                            {/*    id={*/}
-                            {/*        'lock-' +*/}
-                            {/*        ((application && application.name) || 'no-app') +*/}
-                            {/*        '-' +*/}
-                            {/*        ((env && env.name) || 'no-env')*/}
-                            {/*    }*/}
-                            {/*    enabled={true}*/}
-                            {/*    label={'also lock'}*/}
-                            {/*/>*/}
                         </div>
                     </div>
                 </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -224,7 +224,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                             title={
                                 'When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, click the arrow.'
                             }>
-                            <ExpandButton onClickSubmit={deployAndLockClick} defaultButtonLabel={'lock & deploy'} />
+                            <ExpandButton onClickSubmit={deployAndLockClick} defaultButtonLabel={'Deploy & Lock'} />
                         </div>
                     </div>
                 </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -14,7 +14,7 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 import classNames from 'classnames';
-import React, { ReactElement, useCallback } from 'react';
+import React, { ReactElement, useCallback, useState } from 'react';
 import { Environment, Environment_Application, EnvironmentGroup, Lock, LockBehavior, Release } from '../../../api/api';
 import {
     addAction,
@@ -131,6 +131,12 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
         }
     }, [release.version, app, env.name, createAppLock]);
 
+    const [shouldLockToo, setShouldLockToo] = useState(true);
+
+    const toggleAddLock = useCallback(() => {
+        setShouldLockToo(!shouldLockToo);
+    }, [shouldLockToo, setShouldLockToo]);
+
     const queueInfo =
         queuedVersion === 0 ? null : (
             <div
@@ -219,12 +225,21 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                             title={
                                 'When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the "planned actions".'
                             }>
-                            <Button
-                                disabled={application && application.version === release.version}
-                                className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
-                                onClick={deployAndLockClick}
-                                label="Deploy & Lock"
-                            />
+                            <div className={'dropdown-arrow-container'}>
+                                <Button
+                                    disabled={application && application.version === release.version}
+                                    className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
+                                    onClick={deployAndLockClick}
+                                    label="Deploy & Lock"
+                                />
+                                <Button
+                                    disabled={application && application.version === release.version}
+                                    className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
+                                    onClick={toggleAddLock}
+                                    icon={<div className={'dropdown-arrow'}>⌄</div>}
+                                    label=""
+                                />
+                            </div>
                             {/*<Checkbox*/}
                             {/*    id={*/}
                             {/*        'lock-' +*/}

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -32,7 +32,6 @@ import { ArgoAppLink, ArgoTeamLink, DisplayManifestLink, DisplaySourceLink } fro
 import { ReleaseVersion } from '../ReleaseVersion/ReleaseVersion';
 import { PlainDialog } from '../dialog/ConfirmationDialog';
 import { ExpandButton } from '../button/ExpandButton';
-// import { Checkbox } from '../dropdown/checkbox';
 
 export type ReleaseDialogProps = {
     className?: string;
@@ -137,12 +136,6 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
         [release.version, app, env.name, createAppLock]
     );
 
-    // const [shouldLockToo, setShouldLockToo] = useState(true);
-
-    // const toggleAddLock = useCallback(() => {
-    //     setShouldLockToo(!shouldLockToo);
-    // }, [shouldLockToo, setShouldLockToo]);
-
     const queueInfo =
         queuedVersion === 0 ? null : (
             <div
@@ -177,7 +170,6 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
 
         return [returnString, time];
     };
-    const sven = false;
     return (
         <li key={env.name} className={classNames('env-card', className)}>
             <div className="env-card-header">
@@ -237,24 +229,6 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                                 defaultButtonLabel={'lock & deploy'}
                                 defaultButtonIcon={<></>}
                             />
-                            {/*<div>-----</div>*/}
-                            {sven && (
-                                <div className={'dropdown-arrow-container'}>
-                                    <Button
-                                        disabled={application && application.version === release.version}
-                                        className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
-                                        // onClick={() => {}}
-                                        label="Deploy & Lock"
-                                    />
-                                    <Button
-                                        disabled={application && application.version === release.version}
-                                        className={classNames('env-card-deploy-btn', 'mdc-button--unelevated')}
-                                        // onClick={toggleAddLock}
-                                        icon={<div className={'dropdown-arrow'}>⌄</div>}
-                                        label=""
-                                    />
-                                </div>
-                            )}
                         </div>
                     </div>
                 </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                           >
                             <button
                               aria-label="lock & deploy"
-                              class="mdc-button button-first env-card-deploy-btn mdc-button--unelevated"
+                              class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated"
                             >
                               <div
                                 class="mdc-button__ripple"
@@ -229,7 +229,7 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                             </button>
                             <button
                               aria-label=""
-                              class="mdc-button button-second"
+                              class="mdc-button button-expand"
                             >
                               <div
                                 class="mdc-button__ripple"
@@ -475,7 +475,7 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                           >
                             <button
                               aria-label="lock & deploy"
-                              class="mdc-button button-first env-card-deploy-btn mdc-button--unelevated"
+                              class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated"
                             >
                               <div
                                 class="mdc-button__ripple"
@@ -488,7 +488,7 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                             </button>
                             <button
                               aria-label=""
-                              class="mdc-button button-second"
+                              class="mdc-button button-expand"
                             >
                               <div
                                 class="mdc-button__ripple"
@@ -734,7 +734,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                           >
                             <button
                               aria-label="lock & deploy"
-                              class="mdc-button button-first env-card-deploy-btn mdc-button--unelevated"
+                              class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated"
                             >
                               <div
                                 class="mdc-button__ripple"
@@ -747,7 +747,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                             </button>
                             <button
                               aria-label=""
-                              class="mdc-button button-second"
+                              class="mdc-button button-expand"
                             >
                               <div
                                 class="mdc-button__ripple"
@@ -919,7 +919,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                           >
                             <button
                               aria-label="lock & deploy"
-                              class="mdc-button button-first env-card-deploy-btn mdc-button--unelevated"
+                              class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated"
                             >
                               <div
                                 class="mdc-button__ripple"
@@ -932,7 +932,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                             </button>
                             <button
                               aria-label=""
-                              class="mdc-button button-second"
+                              class="mdc-button button-expand"
                             >
                               <div
                                 class="mdc-button__ripple"

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -206,22 +206,42 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                         </span>
                       </button>
                       <div
-                        title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                        title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, click the arrow."
                       >
-                        <button
-                          aria-label="Deploy & Lock"
-                          class="mdc-button env-card-deploy-btn mdc-button--unelevated"
-                          disabled=""
+                        <div
+                          class="expand-button"
                         >
                           <div
-                            class="mdc-button__ripple"
-                          />
-                          <span
-                            class="mdc-button__label"
+                            class="first-two"
                           >
-                            Deploy & Lock
-                          </span>
-                        </button>
+                            <button
+                              aria-label="lock & deploy"
+                              class="mdc-button button-first env-card-deploy-btn mdc-button--unelevated"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <span
+                                class="mdc-button__label"
+                              >
+                                lock & deploy
+                              </span>
+                            </button>
+                            <button
+                              aria-label=""
+                              class="mdc-button button-second"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <div
+                                class="dropdown-arrow"
+                              >
+                                ⌄
+                              </div>
+                            </button>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -445,22 +465,42 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                         </span>
                       </button>
                       <div
-                        title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                        title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, click the arrow."
                       >
-                        <button
-                          aria-label="Deploy & Lock"
-                          class="mdc-button env-card-deploy-btn mdc-button--unelevated"
-                          disabled=""
+                        <div
+                          class="expand-button"
                         >
                           <div
-                            class="mdc-button__ripple"
-                          />
-                          <span
-                            class="mdc-button__label"
+                            class="first-two"
                           >
-                            Deploy & Lock
-                          </span>
-                        </button>
+                            <button
+                              aria-label="lock & deploy"
+                              class="mdc-button button-first env-card-deploy-btn mdc-button--unelevated"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <span
+                                class="mdc-button__label"
+                              >
+                                lock & deploy
+                              </span>
+                            </button>
+                            <button
+                              aria-label=""
+                              class="mdc-button button-second"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <div
+                                class="dropdown-arrow"
+                              >
+                                ⌄
+                              </div>
+                            </button>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -684,22 +724,42 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                         </span>
                       </button>
                       <div
-                        title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                        title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, click the arrow."
                       >
-                        <button
-                          aria-label="Deploy & Lock"
-                          class="mdc-button env-card-deploy-btn mdc-button--unelevated"
-                          disabled=""
+                        <div
+                          class="expand-button"
                         >
                           <div
-                            class="mdc-button__ripple"
-                          />
-                          <span
-                            class="mdc-button__label"
+                            class="first-two"
                           >
-                            Deploy & Lock
-                          </span>
-                        </button>
+                            <button
+                              aria-label="lock & deploy"
+                              class="mdc-button button-first env-card-deploy-btn mdc-button--unelevated"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <span
+                                class="mdc-button__label"
+                              >
+                                lock & deploy
+                              </span>
+                            </button>
+                            <button
+                              aria-label=""
+                              class="mdc-button button-second"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <div
+                                class="dropdown-arrow"
+                              >
+                                ⌄
+                              </div>
+                            </button>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -849,21 +909,42 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                         </span>
                       </button>
                       <div
-                        title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, you can remove it from the \\"planned actions\\"."
+                        title="When doing manual deployments, it is usually best to also lock the app. If you omit the lock, an automatic release train or another person may deploy an unintended version. If you do not want a lock, click the arrow."
                       >
-                        <button
-                          aria-label="Deploy & Lock"
-                          class="mdc-button env-card-deploy-btn mdc-button--unelevated"
+                        <div
+                          class="expand-button"
                         >
                           <div
-                            class="mdc-button__ripple"
-                          />
-                          <span
-                            class="mdc-button__label"
+                            class="first-two"
                           >
-                            Deploy & Lock
-                          </span>
-                        </button>
+                            <button
+                              aria-label="lock & deploy"
+                              class="mdc-button button-first env-card-deploy-btn mdc-button--unelevated"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <span
+                                class="mdc-button__label"
+                              >
+                                lock & deploy
+                              </span>
+                            </button>
+                            <button
+                              aria-label=""
+                              class="mdc-button button-second"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <div
+                                class="dropdown-arrow"
+                              >
+                                ⌄
+                              </div>
+                            </button>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -215,7 +215,7 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                             class="first-two"
                           >
                             <button
-                              aria-label="lock & deploy"
+                              aria-label="Deploy & Lock"
                               class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated"
                             >
                               <div
@@ -224,7 +224,7 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                               <span
                                 class="mdc-button__label"
                               >
-                                lock & deploy
+                                Deploy & Lock
                               </span>
                             </button>
                             <button
@@ -474,7 +474,7 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                             class="first-two"
                           >
                             <button
-                              aria-label="lock & deploy"
+                              aria-label="Deploy & Lock"
                               class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated"
                             >
                               <div
@@ -483,7 +483,7 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                               <span
                                 class="mdc-button__label"
                               >
-                                lock & deploy
+                                Deploy & Lock
                               </span>
                             </button>
                             <button
@@ -733,7 +733,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                             class="first-two"
                           >
                             <button
-                              aria-label="lock & deploy"
+                              aria-label="Deploy & Lock"
                               class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated"
                             >
                               <div
@@ -742,7 +742,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                               <span
                                 class="mdc-button__label"
                               >
-                                lock & deploy
+                                Deploy & Lock
                               </span>
                             </button>
                             <button
@@ -918,7 +918,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                             class="first-two"
                           >
                             <button
-                              aria-label="lock & deploy"
+                              aria-label="Deploy & Lock"
                               class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated"
                             >
                               <div
@@ -927,7 +927,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                               <span
                                 class="mdc-button__label"
                               >
-                                lock & deploy
+                                Deploy & Lock
                               </span>
                             </button>
                             <button

--- a/services/frontend-service/src/ui/components/button/ExpandButton.test.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.test.tsx
@@ -1,0 +1,102 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { elementQuerySelectorSafe } from '../../../setupTests';
+import { ExpandButton, ExpandButtonProps } from './ExpandButton';
+
+describe('ExpandButton', () => {
+    const mySubmitSpy = jest.fn(() => {});
+    const defaultProps: ExpandButtonProps = {
+        onClickSubmit: mySubmitSpy,
+        defaultButtonLabel: 'default-button',
+    };
+
+    const getNode = (): JSX.Element => <ExpandButton {...defaultProps} />;
+
+    const getWrapper = () => render(getNode());
+
+    type TestData = {
+        name: string;
+        props: Partial<ExpandButtonProps>;
+        // if we click these buttons...
+        clickThis: string[];
+        // then we expect the popup to show up:
+        expectExpanded: boolean;
+        expectSubmitCalledTimes: number;
+        expectSubmitCalledWith: Object; // only relevant if expectCalledTimes != 0
+    };
+
+    const data: TestData[] = [
+        {
+            name: 'click expand once',
+            props: {},
+            clickThis: ['.button-expand'],
+            expectExpanded: true,
+            expectSubmitCalledTimes: 0,
+            expectSubmitCalledWith: {},
+        },
+        {
+            name: 'click expand twice',
+            props: {},
+            clickThis: ['.button-expand', '.button-expand'],
+            expectExpanded: false,
+            expectSubmitCalledTimes: 0,
+            expectSubmitCalledWith: {},
+        },
+        {
+            name: 'click Main button',
+            props: {},
+            clickThis: ['.button-main'],
+            expectExpanded: false,
+            expectSubmitCalledTimes: 1,
+            expectSubmitCalledWith: true,
+        },
+        {
+            name: 'click expand, then alternative button',
+            props: {},
+            clickThis: ['.button-expand', '.button-popup'],
+            expectExpanded: true,
+            expectSubmitCalledTimes: 1,
+            expectSubmitCalledWith: false,
+        },
+    ];
+
+    describe.each(data)(`Renders a navigation item with selected`, (testcase) => {
+        it(testcase.name, () => {
+            mySubmitSpy.mockReset();
+            const { container } = getWrapper();
+
+            expect(document.getElementsByClassName('expand-dialog').length).toBe(0);
+            expect(mySubmitSpy).toHaveBeenCalledTimes(0);
+
+            testcase.clickThis.forEach((clickMe: string) => {
+                const button = elementQuerySelectorSafe(container, clickMe);
+                act(() => {
+                    button.click();
+                });
+            });
+
+            const expectedCount = testcase.expectExpanded ? 1 : 0;
+            expect(document.getElementsByClassName('expand-dialog').length).toBe(expectedCount);
+
+            expect(mySubmitSpy).toHaveBeenCalledTimes(testcase.expectSubmitCalledTimes);
+            if (testcase.expectSubmitCalledTimes !== 0) {
+                expect(mySubmitSpy).toHaveBeenCalledWith(testcase.expectSubmitCalledWith);
+            }
+        });
+    });
+});

--- a/services/frontend-service/src/ui/components/button/ExpandButton.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.tsx
@@ -24,13 +24,14 @@ import { PlainDialog } from '../dialog/ConfirmationDialog';
  * Displays one normal button on the left, and one arrow on the right to select a different option.
  */
 export const ExpandButton = (props: {
-    onClickSubmit: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    onClickSubmit: (shouldLockToo: boolean) => void;
     defaultButtonLabel: string;
     defaultButtonIcon: JSX.Element;
 }): JSX.Element => {
     const { onClickSubmit } = props;
 
     const [expanded, setExpanded] = useState(false);
+    // const [shouldLock, setShouldLock] = useState(true);
 
     const onClickExpand = useCallback(() => {
         // eslint-disable-next-line no-console
@@ -41,29 +42,38 @@ export const ExpandButton = (props: {
         setExpanded(false);
     }, [setExpanded]);
 
+    const onClickSubmitMain = useCallback(() => {
+        onClickSubmit(true);
+    }, [onClickSubmit]);
+    const onClickSubmitAlternative = useCallback(() => {
+        onClickSubmit(false);
+    }, [onClickSubmit]);
+
     // const  = useCallback(() => {
     //     setShouldLockToo(!shouldLockToo);
     // }, [shouldLockToo, setShouldLockToo]);
 
     return (
         <div className={'expand-button'}>
-            {/* the main button: */}
-            <Button
-                id={'expand-1'}
-                onClick={onClickSubmit}
-                className={'button-first env-card-deploy-btn mdc-button--unelevated'}
-                key={'button-first-key'}
-                label={props.defaultButtonLabel}
-            />
-            {/* the button to expand the dialog: */}
-            <Button
-                id={'expand-2'}
-                onClick={onClickExpand}
-                className={'button-second'}
-                key={'button-second-key'}
-                label={''}
-                icon={<div className={'dropdown-arrow'}>⌄</div>}
-            />
+            <div className={'first-two'}>
+                {/* the main button: */}
+                <Button
+                    id={'expand-1'}
+                    onClick={onClickSubmitMain}
+                    className={'button-first env-card-deploy-btn mdc-button--unelevated'}
+                    key={'button-first-key'}
+                    label={props.defaultButtonLabel}
+                />
+                {/* the button to expand the dialog: */}
+                <Button
+                    id={'expand-2'}
+                    onClick={onClickExpand}
+                    className={'button-second'}
+                    key={'button-second-key'}
+                    label={''}
+                    icon={<div className={'dropdown-arrow'}>⌄</div>}
+                />
+            </div>
             {/*TODO SU REMOVE: */}
             {/*{expanded ? 'exp' : 'not-exp'}*/}
             {expanded && (
@@ -73,17 +83,18 @@ export const ExpandButton = (props: {
                     classNames={'expand-dialog'}
                     disableBackground={false}
                     center={false}>
-                    <div>
-                        {/*<div>Deploy without creating a lock:</div>*/}
-                        <Button
-                            id={'expand-3'}
-                            onClick={onClickExpand}
-                            className={'button-second env-card-deploy-btn mdc-button--unelevated'}
-                            key={'button-second-key'}
-                            label={'Deploy only'}
-                            icon={undefined}
-                        />
-                    </div>
+                    <>
+                        <div>
+                            <Button
+                                id={'expand-3'}
+                                onClick={onClickSubmitAlternative}
+                                className={'button-second env-card-deploy-btn mdc-button--unelevated'}
+                                key={'button-second-key'}
+                                label={'Deploy only'}
+                                icon={undefined}
+                            />
+                        </div>
+                    </>
                 </PlainDialog>
             )}
         </div>

--- a/services/frontend-service/src/ui/components/button/ExpandButton.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.tsx
@@ -17,6 +17,11 @@ import { useCallback, useState } from 'react';
 import * as React from 'react';
 import { Button } from './button';
 
+/**
+ * Two buttons combined into one.
+ * Inspired by GitHubs merge button.
+ * Displays one normal button on the left, and one arrow on the right to select a different option.
+ */
 export const ExpandButton = (props: {
     onClickSubmit: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }): JSX.Element => {

--- a/services/frontend-service/src/ui/components/button/ExpandButton.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.tsx
@@ -1,0 +1,43 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+import { useCallback, useState } from 'react';
+import * as React from 'react';
+import { Button } from './button';
+
+export const ExpandButton = (props: {
+    onClickSubmit: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}): JSX.Element => {
+    const { onClickSubmit } = props;
+
+    const [expanded, setExpanded] = useState(false);
+
+    const onClickExpand = useCallback(() => {
+        setExpanded(!expanded);
+    }, [setExpanded, expanded]);
+
+    // const  = useCallback(() => {
+    //     setShouldLockToo(!shouldLockToo);
+    // }, [shouldLockToo, setShouldLockToo]);
+
+    return (
+        <div>
+            <Button onClick={onClickSubmit} className={'button-first'} key={'button-first-key'} />
+            <Button onClick={onClickExpand} className={'button-second'} key={'button-second-key'} />
+
+            {expanded ? 'expanded' : 'not-expanded'}
+        </div>
+    );
+};

--- a/services/frontend-service/src/ui/components/button/ExpandButton.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.tsx
@@ -31,13 +31,11 @@ export const ExpandButton = (props: {
     const { onClickSubmit } = props;
 
     const [expanded, setExpanded] = useState(false);
-    // const [shouldLock, setShouldLock] = useState(true);
 
     const onClickExpand = useCallback(() => {
-        // eslint-disable-next-line no-console
-        console.info('SU DEBUG: click old: expanded=', expanded); // eslint-disable-next-line no-console
         setExpanded(!expanded);
     }, [setExpanded, expanded]);
+
     const onClickClose = useCallback(() => {
         setExpanded(false);
     }, [setExpanded]);
@@ -45,20 +43,16 @@ export const ExpandButton = (props: {
     const onClickSubmitMain = useCallback(() => {
         onClickSubmit(true);
     }, [onClickSubmit]);
+
     const onClickSubmitAlternative = useCallback(() => {
         onClickSubmit(false);
     }, [onClickSubmit]);
-
-    // const  = useCallback(() => {
-    //     setShouldLockToo(!shouldLockToo);
-    // }, [shouldLockToo, setShouldLockToo]);
 
     return (
         <div className={'expand-button'}>
             <div className={'first-two'}>
                 {/* the main button: */}
                 <Button
-                    id={'expand-1'}
                     onClick={onClickSubmitMain}
                     className={'button-first env-card-deploy-btn mdc-button--unelevated'}
                     key={'button-first-key'}
@@ -66,7 +60,6 @@ export const ExpandButton = (props: {
                 />
                 {/* the button to expand the dialog: */}
                 <Button
-                    id={'expand-2'}
                     onClick={onClickExpand}
                     className={'button-second'}
                     key={'button-second-key'}
@@ -74,8 +67,6 @@ export const ExpandButton = (props: {
                     icon={<div className={'dropdown-arrow'}>⌄</div>}
                 />
             </div>
-            {/*TODO SU REMOVE: */}
-            {/*{expanded ? 'exp' : 'not-exp'}*/}
             {expanded && (
                 <PlainDialog
                     open={expanded}

--- a/services/frontend-service/src/ui/components/button/ExpandButton.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.tsx
@@ -23,11 +23,12 @@ import { PlainDialog } from '../dialog/ConfirmationDialog';
  * Inspired by GitHubs merge button.
  * Displays one normal button on the left, and one arrow on the right to select a different option.
  */
-export const ExpandButton = (props: {
+export type ExpandButtonProps = {
     onClickSubmit: (shouldLockToo: boolean) => void;
     defaultButtonLabel: string;
-    defaultButtonIcon: JSX.Element;
-}): JSX.Element => {
+};
+
+export const ExpandButton = (props: ExpandButtonProps): JSX.Element => {
     const { onClickSubmit } = props;
 
     const [expanded, setExpanded] = useState(false);
@@ -54,14 +55,14 @@ export const ExpandButton = (props: {
                 {/* the main button: */}
                 <Button
                     onClick={onClickSubmitMain}
-                    className={'button-first env-card-deploy-btn mdc-button--unelevated'}
+                    className={'button-main env-card-deploy-btn mdc-button--unelevated'}
                     key={'button-first-key'}
                     label={props.defaultButtonLabel}
                 />
                 {/* the button to expand the dialog: */}
                 <Button
                     onClick={onClickExpand}
-                    className={'button-second'}
+                    className={'button-expand'}
                     key={'button-second-key'}
                     label={''}
                     icon={<div className={'dropdown-arrow'}>⌄</div>}
@@ -77,9 +78,8 @@ export const ExpandButton = (props: {
                     <>
                         <div>
                             <Button
-                                id={'expand-3'}
                                 onClick={onClickSubmitAlternative}
-                                className={'button-second env-card-deploy-btn mdc-button--unelevated'}
+                                className={'button-popup env-card-deploy-btn mdc-button--unelevated'}
                                 key={'button-second-key'}
                                 label={'Deploy only'}
                                 icon={undefined}

--- a/services/frontend-service/src/ui/components/button/ExpandButton.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.tsx
@@ -16,6 +16,7 @@ Copyright 2023 freiheit.com*/
 import { useCallback, useState } from 'react';
 import * as React from 'react';
 import { Button } from './button';
+import { PlainDialog } from '../dialog/ConfirmationDialog';
 
 /**
  * Two buttons combined into one.
@@ -24,25 +25,67 @@ import { Button } from './button';
  */
 export const ExpandButton = (props: {
     onClickSubmit: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    defaultButtonLabel: string;
+    defaultButtonIcon: JSX.Element;
 }): JSX.Element => {
     const { onClickSubmit } = props;
 
     const [expanded, setExpanded] = useState(false);
 
     const onClickExpand = useCallback(() => {
+        // eslint-disable-next-line no-console
+        console.info('SU DEBUG: click old: expanded=', expanded); // eslint-disable-next-line no-console
         setExpanded(!expanded);
     }, [setExpanded, expanded]);
+    const onClickClose = useCallback(() => {
+        setExpanded(false);
+    }, [setExpanded]);
 
     // const  = useCallback(() => {
     //     setShouldLockToo(!shouldLockToo);
     // }, [shouldLockToo, setShouldLockToo]);
 
     return (
-        <div>
-            <Button onClick={onClickSubmit} className={'button-first'} key={'button-first-key'} />
-            <Button onClick={onClickExpand} className={'button-second'} key={'button-second-key'} />
-
-            {expanded ? 'expanded' : 'not-expanded'}
+        <div className={'expand-button'}>
+            {/* the main button: */}
+            <Button
+                id={'expand-1'}
+                onClick={onClickSubmit}
+                className={'button-first env-card-deploy-btn mdc-button--unelevated'}
+                key={'button-first-key'}
+                label={props.defaultButtonLabel}
+            />
+            {/* the button to expand the dialog: */}
+            <Button
+                id={'expand-2'}
+                onClick={onClickExpand}
+                className={'button-second'}
+                key={'button-second-key'}
+                label={''}
+                icon={<div className={'dropdown-arrow'}>⌄</div>}
+            />
+            {/*TODO SU REMOVE: */}
+            {/*{expanded ? 'exp' : 'not-exp'}*/}
+            {expanded && (
+                <PlainDialog
+                    open={expanded}
+                    onClose={onClickClose}
+                    classNames={'expand-dialog'}
+                    disableBackground={false}
+                    center={false}>
+                    <div>
+                        {/*<div>Deploy without creating a lock:</div>*/}
+                        <Button
+                            id={'expand-3'}
+                            onClick={onClickExpand}
+                            className={'button-second env-card-deploy-btn mdc-button--unelevated'}
+                            key={'button-second-key'}
+                            label={'Deploy only'}
+                            icon={undefined}
+                        />
+                    </div>
+                </PlainDialog>
+            )}
         </div>
     );
 };

--- a/services/frontend-service/src/ui/components/button/button.scss
+++ b/services/frontend-service/src/ui/components/button/button.scss
@@ -18,3 +18,7 @@ Copyright 2023 freiheit.com*/
 .mdc-button {
     @extend .font;
 }
+
+.expand-button {
+    color: red;
+}

--- a/services/frontend-service/src/ui/components/button/button.scss
+++ b/services/frontend-service/src/ui/components/button/button.scss
@@ -32,10 +32,10 @@ Copyright 2023 freiheit.com*/
             border-bottom-right-radius: 0;
         }
         #expand-2 {
-            //padding: 0 8px 0 8px;
             padding: 0;
             min-width: 36px;
             .dropdown-arrow {
+                margin-bottom: 40%; // to center the arrow
                 font-size: xx-large;
             }
         }

--- a/services/frontend-service/src/ui/components/button/button.scss
+++ b/services/frontend-service/src/ui/components/button/button.scss
@@ -20,7 +20,7 @@ Copyright 2023 freiheit.com*/
 }
 
 .expand-button {
-    border-width: medium;
+    border-width: thin;
     border-radius: 14px;
     border-color: blue;
     border-style: groove;
@@ -28,8 +28,7 @@ Copyright 2023 freiheit.com*/
     .first-two {
         height: 36px;
         .button-main {
-            border-top-right-radius: 0;
-            border-bottom-right-radius: 0;
+            border-radius: 12px 0 0 12px;
         }
         .button-expand {
             padding: 0;

--- a/services/frontend-service/src/ui/components/button/button.scss
+++ b/services/frontend-service/src/ui/components/button/button.scss
@@ -27,11 +27,11 @@ Copyright 2023 freiheit.com*/
 
     .first-two {
         height: 36px;
-        #expand-1 {
+        .button-first {
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;
         }
-        #expand-2 {
+        .button-second {
             padding: 0;
             min-width: 36px;
             .dropdown-arrow {

--- a/services/frontend-service/src/ui/components/button/button.scss
+++ b/services/frontend-service/src/ui/components/button/button.scss
@@ -20,5 +20,24 @@ Copyright 2023 freiheit.com*/
 }
 
 .expand-button {
-    color: red;
+    border-width: medium;
+    border-radius: 14px;
+    border-color: blue;
+    border-style: groove;
+
+    .first-two {
+        height: 36px;
+        #expand-1 {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+        }
+        #expand-2 {
+            //padding: 0 8px 0 8px;
+            padding: 0;
+            min-width: 36px;
+            .dropdown-arrow {
+                font-size: xx-large;
+            }
+        }
+    }
 }

--- a/services/frontend-service/src/ui/components/button/button.scss
+++ b/services/frontend-service/src/ui/components/button/button.scss
@@ -27,11 +27,11 @@ Copyright 2023 freiheit.com*/
 
     .first-two {
         height: 36px;
-        .button-first {
+        .button-main {
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;
         }
-        .button-second {
+        .button-expand {
             padding: 0;
             min-width: 36px;
             .dropdown-arrow {

--- a/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.scss
+++ b/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.scss
@@ -50,9 +50,9 @@ Copyright 2023 freiheit.com*/
     // the border radius should be the same as the release dialog:
     border-radius: $release-dialog-outer-border-radius;
     box-shadow:
-            rgba(0, 0, 0, 0.2) 0 5px 5px -3px,
-            rgba(0, 0, 0, 0.14) 0px 8px 10px 1px,
-            rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
+        rgba(0, 0, 0, 0.2) 0 5px 5px -3px,
+        rgba(0, 0, 0, 0.14) 0px 8px 10px 1px,
+        rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
 }
 
 .confirmation-dialog-open {

--- a/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.scss
+++ b/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.scss
@@ -16,7 +16,6 @@ Copyright 2023 freiheit.com*/
 
 .confirmation-dialog-container {
     display: flex;
-    //position: relative;
 }
 
 .plain-dialog-container {
@@ -40,18 +39,12 @@ Copyright 2023 freiheit.com*/
 
 .plain-dialog-open {
     position: absolute;
-    //min-width: 200px;
-
     max-height: 80vh;
     display: grid;
     grid-template-rows: auto 1fr auto;
     background: white;
     color: black;
-    //position: fixed;
     float: left;
-    //left: 50%;
-    //top: 50%;
-    //transform: translate(-50%, -50%);
 
     z-index: 1000;
     // the border radius has to align with the border radius of the release dialog:
@@ -65,9 +58,6 @@ Copyright 2023 freiheit.com*/
 }
 
 .confirmation-dialog-open {
-    //position: absolute;
-    //min-width: 200px;
-
     max-height: 80vh;
     display: grid;
     grid-template-rows: auto 1fr auto;
@@ -77,6 +67,8 @@ Copyright 2023 freiheit.com*/
     float: left;
     left: 50%;
     top: 50%;
+    // confirmation dialogs are centered around the middle of the screen
+    // (plain dialogs are centered around an ancestor element)
     transform: translate(-50%, -50%);
 
     z-index: 1000;

--- a/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.scss
+++ b/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.scss
@@ -16,6 +16,12 @@ Copyright 2023 freiheit.com*/
 
 .confirmation-dialog-container {
     display: flex;
+    //position: relative;
+}
+
+.plain-dialog-container {
+    display: flex;
+    position: relative;
 }
 
 .confirmation-dialog-container-open {
@@ -32,7 +38,36 @@ Copyright 2023 freiheit.com*/
     }
 }
 
+.plain-dialog-open {
+    position: absolute;
+    //min-width: 200px;
+
+    max-height: 80vh;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    background: white;
+    color: black;
+    //position: fixed;
+    float: left;
+    //left: 50%;
+    //top: 50%;
+    //transform: translate(-50%, -50%);
+
+    z-index: 1000;
+    // the border radius has to align with the border radius of the release dialog:
+    border-radius: $release-dialog-outer-border-radius;
+    box-shadow:
+            rgba(0, 0, 0, 0.2) 0 5px 5px -3px,
+            rgba(0, 0, 0, 0.14) 0px 8px 10px 1px,
+            rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
+
+
+}
+
 .confirmation-dialog-open {
+    //position: absolute;
+    //min-width: 200px;
+
     max-height: 80vh;
     display: grid;
     grid-template-rows: auto 1fr auto;

--- a/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.scss
+++ b/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.scss
@@ -47,14 +47,12 @@ Copyright 2023 freiheit.com*/
     float: left;
 
     z-index: 1000;
-    // the border radius has to align with the border radius of the release dialog:
+    // the border radius should be the same as the release dialog:
     border-radius: $release-dialog-outer-border-radius;
     box-shadow:
             rgba(0, 0, 0, 0.2) 0 5px 5px -3px,
             rgba(0, 0, 0, 0.14) 0px 8px 10px 1px,
             rgba(0, 0, 0, 0.12) 0px 3px 14px 2px;
-
-
 }
 
 .confirmation-dialog-open {

--- a/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.tsx
+++ b/services/frontend-service/src/ui/components/dialog/ConfirmationDialog.tsx
@@ -31,7 +31,12 @@ export type ConfirmationDialogProps = {
  * A dialog that is used to confirm a question with either yes or no.
  */
 export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => (
-    <PlainDialog open={props.open} onClose={props.onCancel} classNames={props.classNames}>
+    <PlainDialog
+        open={props.open}
+        onClose={props.onCancel}
+        classNames={props.classNames}
+        disableBackground={true}
+        center={true}>
         <>
             <div className={'confirmation-dialog-header'}>{props.headerLabel}</div>
             <hr />
@@ -62,6 +67,8 @@ export type PlainDialogProps = {
     onClose: () => void;
     children: JSX.Element;
     classNames: string;
+    disableBackground: boolean;
+    center: boolean;
 };
 
 /**
@@ -69,6 +76,7 @@ export type PlainDialogProps = {
  */
 export const PlainDialog: React.FC<PlainDialogProps> = (props) => {
     const { onClose, open, children } = props;
+    const classPrefix = props.center ? 'confirmation' : 'plain';
     React.useEffect(() => {
         window.addEventListener('keyup', (event) => {
             if (event.key === 'Escape') {
@@ -78,21 +86,22 @@ export const PlainDialog: React.FC<PlainDialogProps> = (props) => {
         document.addEventListener('click', (event) => {
             if (open) {
                 if (event.target instanceof HTMLElement) {
-                    const isOutside = event.target.className.indexOf('confirmation-dialog-container') >= 0;
+                    const isOutside = event.target.className.indexOf(classPrefix + '-dialog-container') >= 0;
                     if (isOutside) {
                         onClose();
                     }
                 }
             }
         });
-    }, [onClose, open]);
+    }, [onClose, open, classPrefix]);
 
     if (!open) {
-        return <div className={'confirmation-dialog-hidden'}></div>;
+        return <div className={''}></div>;
     }
+    const clas = props.disableBackground ? classPrefix + '-dialog-container-open' : '';
     return (
-        <div className={'confirmation-dialog-container ' + (props.open ? 'confirmation-dialog-container-open' : '')}>
-            <div className={'confirmation-dialog-open ' + props.classNames}>{children}</div>
+        <div className={classPrefix + '-dialog-container ' + (props.open ? clas : '')}>
+            <div className={classPrefix + '-dialog-open ' + props.classNames}>{children}</div>
         </div>
     );
 };

--- a/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
+++ b/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
@@ -66,7 +66,7 @@ export const DropdownSelect: React.FC<DropdownSelectProps> = (props) => {
     return (
         <div className={'dropdown-container'}>
             <div className={'dropdown-arrow-container'}>
-                <div className={'dropdown-arrow'}>⌄</div>
+                <div className={'dropdown-arrow aha123'}>⌄</div>
                 <input
                     type="text"
                     className="dropdown-input"

--- a/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
+++ b/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
@@ -66,7 +66,7 @@ export const DropdownSelect: React.FC<DropdownSelectProps> = (props) => {
     return (
         <div className={'dropdown-container'}>
             <div className={'dropdown-arrow-container'}>
-                <div className={'dropdown-arrow aha123'}>⌄</div>
+                <div className={'dropdown-arrow'}>⌄</div>
                 <input
                     type="text"
                     className="dropdown-input"

--- a/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
+++ b/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
@@ -78,7 +78,7 @@ export const DropdownSelect: React.FC<DropdownSelectProps> = (props) => {
                     data-testid="teams-dropdown-input"
                 />
             </div>
-            <PlainDialog open={open} onClose={onCancel} classNames={'dropdown'}>
+            <PlainDialog open={open} onClose={onCancel} classNames={'dropdown'} disableBackground={true} center={false}>
                 <div>
                     {allTeams.map((team: string) => (
                         <div key={team}>


### PR DESCRIPTION
Adds a new button "Deploy only" that pops up when the user clicks the dropdown.
This makes it easier for users to deploy without creating a lock. But the default is still to create a lock with every manual deployment.

![image](https://github.com/freiheit-com/kuberpult/assets/3481382/1cdac2c3-5e95-4f77-8f52-51ad46a638c8)
