### PR TITLE
fix: Refactor Snackbar to not use external libraries

### DIFF
--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -391,7 +391,7 @@ export const SideBar: React.FC<{ className?: string; toggleSidebar: () => void }
                 <h4>Conflicting App Locks:</h4>
                 <ul>
                     {conflictingLocks.appLocks.map((appLock: DisplayLock) => (
-                        <li>
+                        <li key={appLock.lockId + '-' + appLock.application + '-' + appLock.environment}>
                             <DisplayLockInlineRenderer
                                 lock={appLock}
                                 key={appLock.lockId + '-' + appLock.application + '-' + appLock.environment}

--- a/services/frontend-service/src/ui/components/snackbar/snackbar.scss
+++ b/services/frontend-service/src/ui/components/snackbar/snackbar.scss
@@ -13,29 +13,50 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-@use '@material/snackbar/mdc-snackbar';
+@import '../../../assets/variables';
 
-.mdc-snackbar {
+.k-snackbar {
+    // align to the bottom of the viewport:
+    position: fixed;
+    bottom: 8px;
+    // do not overlap with the nav bar on the left:
     margin-left: ($nav-bar-width + 0.5em);
+    padding: 1em 0 1em 20px;
+
+    color: white;
+
     .mdc-snackbar__surface {
         border-radius: 6px;
     }
-}
-
-.mdc-snackbar--success {
-    .mdc-snackbar__surface {
-        background: var(--mdc-theme-success);
+    &.snackbar-color-error {
+        background-color: var(--mdc-theme-error);
     }
-}
-
-.mdc-snackbar--warn {
-    .mdc-snackbar__surface {
-        background: var(--mdc-theme-warn);
+    &.snackbar-color-warn {
+        background-color: var(--mdc-theme-warn);
     }
-}
+    &.snackbar-color-success {
+        background-color: var(--mdc-theme-success);
+    }
 
-.mdc-snackbar--error {
-    .mdc-snackbar__surface {
-        background: var(--mdc-theme-error);
+    .mdc-button.mdc-ripple-upgraded {
+        color: white;
+    }
+
+    .k-snackbar-content {
+        display: flex;
+
+        .k-snackbar-text {
+            flex: 1;
+            text-align: center;
+        }
+
+        .k-snackbar-button {
+            margin-left: 20px;
+            button {
+                // the button is naturally bigger than the span (k-snackbar-text)
+                // thus we reduce it, so they are aligned:
+                max-height: 14px;
+            }
+        }
     }
 }

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -128,7 +128,6 @@ export const showSnackbarError = (content: string): void =>
     UpdateSnackbar.set({ show: true, status: SnackbarStatus.ERROR, content: content });
 export const showSnackbarWarn = (content: string): void =>
     UpdateSnackbar.set({ show: true, status: SnackbarStatus.WARN, content: content });
-
 export const useSidebarShown = (): boolean => useSidebar(({ shown }) => shown);
 
 export const useNumberOfActions = (): number => useAction(({ actions }) => actions.length);


### PR DESCRIPTION
This is mostly a refactoring, with 2 exceptions:
* It also fixes a react warning about a missing `key` attribute
* It increases the time to show the snackbar (errors/warnings/successes) to 15 seconds instead of 5.


New Snackbar success:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/481f100b-dcf8-46ac-98d3-8d7b6ff13ec9)

New Snackbar error:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/30b6e369-d885-49f5-be4b-941d8fb13ad1)

