### PR TITLE
SRC-K0RM01: improve UX for app and team filters (#1033, #1034)

### DIFF
--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -14,7 +14,6 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 import { NavigationBar } from '../components/NavigationBar/NavigationBar';
-import { TopAppBar } from '../components/TopAppBar/TopAppBar';
 import { ReleaseDialog } from '../components/ReleaseDialog/ReleaseDialog';
 import { PageRoutes } from './PageRoutes';
 import '../../assets/app-v2.scss';
@@ -139,7 +138,6 @@ export const App: React.FC = () => {
                 {app && version ? <ReleaseDialog app={app} version={version} /> : null}
                 <NavigationBar />
                 <div className="mdc-drawer-app-content">
-                    <TopAppBar />
                     <PageRoutes />
                     <Snackbar />
                 </div>

--- a/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.tsx
@@ -17,6 +17,7 @@ import { useEnvironmentGroups, useEnvironments, useGlobalLoadingState } from '..
 import { EnvironmentCard, EnvironmentGroupCard } from '../../components/EnvironmentCard/EnvironmentCard';
 import { LoadingStateSpinner } from '../../utils/LoadingStateSpinner';
 import React from 'react';
+import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
 
 export const EnvironmentsPage: React.FC = () => {
     const envsGroups = useEnvironmentGroups();
@@ -30,16 +31,13 @@ export const EnvironmentsPage: React.FC = () => {
         return <LoadingStateSpinner loadingState={loadingState} />;
     }
 
-    if (useGroups) {
-        return (
-            <main className="main-content">
-                {envsGroups.map((envGroup) => (
-                    <EnvironmentGroupCard environmentGroup={envGroup} key={envGroup.environmentGroupName} />
-                ))}
-            </main>
-        );
-    }
-    return (
+    const mainContent: JSX.Element = useGroups ? (
+        <main className="main-content">
+            {envsGroups.map((envGroup) => (
+                <EnvironmentGroupCard environmentGroup={envGroup} key={envGroup.environmentGroupName} />
+            ))}
+        </main>
+    ) : (
         <main className="main-content">
             {/*if there are no groups, wrap everything in one group: */}
             <div className="environment-group-lane">
@@ -48,5 +46,11 @@ export const EnvironmentsPage: React.FC = () => {
                 ))}
             </div>
         </main>
+    );
+    return (
+        <div>
+            <TopAppBar showAppFilter={true} showTeamFilter={true} />
+            {mainContent}
+        </div>
     );
 };

--- a/services/frontend-service/src/ui/Pages/Home/Home.tsx
+++ b/services/frontend-service/src/ui/Pages/Home/Home.tsx
@@ -18,6 +18,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useFilteredApps, useGlobalLoadingState, useSearchedApplications } from '../../utils/store';
 import React from 'react';
 import { LoadingStateSpinner } from '../../utils/LoadingStateSpinner';
+import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
 
 export const Home: React.FC = () => {
     const [params] = useSearchParams();
@@ -34,10 +35,13 @@ export const Home: React.FC = () => {
     }
 
     return (
-        <main className="main-content">
-            {apps.map((app) => (
-                <ServiceLane application={app} key={app.name} />
-            ))}
-        </main>
+        <div>
+            <TopAppBar showAppFilter={true} showTeamFilter={true} />
+            <main className="main-content">
+                {apps.map((app) => (
+                    <ServiceLane application={app} key={app.name} />
+                ))}
+            </main>
+        </div>
     );
 };

--- a/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
@@ -18,6 +18,7 @@ import { LocksTable } from '../../components/LocksTable/LocksTable';
 import { searchCustomFilter, sortLocks, useEnvironments, useGlobalLoadingState } from '../../utils/store';
 import { useSearchParams } from 'react-router-dom';
 import { LoadingStateSpinner } from '../../utils/LoadingStateSpinner';
+import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
 
 const applicationFieldHeaders = [
     'Date',
@@ -84,9 +85,12 @@ export const LocksPage: React.FC = () => {
         return <LoadingStateSpinner loadingState={loadingState} />;
     }
     return (
-        <main className="main-content">
-            <LocksTable headerTitle="Environment Locks" columnHeaders={environmentFieldHeaders} locks={envLocks} />
-            <LocksTable headerTitle="Application Locks" columnHeaders={applicationFieldHeaders} locks={appLocks} />
-        </main>
+        <div>
+            <TopAppBar showAppFilter={false} showTeamFilter={false} />
+            <main className="main-content">
+                <LocksTable headerTitle="Environment Locks" columnHeaders={environmentFieldHeaders} locks={envLocks} />
+                <LocksTable headerTitle="Application Locks" columnHeaders={applicationFieldHeaders} locks={appLocks} />
+            </main>
+        </div>
     );
 };

