### PR TITLE
fix: publish to both docker registries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,15 @@ jobs:
             registry: europe-west3-docker.pkg.dev
             username: _json_key
             password: ${{ secrets.GCP_ARTIFACT_REGISTRY_PUSH_JSON_KEY }}
-      - name: Retag service images with release version
+      - name: Re-tag service images with release version for google docker registry
         run: |
           git fetch --tags # this should have been done by the checkout action before.
           make tag-release-images RELEASE_IMAGE_TAG=v$RELEASE_IMAGE_VERSION
+        env:
+          RELEASE_IMAGE_VERSION: ${{ steps.new-semrel-version.outputs.version }}
+      - name: Re-tag service images with release version for github docker registry
+        run: |
+          DOCKER_REGISTRY_URI=ghcr.io/freiheit-com/kuberpult make tag-release-images RELEASE_IMAGE_TAG=v$RELEASE_IMAGE_VERSION
         env:
           RELEASE_IMAGE_VERSION: ${{ steps.new-semrel-version.outputs.version }}
       - name: Create release


### PR DESCRIPTION
This fixes an issue were the release of kuberpult did only pushed to
europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult

Now it also pushes to
ghcr.io/freiheit-com/kuberpult