### PR TITLE
feat: Add TLS support for

### DIFF
--- a/docker-compose-earthly.yml
+++ b/docker-compose-earthly.yml
@@ -20,6 +20,7 @@ services:
     container_name: kuberpult-frontend-service
     environment:
       - KUBERPULT_CDSERVER=cd-service:8443
+      - KUBERPULT_CD_SERVER_SECURE=false
       - LOG_LEVEL=INFO
       - KUBERPULT_ALLOWED_ORIGINS=localhost:*
       - KUBERPULT_GIT_AUTHOR_NAME=user-local-dev-docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     container_name: kuberpult-frontend-service
     environment:
       - KUBERPULT_CDSERVER=cd-service:8443
+      - KUBERPULT_CD_SERVER_SECURE=false
       - LOG_LEVEL=INFO
       - KUBERPULT_ALLOWED_ORIGINS=localhost:*
       - KUBERPULT_GIT_AUTHOR_NAME=user-local-dev-docker-compose

--- a/services/frontend-service/pkg/config/config.go
+++ b/services/frontend-service/pkg/config/config.go
@@ -20,6 +20,7 @@ import "time"
 
 type ServerConfig struct {
 	CdServer            string        `default:"kuberpult-cd-service:8443"`
+	CdServerSecure      bool          `default:"false" split_words:"true"`
 	RolloutServer       string        `default:""`
 	HttpCdServer        string        `default:"http://kuberpult-cd-service:80" split_words:"true"`
 	GKEProjectNumber    string        `default:"" split_words:"true"`


### PR DESCRIPTION
* Add support for  environment variable `KUBERPULT_CD_SERVER_SECURE` to enable TLS communication to the cd-service.