--- a/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.tsx
+++ b/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.tsx
@@ -17,6 +17,7 @@ Copyright 2023 freiheit.com*/
 import { useGlobalLoadingState } from '../../utils/store';
 import { LoadingStateSpinner } from '../../utils/LoadingStateSpinner';
 import { ProductVersion } from '../../components/ProductVersion/ProductVersion';
+import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
 
 export const ProductVersionPage: React.FC = () => {
     const url = window.location.pathname.split('/');
@@ -26,8 +27,11 @@ export const ProductVersionPage: React.FC = () => {
         return <LoadingStateSpinner loadingState={loadingState} />;
     }
     return (
-        <main className="main-content">
-            <ProductVersion environment={environmentName} />
-        </main>
+        <div>
+            <TopAppBar showAppFilter={true} showTeamFilter={true} />
+            <main className="main-content">
+                <ProductVersion environment={environmentName} />
+            </main>
+        </div>
     );
 };

--- a/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.tsx
@@ -17,6 +17,7 @@ import { Releases } from '../../components/Releases/Releases';
 import { useGlobalLoadingState } from '../../utils/store';
 import { LoadingStateSpinner } from '../../utils/LoadingStateSpinner';
 import React from 'react';
+import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
 
 export const ReleasesPage: React.FC = () => {
     const url = window.location.pathname.split('/');
@@ -28,8 +29,11 @@ export const ReleasesPage: React.FC = () => {
     }
 
     return (
-        <main className="main-content">
-            <Releases app={app_name} />
-        </main>
+        <div>
+            <TopAppBar showAppFilter={true} showTeamFilter={true} />
+            <main className="main-content">
+                <Releases app={app_name} />
+            </main>
+        </div>
     );
 };

--- a/services/frontend-service/src/ui/components/TopAppBar/TopAppBar.tsx
+++ b/services/frontend-service/src/ui/components/TopAppBar/TopAppBar.tsx
@@ -26,7 +26,12 @@ import classNames from 'classnames';
 import { UpdateSidebar, useAllWarnings, useKuberpultVersion, useSidebarShown } from '../../utils/store';
 import { Warning } from '../../../api/api';
 
-export const TopAppBar: React.FC = () => {
+export type TopAppBarProps = {
+    showAppFilter: boolean;
+    showTeamFilter: boolean;
+};
+
+export const TopAppBar: React.FC<TopAppBarProps> = (props) => {
     const control = useRef<HTMLDivElement>(null);
     const MDComponent = useRef<MDCTopAppBar>();
     const sideBar = useSidebarShown();
@@ -52,6 +57,27 @@ export const TopAppBar: React.FC = () => {
             <div className="service-lane__warning">There are {allWarnings.length} warnings total.</div>
         );
 
+    const renderedAppFilter =
+        props.showAppFilter === true ? (
+            <div className="mdc-top-app-bar__section">
+                <Textfield
+                    className={'top-app-bar-search-field'}
+                    floatingLabel={'Application Name'}
+                    value={query}
+                    leadingIcon={'search'}
+                />
+            </div>
+        ) : (
+            ''
+        );
+    const renderedTeamsFilter =
+        props.showTeamFilter === true ? (
+            <div className="mdc-top-app-bar__section">
+                <Dropdown className={'top-app-bar-search-field'} floatingLabel={'Teams'} leadingIcon={'search'} />
+            </div>
+        ) : (
+            ''
+        );
     return (
         <div className="mdc-top-app-bar" ref={control}>
             <div className="mdc-top-app-bar__row">
@@ -59,15 +85,8 @@ export const TopAppBar: React.FC = () => {
                     <span className="mdc-top-app-bar__title">Kuberpult v{version}</span>
                 </div>
                 <div className="mdc-top-app-bar__section">{renderedWarnings}</div>
-                <div className="mdc-top-app-bar__section">
-                    <Textfield
-                        className={'top-app-bar-search-field'}
-                        floatingLabel={'Application Name'}
-                        value={query}
-                        leadingIcon={'search'}
-                    />
-                    <Dropdown className={'top-app-bar-search-field'} floatingLabel={'Teams'} leadingIcon={'search'} />
-                </div>
+                {renderedAppFilter}
+                {renderedTeamsFilter}
                 <div className="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
                     <strong className="sub-headline1">Planned Actions</strong>
                     <Button


### PR DESCRIPTION
- move TopAppBar from outside main content router to inside it
- add props to TopAppBar to allow toggling the display of the app and
  team filters
- hide these filters on the locks page
