### PR TITLE
Reduce network timeout for local setup

### DIFF
--- a/docker-compose-earthly.yml
+++ b/docker-compose-earthly.yml
@@ -5,6 +5,7 @@ services:
       - LOG_LEVEL=INFO
       - KUBERPULT_GIT_URL=/kp/kuberpult/repository_remote
       - KUBERPULT_GIT_BRANCH=master
+      - KUBERPULT_GIT_NETWORK_TIMEOUT=3s
       - KUBERPULT_DEX_MOCK=false
       - KUBERPULT_DEX_ENABLED=false
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - KUBERPULT_GIT_BRANCH=master
       - KUBERPULT_DEX_MOCK=false
       - KUBERPULT_DEX_ENABLED=false
+      - KUBERPULT_GIT_NETWORK_TIMEOUT=3s
     ports:
       - "8080:8080"
       - "8443:8443"


### PR DESCRIPTION
When running locally, we usually have a local repository, so we do not need to wait long for the repository to respond.

Effectively this changes the timeout from 1 minute to 3 seconds.

Reference: SRX-976IRJ