### PR TITLE
fix: change `docker-compose` to `docker compose`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ kuberpult:
 
 kuberpult-earthly:
 	earthly +all-services --UID=$(USER_UID) --target docker
-	docker-compose -f docker-compose-earthly.yml up 
+	docker compose -f docker-compose-earthly.yml up 
 
 cache:
 	earthly --remote-cache=ghcr.io/freiheit-com/kuberpult/kuberpult-frontend-service:cache --push +frontend-service --target release --UID=$(USER_UID)


### PR DESCRIPTION
In this particular case this caused the build to fail with some invalid syntax error. However, in general, `docker-compose` refers to `v1` of compose, which is deprecated now and probably must be avoided in favor of `v2` with `docker compose` command.