### PR TITLE
Fix dropdown to display the selectedTag

### DIFF
--- a/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.test.tsx
+++ b/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.test.tsx
@@ -32,7 +32,7 @@ describe('Product Version Data', () => {
             name: 'No tags to Display',
             environmentName: 'tester',
             tags: [],
-            expectedDropDown: 'Select a Tag',
+            expectedDropDown: '',
             productSummary: [],
         },
         {
@@ -73,7 +73,9 @@ describe('Product Version Data', () => {
             );
             expect(document.body).toMatchSnapshot();
             expect(document.querySelector('.environment_name')?.textContent).toContain(testCase.environmentName);
-            expect(document.querySelector('.drop_down')?.textContent).toContain(testCase.expectedDropDown);
+            if (testCase.expectedDropDown !== '') {
+                expect(document.querySelector('.drop_down')?.textContent).toContain(testCase.expectedDropDown);
+            }
 
             if (testCase.productSummary.length > 0) {
                 expect(document.querySelector('.table')?.textContent).toContain('App Name');

--- a/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.tsx
+++ b/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.tsx
@@ -37,11 +37,13 @@ export const ProductVersion: React.FC<ProductVersionProps> = (props) => {
             setShowSummarySpinner(true);
             getSummary(e.target.value, environment);
             setOpen(!open);
+            setSelectedTag(e.target.value);
         },
         [open, setOpen, environment]
     );
     const [showTagsSpinner, setShowTagsSpinner] = React.useState(false);
     const [showSummarySpinner, setShowSummarySpinner] = React.useState(false);
+    const [selectedTag, setSelectedTag] = React.useState('');
     var versionToDisplay = (app: ProductSummary): string => {
         if (app.displayVersion !== '') {
             return app.displayVersion;
@@ -82,18 +84,28 @@ export const ProductVersion: React.FC<ProductVersionProps> = (props) => {
     return (
         <div className="product_version">
             <h1 className="environment_name">{'Product Version for ' + environment}</h1>
-            <div className="dropdown_div">
-                <select onChange={openClose} onSelect={openClose} className="drop_down" data-testid="drop_down">
-                    <option value="default" disabled>
-                        Select a Tag
-                    </option>
-                    {tagsResponse.response.tagData.map((tag) => (
-                        <option value={tag.commitId} key={tag.tag}>
-                            {tag.tag.slice(10)}
+
+            {tagsResponse.response.tagData.length > 0 ? (
+                <div className="dropdown_div">
+                    <select
+                        onChange={openClose}
+                        onSelect={openClose}
+                        className="drop_down"
+                        data-testid="drop_down"
+                        value={selectedTag}>
+                        <option value="default" disabled>
+                            Select a Tag
                         </option>
-                    ))}
-                </select>
-            </div>
+                        {tagsResponse.response.tagData.map((tag) => (
+                            <option value={tag.commitId} key={tag.tag}>
+                                {tag.tag.slice(10)}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+            ) : (
+                <div></div>
+            )}
             <div>
                 {displaySummary ? (
                     <div className="table_padding">

--- a/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.tsx
+++ b/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.tsx
@@ -104,7 +104,7 @@ export const ProductVersion: React.FC<ProductVersionProps> = (props) => {
                     </select>
                 </div>
             ) : (
-                <div></div>
+                <div />
             )}
             <div>
                 {displaySummary ? (

--- a/services/frontend-service/src/ui/components/ProductVersion/__snapshots__/ProductVersion.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ProductVersion/__snapshots__/ProductVersion.test.tsx.snap
@@ -11,21 +11,7 @@ exports[`Product Version Data Displays Product Version Page No tags to Display 1
       >
         Product Version for tester
       </h1>
-      <div
-        class="dropdown_div"
-      >
-        <select
-          class="drop_down"
-          data-testid="drop_down"
-        >
-          <option
-            disabled=""
-            value="default"
-          >
-            Select a Tag
-          </option>
-        </select>
-      </div>
+      <div />
       <div>
         <div
           class="page_description"


### PR DESCRIPTION
Bug was noticed where only the first tag in the list was every displayed in dropdown

Two screenshots showing different tags displayed

<img width="546" alt="Screenshot 2023-11-29 at 14 27 34" src="https://github.com/freiheit-com/kuberpult/assets/47796934/b73902e7-4fed-4771-827e-121a092c5313">
<img width="609" alt="Screenshot 2023-11-29 at 14 27 38" src="https://github.com/freiheit-com/kuberpult/assets/47796934/719ac375-2016-460b-88c2-ba5e7089d155">

REV: DSN-FE1RG6