### PR TITLE
fix: Improve alignment of lock & rollout status in release dialog

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -135,10 +135,9 @@ Copyright 2023 freiheit.com*/
                 .env-card-app-locks {
                     display: flex;
                     position: relative;
-                    top: 10px;
                     right: 36px;
                     flex-direction: row;
-                    align-items: start;
+                    align-items: center;
                     gap: 0;
 
                     svg {


### PR DESCRIPTION
Before:
![image](https://github.com/freiheit-com/kuberpult/assets/50741717/4129da1c-5227-4a2a-baa6-64882accf37a)
After: 
![image](https://github.com/freiheit-com/kuberpult/assets/50741717/f7828b72-8147-4611-9de8-aa3c4b245b35)
