### PR TITLE
feat: reading and returning events of type newRelease from GetCommitInfo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/freiheit-com/kuberpult
 go 1.19
 
 require (
-	4d63.com/uuid v0.0.0-20171104051829-d0d07a5b6915
 	github.com/DataDog/datadog-go/v5 v5.3.0
 	github.com/MicahParks/keyfunc/v2 v2.1.0
 	github.com/argoproj/argo-cd/v2 v2.9.3
@@ -23,6 +22,7 @@ require (
 	github.com/libgit2/git2go/v34 v34.0.0
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a
+	github.com/onokonem/sillyQueueServer v0.0.0-20170829113733-84501ce98da1
 	github.com/prometheus/client_golang v1.17.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.44.0
 	go.opentelemetry.io/otel/metric v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-4d63.com/uuid v0.0.0-20171104051829-d0d07a5b6915 h1:6+9nKwkNukd9X3yYrXF66+CvICTpnjK7gTHrxSKbCp0=
-4d63.com/uuid v0.0.0-20171104051829-d0d07a5b6915/go.mod h1:VSb0E15rsSjtBOxKo8sxBfydxUqoS1a69lhhCp/ffTo=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690/go.mod h1:Ulb78X89vxKYgdL24HMTiXYHlyHEvruOj1ZPlqeNEZM=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -792,6 +790,8 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852/go.mod h1:eqOVx5Vwu4gd2mmMZvVZsgIqNSaW3xxRThUJ0k/TPk4=
+github.com/onokonem/sillyQueueServer v0.0.0-20170829113733-84501ce98da1 h1:969SrwVC2lRY0dGJdEJ1oaNcoCp3sU+MdUGwBPMWY8c=
+github.com/onokonem/sillyQueueServer v0.0.0-20170829113733-84501ce98da1/go.mod h1:IpAiw6LQdXgJQrftzzOa3Q/rsvTdMslnC9aolEwTKT8=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -47,6 +47,21 @@ message GetCommitInfoRequest {
 message GetCommitInfoResponse {
   string commit_message = 1;
   repeated string touched_apps = 2;
+  repeated Event events = 3;
+}
+
+message Event {
+  // data that ALL events have:
+  google.protobuf.Timestamp created_at = 1;
+
+  // data that is different per event type:
+  oneof event_type {
+    CreateReleaseEvent create_release_event = 2;
+  }
+}
+
+message CreateReleaseEvent {
+  repeated string environment_names = 1;
 }
 
 message TagData {

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -18,7 +18,6 @@ package uuid
 
 import (
 	"github.com/onokonem/sillyQueueServer/timeuuid"
-
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/pkg/uuid/uuid_test.go
+++ b/pkg/uuid/uuid_test.go
@@ -1,0 +1,59 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package uuid
+
+import (
+	"github.com/onokonem/sillyQueueServer/timeuuid"
+	"testing"
+	"time"
+)
+
+// this tests that we can get the time out of a time-uuid.
+func TestUuidTimeRoundTrip(t *testing.T) {
+	tcs := []struct {
+		Name      string
+		InputTime time.Time
+	}{
+		{
+			Name: "current time",
+			// note the 0 at the end: we do not support nanosecond precision (milliseconds are good enough)
+			InputTime: time.Date(2024, 1, 1, 1, 1, 1, 0, time.UTC),
+		},
+		{
+			Name:      "future time",
+			InputTime: time.Date(2042, 7, 1, 1, 1, 1, 0, time.UTC),
+		},
+		{
+			Name:      "past time",
+			InputTime: time.Date(1999, 12, 7, 1, 1, 1, 0, time.UTC),
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			uuidFromTime := timeuuid.UUIDFromTime(tc.InputTime)
+			timestamp := GetTime(&uuidFromTime)
+			actualTime := timestamp.AsTime()
+
+			if actualTime != tc.InputTime {
+				t.Fatalf("expected a different time.\nExpected: %v\nGot %v", tc.InputTime, actualTime)
+			}
+		})
+	}
+}

--- a/services/cd-service/pkg/event/event.go
+++ b/services/cd-service/pkg/event/event.go
@@ -13,30 +13,8 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
+package event
 
-package uuid
-
-import (
-	"github.com/onokonem/sillyQueueServer/timeuuid"
-
-	"google.golang.org/protobuf/types/known/timestamppb"
+const (
+	NewReleaseEventName = "new-release"
 )
-
-type UUID = timeuuid.UUID // just an alias for convenience
-
-type GenerateUUIDs interface {
-	Generate() string
-}
-
-type RealUUIDGenerator struct {
-}
-
-func (t RealUUIDGenerator) Generate() string {
-	return timeuuid.TimeUUID().String()
-}
-
-func GetTime(id *UUID) *timestamppb.Timestamp {
-	var ts = id.Time()
-	result := timestamppb.New(ts)
-	return result
-}

--- a/services/cd-service/pkg/repository/testutil/testutil.go
+++ b/services/cd-service/pkg/repository/testutil/testutil.go
@@ -35,6 +35,8 @@ package testutil
 import (
 	"context"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/config"
+	"github.com/onokonem/sillyQueueServer/timeuuid"
+	"time"
 
 	"github.com/freiheit-com/kuberpult/pkg/auth"
 	"google.golang.org/grpc/metadata"
@@ -99,4 +101,12 @@ func MakeEnvConfigUpstream(upstream string, argoCd *config.EnvironmentConfigArgo
 		ArgoCd:           argoCd,
 		EnvironmentGroup: nil,
 	}
+}
+
+type TestGenerator struct {
+	Time time.Time
+}
+
+func (t TestGenerator) Generate() string {
+	return timeuuid.UUIDFromTime(t.Time).String()
 }

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/freiheit-com/kuberpult/pkg/uuid"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/event"
 	"io"
 	"io/fs"
 	"os"
@@ -408,7 +409,7 @@ func getGeneratorFromContext(ctx context.Context) (uuid.GenerateUUIDs, bool) {
 	return gen, ok
 }
 
-func addGeneratorToContext(ctx context.Context, gen uuid.GenerateUUIDs) context.Context {
+func AddGeneratorToContext(ctx context.Context, gen uuid.GenerateUUIDs) context.Context {
 	return context.WithValue(ctx, ctxMarkerGenerateUuidKey, gen)
 }
 
@@ -460,11 +461,8 @@ func writeEvent(ctx context.Context, eventId string, sourceCommitId string, file
 			return fmt.Errorf("could not write file %s: %v", environmentNamePath, err)
 		}
 	}
-	const (
-		EventTypeNewRelease = "new-release"
-	)
 	eventTypePath := filesystem.Join(eventDir, "eventType")
-	if err := util.WriteFile(filesystem, eventTypePath, []byte(EventTypeNewRelease), 0666); err != nil {
+	if err := util.WriteFile(filesystem, eventTypePath, []byte(event.NewReleaseEventName), 0666); err != nil {
 		return fmt.Errorf("could not write file %s: %v", eventTypePath, err)
 	}
 

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -457,7 +457,7 @@ func writeEvent(ctx context.Context, eventId string, sourceCommitId string, file
 			return fmt.Errorf("could not create directory %s: %v", environmentDir, err)
 		}
 		environmentNamePath := filesystem.Join(environmentDir, ".gitkeep")
-		if err := util.WriteFile(filesystem, environmentNamePath, []byte(""), 0666); err != nil {
+		if err := util.WriteFile(filesystem, environmentNamePath, make([]byte, 0), 0666); err != nil {
 			return fmt.Errorf("could not write file %s: %v", environmentNamePath, err)
 		}
 	}

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -408,9 +408,8 @@ func TestCreateUndeployApplicationVersionErrors(t *testing.T) {
 }
 
 func TestCreateApplicationVersionEvents(t *testing.T) {
-	fakeGen := TestGenerator{
-		Prefix:        "myEventIsHere",
-		currentNumber: 0,
+	fakeGen := testutil.TestGenerator{
+		Time: timeNowOld,
 	}
 
 	tcs := []struct {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -443,9 +443,9 @@ func TestCreateApplicationVersionEvents(t *testing.T) {
 			},
 			expectedError: "",
 			expectedPaths: []string{
-				"commits/ca/fe1cafe2cafe1cafe2cafe1cafe2cafe1cafe2/events/myEventIsHere0/environments/acceptance/.gitkeep",
-				"commits/ca/fe1cafe2cafe1cafe2cafe1cafe2cafe1cafe2/events/myEventIsHere0/environments/production/.gitkeep",
-				"commits/ca/fe1cafe2cafe1cafe2cafe1cafe2cafe1cafe2/events/myEventIsHere0/eventType",
+				"environments/acceptance/.gitkeep",
+				"environments/production/.gitkeep",
+				"eventType",
 			},
 		},
 	}
@@ -460,18 +460,25 @@ func TestCreateApplicationVersionEvents(t *testing.T) {
 			if err != nil {
 				t.Fatalf("expected no error but transformer failed with %v", err)
 			}
+			// find out the name of the events directory:
+			baseDir := "commits/ca/fe1cafe2cafe1cafe2cafe1cafe2cafe1cafe2/events/"
+			fs := updatedState.Filesystem
+			files, err := fs.ReadDir(baseDir)
+			if len(files) != 1 {
+				t.Fatalf("Expected one event: %s - bot got %d", baseDir, len(files))
+			}
+			file := files[0]
+			eventId := file.Name()
+
 			for i := range tc.expectedPaths {
 				expectedPath := tc.expectedPaths[i]
-				filename := updatedState.Filesystem.Join(updatedState.Filesystem.Root(), expectedPath)
+				expectedFullPath := fs.Join(baseDir, eventId, expectedPath)
+				filename := updatedState.Filesystem.Join(updatedState.Filesystem.Root(), expectedFullPath)
 				_, err := util.ReadFile(updatedState.Filesystem, filename)
 				if err != nil {
 					t.Fatalf("Expected no error: %v - file issue %s", err, filename)
 				}
-				//if !cmp.Equal(fileData, tc.expectedFileData) {
-				//	t.Fatalf("Expected %v, got %v", tc.expectedFileData, fileData)
-				//}
 			}
-
 		})
 	}
 }

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -60,16 +60,6 @@ const (
 
 var timeNowOld = time.Date(1999, 01, 02, 03, 04, 05, 0, time.UTC)
 
-type TestGenerator struct {
-	Prefix        string
-	currentNumber int
-}
-
-func (t TestGenerator) Generate() string {
-	t.currentNumber++
-	return fmt.Sprintf("%s%d", t.Prefix, t.currentNumber-1)
-}
-
 func TestUndeployApplicationErrors(t *testing.T) {
 	tcs := []struct {
 		Name              string
@@ -466,7 +456,7 @@ func TestCreateApplicationVersionEvents(t *testing.T) {
 			t.Parallel()
 			repo := setupRepositoryTest(t)
 			ctx := testutil.MakeTestContext()
-			ctx = addGeneratorToContext(ctx, fakeGen)
+			ctx = AddGeneratorToContext(ctx, fakeGen)
 			_, updatedState, _, err := repo.ApplyTransformersInternal(ctx, tc.Transformers...)
 			if err != nil {
 				t.Fatalf("expected no error but transformer failed with %v", err)

--- a/services/cd-service/pkg/service/git.go
+++ b/services/cd-service/pkg/service/git.go
@@ -175,7 +175,7 @@ func (s *GitServer) GetEvents(ctx context.Context, fs billy.Filesystem, hash str
 	errorTemplate := func(message string, err error) error {
 		return fmt.Errorf("could not get events for hash '%s' in path '%s' - error %w", hash, commitPath, err)
 	}
-	var result []*api.Event = nil
+	var result []*api.Event
 	allEventsPath := fs.Join(commitPath, "events")
 	potentialEventDirs, err := fs.ReadDir(allEventsPath)
 	if err != nil {
@@ -190,8 +190,8 @@ func (s *GitServer) GetEvents(ctx context.Context, fs billy.Filesystem, hash str
 				return nil, errorTemplate(fmt.Sprintf("could not read event, because it is not a UUID '%s'", fileName), err)
 			}
 
-			var event *api.Event = nil
-			event, err = s.ReadEvent(ctx, fs, fs.Join(allEventsPath, oneEventDir.Name()), rawUUID)
+			var event *api.Event
+			event, err = s.ReadEvent(ctx, fs, fs.Join(allEventsPath, fileName), rawUUID)
 			if err != nil {
 				return nil, errorTemplate("could not read event", err)
 			}
@@ -246,6 +246,5 @@ func (s *GitServer) ReadEvent(ctx context.Context, fs billy.Filesystem, eventPat
 		return result, nil
 	}
 	err = fmt.Errorf("could not read event, did not recognize event type '%s'", eventType)
-	logger.FromContext(ctx).Sugar().Warnf("%v", err)
 	return nil, err
 }

--- a/services/cd-service/pkg/service/git_test.go
+++ b/services/cd-service/pkg/service/git_test.go
@@ -20,12 +20,14 @@ import (
 	"errors"
 	"fmt"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository/testutil"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"testing"
+	"time"
 
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	
+
 	"github.com/freiheit-com/kuberpult/pkg/ptr"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/config"
 	rp "github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
@@ -262,7 +264,11 @@ func TestGetProductOverview(t *testing.T) {
 	}
 }
 
+func fixedTime() time.Time {
+	return time.Unix(666, 0)
+}
 func TestGetCommitInfo(t *testing.T) {
+
 	type TestCase struct {
 		name             string
 		transformers     []rp.Transformer
@@ -279,6 +285,9 @@ func TestGetCommitInfo(t *testing.T) {
 					Application:    "app",
 					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					SourceMessage:  "some message",
+					Manifests: map[string]string{
+						"dev": "dev-manifest",
+					},
 				},
 			},
 			request: &api.GetCommitInfoRequest{
@@ -290,6 +299,16 @@ func TestGetCommitInfo(t *testing.T) {
 				TouchedApps: []string{
 					"app",
 				},
+				Events: []*api.Event{
+					{
+						CreatedAt: timestamppb.New(fixedTime()),
+						EventType: &api.Event_CreateReleaseEvent{
+							CreateReleaseEvent: &api.CreateReleaseEvent{
+								EnvironmentNames: []string{"dev"},
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -299,16 +318,25 @@ func TestGetCommitInfo(t *testing.T) {
 					Application:    "app1",
 					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					SourceMessage:  "some message",
+					Manifests: map[string]string{
+						"dev": "dev-manifest1",
+					},
 				},
 				&rp.CreateApplicationVersion{
 					Application:    "app2",
 					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					SourceMessage:  "some message",
+					Manifests: map[string]string{
+						"dev2": "dev-manifest2",
+					},
 				},
 				&rp.CreateApplicationVersion{
 					Application:    "app3",
 					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					SourceMessage:  "some message",
+					Manifests: map[string]string{
+						"dev3": "dev-manifest3",
+					},
 				},
 			},
 			request: &api.GetCommitInfoRequest{
@@ -321,6 +349,32 @@ func TestGetCommitInfo(t *testing.T) {
 					"app1",
 					"app2",
 					"app3",
+				},
+				Events: []*api.Event{
+					{
+						CreatedAt: timestamppb.New(fixedTime()),
+						EventType: &api.Event_CreateReleaseEvent{
+							CreateReleaseEvent: &api.CreateReleaseEvent{
+								EnvironmentNames: []string{"dev"},
+							},
+						},
+					},
+					{
+						CreatedAt: timestamppb.New(fixedTime().Add(time.Second * time.Duration(1))),
+						EventType: &api.Event_CreateReleaseEvent{
+							CreateReleaseEvent: &api.CreateReleaseEvent{
+								EnvironmentNames: []string{"dev2"},
+							},
+						},
+					},
+					{
+						CreatedAt: timestamppb.New(fixedTime().Add(time.Second * time.Duration(2))),
+						EventType: &api.Event_CreateReleaseEvent{
+							CreateReleaseEvent: &api.CreateReleaseEvent{
+								EnvironmentNames: []string{"dev3"},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -336,7 +390,7 @@ func TestGetCommitInfo(t *testing.T) {
 			request: &api.GetCommitInfoRequest{
 				CommitHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 			},
-			expectedError: status.Error(codes.NotFound, "error: commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb was not found in the manifest repo"),
+			expectedError:    status.Error(codes.NotFound, "error: commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb was not found in the manifest repo"),
 			expectedResponse: nil,
 		},
 	}
@@ -349,18 +403,28 @@ func TestGetCommitInfo(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error setting up repository test: %v", err)
 			}
+			var variableTime time.Time = fixedTime()
 			for _, transformer := range tc.transformers {
-				repo.Apply(testutil.MakeTestContext(), transformer)
+				ctx := rp.AddGeneratorToContext(testutil.MakeTestContext(), testutil.TestGenerator{
+					Time: variableTime,
+				})
+				err := repo.Apply(ctx, transformer)
+				if err != nil {
+					t.Fatalf("expected no error in transformer but got:\n%v\n", err)
+				}
+				// each consecutive transformer will get 1 second added:
+				variableTime = variableTime.Add(time.Second * time.Duration(1))
 			}
 			sv := &GitServer{OverviewService: &OverviewServiceServer{Repository: repo, Shutdown: shutdown}}
 
-			commitInfo, err := sv.GetCommitInfo(testutil.MakeTestContext(), tc.request)
+			ctx := testutil.MakeTestContext()
+			commitInfo, err := sv.GetCommitInfo(ctx, tc.request)
 
 			if !errors.Is(err, tc.expectedError) {
-				t.Fatalf("expected error %v, received error %v", tc.expectedError, err)
+				t.Fatalf("expected error %v\nreceived error %v", tc.expectedError, err)
 			}
 			if !proto.Equal(tc.expectedResponse, commitInfo) {
-				t.Fatalf("expected response %v, received response %v", tc.expectedResponse, commitInfo)
+				t.Fatalf("expected response:\n%v\nreceived response:\n%v\n", tc.expectedResponse, commitInfo)
 			}
 		})
 	}

--- a/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
@@ -114,6 +114,7 @@ describe('Commit info page tests', () => {
         
 Commit message body line 1
 Commit message body line 2`,
+                    events: [],
                 },
             },
         },

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.test.tsx
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.test.tsx
@@ -36,6 +36,7 @@ test('CommitInfo component renders commit info when the response is valid', () =
 Commit message body line 1
 Commit message body line 2`,
         touchedApps: ['google', 'windows'],
+        events: [],
     };
     render(
         <MemoryRouter>

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
@@ -14,7 +14,7 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 
-import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
+import { TopAppBar } from '../TopAppBar/TopAppBar';
 import React from 'react';
 import { GetCommitInfoResponse } from '../../../api/api';
 


### PR DESCRIPTION
Adds a new event type "newRelease" and returns the events in the grpc call "GetCommitInfo"

The event is not yet rendered in the UI.