### PR TITLE
Fix return from endpoint GetProductSummary() for empty Summary

### DIFF
--- a/services/cd-service/pkg/service/tags.go
+++ b/services/cd-service/pkg/service/tags.go
@@ -69,7 +69,7 @@ func (s *TagsServer) GetProductSummary(ctx context.Context, in *api.GetProductSu
 			}
 		}
 		if len(summaryFromEnv) == 0 {
-			return nil, nil
+			return &api.GetProductSummaryResponse{}, nil
 		}
 		sort.Slice(summaryFromEnv, func(i, j int) bool {
 			a := summaryFromEnv[i].App

--- a/services/frontend-service/src/ui/utils/Links.tsx
+++ b/services/frontend-service/src/ui/utils/Links.tsx
@@ -179,7 +179,7 @@ export const ProductVersionLink: React.FC<{ env: string; groupName: string }> = 
     return (
         <a
             title={'Opens the release directory in the manifest repository for this release'}
-            href={addParam[0] + '/productVersion' + '?' + queryString}>
+            href={addParam[0] + '/productVersion?' + queryString}>
             Display Version for {env}
         </a>
     );


### PR DESCRIPTION
- fixes error Internal desc = grpc: error while marshaling: proto: Marshal called with nil
- Frontend no longer stuck on loading when there are no apps associated with environment based on a git tag
- also fix prettier warning within Links
<img width="942" alt="Screenshot 2023-12-06 at 17 34 58" src="https://github.com/freiheit-com/kuberpult/assets/47796934/e2302f2c-7204-4b66-9851-1b1511f2ba32">
