### PR TITLE
feat: Group the rollout status in the release tooltip by env-group

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.test.tsx
@@ -245,6 +245,7 @@ describe('Release Card Rollout Status', () => {
         environmentGroups: EnvironmentGroup[];
         rolloutStatus: StreamStatusResponse[];
         expectedStatusIcon: RolloutStatus;
+        expectedRolloutDetails: { [name: string]: RolloutStatus };
     };
     const data: TestData[] = [
         {
@@ -281,8 +282,44 @@ describe('Release Card Rollout Status', () => {
                             distanceToUpstream: 0,
                             priority: Priority.OTHER,
                         },
+                        {
+                            name: 'development2',
+                            applications: {
+                                test1: {
+                                    version: 2,
+                                    name: '',
+                                    locks: {},
+                                    queuedVersion: 0,
+                                    undeployVersion: false,
+                                },
+                            },
+                            locks: {},
+                            distanceToUpstream: 0,
+                            priority: Priority.OTHER,
+                        },
                     ],
 
+                    distanceToUpstream: 0,
+                },
+                {
+                    environmentGroupName: 'staging',
+                    environments: [
+                        {
+                            name: 'staging',
+                            applications: {
+                                test1: {
+                                    version: 2,
+                                    name: '',
+                                    locks: {},
+                                    queuedVersion: 0,
+                                    undeployVersion: false,
+                                },
+                            },
+                            locks: {},
+                            distanceToUpstream: 0,
+                            priority: Priority.OTHER,
+                        },
+                    ],
                     distanceToUpstream: 0,
                 },
             ],
@@ -293,9 +330,25 @@ describe('Release Card Rollout Status', () => {
                     version: 2,
                     rolloutStatus: RolloutStatus.ROLLOUT_STATUS_SUCCESFUL,
                 },
+                {
+                    environment: 'development2',
+                    application: 'test1',
+                    version: 2,
+                    rolloutStatus: RolloutStatus.ROLLOUT_STATUS_SUCCESFUL,
+                },
+                {
+                    environment: 'staging',
+                    application: 'test1',
+                    version: 2,
+                    rolloutStatus: RolloutStatus.ROLLOUT_STATUS_SUCCESFUL,
+                },
             ],
 
             expectedStatusIcon: RolloutStatus.ROLLOUT_STATUS_SUCCESFUL,
+            expectedRolloutDetails: {
+                dev: RolloutStatus.ROLLOUT_STATUS_SUCCESFUL,
+                staging: RolloutStatus.ROLLOUT_STATUS_SUCCESFUL,
+            },
         },
     ];
 
@@ -321,10 +374,32 @@ describe('Release Card Rollout Status', () => {
             const { container } = getWrapper(testcase.props);
             // then
             expect(container.querySelector('.release__status')).not.toBeNull();
-            switch (testcase.expectedStatusIcon) {
-                case RolloutStatus.ROLLOUT_STATUS_SUCCESFUL:
-                    expect(container.querySelector('.release__status .rollout__icon_successful')).not.toBeNull();
+            expect(
+                container.querySelector(
+                    `.release__status .rollout__icon_${rolloutStatusName(testcase.expectedStatusIcon)}`
+                )
+            ).not.toBeNull();
+            for (const [envGroup, status] of Object.entries(testcase.expectedRolloutDetails)) {
+                const row = container.querySelector(`tr[key="${envGroup}"]`);
+                expect(row?.querySelector(`.rollout__description_${rolloutStatusName(status)}`)).not.toBeNull();
             }
         });
     });
 });
+
+const rolloutStatusName = (status: RolloutStatus): string => {
+    switch (status) {
+        case RolloutStatus.ROLLOUT_STATUS_SUCCESFUL:
+            return 'successful';
+        case RolloutStatus.ROLLOUT_STATUS_PROGRESSING:
+            return 'progressing';
+        case RolloutStatus.ROLLOUT_STATUS_PENDING:
+            return 'pending';
+        case RolloutStatus.ROLLOUT_STATUS_ERROR:
+            return 'error';
+        case RolloutStatus.ROLLOUT_STATUS_UNHEALTHY:
+            return 'unhealthy';
+        default:
+            return 'unknown';
+    }
+};

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -108,7 +108,7 @@ const calculateDeploymentStatus = (
     if (!rolloutEnabled) {
         return [[], undefined];
     }
-    const rolloutEnvs = deployedAt.map((envGroup) => {
+    const rolloutEnvGroups = deployedAt.map((envGroup) => {
         const status = envGroup.environments.reduce((cur: RolloutStatus | undefined, env) => {
             const appVersion: number | undefined = env.applications[app]?.version;
             const status = getAppRolloutStatus(rolloutStatus[env.name], appVersion);
@@ -125,7 +125,7 @@ const calculateDeploymentStatus = (
             rolloutStatus: status ?? RolloutStatus.ROLLOUT_STATUS_UNKNOWN,
         };
     });
-    rolloutEnvs.sort((a, b) => {
+    rolloutEnvGroups.sort((a, b) => {
         if (a.environmentGroup < b.environmentGroup) {
             return -1;
         } else if (a.environmentGroup > b.environmentGroup) {
@@ -134,7 +134,7 @@ const calculateDeploymentStatus = (
         return 0;
     });
     // Calculates the most interesting rollout status according to the `rolloutStatusPriority`.
-    const mostInteresting = rolloutEnvs.reduce(
+    const mostInteresting = rolloutEnvGroups.reduce(
         (cur: RolloutStatus | undefined, item) =>
             cur === undefined
                 ? item.rolloutStatus
@@ -143,7 +143,7 @@ const calculateDeploymentStatus = (
                   : cur,
         undefined
     );
-    return [rolloutEnvs, mostInteresting];
+    return [rolloutEnvGroups, mostInteresting];
 };
 
 export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {


### PR DESCRIPTION
Listing the rollout status for each environment can make the tooltip to big in projects with many environments. Instead, we group the rollout status by environment group, which results in much fewer entries. The rollout status is accumulated in the same way as the overall rollout status displayed in the card, i.e. the most important rollout status is chosen.
![image](https://github.com/freiheit-com/kuberpult/assets/50741717/9fdb09f4-2546-4f22-ad21-53bd2559fd6d)
