### PR TITLE
Add RBAC policy to docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
       - LOG_LEVEL=INFO
       - KUBERPULT_GIT_URL=/kp/kuberpult/repository_remote
       - KUBERPULT_GIT_BRANCH=master
-      - KUBERPULT_DEX_MOCK=false
-      - KUBERPULT_DEX_ENABLED=false
+      - KUBERPULT_DEX_MOCK=true
+      - KUBERPULT_DEX_ENABLED=true
+      - KUBERPULT_DEX_RBAC_POLICY_PATH=/kp/kuberpult/policy.csv
     ports:
       - "8080:8080"
       - "8443:8443"

--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -173,6 +173,10 @@ func ValidateRbacPermission(line string) (p *Permission, err error) {
 	}, nil
 }
 
+func wrapFileError(e error, filename string, message string) error {
+	return fmt.Errorf("%s '%s': %w", message, filename, e)
+}
+
 func ReadRbacPolicy(dexEnabled bool, DexRbacPolicyPath string) (policy map[string]*Permission, err error) {
 	if !dexEnabled {
 		return nil, nil
@@ -180,7 +184,7 @@ func ReadRbacPolicy(dexEnabled bool, DexRbacPolicyPath string) (policy map[strin
 
 	file, err := os.Open(DexRbacPolicyPath)
 	if err != nil {
-		return nil, err
+		return nil, wrapFileError(err, DexRbacPolicyPath, "error opening policy")
 	}
 	defer file.Close()
 

--- a/services/cd-service/Makefile
+++ b/services/cd-service/Makefile
@@ -25,9 +25,6 @@ export CGO_ENABLED=1
 IMAGENAME?=$(IMAGE_REGISTRY)/kuberpult-cd-service:$(VERSION)
 ARTIFACT_REGISTRY_IMAGE_NAME=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult/kuberpult-cd-service:${VERSION}
 
-export KUBERPULT_DEX_MOCK=false
-export KUBERPULT_DEX_ENABLED=false
-
 ifeq ($(WITH_DOCKER),)
 COMPILE_WITH_DOCKER := false
 else


### PR DESCRIPTION
References the `policy.csv` file on the `docker-compose.yaml` to allow local Kuberpult execution using RBAC.