### PR TITLE
fix: issues in rollout-service overview response

### DIFF
--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -196,6 +196,9 @@ $(sed -e "s/^/        /" <../../services/cd-service/known_hosts)
   rbac:
     policy.csv: |
       p, role:kuberpult, applications, get, */*, allow
+      p, role:kuberpult, applications, create, */*, allow
+      p, role:kuberpult, applications, sync, */*, allow
+      p, role:kuberpult, applications, delete, */*, allow
       g, kuberpult, role:kuberpult
 
 YAML
@@ -293,6 +296,7 @@ log:
 git:
   url: "ssh://git@server.${GIT_NAMESPACE}.svc.cluster.local/git/repos/manifests"
   sourceRepoUrl: "https://github.com/freiheit-com/kuberpult/tree/{branch}/{dir}"
+  branch: "main"
   networkTimeout: 1s
 ssh:
   identity: |
@@ -305,6 +309,9 @@ argocd:
   insecure: true
   refresh:
     enabled: true
+manageArgoApplications:
+  enabled: true
+  filter: "sreteam"
 pgp:
   keyRing: |
 $(sed -e "s/^/    /" <./kuberpult-keyring.gpg)

--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -310,8 +310,8 @@ argocd:
   refresh:
     enabled: true
 manageArgoApplications:
-  enabled: true
-  filter: "sreteam"
+  enabled: false
+  filter: ""
 pgp:
   keyRing: |
 $(sed -e "s/^/    /" <./kuberpult-keyring.gpg)

--- a/services/cd-service/pkg/mapper/environments_config.go
+++ b/services/cd-service/pkg/mapper/environments_config.go
@@ -290,3 +290,58 @@ func TransformSyncWindows(syncWindows []config.ArgoCdSyncWindow, appName string)
 	}
 	return envAppSyncWindows, nil
 }
