### PR TITLE
feat: Add `--max-remote-cache` option to earthly buids

### DIFF
--- a/services/cd-service/Makefile
+++ b/services/cd-service/Makefile
@@ -62,10 +62,10 @@ bin/:
 
 build: bin/main
 
-build-pr: test release
+build-pr: test release-pr
 	echo "build on pull request"
 
-build-main: test release
+build-main: test release-main
 	echo "build on main"
 
 .PHONY: cleanup-pr
@@ -98,11 +98,18 @@ docker:
 
 # set IMAGENAME=... to the image where you want to deploy (registry of the project)
 # e.g IMAGENAME=ghcr.io/replace_me...cd-service:1.2.3 make release
-release:
+release-pr:
+	$(EARTHLY) --push +release --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
+ifeq ($(ARTIFACT_REGISTRY_MIRROR), true)
+	$(EARTHLY) --push +release --registry=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult --tag=$(VERSION)
+endif
+
+release-main:
 	$(EARTHLY) --push --max-remote-cache +release --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
 ifeq ($(ARTIFACT_REGISTRY_MIRROR), true)
 	$(EARTHLY) --push --max-remote-cache +release --registry=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult --tag=$(VERSION)
 endif
+
 all: test docker
 
 .PHONY: publish

--- a/services/cd-service/Makefile
+++ b/services/cd-service/Makefile
@@ -99,9 +99,9 @@ docker:
 # set IMAGENAME=... to the image where you want to deploy (registry of the project)
 # e.g IMAGENAME=ghcr.io/replace_me...cd-service:1.2.3 make release
 release:
-	$(EARTHLY) --push +release --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
+	$(EARTHLY) --push --max-remote-cache +release --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
 ifeq ($(ARTIFACT_REGISTRY_MIRROR), true)
-	$(EARTHLY) --push +release --registry=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult --tag=$(VERSION)
+	$(EARTHLY) --push --max-remote-cache +release --registry=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult --tag=$(VERSION)
 endif
 all: test docker
 

--- a/services/frontend-service/Makefile
+++ b/services/frontend-service/Makefile
@@ -57,10 +57,10 @@ run: bin/main
 
 build: bin/main
 
-build-pr: test release
+build-pr: test release-pr
 	echo "build on pull request"
 
-build-main: test release
+build-main: test release-main
 	echo "build on main"
 
 .PHONY: cleanup-pr
@@ -103,11 +103,18 @@ lint-scss: deps
 docker:
 	$(EARTHLY) +docker --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
 
-release:
+release-pr:
+	$(EARTHLY) --push +release --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
+ifeq ($(ARTIFACT_REGISTRY_MIRROR), true)
+	$(EARTHLY) --push +release --registry=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult --tag=$(VERSION)
+endif
+
+release-main:
 	$(EARTHLY) --push --max-remote-cache +release --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
 ifeq ($(ARTIFACT_REGISTRY_MIRROR), true)
 	$(EARTHLY) --push --max-remote-cache +release --registry=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult --tag=$(VERSION)
 endif
+
 all: test docker
 
 .PHONY: all release test docker clean

--- a/services/frontend-service/Makefile
+++ b/services/frontend-service/Makefile
@@ -104,9 +104,9 @@ docker:
 	$(EARTHLY) +docker --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
 
 release:
-	$(EARTHLY) --push +release --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
+	$(EARTHLY) --push --max-remote-cache +release --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
 ifeq ($(ARTIFACT_REGISTRY_MIRROR), true)
-	$(EARTHLY) --push +release --registry=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult --tag=$(VERSION)
+	$(EARTHLY) --push --max-remote-cache +release --registry=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult --tag=$(VERSION)
 endif
 all: test docker
 

--- a/services/rollout-service/Makefile
+++ b/services/rollout-service/Makefile
@@ -44,10 +44,10 @@ run: bin/main
 
 build: bin/main
 
-build-pr: test release
+build-pr: test release-pr
 	echo "build on pull request"
 
-build-main: test release
+build-main: test release-main
 	echo "build on main"
 
 .PHONY: cleanup-pr
@@ -73,11 +73,18 @@ test-go: $(GO_FILES) proto
 docker:
 	$(EARTHLY) +docker --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
 
-release:
+release-pr:
+	$(EARTHLY) --push +release --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
+ifeq ($(ARTIFACT_REGISTRY_MIRROR), true)
+	$(EARTHLY) --push +release --registry=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult --tag=$(VERSION)
+endif
+
+release-main:
 	$(EARTHLY) --push --max-remote-cache +release --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
 ifeq ($(ARTIFACT_REGISTRY_MIRROR), true)
 	$(EARTHLY) --push --max-remote-cache +release --registry=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult --tag=$(VERSION)
 endif
+
 all: test docker
 
 .PHONY: all release test docker clean

--- a/services/rollout-service/Makefile
+++ b/services/rollout-service/Makefile
@@ -74,9 +74,9 @@ docker:
 	$(EARTHLY) +docker --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
 
 release:
-	$(EARTHLY) --push +release --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
+	$(EARTHLY) --push --max-remote-cache +release --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
 ifeq ($(ARTIFACT_REGISTRY_MIRROR), true)
-	$(EARTHLY) --push +release --registry=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult --tag=$(VERSION)
+	$(EARTHLY) --push --max-remote-cache +release --registry=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult --tag=$(VERSION)
 endif
 all: test docker
 


### PR DESCRIPTION
This is not the intended final behvaior; we would like to upload the maximum cache only upon pushedto main. This is merely a test commit.

Edit: added new commits, so now the behavior is correct.