### PR TITLE
Require kuberpult AND argocd version to mark app as deployed

### DIFF
--- a/services/rollout-service/pkg/service/broadcast_test.go
+++ b/services/rollout-service/pkg/service/broadcast_test.go
@@ -107,6 +107,13 @@ func TestBroadcast(t *testing.T) {
 						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
 						HealthStatusCode: health.HealthStatusHealthy,
 					},
+				},
+				{
+					VersionEvent: &versions.KuberpultEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     &versions.VersionInfo{Version: 1},
+					},
 
 					ExpectStatus: &RolloutStatusSuccesful,
 				},
@@ -138,7 +145,7 @@ func TestBroadcast(t *testing.T) {
 						HealthStatusCode: health.HealthStatusHealthy,
 					},
 
-					ExpectStatus: &RolloutStatusSuccesful,
+					ExpectStatus: &RolloutStatusUnknown,
 				},
 				{
 					ArgoEvent: &ArgoEvent{
@@ -157,6 +164,15 @@ func TestBroadcast(t *testing.T) {
 			Name: "app syncing and becomming healthy",
 			Steps: []step{
 				{
+					VersionEvent: &versions.KuberpultEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     &versions.VersionInfo{Version: 1},
+					},
+
+					ExpectStatus: &RolloutStatusUnknown,
+				},
+				{
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
@@ -168,10 +184,19 @@ func TestBroadcast(t *testing.T) {
 					ExpectStatus: &RolloutStatusSuccesful,
 				},
 				{
+					VersionEvent: &versions.KuberpultEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     &versions.VersionInfo{Version: 2},
+					},
+
+					ExpectStatus: &RolloutStatusPending,
+				},
+				{
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          &versions.VersionInfo{Version: 1},
+						Version:          &versions.VersionInfo{Version: 2},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeOutOfSync,
 						HealthStatusCode: health.HealthStatusHealthy,
 					},
@@ -182,7 +207,7 @@ func TestBroadcast(t *testing.T) {
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
 						Environment:      "bar",
-						Version:          &versions.VersionInfo{Version: 1},
+						Version:          &versions.VersionInfo{Version: 2},
 						SyncStatusCode:   v1alpha1.SyncStatusCodeOutOfSync,
 						HealthStatusCode: health.HealthStatusProgressing,
 					},
@@ -205,6 +230,15 @@ func TestBroadcast(t *testing.T) {
 		{
 			Name: "app becomming unhealthy and recovers",
 			Steps: []step{
+				{
+					VersionEvent: &versions.KuberpultEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     &versions.VersionInfo{Version: 1},
+					},
+
+					ExpectStatus: &RolloutStatusUnknown,
+				},
 				{
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",
@@ -281,6 +315,15 @@ func TestBroadcast(t *testing.T) {
 		{
 			Name: "healthy app switches to pending when a new version in kuberpult is deployed",
 			Steps: []step{
+				{
+					VersionEvent: &versions.KuberpultEvent{
+						Application: "foo",
+						Environment: "bar",
+						Version:     &versions.VersionInfo{Version: 1},
+					},
+
+					ExpectStatus: &RolloutStatusUnknown,
+				},
 				{
 					ArgoEvent: &ArgoEvent{
 						Application:      "foo",

--- a/services/rollout-service/pkg/service/service_test.go
+++ b/services/rollout-service/pkg/service/service_test.go
@@ -162,7 +162,7 @@ func TestArgoConection(t *testing.T) {
 			Name: "stops when ctx closes in the watch call",
 			Steps: []step{
 				{
-					RecvErr: status.Error(codes.Canceled, "context cancelled"),
+					RecvErr:       status.Error(codes.Canceled, "context cancelled"),
 					CancelContext: true,
 				},
 			},

--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -55,6 +55,16 @@ type VersionInfo struct {
 	DeployedAt     time.Time
 }
 
+func (v *VersionInfo) Equal(w *VersionInfo) bool {
+	if v == nil {
+		return w == nil
+	}
+	if w == nil {
+		return false
+	}
+	return v.Version == w.Version
+}
+
 // GetVersion implements VersionClient
 func (v *versionClient) GetVersion(ctx context.Context, revision, environment, application string) (*VersionInfo, error) {
 	var overview *api.GetOverviewResponse

--- a/services/rollout-service/pkg/versions/versions_test.go
+++ b/services/rollout-service/pkg/versions/versions_test.go
@@ -448,7 +448,7 @@ func TestVersionClientStream(t *testing.T) {
 				{
 					Overview: testOverview,
 
-					ExpectReady:    true,
+					ExpectReady: true,
 				},
 				{
 					RecvErr:       status.Error(codes.Canceled, "context cancelled"),
@@ -521,7 +521,7 @@ func TestVersionClientStream(t *testing.T) {
 				{
 					RecvErr: fmt.Errorf("no"),
 
-					ExpectReady:    false,
+					ExpectReady: false,
 				},
 				{
 					Overview: emptyTestOverview,


### PR DESCRIPTION
I re-read the code and I think we made a mistake here. The code basically says that we mark applications as successfully deployed even when we don't know the right version yet. That doesn't make sense. We should have complete data here before saying everything is fine.