+
+func TransformArgocd(config config.EnvironmentConfigArgoCd) *api.EnvironmentConfig_ArgoCD {
+	if &config == nil {
+		return nil
+	}
+	var syncWindows []*api.EnvironmentConfig_ArgoCD_SyncWindows
+	var accessList []*api.EnvironmentConfig_ArgoCD_AccessEntry
+	var ignoreDifferences []*api.EnvironmentConfig_ArgoCD_IgnoreDifferences
+
+	for _, i := range config.SyncWindows {
+		syncWindow := &api.EnvironmentConfig_ArgoCD_SyncWindows{
+			Kind:         i.Kind,
+			Duration:     i.Duration,
+			Schedule:     i.Schedule,
+			Applications: i.Apps,
+		}
+		syncWindows = append(syncWindows, syncWindow)
+	}
+
+	for _, i := range config.ClusterResourceWhitelist {
+		access := &api.EnvironmentConfig_ArgoCD_AccessEntry{
+			Group: i.Group,
+			Kind:  i.Kind,
+		}
+		accessList = append(accessList, access)
+	}
+
+	for _, i := range config.IgnoreDifferences {
+		ignoreDiff := &api.EnvironmentConfig_ArgoCD_IgnoreDifferences{
+			Group:                 i.Group,
+			Kind:                  i.Kind,
+			Name:                  i.Name,
+			Namespace:             i.Namespace,
+			JsonPointers:          i.JSONPointers,
+			JqPathExpressions:     i.JqPathExpressions,
+			ManagedFieldsManagers: i.ManagedFieldsManagers,
+		}
+		ignoreDifferences = append(ignoreDifferences, ignoreDiff)
+	}
+
+	return &api.EnvironmentConfig_ArgoCD{
+		Destination: &api.EnvironmentConfig_ArgoCD_Destination{
+			Name:                 config.Destination.Name,
+			Server:               config.Destination.Server,
+			Namespace:            config.Destination.Namespace,
+			AppProjectNamespace:  config.Destination.AppProjectNamespace,
+			ApplicationNamespace: config.Destination.ApplicationNamespace,
+		},
+		SyncWindows:            syncWindows,
+		AccessList:             accessList,
+		IgnoreDifferences:      ignoreDifferences,
+		ApplicationAnnotations: config.ApplicationAnnotations,
+		SyncOptions:            config.SyncOptions,
+	}
+}

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -95,11 +95,15 @@ func (o *OverviewServiceServer) getOverview(
 		for envName, config := range envs {
 			var groupName = mapper.DeriveGroupName(config, envName)
 			var envInGroup = getEnvironmentInGroup(result.EnvironmentGroups, groupName, envName)
+			argocd := &api.EnvironmentConfig_ArgoCD{}
+			if config.ArgoCd != nil {
+				argocd = mapper.TransformArgocd(*config.ArgoCd)
+			}
 			env := api.Environment{
 				Name: envName,
 				Config: &api.EnvironmentConfig{
 					Upstream:         mapper.TransformUpstream(config.Upstream),
-					Argocd:           mapper.TransformArgocd(*config.ArgoCd),
+					Argocd:           argocd,
 					EnvironmentGroup: &groupName,
 				},
 				Locks:        map[string]*api.Lock{},

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -99,11 +99,13 @@ func (o *OverviewServiceServer) getOverview(
 				Name: envName,
 				Config: &api.EnvironmentConfig{
 					Upstream:         mapper.TransformUpstream(config.Upstream),
+					Argocd:           mapper.TransformArgocd(*config.ArgoCd),
 					EnvironmentGroup: &groupName,
 				},
 				Locks:        map[string]*api.Lock{},
 				Applications: map[string]*api.Environment_Application{},
 			}
+			envInGroup.Config = env.Config
 			if locks, err := s.GetEnvironmentLocks(envName); err != nil {
 				return nil, err
 			} else {

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -143,10 +143,6 @@ func (a ArgoAppProcessor) CreateOrUpdateApp(ctx context.Context, overview *api.G
 				Upsert:      &upsert,
 				Validate:    &validate,
 			}
-			//TODO (LS): We need to allow for an app to be created in any project
-			if appToCreate.Spec.Project != env.Name {
-				return
-			}
 			_, err := a.ApplicationClient.Create(ctx, appCreateRequest)
 			if err != nil {
 				// We check if the application was created in the meantime

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -1,4 +1,5 @@
-/*This file is part of kuberpult.
+/*
+This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -12,7 +13,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright 2023 freiheit.com*/
+Copyright 2023 freiheit.com
+*/
 package argo
 
 import (
@@ -107,10 +109,10 @@ func (a *ArgoAppProcessor) Consume(ctx context.Context, hlth *setup.HealthReport
 			envKnownToArgo := appsKnownToArgo[envName]
 			switch ev.Type {
 			case "ADDED", "MODIFIED":
-				l.Info("created/updated app:" + ev.Application.Name + ",env:" + envName)
+				l.Info("created/updated:kuberpult.application:" + ev.Application.Name + ",kuberpult.environment:" + envName)
 				envKnownToArgo[appName] = &ev.Application
 			case "DELETED":
-				l.Info("deleted app:" + ev.Application.Name + ",env:" + envName)
+				l.Info("deleted:kuberpult.application:" + ev.Application.Name + ",kuberpult.environment:" + envName)
 				delete(envKnownToArgo, appName)
 			}
 			appsKnownToArgo[envName] = envKnownToArgo

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -1,4 +1,5 @@
-/*This file is part of kuberpult.
+/*
+This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -12,7 +13,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright 2023 freiheit.com*/
+Copyright 2023 freiheit.com
+*/
 package argo
 
 import (
@@ -74,8 +76,9 @@ func (a *ArgoAppProcessor) Push(ctx context.Context, last *api.GetOverviewRespon
 	}
 }
 
-func (a *ArgoAppProcessor) Consume(ctx context.Context) error {
-	l := logger.FromContext(ctx).With(zap.String("event-consuming", "ready"))
+func (a *ArgoAppProcessor) Consume(ctx context.Context, hlth *setup.HealthReporter) error {
+	hlth.ReportReady("event-consuming ready")
+	l := logger.FromContext(ctx).With(zap.String("self-manage", "consuming"))
 	appsKnownToArgo := map[string]map[string]*v1alpha1.Application{}
 	for {
 		select {
@@ -84,7 +87,6 @@ func (a *ArgoAppProcessor) Consume(ctx context.Context) error {
 				for _, env := range envGroup.Environments {
 					envAppsKnownToArgo := appsKnownToArgo[env.Name]
 					err := a.DeleteArgoApps(ctx, envAppsKnownToArgo, env.Applications)
-
 					if err != nil {
 						l.Error("deleting applications")
 						continue
@@ -107,8 +109,10 @@ func (a *ArgoAppProcessor) Consume(ctx context.Context) error {
 			envKnownToArgo := appsKnownToArgo[envName]
 			switch ev.Type {
 			case "ADDED", "MODIFIED":
+				fmt.Println("creating/updating the app " + ev.Application.Name)
 				envKnownToArgo[appName] = &ev.Application
 			case "DELETED":
+				fmt.Println("deleting the app " + appName)
 				delete(envKnownToArgo, appName)
 			}
 
@@ -124,7 +128,6 @@ func (a ArgoAppProcessor) CreateOrUpdateApp(ctx context.Context, overview *api.G
 		k := Key{AppName: app.Name, EnvName: env.Name, Application: app, Environment: env}
 
 		appExists := false
-
 		for _, argoApp := range appsKnownToArgo {
 			if argoApp.Annotations["com.freiheit.kuberpult/application"] != "" {
 				appExists = true
@@ -146,7 +149,7 @@ func (a ArgoAppProcessor) CreateOrUpdateApp(ctx context.Context, overview *api.G
 			if err != nil {
 				// We check if the application was created in the meantime
 				if status.Code(err) != codes.InvalidArgument {
-					logger.FromContext(ctx).Error("creating application: %w")
+					logger.FromContext(ctx).Error("creating application: " + appToCreate.Name)
 				}
 			}
 		} else {
@@ -158,7 +161,7 @@ func (a ArgoAppProcessor) CreateOrUpdateApp(ctx context.Context, overview *api.G
 			}
 			_, err := a.ApplicationClient.UpdateSpec(ctx, appUpdateRequest)
 			if err != nil {
-				logger.FromContext(ctx).Error("updating application")
+				logger.FromContext(ctx).Error("updating application: " + appToUpdate.Name)
 			}
 		}
 	}
@@ -203,9 +206,8 @@ func (a ArgoAppProcessor) DeleteArgoApps(ctx context.Context, argoApps map[strin
 	toDelete := make([]*v1alpha1.Application, 0)
 	for _, argoApp := range argoApps {
 		if apps[argoApp.Annotations["com.freiheit.kuberpult/application"]] == nil {
-			break
+			toDelete = append(toDelete, argoApp)
 		}
-		toDelete = append(toDelete, argoApp)
 	}
 
 	for i := range toDelete {
@@ -238,46 +240,64 @@ func CreateArgoApplication(overview *api.GetOverviewResponse, app *api.Environme
 	annotations["argocd.argoproj.io/manifest-generate-paths"] = "/" + manifestPath
 	labels["com.freiheit.kuberpult/team"] = team(overview, app.Name)
 
-	if env.Config.Argocd.Destination.Namespace != nil {
-		applicationNs = *env.Config.Argocd.Destination.Namespace
-	} else if env.Config.Argocd.Destination.ApplicationNamespace != nil {
-		applicationNs = *env.Config.Argocd.Destination.ApplicationNamespace
-	}
+	var applicationDestination v1alpha1.ApplicationDestination
+	var syncWindows v1alpha1.SyncWindows
+	var ignoreDifferences []v1alpha1.ResourceIgnoreDifferences
+	var syncOptions []string
 
-	applicationDestination := v1alpha1.ApplicationDestination{
-		Name:      env.Config.Argocd.Destination.Name,
-		Namespace: applicationNs,
-		Server:    env.Config.Argocd.Destination.Server,
-	}
-
-	syncWindows := v1alpha1.SyncWindows{}
-
-	ignoreDifferences := make([]v1alpha1.ResourceIgnoreDifferences, len(env.Config.Argocd.IgnoreDifferences))
-	for index, value := range env.Config.Argocd.IgnoreDifferences {
-		difference := v1alpha1.ResourceIgnoreDifferences{
-			Group:                 value.Group,
-			Kind:                  value.Kind,
-			Name:                  value.Name,
-			Namespace:             value.Namespace,
-			JSONPointers:          value.JsonPointers,
-			JQPathExpressions:     value.JqPathExpressions,
-			ManagedFieldsManagers: value.ManagedFieldsManagers,
+	if env.Config.Argocd == nil {
+		applicationDestination = v1alpha1.ApplicationDestination{
+			Name:      fmt.Sprintf("%s-%s", env.Name, app.Name),
+			Namespace: "default",
+			Server:    "https://kubernetes.default.svc",
 		}
-		ignoreDifferences[index] = difference
-	}
 
-	for _, w := range env.Config.Argocd.SyncWindows {
-		apps := []string{"*"}
-		if len(w.Applications) > 0 {
-			apps = w.Applications
+		syncWindows = v1alpha1.SyncWindows{}
+		ignoreDifferences = make([]v1alpha1.ResourceIgnoreDifferences, 0)
+		syncOptions = []string{}
+
+	} else {
+		if env.Config.Argocd.Destination.Namespace != nil {
+			applicationNs = *env.Config.Argocd.Destination.Namespace
+		} else if env.Config.Argocd.Destination.ApplicationNamespace != nil {
+			applicationNs = *env.Config.Argocd.Destination.ApplicationNamespace
 		}
-		syncWindows = append(syncWindows, &v1alpha1.SyncWindow{
-			Applications: apps,
-			Schedule:     w.Schedule,
-			Duration:     w.Duration,
-			Kind:         w.Kind,
-			ManualSync:   true,
-		})
+
+		applicationDestination = v1alpha1.ApplicationDestination{
+			Name:      env.Config.Argocd.Destination.Name,
+			Namespace: applicationNs,
+			Server:    env.Config.Argocd.Destination.Server,
+		}
+
+		ignoreDifferences = make([]v1alpha1.ResourceIgnoreDifferences, len(env.Config.Argocd.IgnoreDifferences))
+		for index, value := range env.Config.Argocd.IgnoreDifferences {
+			difference := v1alpha1.ResourceIgnoreDifferences{
+				Group:                 value.Group,
+				Kind:                  value.Kind,
+				Name:                  value.Name,
+				Namespace:             value.Namespace,
+				JSONPointers:          value.JsonPointers,
+				JQPathExpressions:     value.JqPathExpressions,
+				ManagedFieldsManagers: value.ManagedFieldsManagers,
+			}
+			ignoreDifferences[index] = difference
+		}
+
+		for _, w := range env.Config.Argocd.SyncWindows {
+			apps := []string{"*"}
+			if len(w.Applications) > 0 {
+				apps = w.Applications
+			}
+			syncWindows = append(syncWindows, &v1alpha1.SyncWindow{
+				Applications: apps,
+				Schedule:     w.Schedule,
+				Duration:     w.Duration,
+				Kind:         w.Kind,
+				ManualSync:   true,
+			})
+		}
+
+		syncOptions = env.Config.Argocd.SyncOptions
 	}
 
 	deployApp := &v1alpha1.Application{
@@ -302,7 +322,7 @@ func CreateArgoApplication(overview *api.GetOverviewResponse, app *api.Environme
 					// We always allow empty, because it makes it easier to delete apps/environments
 					AllowEmpty: true,
 				},
-				SyncOptions: env.Config.Argocd.SyncOptions,
+				SyncOptions: syncOptions,
 			},
 			IgnoreDifferences: ignoreDifferences,
 		},

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -1,5 +1,4 @@
-/*
-This file is part of kuberpult.
+/*This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -13,8 +12,7 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright 2023 freiheit.com
-*/
+Copyright 2023 freiheit.com*/
 package argo
 
 import (

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -75,7 +75,7 @@ func (a *ArgoAppProcessor) Push(ctx context.Context, last *api.GetOverviewRespon
 }
 
 func (a *ArgoAppProcessor) Consume(ctx context.Context, hlth *setup.HealthReporter) error {
-	hlth.ReportReady("event-consuming ready")
+	hlth.ReportReady("event-consuming")
 	l := logger.FromContext(ctx).With(zap.String("self-manage", "consuming"))
 	appsKnownToArgo := map[string]map[string]*v1alpha1.Application{}
 	for {
@@ -238,8 +238,6 @@ func CreateArgoApplication(overview *api.GetOverviewResponse, app *api.Environme
 	annotations["argocd.argoproj.io/manifest-generate-paths"] = "/" + manifestPath
 	labels["com.freiheit.kuberpult/team"] = team(overview, app.Name)
 
-	var syncWindows v1alpha1.SyncWindows
-
 	if env.Config.Argocd.Destination.Namespace != nil {
 		applicationNs = *env.Config.Argocd.Destination.Namespace
 	} else if env.Config.Argocd.Destination.ApplicationNamespace != nil {
@@ -251,6 +249,8 @@ func CreateArgoApplication(overview *api.GetOverviewResponse, app *api.Environme
 		Namespace: applicationNs,
 		Server:    env.Config.Argocd.Destination.Server,
 	}
+
+	syncWindows := v1alpha1.SyncWindows{}
 
 	ignoreDifferences := make([]v1alpha1.ResourceIgnoreDifferences, len(env.Config.Argocd.IgnoreDifferences))
 	for index, value := range env.Config.Argocd.IgnoreDifferences {

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -1,4 +1,5 @@
-/*This file is part of kuberpult.
+/*
+This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -12,7 +13,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright 2023 freiheit.com*/
+Copyright 2023 freiheit.com
+*/
 package argo
 
 import (
@@ -284,8 +286,6 @@ func CreateArgoApplication(overview *api.GetOverviewResponse, app *api.Environme
 		})
 	}
 
-	syncOptions := env.Config.Argocd.SyncOptions
-
 	deployApp := &v1alpha1.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        app.Name,
@@ -308,7 +308,7 @@ func CreateArgoApplication(overview *api.GetOverviewResponse, app *api.Environme
 					// We always allow empty, because it makes it easier to delete apps/environments
 					AllowEmpty: true,
 				},
-				SyncOptions: syncOptions,
+				SyncOptions: env.Config.Argocd.SyncOptions,
 			},
 			IgnoreDifferences: ignoreDifferences,
 		},

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -273,6 +273,5 @@ func runServer(ctx context.Context, config Config) error {
 			return nil
 		},
 	})
-	fmt.Println("closing parent service")
 	return nil
 }

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -185,7 +185,6 @@ func runServer(ctx context.Context, config Config) error {
 	shutdownCh := make(chan struct{})
 	versionC := versions.New(overviewGrpc, versionGrpc, appClient, config.ManageArgoApplicationsEnabled, config.ManageArgoApplicationsFilter)
 	dispatcher := service.NewDispatcher(broadcast, versionC)
-
 	backgroundTasks := []setup.BackgroundTaskConfig{
 		{
 			Name: "consume argocd events",
@@ -202,7 +201,7 @@ func runServer(ctx context.Context, config Config) error {
 		{
 			Name: "consume self-manage events",
 			Run: func(ctx context.Context, health *setup.HealthReporter) error {
-				return versionC.GetArgoProcessor().Consume(ctx)
+				return versionC.GetArgoProcessor().Consume(ctx, health)
 			},
 		},
 		{
@@ -274,5 +273,6 @@ func runServer(ctx context.Context, config Config) error {
 			return nil
 		},
 	})
+	fmt.Println("closing parent service")
 	return nil
 }

--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -208,7 +208,6 @@ func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEven
 			v.cache.Add(overview.GitRevision, overview)
 			l.Info("overview.get")
 			seen := make(map[key]uint64, len(versions))
-			v.ArgoProcessor.Push(ctx, overview)
 			for _, envGroup := range overview.EnvironmentGroups {
 				for _, env := range envGroup.Environments {
 					for _, app := range env.Applications {
@@ -242,6 +241,7 @@ func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEven
 				}
 			}
 			l.Info("version.push")
+			v.ArgoProcessor.Push(ctx, overview)
 			// Send events with version 0 for deleted applications so that we can react
 			// to apps getting deleted.
 			for k := range versions {

--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -208,7 +208,7 @@ func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEven
 			v.cache.Add(overview.GitRevision, overview)
 			l.Info("overview.get")
 			seen := make(map[key]uint64, len(versions))
-			l.Info(strconv.Itoa(len(overview.EnvironmentGroups)))
+			v.ArgoProcessor.Push(ctx, overview)
 			for _, envGroup := range overview.EnvironmentGroups {
 				for _, env := range envGroup.Environments {
 					for _, app := range env.Applications {
@@ -242,7 +242,6 @@ func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEven
 				}
 			}
 			l.Info("version.push")
-			v.ArgoProcessor.Push(ctx, overview)
 			// Send events with version 0 for deleted applications so that we can react
 			// to apps getting deleted.
 			for k := range versions {


### PR DESCRIPTION
There were some issues with the rollout-service and how the overview response is used. We were not providing the argo config to each environment. This caused for new apps to be wrongly configured and created improperly (in some cases, not created at all).