### PR TITLE
feat: save commits info in manifest repo

### DIFF
--- a/pkg/valid/validations.go
+++ b/pkg/valid/validations.go
@@ -53,6 +53,6 @@ func LockId(lockId string) bool {
 	return len(lockId) < 100 && len(lockId) > 1 && lockId != ".." && lockId != "." && !strings.ContainsAny(lockId, "/")
 }
 
-func CommitID(commitID string) bool {
+func SHA1CommitID(commitID string) bool {
 	return commitIDRx.MatchString(commitID)
 }

--- a/pkg/valid/validations.go
+++ b/pkg/valid/validations.go
@@ -26,12 +26,14 @@ const (
 	AppNameRegExp  = `\A[a-z0-9]+(?:-[a-z0-9]+)*\z`
 	TeamNameRegExp = AppNameRegExp
 	EnvNameRegExp  = AppNameRegExp
+	CommitIDRegExp = `^[0-9a-f]{40}$`
 )
 
 var (
 	applicationNameRx = regexp.MustCompile(AppNameRegExp)
 	teamNameRx        = regexp.MustCompile(TeamNameRegExp)
 	envNameRx         = regexp.MustCompile(EnvNameRegExp)
+	commitIDRx        = regexp.MustCompile(CommitIDRegExp)
 )
 
 // {application}-{environment} should be a valid dns name
@@ -49,4 +51,8 @@ func TeamName(name string) bool {
 // Lock names must be valid file names
 func LockId(lockId string) bool {
 	return len(lockId) < 100 && len(lockId) > 1 && lockId != ".." && lockId != "." && !strings.ContainsAny(lockId, "/")
+}
+
+func CommitID(commitID string) bool {
+	return commitIDRx.MatchString(commitID)
 }

--- a/pkg/valid/validations.go
+++ b/pkg/valid/validations.go
@@ -26,7 +26,7 @@ const (
 	AppNameRegExp  = `\A[a-z0-9]+(?:-[a-z0-9]+)*\z`
 	TeamNameRegExp = AppNameRegExp
 	EnvNameRegExp  = AppNameRegExp
-	CommitIDRegExp = `^[0-9a-f]{40}$`
+	CommitIDRegExp = `^[0-9a-fA-F]{40}$`
 )
 
 var (

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -848,7 +848,7 @@ func (c *CleanupOldApplicationVersions) Transform(ctx context.Context, state *St
 		}
 
 		{
-			commitIDFile := fs.Join(releasesDir, "source_commit_id")
+			commitIDFile := fs.Join(releasesDir, fieldSourceCommitId)
 			dat, err := util.ReadFile(fs, commitIDFile)
 			if err != nil {
 				// not a problem, might be the undeploy commit

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -867,6 +867,7 @@ func (c *CleanupOldApplicationVersions) Transform(ctx context.Context, state *St
 				if valid.SHA1CommitID(commitID) {
 					if err := removeCommit(fs, commitID, c.Application); err != nil {
 						return "", nil, wrapFileError(err, releasesDir, "CleanupOldApplicationVersions: could not remove commit path")
+					}
 				}
 			}
 		}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -709,7 +709,6 @@ func (u *UndeployApplication) Transform(ctx context.Context, state *State) (stri
 		if file.IsDir() {
 			releaseDir := fs.Join(releasesDir, file.Name())
 			commitIDFile := fs.Join(releaseDir, "source_commit_id")
-			fmt.Println(commitIDFile)
 			var commitID string
 			if dat, err := util.ReadFile(fs, commitIDFile); err != nil {
 				// release does not have a corresponding commit, which might be the case if it's an undeploy release, no prob

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -861,12 +861,12 @@ func (c *CleanupOldApplicationVersions) Transform(ctx context.Context, state *St
 			commitIDFile := fs.Join(releasesDir, "source_commit_id")
 			dat, err := util.ReadFile(fs, commitIDFile)
 			if err != nil {
-				return "", nil, wrapFileError(err, releasesDir, "CleanupOldApplicationVersions: could not read commit ID")
-			}
-			commitID := string(dat)
-			if valid.SHA1CommitID(commitID) {
-				if err := removeCommit(fs, commitID, c.Application); err != nil {
-					return "", nil, wrapFileError(err, releasesDir, "CleanupOldApplicationVersions: could not remove commit path")
+				// not a problem, might be the undeploy commit
+			} else {
+				commitID := string(dat)
+				if valid.SHA1CommitID(commitID) {
+					if err := removeCommit(fs, commitID, c.Application); err != nil {
+						return "", nil, wrapFileError(err, releasesDir, "CleanupOldApplicationVersions: could not remove commit path")
 				}
 			}
 		}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -693,7 +693,7 @@ func (u *UndeployApplication) Transform(ctx context.Context, state *State) (stri
 	releasesDir := fs.Join(appDir, "releases")
 	files, err := fs.ReadDir(releasesDir)
 	if err != nil {
-		return "", nil, fmt.Errorf("could not read the releases directory: %w", err)
+		return "", nil, fmt.Errorf("could not read the releases directory %s %w", releasesDir, err)
 	}
 	for _, file := range files {
 		if file.IsDir() {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -270,13 +270,6 @@ func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) 
 		if err := util.WriteFile(fs, fs.Join(releaseDir, fieldSourceCommitId), []byte(c.SourceCommitId), 0666); err != nil {
 			return "", nil, GetCreateReleaseGeneralFailure(err)
 		}
-		if len(c.SourceCommitId) != 40 {
-			return "", nil, GetCreateReleaseGeneralFailure(fmt.Errorf("source commit ID %s has incorrect length: expected 40, got %d", c.SourceCommitId, len(c.SourceCommitId)))
-		}
-		commitDir := commitApplicationDirectory(fs, c.SourceCommitId, c.Application)
-		if err := fs.MkdirAll(commitDir, 0777); err != nil {
-			return "", nil, GetCreateReleaseGeneralFailure(err)
-		}
 		if valid.SHA1CommitID(c.SourceCommitId) {
 			commitDir := commitApplicationDirectory(fs, c.SourceCommitId, c.Application)
 			if err := fs.MkdirAll(commitDir, 0777); err != nil {
@@ -285,9 +278,6 @@ func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) 
 			if err := util.WriteFile(fs, fs.Join(commitDir, ".empty"), make([]byte, 0), 0666); err != nil {
 				return "", nil, GetCreateReleaseGeneralFailure(err)
 			}
-		}
-		if err := util.WriteFile(fs, fs.Join(releaseDir, "source_commit_id"), []byte(c.SourceCommitId), 0666); err != nil {
-			return "", nil, GetCreateReleaseGeneralFailure(err)
 		}
 	}
 	if c.SourceAuthor != "" {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strconv"
 	"time"
+	"strings"
 
 	"github.com/freiheit-com/kuberpult/pkg/grpc"
 	"github.com/freiheit-com/kuberpult/pkg/valid"
@@ -255,7 +256,7 @@ func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) 
 	}
 
 	if !valid.SHA1CommitID(c.SourceCommitId) {
-		logger.FromContext(ctx).Sugar().Warnf("commit ID is not a valid SHA1 hash, should be exactly 40 characters [0-9a-f] %s\n", c.SourceCommitId)
+		logger.FromContext(ctx).Sugar().Warnf("commit ID is not a valid SHA1 hash, should be exactly 40 characters [0-9a-fA-F] %s\n", c.SourceCommitId)
 	}
 
 	configs, err := state.GetEnvironmentConfigs()
@@ -267,6 +268,7 @@ func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) 
 	}
 
 	if c.SourceCommitId != "" {
+		c.SourceCommitId = strings.ToLower(c.SourceCommitId)
 		if err := util.WriteFile(fs, fs.Join(releaseDir, fieldSourceCommitId), []byte(c.SourceCommitId), 0666); err != nil {
 			return "", nil, GetCreateReleaseGeneralFailure(err)
 		}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -605,10 +605,10 @@ func (c *CreateUndeployApplicationVersion) Transform(ctx context.Context, state 
 }
 
 func removeCommit(fs billy.Filesystem, commitID, application string) error {
-	couldNotRemoveAppFormat := "could not remove the application from the commit directory %w"
+	couldNotRemoveAppFormat := "could not remove the application %s from the directory of commit %s, error: %w"
 	commitApplicationDir := commitApplicationDirectory(fs, commitID, application)
 	if err := fs.Remove(commitApplicationDir); err != nil {
-		return fmt.Errorf(couldNotRemoveAppFormat, err)
+		return fmt.Errorf(couldNotRemoveAppFormat, application, commitID, err)
 	}
 	// check if there are no other services updated by this commit
 	// if there are none, start remove the entire branch of the commit
@@ -616,11 +616,11 @@ func removeCommit(fs billy.Filesystem, commitID, application string) error {
 	deleteDirIfEmpty := func(dir string) error {
 		files, err := fs.ReadDir(dir)
 		if err != nil {
-			return fmt.Errorf(couldNotRemoveAppFormat, err)
+			return fmt.Errorf(couldNotRemoveAppFormat, application, commitID, err)
 		}
 		if len(files) == 0 {
 			if err = fs.Remove(dir); err != nil {
-				return fmt.Errorf(couldNotRemoveAppFormat, err)
+				return fmt.Errorf(couldNotRemoveAppFormat, application, commitID, err)
 			}
 		}
 		return nil

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -710,12 +710,12 @@ func (u *UndeployApplication) Transform(ctx context.Context, state *State) (stri
 			var commitID string
 			if dat, err := util.ReadFile(fs, commitIDFile); err != nil {
 				// release does not have a corresponding commit, which might be the case if it's an undeploy release, no prob
-			} else {
-				commitID = string(dat)
-				if valid.SHA1CommitID(commitID) {
-					if err := removeCommit(fs, commitID, u.Application); err != nil {
-						return "", nil, fmt.Errorf("could not remove the commit: %w", err)
-					}
+				continue
+			}
+			commitID = string(dat)
+			if valid.SHA1CommitID(commitID) {
+				if err := removeCommit(fs, commitID, u.Application); err != nil {
+					return "", nil, fmt.Errorf("could not remove the commit: %w", err)
 				}
 			}
 		}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -627,7 +627,6 @@ func removeCommit(fs billy.Filesystem, commitID, application string) error {
 		}
 		files, err := fs.ReadDir(dir)
 		if err != nil {
-
 			return fmt.Errorf(couldNotRemoveAppFormat, err)
 		}
 		if len(files) == 0 {
@@ -702,22 +701,21 @@ func (u *UndeployApplication) Transform(ctx context.Context, state *State) (stri
 	releasesDir := fs.Join(appDir, "releases")
 	files, err := fs.ReadDir(releasesDir)
 	if err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("could not read the releases directory: %w", err)
 	}
 	for _, file := range files {
 		if file.IsDir() {
 			releaseDir := fs.Join(releasesDir, file.Name())
 			commitIDFile := fs.Join(releaseDir, "source_commit_id")
-
+			fmt.Println(commitIDFile)
 			var commitID string
 			if dat, err := util.ReadFile(fs, commitIDFile); err != nil {
-				return "", nil, err
+				// release does not have a corresponding commit, which might be the case if it's an undeploy release, no prob
 			} else {
 				commitID = string(dat)
-			}
-
-			if err := removeCommit(fs, commitID, u.Application); err != nil {
-				return "", nil, err
+				if err := removeCommit(fs, commitID, u.Application); err != nil {
+					return "", nil, fmt.Errorf("could not remove the commit: %w", err)
+				}
 			}
 		}
 	}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -91,7 +91,7 @@ func commitDirectory(fs billy.Filesystem, commit string) string {
 }
 
 func commitApplicationDirectory(fs billy.Filesystem, commit, application string) string {
-	return fs.Join(commitDirectory(fs, commit), application)
+	return fs.Join(commitDirectory(fs, commit), "applications", application)
 }
 
 func GetEnvironmentLocksCount(fs billy.Filesystem, env string) float64 {
@@ -250,6 +250,14 @@ func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) 
 	releaseDir := releasesDirectoryWithVersion(fs, c.Application, version)
 	appDir := applicationDirectory(fs, c.Application)
 	if err = fs.MkdirAll(releaseDir, 0777); err != nil {
+		return "", nil, GetCreateReleaseGeneralFailure(err)
+	}
+
+	if !valid.CommitID(c.SourceCommitId) {
+		return "", nil, GetCreateReleaseGeneralFailure(fmt.Errorf("the provided commit ID is invalid, given %s, expected a valid SHA1 hash", c.SourceCommitId))
+	}
+	commitDir := commitApplicationDirectory(fs, c.SourceCommitId, c.Application)
+	if err = fs.MkdirAll(commitDir, 0777); err != nil {
 		return "", nil, GetCreateReleaseGeneralFailure(err)
 	}
 

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -851,7 +851,7 @@ func (c *CleanupOldApplicationVersions) Transform(ctx context.Context, state *St
 			commitIDFile := fs.Join(releasesDir, fieldSourceCommitId)
 			dat, err := util.ReadFile(fs, commitIDFile)
 			if err != nil {
-				// not a problem, might be the undeploy commit
+				// not a problem, might be the undeploy commit or the commit has was not specified in CreateApplicationVersion
 			} else {
 				commitID := string(dat)
 				if valid.SHA1CommitID(commitID) {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -613,7 +613,7 @@ func removeCommit(fs billy.Filesystem, commitID, application string) error {
 		return fmt.Errorf(couldNotRemoveAppFormat, application, commitID, err)
 	}
 	// check if there are no other services updated by this commit
-	// if there are none, start remove the entire branch of the commit
+	// if there are none, start removing the entire branch of the commit
 	
 	deleteDirIfEmpty := func(dir string) error {
 		files, err := fs.ReadDir(dir)

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -255,7 +255,7 @@ func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) 
 	}
 
 	if !valid.SHA1CommitID(c.SourceCommitId) {
-		logger.FromContext(ctx).Sugar().Warnf("commit ID is not a valid SHA1 hash: %s\n", c.SourceCommitId)
+		logger.FromContext(ctx).Sugar().Warnf("commit ID is not a valid SHA1 hash, should be exactly 40 characters [0-9a-f] %s\n", c.SourceCommitId)
 	}
 
 	configs, err := state.GetEnvironmentConfigs()

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -708,7 +708,8 @@ func (u *UndeployApplication) Transform(ctx context.Context, state *State) (stri
 			releaseDir := fs.Join(releasesDir, file.Name())
 			commitIDFile := fs.Join(releaseDir, "source_commit_id")
 			var commitID string
-			if dat, err := util.ReadFile(fs, commitIDFile); err != nil {
+			dat, err := util.ReadFile(fs, commitIDFile)
+			if err != nil {
 				// release does not have a corresponding commit, which might be the case if it's an undeploy release, no prob
 				continue
 			}

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -849,13 +849,13 @@ func verifyConsistency(fs billy.Filesystem) error {
 	}
 
 	for _, app := range applications {
-		flag := false
+		commitFound := false
 		for _, commit := range commits {
 			if app.application == commit.application && app.sourceCommitID == commit.sourceCommitID {
-				flag = true
+				commitFound = true
 			}
 		}
-		if !flag {
+		if !commitFound {
 			return fmt.Errorf(`an (app, commit) combination was found in the application tree but not in the commits tree:
 application tree pairs: %v
 commit tree pairs: %v
@@ -864,13 +864,13 @@ directory tree: %v`, applications, commits, app, strings.Join(dumpFilesystem(fs)
 		}
 	}
 	for _, commit := range commits {
-		flag := false
+		appFound := false
 		for _, app := range applications {
 			if app.application == commit.application && app.sourceCommitID == commit.sourceCommitID {
-				flag = true
+				appFound = true
 			}
 		}
-		if !flag {
+		if !appFound {
 			return fmt.Errorf(`an (app, commit) combination was found in the commits tree but not in the applications tree:
 application tree pairs: %v
 commit tree pairs: %v

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1217,6 +1217,34 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 				"commits/no/nsense/applications/app/.empty",
 			},
 		},
+		{
+			Name: "Create application with SHA1 commit ID with uppercase letters",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "acceptance",
+					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: envAcceptance, Latest: false}},
+				},
+				&CreateApplicationVersion{
+					Application:    "app",
+					SourceCommitId: "aaaaaaAAaaaaaaaaaaaaaaaaaaaaaaaaaaAaaaaa",
+					Manifests: map[string]string{
+						envAcceptance: "acceptance",
+					},
+				},
+				&DeployApplicationVersion{
+					Environment:   envAcceptance,
+					Application:   "app",
+					Version:       1,
+					LockBehaviour: api.LockBehavior_Fail,
+				},
+			},
+			ExistentCommitPaths: []string {
+				"commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/applications/app/.empty",
+			},
+			NonExistentCommitPaths: []string{
+				"commits/aa/aaaaAAaaaaaaaaaaaaaaaaaaaaaaaaaaAaaaaa/applications/app/.empty",
+			},
+		},
 		generateLargeTest1(30),
 		generateLargeTest2(30),
 	}

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1209,7 +1209,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
 			ctx := testutil.MakeTestContext()
-			// t.Parallel()
+			t.Parallel()
 			repo := setupRepositoryTest(t)
 			_, updatedState, _, err := repo.ApplyTransformersInternal(ctx, tc.Transformers...)
 			if err != nil {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -965,7 +965,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Environment:   envAcceptance,
 					Application:   "app",
 					Version:       1,
-					LockBehaviour: api.LockBehavior_Fail,
+					LockBehaviour: api.LockBehavior_FAIL,
 				},
 			},
 			ExistentCommitPaths: []string{
@@ -1004,19 +1004,19 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Environment:   envAcceptance,
 					Application:   "app1",
 					Version:       1,
-					LockBehaviour: api.LockBehavior_Fail,
+					LockBehaviour: api.LockBehavior_FAIL,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
 					Application:   "app2",
 					Version:       1,
-					LockBehaviour: api.LockBehavior_Fail,
+					LockBehaviour: api.LockBehavior_FAIL,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
 					Application:   "app3",
 					Version:       1,
-					LockBehaviour: api.LockBehavior_Fail,
+					LockBehaviour: api.LockBehavior_FAIL,
 				},
 			},
 			ExistentCommitPaths: []string{
@@ -1057,19 +1057,19 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Environment:   envAcceptance,
 					Application:   "app1",
 					Version:       1,
-					LockBehaviour: api.LockBehavior_Fail,
+					LockBehaviour: api.LockBehavior_FAIL,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
 					Application:   "app2",
 					Version:       1,
-					LockBehaviour: api.LockBehavior_Fail,
+					LockBehaviour: api.LockBehavior_FAIL,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
 					Application:   "app3",
 					Version:       1,
-					LockBehaviour: api.LockBehavior_Fail,
+					LockBehaviour: api.LockBehavior_FAIL,
 				},
 			},
 			ExistentCommitPaths: []string{
@@ -1110,19 +1110,19 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Environment:   envAcceptance,
 					Application:   "app1",
 					Version:       1,
-					LockBehaviour: api.LockBehavior_Fail,
+					LockBehaviour: api.LockBehavior_FAIL,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
 					Application:   "app2",
 					Version:       1,
-					LockBehaviour: api.LockBehavior_Fail,
+					LockBehaviour: api.LockBehavior_FAIL,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
 					Application:   "app3",
 					Version:       1,
-					LockBehaviour: api.LockBehavior_Fail,
+					LockBehaviour: api.LockBehavior_FAIL,
 				},
 			},
 			ExistentCommitPaths: []string{
@@ -1149,7 +1149,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Environment:   envAcceptance,
 					Application:   "app",
 					Version:       1,
-					LockBehaviour: api.LockBehavior_Fail,
+					LockBehaviour: api.LockBehavior_FAIL,
 				},
 			},
 			NonExistentCommitPaths: []string{
@@ -1174,7 +1174,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Environment:   envAcceptance,
 					Application:   "app",
 					Version:       1,
-					LockBehaviour: api.LockBehavior_Fail,
+					LockBehaviour: api.LockBehavior_FAIL,
 				},
 			},
 			ExistentCommitPaths: []string{
@@ -1199,7 +1199,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 						Environment:   envAcceptance,
 						Application:   "app",
 						Version:       uint64(21),
-						LockBehaviour: api.LockBehavior_Fail,
+						LockBehaviour: api.LockBehavior_FAIL,
 					},
 				},
 			),
@@ -1232,7 +1232,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 						Environment:   envAcceptance,
 						Application:   "app2",
 						Version:       uint64(21),
-						LockBehaviour: api.LockBehavior_Fail,
+						LockBehaviour: api.LockBehavior_FAIL,
 					},
 				},
 			),
@@ -1283,44 +1283,25 @@ func TestUndeployApplicationCommitPath(t *testing.T) {
 		NonExistentCommitPaths []string
 	}
 
-	generateLargeTest1 := func(versionCount uint64) TestCase {
-		name := fmt.Sprintf("Create two applications %d times and then undeploy one of them", versionCount)
+	intToSHA1 := func(n int) string {
+		ret := strconv.Itoa(n)
+		ret = strings.Repeat("0", 40-len(ret)) + ret
+		return ret
+	}
 
-		transformers := make([]Transformer, 0)
-		commitPaths1 := make([]string, 0)
-		commitPaths2 := make([]string, 0)
+	manyCreateApplication := func(app string, n int) []Transformer {
+		ret := make([]Transformer, 0)
 
-		for i := uint64(0); i < versionCount; i++ {
-			commitID := randomCommitID()
-			transformers = append(transformers, &CreateApplicationVersion{
-				Application:    "app1",
-				SourceCommitId: commitID,
+		for i := 1; i <= n; i++ {
+			ret = append(ret, &CreateApplicationVersion{
+				Application:    app,
+				SourceCommitId: intToSHA1(i),
+				Manifests: map[string]string{
+					envAcceptance: "acceptance",
+				},
 			})
-			transformers = append(transformers, &CreateApplicationVersion{
-				Application:    "app2",
-				SourceCommitId: commitID,
-			})
-
-			commitPaths1 = append(commitPaths1, path.Join("commits", commitID[:2], commitID[2:], "applications", "app1", ".empty"))
-			commitPaths2 = append(commitPaths2, path.Join("commits", commitID[:2], commitID[2:], "applications", "app2", ".empty"))
 		}
-
-		transformers = append(transformers, &CreateUndeployApplicationVersion{
-			Application: "app1",
-		})
-		transformers = append(transformers, &UndeployApplication{
-			Application: "app1",
-		})
-
-		existentCommitPaths := commitPaths2
-		NonExistentCommitPaths := commitPaths1
-		return TestCase{
-			Name:                   name,
-			Transformers:           transformers,
-			ExistentCommitPaths:    existentCommitPaths,
-			NonExistentCommitPaths: NonExistentCommitPaths,
-		}
-
+		return ret
 	}
 
 	tcs := []TestCase{
@@ -1367,7 +1348,29 @@ func TestUndeployApplicationCommitPath(t *testing.T) {
 				"commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/applications/app1/.empty",
 			},
 		},
-		generateLargeTest1(30),
+		TestCase{
+			Name: "Create two applications many times and then undeploy one of them",
+			Transformers: concatenate(
+				manyCreateApplication("app1", 20),
+				manyCreateApplication("app2", 20),
+				[]Transformer{
+					&CreateUndeployApplicationVersion{
+						Application: "app2",
+					},
+					&UndeployApplication{
+						Application: "app2",
+					},
+				},
+			),
+			ExistentCommitPaths: []string{
+				"commits/00/00000000000000000000000000000000000001/applications/app1/.empty",
+				"commits/00/00000000000000000000000000000000000020/applications/app1/.empty",
+			},
+			NonExistentCommitPaths: []string{
+				"commits/00/00000000000000000000000000000000000001/applications/app2/.empty",
+				"commits/00/00000000000000000000000000000000000020/applications/app2/.empty",
+			},
+		},
 	}
 
 	for _, tc := range tcs {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -890,7 +890,7 @@ func randomCommitID() string {
 	return hex.EncodeToString(commitID)
 }
 
-func TestCreateApplicationVersionCommitPathConsistency(t *testing.T) {
+func TestCreateApplicationVersionCommitPath(t *testing.T) {
 	type TestCase struct {
 		Name                   string
 		Transformers           []Transformer
@@ -1235,7 +1235,7 @@ func TestCreateApplicationVersionCommitPathConsistency(t *testing.T) {
 	}
 }
 
-func TestUndeployApplicationCommitPathConsistency(t *testing.T) {
+func TestUndeployApplicationCommitPath(t *testing.T) {
 	type TestCase struct {
 		Name                   string
 		Transformers           []Transformer

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -741,7 +741,7 @@ func listFilesHelper(fs billy.Filesystem, path string) []string {
 	files, err := fs.ReadDir(path)
 	if err == nil {
 		for _, file := range files {
-			ret = append(ret, dumpFilesystemHelper(fs, fs.Join(path, file.Name()))...)
+			ret = append(ret, listFilesHelper(fs, fs.Join(path, file.Name()))...)
 		}
 	} else {
 		ret = append(ret, path)
@@ -751,7 +751,7 @@ func listFilesHelper(fs billy.Filesystem, path string) []string {
 }
 
 func listFiles(fs billy.Filesystem) []string {
-	paths := dumpFilesystemHelper(fs, ".")
+	paths := listFilesHelper(fs, ".")
 	sort.Slice(paths, func(i, j int) bool { return paths[i] < paths[j] })
 	return paths
 }
@@ -761,7 +761,7 @@ func verifyCommitPathsExist(fs billy.Filesystem, paths []string) error {
 		_, err := fs.Stat(path)
 		if err != nil {
 			return fmt.Errorf(`error verifying commit path exists. path: %s, error: %v
-directory tree: %s`, path, err, strings.Join(dumpFilesystem(fs), "\n"))
+directory tree: %s`, path, err, strings.Join(listFiles(fs), "\n"))
 		}
 	}
 	return nil
@@ -772,7 +772,7 @@ func verifyCommitPathsDontExist(fs billy.Filesystem, paths []string) error {
 		_, err := fs.Stat(path)
 		if err == nil {
 			return fmt.Errorf(`error verifying commit path doesn't exist. path: %s, error expected but none was raised
-directory tree: %s`, path, strings.Join(dumpFilesystem(fs), "\n"))
+directory tree: %s`, path, strings.Join(listFiles(fs), "\n"))
 		}
 	}
 	return nil
@@ -860,7 +860,7 @@ func verifyConsistency(fs billy.Filesystem) error {
 application tree pairs: %v
 commit tree pairs: %v
 missing: %v
-directory tree: %v`, applications, commits, app, strings.Join(dumpFilesystem(fs), "\n"))
+directory tree: %v`, applications, commits, app, strings.Join(listFiles(fs), "\n"))
 		}
 	}
 	for _, commit := range commits {
@@ -875,7 +875,7 @@ directory tree: %v`, applications, commits, app, strings.Join(dumpFilesystem(fs)
 application tree pairs: %v
 commit tree pairs: %v
 missing: %v
-directory tree: %v`, applications, commits, commit, strings.Join(dumpFilesystem(fs), "\n"))
+directory tree: %v`, applications, commits, commit, strings.Join(listFiles(fs), "\n"))
 		}
 	}
 	return nil

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1306,7 +1306,7 @@ func TestUndeployApplicationCommitPath(t *testing.T) {
 			})
 
 			commitPaths1 = append(commitPaths1, path.Join("commits", commitID[:2], commitID[2:], "applications", "app1", ".empty"))
-			commitPaths2 = append(commitPaths2, path.Join("commits", commitID[:2], commitID[2:], "applications", "app1", ".empty"))
+			commitPaths2 = append(commitPaths2, path.Join("commits", commitID[:2], commitID[2:], "applications", "app2", ".empty"))
 		}
 
 		transformers = append(transformers, &CreateUndeployApplicationVersion{
@@ -1316,8 +1316,8 @@ func TestUndeployApplicationCommitPath(t *testing.T) {
 			Application: "app1",
 		})
 
-		existentCommitPaths := commitPaths2[len(commitPaths2)-20:]
-		NonExistentCommitPaths := append(commitPaths1, commitPaths2[:len(commitPaths2)-20]...)
+		existentCommitPaths := commitPaths2
+		NonExistentCommitPaths := commitPaths1
 		tcs = append(tcs, TestCase{
 			Name:                   name,
 			Transformers:           transformers,
@@ -1328,6 +1328,7 @@ func TestUndeployApplicationCommitPath(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
+			tc := tc
 			ctx := testutil.MakeTestContext()
 			t.Parallel()
 			repo := setupRepositoryTest(t)
@@ -1336,6 +1337,16 @@ func TestUndeployApplicationCommitPath(t *testing.T) {
 				t.Fatalf("encountered error but no error is expected here: %v", err)
 			}
 			fs := updatedState.Filesystem
+
+			err = verifyCommitPathsExist(fs, tc.ExistentCommitPaths)
+			if err != nil {
+				t.Fatalf("some paths failed to create: %v", err)
+			}
+
+			err = verifyCommitPathsDontExist(fs, tc.NonExistentCommitPaths)
+			if err != nil {
+				t.Fatalf("some paths failed to delete: %v", err)
+			}
 
 			err = verifyConsistency(fs)
 			if err != nil {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1100,6 +1100,9 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					LockBehaviour: api.LockBehavior_Fail,
 				},
 			},
+			NonExistentCommitPaths: []string {
+				"commits/no/nsense/applications/app/.empty"	
+			},
 		},
 	}
 

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1348,7 +1348,7 @@ func TestUndeployApplicationCommitPath(t *testing.T) {
 				"commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/applications/app1/.empty",
 			},
 		},
-		TestCase{
+		{
 			Name: "Create two applications many times and then undeploy one of them",
 			Transformers: concatenate(
 				manyCreateApplication("app1", 20),

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -762,8 +762,7 @@ func verifyCommitPathsExist(fs billy.Filesystem, paths []string) error {
 		_, err := fs.Stat(path)
 		if err != nil {
 			return fmt.Errorf(`error verifying commit path exists. path: %s, error: %v
-			
-			directory tree: %s`, path, err, strings.Join(dumpFilesystem(fs), "\n"))
+directory tree: %s`, path, err, strings.Join(dumpFilesystem(fs), "\n"))
 		}
 	}
 	return nil
@@ -774,8 +773,7 @@ func verifyCommitPathsDontExist(fs billy.Filesystem, paths []string) error {
 		_, err := fs.Stat(path)
 		if err == nil {
 			return fmt.Errorf(`error verifying commit path doesn't exist. path: %s, error expected but none was raised
-			
-			directory tree: %s`, path, strings.Join(dumpFilesystem(fs), "\n"))
+directory tree: %s`, path, strings.Join(dumpFilesystem(fs), "\n"))
 		}
 	}
 	return nil
@@ -860,10 +858,10 @@ func verifyConsistency(fs billy.Filesystem) error {
 		}
 		if !flag {
 			return fmt.Errorf(`an (app, commit) combination was found in the application tree but not in the commits tree:
-			application tree pairs: %v
-			commit tree pairs: %v
-			missing: %v
-			directory tree: %v`, applications, commits, app, strings.Join(dumpFilesystem(fs), "\n"))
+application tree pairs: %v
+commit tree pairs: %v
+missing: %v
+directory tree: %v`, applications, commits, app, strings.Join(dumpFilesystem(fs), "\n"))
 		}
 	}
 	for _, commit := range commits {
@@ -875,10 +873,10 @@ func verifyConsistency(fs billy.Filesystem) error {
 		}
 		if !flag {
 			return fmt.Errorf(`an (app, commit) combination was found in the commits tree but not in the applications tree:
-			application tree pairs: %v
-			commit tree pairs: %v
-			missing: %v
-			directory tree: %v`, applications, commits, commit, strings.Join(dumpFilesystem(fs), "\n"))
+application tree pairs: %v
+commit tree pairs: %v
+missing: %v
+directory tree: %v`, applications, commits, commit, strings.Join(dumpFilesystem(fs), "\n"))
 		}
 	}
 	return nil

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1101,7 +1101,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 				},
 			},
 			NonExistentCommitPaths: []string {
-				"commits/no/nsense/applications/app/.empty"	
+				"commits/no/nsense/applications/app/.empty",	
 			},
 		},
 	}

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -735,7 +735,7 @@ func TestCreateApplicationVersionIdempotency(t *testing.T) {
 	}
 }
 
-func dumpFilesystemHelper(fs billy.Filesystem, path string) []string {
+func listFilesHelper(fs billy.Filesystem, path string) []string {
 	ret := make([]string, 0)
 
 	files, err := fs.ReadDir(path)
@@ -750,7 +750,7 @@ func dumpFilesystemHelper(fs billy.Filesystem, path string) []string {
 	return ret
 }
 
-func dumpFilesystem(fs billy.Filesystem) []string {
+func listFiles(fs billy.Filesystem) []string {
 	paths := dumpFilesystemHelper(fs, ".")
 	sort.Slice(paths, func(i, j int) bool { return paths[i] < paths[j] })
 	return paths

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -718,7 +718,6 @@ func TestCreateApplicationVersionIdempotency(t *testing.T) {
 			if err := prototext.Unmarshal([]byte(tc.expectedErrorMsg), &expectedErr); err != nil {
 				t.Fatalf("failed to unmarshal the expected error object: %v", err)
 			}
-
 			repo := setupRepositoryTest(t)
 			_, _, _, err := repo.ApplyTransformersInternal(ctxWithTime, tc.Transformers...)
 			if err == nil {

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -413,7 +413,6 @@ func TestBatchServiceErrors(t *testing.T) {
 					Actions: tc.Batch,
 				},
 			)
-
 			if tc.ExpectedResponse != "" && !proto.Equal(response, &expectedResponseObject) {
 				t.Fatalf("expected:\n%s\ngot:\n%s\n%s", tc.ExpectedResponse, response.String(), processErr)
 			}


### PR DESCRIPTION
Here we add logic to `CreateApplicationVersion`, `UndeployApplication`, and `CleanupOldApplicatioVersions` transformers so that there is a separate `commits` directory in the manifest repository that maintains the currently-tracked commits.

The new path has the format `commits/<first two characters of the hash>/<remaining letters of the hash>/applications/<app>/.empty`. It's possible that there will be more than one application in one commit's subtree. The `.empty` file is there so that the path is tracked by Git.

This is a prerequisite for implementing a commit info page in the UI later.