### PR TITLE
fix: Set node as the default user for the ui image

### DIFF
--- a/services/frontend-service/Earthfile
+++ b/services/frontend-service/Earthfile
@@ -42,6 +42,8 @@ deps-ui:
     FROM node:20.9.0-alpine3.18
     WORKDIR /kp
     RUN npm install -g pnpm@8.9.2
+    RUN chown -R node:node /kp
+    USER node
     COPY package.json pnpm-lock.yaml pnpm-workspace.yaml buf.yaml buf.gen.yaml buf.lock tsconfig.json .eslintrc .prettierrc .npmrc .nvmrc .
     RUN pnpm i
 


### PR DESCRIPTION
* Set `node` as the default user for the ui image. This solves the permission denied errors on ubuntu when trying to delete files which were generated by the  root user in the container. The `node` user has the same uid (1000) as the default uid for ubuntu users.