### PR TITLE
bm/docker compose plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ kuberpult:
 
 kuberpult-earthly:
 	earthly +all-services --UID=$(USER_UID) --target docker
-	docker-compose -f docker-compose-earthly.yml up 
+	docker compose -f docker-compose-earthly.yml up
 
 cache:
 	earthly --remote-cache=ghcr.io/freiheit-com/kuberpult/kuberpult-frontend-service:cache --push +frontend-service --target release --UID=$(USER_UID)

--- a/services/frontend-service/pkg/handler/release.go
+++ b/services/frontend-service/pkg/handler/release.go
@@ -223,7 +223,7 @@ func (s Server) HandleRelease(w http.ResponseWriter, r *http.Request, tail strin
 			return
 		}
 		if ok && s.Code() == codes.AlreadyExists {
-			http.Error(w, err.Error(), http.StatusConflict)
+			w.WriteHeader(http.StatusOK)
 			return
 		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/tests/integration-tests/release_test.go
+++ b/tests/integration-tests/release_test.go
@@ -188,7 +188,7 @@ func TestReleaseCalls(t *testing.T) {
 			expectedStatusCode: 201,
 		},
 		{
-			// this is the same test, but this time we expect 409, because the release already exists:
+			// this is the same test, but this time we expect 201, because the release already exists:
 			name:               "Simple invocation of /release endpoint with valid version",
 			inputApp:           "my-app-" + appSuffix,
 			inputManifest:      theManifest,
@@ -196,7 +196,7 @@ func TestReleaseCalls(t *testing.T) {
 			inputManifestEnv:   devEnv,
 			inputSignatureEnv:  devEnv,
 			inputVersion:       ptr.FromString("99"),
-			expectedStatusCode: 409,
+			expectedStatusCode: 200,
 		},
 		{
 			name:               "Simple invocation of /release endpoint with invalid version",


### PR DESCRIPTION
- Revert "fix(release): if a release already exists, return http/409 Conflict (SRX-627DCD)"
- chore(Makefile): use docker compose plugin, do not require extra standalone one
