### PR TITLE
fix: Copy only source files before compile target

### DIFF
--- a/infrastructure/earthly/go/Earthfile
+++ b/infrastructure/earthly/go/Earthfile
@@ -1,11 +1,15 @@
 VERSION --use-function-keyword 0.7
+LOCALLY
 
 DEPS:
     FUNCTION
     ARG --required service
+    ARG --required src_files
     COPY ../../../pkg+artifacts/pkg pkg
     COPY cmd services/$service/cmd
-    COPY pkg services/$service/pkg
+    FOR src IN $src_files
+        COPY $src services/$service/$src
+    END
 
 COMPILE:
     FUNCTION
@@ -31,6 +35,7 @@ COMPILE:
 
 UNIT_TEST:
     FUNCTION
+    COPY pkg pkg
     RUN go test ./...
 
 DOCKER:

--- a/services/cd-service/Earthfile
+++ b/services/cd-service/Earthfile
@@ -3,12 +3,13 @@ IMPORT ../../infrastructure/earthly/go AS go-build
 
 LOCALLY
 ARG --global service=$(basename $PWD)
+ARG --global src_files=$(find pkg -type f ! -name "*_test.go")
 ARG --global UID=1000
 ARG --global cgo_enabled=1
 
 deps:
     FROM ../../+deps
-    DO go-build+DEPS --service=$service
+    DO go-build+DEPS --service=$service --src_files=$src_files
     WORKDIR services/$service
 
 artifacts:

--- a/services/frontend-service/Earthfile
+++ b/services/frontend-service/Earthfile
@@ -3,12 +3,13 @@ IMPORT ../../infrastructure/earthly/go AS go-build
 
 LOCALLY
 ARG --global service=$(basename $PWD)
+ARG --global src_files=$(find pkg -type f ! -name "*_test.go")
 ARG --global UID=1000
 ARG --global cgo_enabled=0
 
 deps:
     FROM ../../+deps
-    DO go-build+DEPS --service=$service
+    DO go-build+DEPS --service=$service --src_files=$src_files
     COPY (../cd-service/+artifacts/pkg --service=cd-service) services/cd-service/pkg/
     WORKDIR services/$service
 

--- a/services/rollout-service/Earthfile
+++ b/services/rollout-service/Earthfile
@@ -3,12 +3,13 @@ IMPORT ../../infrastructure/earthly/go AS go-build
 
 LOCALLY
 ARG --global service=$(basename $PWD)
+ARG --global src_files=$(find pkg -type f ! -name "*_test.go")
 ARG --global UID=1000
 ARG --global cgo_enabled=0
 
 deps:
     FROM ../../+deps
-    DO go-build+DEPS --service=$service
+    DO go-build+DEPS --service=$service --src_files=$src_files
     COPY (../cd-service/+artifacts/pkg --service=cd-service) /kp/services/cd-service/pkg/
     WORKDIR services/$service
 


### PR DESCRIPTION
* Copy only the source files before the `compile` target.
* Changing test files will now not cause the compile target to re-run.