### PR TITLE
fix(chart): Add healthz endpoint to BackendConfig

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -279,7 +279,7 @@ metadata:
 spec:
   healthCheck:
     type: HTTP
-    requestPath: /health
+    requestPath: /healthz
   timeoutSec: {{ .Values.cd.backendConfig.timeoutSec }}
 {{- end }}
 {{- if .Values.environment_configs.bootstrap_mode }}

--- a/charts/kuberpult/templates/ingress.yaml
+++ b/charts/kuberpult/templates/ingress.yaml
@@ -85,6 +85,9 @@ kind: BackendConfig
 metadata:
   name: kuberpult
 spec:
+  healthCheck:
+    requestPath: /healthz
+    type: HTTP
   iap:
     enabled: true
     oauthclientCredentials:


### PR DESCRIPTION
Closes #1241 

When using `.Values.cd.backendConfig.create` inside the `values.yaml` a `BackendConfig` gets created with
```
healthCheck:
  requestPath:  `/health`
```
instead of the new endpoint `/healthz`.

The same holds for `.Values.ingress.iap.enabled` 