### PR TITLE
Move Disconnect to the go func

### DIFF
--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -423,6 +423,9 @@ func (r *repository) useRemote(ctx context.Context, callback func(*git.Remote) e
 	defer cancel()
 	errCh := make(chan error, 1)
 	go func() {
+                // Usually we call `defer` right after resource allocation (`CreateAnonymous`).
+                // The issue with that is that the `callback` requires the remote, and cannot be cancelled properly.
+                // So `callback` may run longer than `useRemote`, and if at that point `Disconnect` was already called, we get a `panic`.
 		defer remote.Disconnect()
 		errCh <- callback(remote)
 	}()

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -419,11 +419,11 @@ func (r *repository) useRemote(ctx context.Context, callback func(*git.Remote) e
 	if err != nil {
 		return fmt.Errorf("opening remote %q: %w", r.config.URL, err)
 	}
-	defer remote.Disconnect()
 	ctx, cancel := context.WithTimeout(context.Background(), r.config.NetworkTimeout)
 	defer cancel()
 	errCh := make(chan error, 1)
 	go func() {
+		defer remote.Disconnect()
 		errCh <- callback(remote)
 	}()
 	select {


### PR DESCRIPTION
The disconnect might get triggered while the push is still running and then segfaults sometimes.