### PR TITLE
Revert "fix(release): if a release already exists, return http/409 Conflict (SRX-627DCD)"

### DIFF
--- a/services/frontend-service/pkg/handler/release.go
+++ b/services/frontend-service/pkg/handler/release.go
@@ -223,7 +223,7 @@ func (s Server) HandleRelease(w http.ResponseWriter, r *http.Request, tail strin
 			return
 		}
 		if ok && s.Code() == codes.AlreadyExists {
-			http.Error(w, err.Error(), http.StatusConflict)
+			w.WriteHeader(http.StatusOK)
 			return
 		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/tests/integration-tests/release_test.go
+++ b/tests/integration-tests/release_test.go
@@ -188,7 +188,7 @@ func TestReleaseCalls(t *testing.T) {
 			expectedStatusCode: 201,
 		},
 		{
-			// this is the same test, but this time we expect 409, because the release already exists:
+			// this is the same test, but this time we expect 201, because the release already exists:
 			name:               "Simple invocation of /release endpoint with valid version",
 			inputApp:           "my-app-" + appSuffix,
 			inputManifest:      theManifest,
@@ -196,7 +196,7 @@ func TestReleaseCalls(t *testing.T) {
 			inputManifestEnv:   devEnv,
 			inputSignatureEnv:  devEnv,
 			inputVersion:       ptr.FromString("99"),
-			expectedStatusCode: 409,
+			expectedStatusCode: 200,
 		},
 		{
 			name:               "Simple invocation of /release endpoint with invalid version",


### PR DESCRIPTION
We only want to return 409 if the provided yaml contents differ from the previously uploaded ones. This will be merged only once that check is in place.
