### PR TITLE
fix: Automatically renovate the dev-env on new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.semrel.outputs.version }}
+      - name: Renovate standard-setup dev-env
+        run: |
+          curl -X POST -H "Content-type: application/json" https://cloudbuild.googleapis.com/v1/projects/fdc-standard-setup-dev-env/locations/europe-west1/triggers/fdc-standard-setup-dev-env-upgrade-dependencies-trigger:webhook?key=${{ secrets.DEV_ENV_CLOUD_BUILD_API_KEY }}&secret=${{ secrets.DEV_ENV_RENOVATE_WEBHOOK_KEY }}&trigger=fdc-standard-setup-dev-env-upgrade-dependencies-trigger&projectId=fdc-standard-setup-dev-env -d "{}"


### PR DESCRIPTION
Calls a cloudbuild webhook trigger which renovates the standard-setup dev-environment to include the latest version of kuberpult.