### PR TITLE
perf: Add a new simpler protocol for calculating versions in the rollout service

### DIFF
--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -213,6 +213,20 @@ message GetFrontendConfigResponse {
   string manifestRepoUrl = 6;
 }
 
+message GetVersionRequest {
+  string git_revision = 1;
+  string application = 2;
+  string environment = 3;
+}
+
+message GetVersionResponse {
+  uint64 version = 1;
+  google.protobuf.Timestamp deployed_at = 2;
+}
+
+service VersionService {
+  rpc GetVersion (GetVersionRequest) returns (GetVersionResponse) {}
+}
 
 service OverviewService {
   rpc GetOverview (GetOverviewRequest) returns (GetOverviewResponse) {}

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -212,6 +212,7 @@ func RunServer() {
 					}
 					api.RegisterOverviewServiceServer(srv, overviewSrv)
 					api.RegisterGitTagsServiceServer(srv, &service.TagsServer{Config: cfg, OverviewService: overviewSrv})
+					api.RegisterVersionServer(srv, &service.VersionServiceServer{Repository: repo})
 					reflection.Register(srv)
 					reposerver.Register(srv, repo, cfg)
 

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -212,7 +212,7 @@ func RunServer() {
 					}
 					api.RegisterOverviewServiceServer(srv, overviewSrv)
 					api.RegisterGitTagsServiceServer(srv, &service.TagsServer{Config: cfg, OverviewService: overviewSrv})
-					api.RegisterVersionServer(srv, &service.VersionServiceServer{Repository: repo})
+					api.RegisterVersionServiceServer(srv, &service.VersionServiceServer{Repository: repo})
 					reflection.Register(srv)
 					reposerver.Register(srv, repo, cfg)
 

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -423,9 +423,9 @@ func (r *repository) useRemote(ctx context.Context, callback func(*git.Remote) e
 	defer cancel()
 	errCh := make(chan error, 1)
 	go func() {
-                // Usually we call `defer` right after resource allocation (`CreateAnonymous`).
-                // The issue with that is that the `callback` requires the remote, and cannot be cancelled properly.
-                // So `callback` may run longer than `useRemote`, and if at that point `Disconnect` was already called, we get a `panic`.
+		// Usually we call `defer` right after resource allocation (`CreateAnonymous`).
+		// The issue with that is that the `callback` requires the remote, and cannot be cancelled properly.
+		// So `callback` may run longer than `useRemote`, and if at that point `Disconnect` was already called, we get a `panic`.
 		defer remote.Disconnect()
 		errCh <- callback(remote)
 	}()
@@ -753,7 +753,7 @@ func (r *repository) ApplyTransformersInternal(ctx context.Context, transformers
 	} else {
 		var changes []*TransformerResult = nil
 		commitMsg := []string{}
-		ctxWithTime := withTimeNow(ctx, time.Now())
+		ctxWithTime := WithTimeNow(ctx, time.Now())
 		for _, t := range transformers {
 			if msg, subChanges, err := t.Transform(ctxWithTime, state); err != nil {
 				return nil, nil, nil, err

--- a/services/cd-service/pkg/repository/time.go
+++ b/services/cd-service/pkg/repository/time.go
@@ -35,7 +35,7 @@ func getTimeNow(ctx context.Context) time.Time {
 	return t
 }
 
-func withTimeNow(ctx context.Context, t time.Time) context.Context {
+func WithTimeNow(ctx context.Context, t time.Time) context.Context {
 	if _, ok := ctx.Value(ctxMarkerKey).(time.Time); ok {
 		// already has time. used in testing
 		return ctx

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -695,7 +695,7 @@ func TestDeployApplicationVersion(t *testing.T) {
 	for _, tc := range tcs {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
-			ctxWithTime := withTimeNow(testutil.MakeTestContext(), timeNowOld)
+			ctxWithTime := WithTimeNow(testutil.MakeTestContext(), timeNowOld)
 			t.Parallel()
 			repo := setupRepositoryTest(t)
 			_, updatedState, _, err := repo.ApplyTransformersInternal(ctxWithTime, tc.Transformers...)
@@ -3605,7 +3605,7 @@ spec:
 			}
 
 			for i, tf := range tc.Transformers {
-				ctxWithTime := withTimeNow(testutil.MakeTestContext(), timeNowOld)
+				ctxWithTime := WithTimeNow(testutil.MakeTestContext(), timeNowOld)
 				err = repo.Apply(ctxWithTime, tf)
 				if err != nil {
 					if tc.ErrorTest != nil && i == len(tc.Transformers)-1 {

--- a/services/cd-service/pkg/service/version.go
+++ b/services/cd-service/pkg/service/version.go
@@ -1,3 +1,19 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
 package service
 
 import (

--- a/services/cd-service/pkg/service/version.go
+++ b/services/cd-service/pkg/service/version.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/freiheit-com/kuberpult/pkg/api"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
+	git "github.com/libgit2/git2go/v34"
+)
+
+type VersionServiceServer struct {
+	Repository repository.Repository
+}
+
+func (o *VersionServiceServer) GetVersion(
+	ctx context.Context,
+	in *api.GetVersionRequest) (*api.GetVersionResponse, error) {
+	oid, err := git.NewOid(in.GitRevision)
+	if err != nil {
+		return nil, err
+	}
+	state, err := o.Repository.StateAt(oid)
+	if err != nil {
+		var gerr *git.GitError
+		if errors.As(err, &gerr) {
+			if gerr.Code == git.ErrNotFound {
+				return nil, status.Error(codes.NotFound, "not found")
+			}
+		}
+		return nil, err
+	}
+	res := api.GetVersionResponse{}
+	version, err := state.GetEnvironmentApplicationVersion(in.Environment, in.Application)
+	if version != nil {
+		res.Version = *version
+		_, deployedAt, err := state.GetDeploymentMetaData(ctx, in.Environment, in.Application)
+		if err != nil {
+			return nil, err
+		}
+		res.DeployedAt = timestamppb.New(deployedAt)
+	}
+	return &res, nil
+}

--- a/services/cd-service/pkg/service/version_test.go
+++ b/services/cd-service/pkg/service/version_test.go
@@ -1,0 +1,127 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
+
+	"github.com/freiheit-com/kuberpult/pkg/api"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/config"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
+)
+
+func TestVersion(t *testing.T) {
+	type expectedVersion struct {
+		Environment        string
+		Application        string
+		ExpectedVersion    uint64
+		ExpectedDeployedAt time.Time
+	}
+	tcs := []struct {
+		Name             string
+		Setup            []repository.Transformer
+		ExpectedVersions []expectedVersion
+	}{
+		{
+			Name: "simple-tests",
+			Setup: []repository.Transformer{
+				&repository.CreateEnvironment{
+					Environment: "development",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Latest: true,
+						},
+					},
+				},
+				&repository.CreateEnvironment{
+					Environment: "staging",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Latest: true,
+						},
+					},
+				},
+				&repository.CreateApplicationVersion{
+					Application: "test",
+					Version:     1,
+					Manifests: map[string]string{
+						"development": "dev",
+					},
+				},
+			},
+			ExpectedVersions: []expectedVersion{
+				{
+					Environment:        "development",
+					Application:        "test",
+					ExpectedVersion:    1,
+					ExpectedDeployedAt: time.Unix(2, 0),
+				},
+				{
+					Environment:     "staging",
+					Application:     "test",
+					ExpectedVersion: 0,
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			repo, err := setupRepositoryTest(t)
+			if err != nil {
+				t.Fatalf("error setting up repository test: %v", err)
+			}
+			sv := &VersionServiceServer{Repository: repo}
+
+			for i, transformer := range tc.Setup {
+				now := time.Unix(int64(i), 0)
+				ctx := repository.WithTimeNow(testutil.MakeTestContext(), now)
+				err := repo.Apply(ctx, transformer)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			cid := repo.State().Commit.Id().String()
+			for _, ev := range tc.ExpectedVersions {
+				res, err := sv.GetVersion(context.Background(), &api.GetVersionRequest{
+					GitRevision: cid,
+					Application: ev.Application,
+					Environment: ev.Environment,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if res.Version != ev.ExpectedVersion {
+					t.Errorf("got wrong version for %s/%s: expected %d but got %d", ev.Application, ev.Environment, ev.ExpectedVersion, res.Version)
+				}
+				if ev.ExpectedDeployedAt.IsZero() {
+					if res.DeployedAt != nil {
+						t.Errorf("got wrong deployed at for %s/%s: expected <nil> but got %q", ev.Application, ev.Environment, res.DeployedAt)
+					}
+				} else {
+					if !res.DeployedAt.AsTime().Equal(ev.ExpectedDeployedAt) {
+						t.Errorf("got wrong deployed at for %s/%s: expected %q but got %q", ev.Application, ev.Environment, ev.ExpectedDeployedAt, res.DeployedAt.AsTime())
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently this relies on the much heavier GetOverview endpoint which is tricky because it slows down the rollout service in wawi. This new endpoint contains exactly what we need and nothing else.