### PR TITLE
fix: env prefix for self-manage applications

### DIFF
--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -282,7 +282,7 @@ func CreateArgoApplication(overview *api.GetOverviewResponse, app *api.Environme
 
 	deployApp := &v1alpha1.Application{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        app.Name,
+			Name:        fmt.Sprintf("%s-%s", env.Name, app.Name),
 			Annotations: annotations,
 			Labels:      labels,
 			Finalizers:  calculateFinalizers(),


### PR DESCRIPTION
When updating apps that are self-managed, the request to update fails because we are not using the env as prefix as we set it using the normal argo requests. Example: https://argocd.int.wawi.lidl/applications?search=blueprint&appNamespace=argocd&showFavorites=false&proj=&sync=&autoSync=&health=&namespace=&cluster=&labels= 