### PR TITLE
feat: add feature toggle for writing commit data

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -175,6 +175,8 @@ spec:
           value: "{{ .Values.cd.enableSqlite }}"
         - name: KUBERPULT_GIT_NETWORK_TIMEOUT
           value: "{{ .Values.git.networkTimeout }}"
+        - name: KUBERPULT_GIT_WRITE_COMMIT_DATA
+          value: "{{ .Values.git.enableWritingCommitData }}"
         volumeMounts:
         - name: repository
           mountPath: /repository

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -33,7 +33,8 @@ git:
   # Timeout used for network operations
   networkTimeout: 1m
 
-  # If enabled, write data to the `/commit` directory in the manifest repo on every release
+  # If enabled, write data to the `/commit` directory in the manifest repo on every release.
+  # Disabling this option does not delete the `/commit` directory.
   enableWritingCommitData: false
 
 hub: europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -33,6 +33,9 @@ git:
   # Timeout used for network operations
   networkTimeout: 1m
 
+  # If enabled, write data to the `/commit` directory in the manifest repo on every release
+  enableWritingCommitData: false
+
 hub: europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
 
 log:

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -45,28 +45,29 @@ import (
 
 type Config struct {
 	// these will be mapped to "KUBERPULT_GIT_URL", etc.
-	GitUrl            string        `required:"true" split_words:"true"`
-	GitBranch         string        `default:"master" split_words:"true"`
-	BootstrapMode     bool          `default:"false" split_words:"true"`
-	GitCommitterEmail string        `default:"kuberpult@freiheit.com" split_words:"true"`
-	GitCommitterName  string        `default:"kuberpult" split_words:"true"`
-	GitSshKey         string        `default:"/etc/ssh/identity" split_words:"true"`
-	GitSshKnownHosts  string        `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
-	GitNetworkTimeout time.Duration `default:"1m" split_words:"true"`
-	PgpKeyRingPath    string        `split_words:"true"`
-	AzureEnableAuth   bool          `default:"false" split_words:"true"`
-	DexEnabled        bool          `default:"false" split_words:"true"`
-	DexRbacPolicyPath string        `split_words:"true"`
-	EnableTracing     bool          `default:"false" split_words:"true"`
-	EnableMetrics     bool          `default:"false" split_words:"true"`
-	EnableEvents      bool          `default:"false" split_words:"true"`
-	DogstatsdAddr     string        `default:"127.0.0.1:8125" split_words:"true"`
-	EnableSqlite      bool          `default:"true" split_words:"true"`
-	DexMock           bool          `default:"false" split_words:"true"`
-	DexMockRole       string        `default:"Developer" split_words:"true"`
-	ArgoCdServer      string        `default:"" split_words:"true"`
-	ArgoCdInsecure    bool          `default:"false" split_words:"true"`
-	GitWebUrl         string        `default:"" split_words:"true"`
+	GitUrl             string        `required:"true" split_words:"true"`
+	GitBranch          string        `default:"master" split_words:"true"`
+	BootstrapMode      bool          `default:"false" split_words:"true"`
+	GitCommitterEmail  string        `default:"kuberpult@freiheit.com" split_words:"true"`
+	GitCommitterName   string        `default:"kuberpult" split_words:"true"`
+	GitSshKey          string        `default:"/etc/ssh/identity" split_words:"true"`
+	GitSshKnownHosts   string        `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
+	GitNetworkTimeout  time.Duration `default:"1m" split_words:"true"`
+	GitWriteCommitData bool          `default:"false" split_words:"true"`
+	PgpKeyRingPath     string        `split_words:"true"`
+	AzureEnableAuth    bool          `default:"false" split_words:"true"`
+	DexEnabled         bool          `default:"false" split_words:"true"`
+	DexRbacPolicyPath  string        `split_words:"true"`
+	EnableTracing      bool          `default:"false" split_words:"true"`
+	EnableMetrics      bool          `default:"false" split_words:"true"`
+	EnableEvents       bool          `default:"false" split_words:"true"`
+	DogstatsdAddr      string        `default:"127.0.0.1:8125" split_words:"true"`
+	EnableSqlite       bool          `default:"true" split_words:"true"`
+	DexMock            bool          `default:"false" split_words:"true"`
+	DexMockRole        string        `default:"Developer" split_words:"true"`
+	ArgoCdServer       string        `default:"" split_words:"true"`
+	ArgoCdInsecure     bool          `default:"false" split_words:"true"`
+	GitWebUrl          string        `default:"" split_words:"true"`
 }
 
 func (c *Config) storageBackend() repository.StorageBackend {
@@ -173,6 +174,7 @@ func RunServer() {
 			WebURL:                 c.GitWebUrl,
 			NetworkTimeout:         c.GitNetworkTimeout,
 			DogstatsdEvents:        c.EnableMetrics,
+			WriteCommitData:        c.GitWriteCommitData,
 		}
 		repo, repoQueue, err := repository.New2(ctx, cfg)
 		if err != nil {
@@ -212,6 +214,9 @@ func RunServer() {
 						RBACConfig: auth.RBACConfig{
 							DexEnabled: c.DexEnabled,
 							Policy:     dexRbacPolicy,
+						},
+						Config: service.BatchServerConfig{
+							WriteCommitData: c.GitWriteCommitData,
 						},
 					})
 

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -139,6 +139,7 @@ type RepositoryConfig struct {
 	// the url to the git repo, like the browser requires it (https protocol)
 	WebURL          string
 	DogstatsdEvents bool
+	WriteCommitData bool
 }
 
 func openOrCreate(path string, storageBackend StorageBackend) (*git.Repository, error) {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -291,9 +291,6 @@ func (c *CreateApplicationVersion) Transform(ctx context.Context, state *State) 
 			if err := fs.MkdirAll(commitDir, 0777); err != nil {
 				return "", nil, GetCreateReleaseGeneralFailure(err)
 			}
-			if err := util.WriteFile(fs, fs.Join(commitDir, ".empty"), make([]byte, 0), 0666); err != nil {
-				return "", nil, GetCreateReleaseGeneralFailure(err)
-			}
 		}
 	}
 	if c.SourceAuthor != "" {
@@ -421,6 +418,9 @@ func writeCommitData(ctx context.Context, sourceCommitId string, sourceMessage s
 		return nil
 	}
 	commitDir := commitDirectory(fs, sourceCommitId)
+	if err := util.WriteFile(fs, fs.Join(commitDir, ".empty"), make([]byte, 0), 0666); err != nil {
+		return GetCreateReleaseGeneralFailure(err)
+	}
 	commitAppDir := commitApplicationDirectory(fs, sourceCommitId, app)
 	if err := fs.MkdirAll(commitAppDir, 0777); err != nil {
 		return GetCreateReleaseGeneralFailure(err)

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository/testutil"
 	"io"
 	"math/rand"
 	"os/exec"
@@ -33,6 +32,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository/testutil"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -87,6 +88,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -107,6 +109,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -134,6 +137,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -164,6 +168,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -194,6 +199,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateEnvironmentLock{
 					Environment: "acceptance",
@@ -227,6 +233,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -251,6 +258,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -276,16 +284,18 @@ func TestUndeployApplicationErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
 				},
 				&CreateApplicationVersion{
-					Application:    "app1",
-					Manifests:      nil,
-					SourceCommitId: "",
-					SourceAuthor:   "",
-					SourceMessage:  "",
+					Application:     "app1",
+					Manifests:       nil,
+					SourceCommitId:  "",
+					SourceAuthor:    "",
+					SourceMessage:   "",
+					WriteCommitData: true,
 				},
 				&UndeployApplication{
 					Application: "app1",
@@ -347,6 +357,7 @@ func TestCreateUndeployApplicationVersionErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -369,6 +380,7 @@ func TestCreateUndeployApplicationVersionErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 			},
 			expectedError:    "file does not exist",
@@ -433,12 +445,13 @@ func TestCreateApplicationVersionEvents(t *testing.T) {
 						envAcceptance: envAcceptance,
 						envProduction: envProduction,
 					},
-					SourceCommitId: "cafe1cafe2cafe1cafe2cafe1cafe2cafe1cafe2",
-					SourceAuthor:   "best Author",
-					SourceMessage:  "smart message",
-					SourceRepoUrl:  "",
-					Team:           "",
-					DisplayVersion: "",
+					SourceCommitId:  "cafe1cafe2cafe1cafe2cafe1cafe2cafe1cafe2",
+					SourceAuthor:    "best Author",
+					SourceMessage:   "smart message",
+					SourceRepoUrl:   "",
+					Team:            "",
+					DisplayVersion:  "",
+					WriteCommitData: true,
 				},
 			},
 			expectedError: "",
@@ -510,6 +523,7 @@ func TestDeployOnSelectedEnvs(t *testing.T) {
 						envAcceptance: "acc1",
 						envProduction: "prod1",
 					},
+					WriteCommitData: true,
 				},
 			},
 			Expected: []Expected{
@@ -612,6 +626,7 @@ spec:
 						envAcceptance: "acc2",
 						envProduction: "prod2",
 					},
+					WriteCommitData: true,
 				},
 			},
 			Expected: []Expected{
@@ -724,6 +739,7 @@ func TestCreateApplicationVersionIdempotency(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "{}",
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application: "app1",
@@ -731,6 +747,7 @@ func TestCreateApplicationVersionIdempotency(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "{}",
 					},
+					WriteCommitData: true,
 				},
 			},
 			expectedErrorMsg: "already_exists_same:{}",
@@ -748,6 +765,7 @@ func TestCreateApplicationVersionIdempotency(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: `{}`,
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application: "app1",
@@ -755,6 +773,7 @@ func TestCreateApplicationVersionIdempotency(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: `{ "different": "yes" }`,
 					},
+					WriteCommitData: true,
 				},
 			},
 			expectedErrorMsg: `already_exists_different:{first_differing_field:MANIFESTS diff:"--- acceptance-existing\n+++ acceptance-request\n@@ -1 +1 @@\n-{}\n\\ No newline at end of file\n+{ \"different\": \"yes\" }\n\\ No newline at end of file\n"}`,
@@ -772,6 +791,7 @@ func TestCreateApplicationVersionIdempotency(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: `{ "different":                  "yes" }`,
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application: "app1",
@@ -779,6 +799,7 @@ func TestCreateApplicationVersionIdempotency(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: `{ "different": "yes" }`,
 					},
+					WriteCommitData: true,
 				},
 			},
 			expectedErrorMsg: "already_exists_same:{}",
@@ -1019,6 +1040,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 				Manifests: map[string]string{
 					envAcceptance: "acceptance",
 				},
+				WriteCommitData: true,
 			})
 		}
 		return ret
@@ -1038,6 +1060,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
@@ -1063,6 +1086,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application:    "app2",
@@ -1070,6 +1094,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application:    "app3",
@@ -1077,6 +1102,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
@@ -1116,6 +1142,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application:    "app2",
@@ -1123,6 +1150,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application:    "app3",
@@ -1130,6 +1158,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
@@ -1169,6 +1198,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application:    "app2",
@@ -1176,6 +1206,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application:    "app3",
@@ -1183,6 +1214,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
@@ -1222,6 +1254,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
@@ -1247,6 +1280,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
@@ -1302,6 +1336,7 @@ func TestCreateApplicationVersionCommitPath(t *testing.T) {
 						Manifests: map[string]string{
 							envAcceptance: "acceptance",
 						},
+						WriteCommitData: true,
 					},
 				},
 				manyCreateApplication("app2", 21),
@@ -1377,6 +1412,7 @@ func TestUndeployApplicationCommitPath(t *testing.T) {
 				Manifests: map[string]string{
 					envAcceptance: "acceptance",
 				},
+				WriteCommitData: true,
 			})
 		}
 		return ret
@@ -1387,8 +1423,9 @@ func TestUndeployApplicationCommitPath(t *testing.T) {
 			Name: "Create one application with SHA1 commit ID and then undeploy it",
 			Transformers: []Transformer{
 				&CreateApplicationVersion{
-					Application:    "app",
-					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Application:     "app",
+					SourceCommitId:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app",
@@ -1405,12 +1442,14 @@ func TestUndeployApplicationCommitPath(t *testing.T) {
 			Name: "Create two applications and then undeploy one of them",
 			Transformers: []Transformer{
 				&CreateApplicationVersion{
-					Application:    "app1",
-					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Application:     "app1",
+					SourceCommitId:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
-					Application:    "app2",
-					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Application:     "app2",
+					SourceCommitId:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -1507,6 +1546,7 @@ func TestDeployApplicationVersion(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance", // not empty
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
@@ -1537,6 +1577,7 @@ func TestDeployApplicationVersion(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "", // empty!
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
@@ -1629,14 +1670,16 @@ func TestCreateApplicationVersionWithVersion(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "first version (100) manifest",
 					},
-					Version: 100,
+					Version:         100,
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application: "app1",
 					Manifests: map[string]string{
 						envAcceptance: "second version (101) manifest",
 					},
-					Version: 101,
+					Version:         101,
+					WriteCommitData: true,
 				},
 			},
 			expectedPath:     "applications/app1/releases/101/environments/acceptance/manifests.yaml",
@@ -1654,14 +1697,16 @@ func TestCreateApplicationVersionWithVersion(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "first version (100) manifest",
 					},
-					Version: 100,
+					Version:         100,
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application: "app1",
 					Manifests: map[string]string{
 						envAcceptance: "second version (99) manifest",
 					},
-					Version: 99,
+					Version:         99,
+					WriteCommitData: true,
 				},
 			},
 			expectedPath:     "applications/app1/releases/99/environments/acceptance/manifests.yaml",
@@ -1679,8 +1724,9 @@ func TestCreateApplicationVersionWithVersion(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "manifest",
 					},
-					Version:        100,
-					DisplayVersion: "1.3.1",
+					Version:         100,
+					DisplayVersion:  "1.3.1",
+					WriteCommitData: true,
 				},
 			},
 			expectedPath:     "applications/app1/releases/100/display_version",
@@ -1734,6 +1780,7 @@ func TestUndeployErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -1751,16 +1798,18 @@ func TestUndeployErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
 				},
 				&CreateApplicationVersion{
-					Application:    "app1",
-					Manifests:      nil,
-					SourceCommitId: "",
-					SourceAuthor:   "",
-					SourceMessage:  "",
+					Application:     "app1",
+					Manifests:       nil,
+					SourceCommitId:  "",
+					SourceAuthor:    "",
+					SourceMessage:   "",
+					WriteCommitData: true,
 				},
 			},
 			expectedError:     "",
@@ -1775,6 +1824,7 @@ func TestUndeployErrors(t *testing.T) {
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -2073,6 +2123,7 @@ func TestTransformerChanges(t *testing.T) {
 						envProduction: envProduction,
 						envAcceptance: envAcceptance,
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application: "bar",
@@ -2080,6 +2131,7 @@ func TestTransformerChanges(t *testing.T) {
 						envProduction: envProduction,
 						envAcceptance: envAcceptance,
 					},
+					WriteCommitData: true,
 				},
 				&ReleaseTrain{
 					Target: envProduction,
@@ -2117,6 +2169,7 @@ func TestTransformerChanges(t *testing.T) {
 						envProduction: envProduction,
 						envAcceptance: envAcceptance,
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application: "bar",
@@ -2124,6 +2177,7 @@ func TestTransformerChanges(t *testing.T) {
 						envProduction: envProduction,
 						envAcceptance: envAcceptance,
 					},
+					WriteCommitData: true,
 				},
 				&ReleaseTrain{
 					Target: envProduction,
@@ -2179,6 +2233,7 @@ func TestTransformerChanges(t *testing.T) {
 						envProduction: envProduction,
 						envAcceptance: envAcceptance,
 					},
+					WriteCommitData: true,
 				},
 				&DeleteEnvFromApp{
 					Application: "foo",
@@ -2216,6 +2271,7 @@ func TestTransformerChanges(t *testing.T) {
 						envProduction: envProduction,
 						envAcceptance: envAcceptance,
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Authentication: Authentication{},
@@ -2281,7 +2337,8 @@ func TestRbacTransformerTest(t *testing.T) {
 						"production": "production",
 						"staging":    "staging",
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application:    "app1",
@@ -2315,7 +2372,8 @@ func TestRbacTransformerTest(t *testing.T) {
 						"production": "production",
 						"staging":    "staging",
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application:    "app1",
@@ -2379,7 +2437,8 @@ func TestRbacTransformerTest(t *testing.T) {
 						"production": "production",
 						"staging":    "staging",
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -2410,7 +2469,8 @@ func TestRbacTransformerTest(t *testing.T) {
 						"production": "production",
 						"staging":    "staging",
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -2441,7 +2501,8 @@ func TestRbacTransformerTest(t *testing.T) {
 						"production": "production",
 						"staging":    "staging",
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -2497,6 +2558,7 @@ func TestRbacTransformerTest(t *testing.T) {
 						"developer,CreateRelease,acceptance:*,app1-testing,allow": {Role: "developer"},
 						"developer,DeployRelease,acceptance:*,app1-testing,allow": {Role: "developer"},
 					}}},
+					WriteCommitData: true,
 				},
 			},
 		},
@@ -2516,6 +2578,7 @@ func TestRbacTransformerTest(t *testing.T) {
 					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{
 						"developer,CreateRelease,acceptance:*,app1-testing,allow": {Role: "developer"},
 					}}},
+					WriteCommitData: true,
 				},
 			},
 			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'DeployRelease' on environment 'acceptance'",
@@ -2533,7 +2596,8 @@ func TestRbacTransformerTest(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance", // not empty
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: true, Policy: map[string]*auth.Permission{}}},
+					WriteCommitData: true,
 				},
 			},
 			ExpectedError: "PermissionDenied: The user 'test tester' with role 'developer' is not allowed to perform the action 'CreateRelease' on environment '*'",
@@ -2551,7 +2615,8 @@ func TestRbacTransformerTest(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance", // not empty
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envAcceptance,
@@ -2576,7 +2641,8 @@ func TestRbacTransformerTest(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance", // not empty
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:    envAcceptance,
@@ -2695,7 +2761,8 @@ func TestRbacTransformerTest(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "productionmanifest",
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&CreateEnvironmentApplicationLock{
 					Environment:    "production",
@@ -2719,7 +2786,8 @@ func TestRbacTransformerTest(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "productionmanifest",
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&CreateEnvironmentApplicationLock{
 					Environment: "production",
@@ -2744,7 +2812,8 @@ func TestRbacTransformerTest(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "productionmanifest",
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&CreateEnvironmentApplicationLock{
 					Environment:    "production",
@@ -2774,7 +2843,8 @@ func TestRbacTransformerTest(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "productionmanifest",
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&CreateEnvironmentApplicationLock{
 					Environment: "production",
@@ -2808,7 +2878,8 @@ func TestRbacTransformerTest(t *testing.T) {
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:    envProduction,
@@ -2838,7 +2909,8 @@ func TestRbacTransformerTest(t *testing.T) {
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
-					Authentication: Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					Authentication:  Authentication{RBACConfig: auth.RBACConfig{DexEnabled: false}},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:    envProduction,
@@ -2929,6 +3001,7 @@ func ReleaseTrainTestSetup(releaseTrainTransformer Transformer) []Transformer {
 				envProduction: "productionmanifest",
 				envAcceptance: "acceptancenmanifest",
 			},
+			WriteCommitData: true,
 		},
 		&DeployApplicationVersion{
 			Environment: envProduction,
@@ -2941,6 +3014,7 @@ func ReleaseTrainTestSetup(releaseTrainTransformer Transformer) []Transformer {
 				envProduction: "productionmanifest",
 				envAcceptance: "acceptancenmanifest",
 			},
+			WriteCommitData: true,
 		},
 		&DeployApplicationVersion{
 			Environment: envAcceptance,
@@ -3079,6 +3153,7 @@ func TestTransformer(t *testing.T) {
 						envProduction: "productionmanifest",
 						envAcceptance: "acceptancenmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment: envProduction,
@@ -3091,6 +3166,7 @@ func TestTransformer(t *testing.T) {
 						envProduction: "productionmanifest",
 						envAcceptance: "acceptancenmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment: envAcceptance,
@@ -3141,12 +3217,14 @@ func TestTransformer(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptancenmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application: "test",
 					Manifests: map[string]string{
 						envAcceptance: "acceptancenmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&ReleaseTrain{
 					Target: envAcceptance,
@@ -3190,7 +3268,8 @@ func TestTransformer(t *testing.T) {
 						envProduction: "productionmanifest",
 						envAcceptance: "acceptancenmanifest",
 					},
-					Team: "test",
+					Team:            "test",
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment: envProduction,
@@ -3203,6 +3282,7 @@ func TestTransformer(t *testing.T) {
 						envProduction: "productionmanifest",
 						envAcceptance: "acceptancenmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment: envAcceptance,
@@ -3277,6 +3357,7 @@ func TestTransformer(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&CreateEnvironmentApplicationLock{
 					Environment: "production",
@@ -3390,6 +3471,7 @@ func TestTransformer(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment: "production",
@@ -3454,6 +3536,7 @@ func TestTransformer(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 			},
 			Test: func(t *testing.T, s *State) {
@@ -3489,7 +3572,8 @@ func TestTransformer(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "productionmanifest",
 					},
-					Team: "test-team",
+					Team:            "test-team",
+					WriteCommitData: true,
 				},
 			},
 			Test: func(t *testing.T, s *State) {
@@ -3514,6 +3598,7 @@ func TestTransformer(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 			},
 			Test: func(t *testing.T, s *State) {
@@ -3539,6 +3624,7 @@ func TestTransformer(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Version:     42,
@@ -3546,6 +3632,7 @@ func TestTransformer(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 			},
 			ErrorTest: func(t *testing.T, err error) {
@@ -3564,6 +3651,7 @@ func TestTransformer(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "42",
 					},
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Version:     41,
@@ -3571,6 +3659,7 @@ func TestTransformer(t *testing.T) {
 					Manifests: map[string]string{
 						"production": "41",
 					},
+					WriteCommitData: true,
 				},
 			},
 			Test: func(t *testing.T, s *State) {
@@ -3594,6 +3683,7 @@ func TestTransformer(t *testing.T) {
 						Manifests: map[string]string{
 							"production": "42",
 						},
+						WriteCommitData: true,
 					})
 				}
 				return t
@@ -3615,6 +3705,7 @@ func TestTransformer(t *testing.T) {
 						"one": "productionmanifest",
 						"two": "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment: "one",
@@ -3665,6 +3756,7 @@ func TestTransformer(t *testing.T) {
 						"one": "productionmanifest",
 						"two": "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 			},
 			Test: func(t *testing.T, s *State) {
@@ -3712,6 +3804,7 @@ func TestTransformer(t *testing.T) {
 						"one": "productionmanifest",
 						"two": "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment: "one",
@@ -3987,6 +4080,7 @@ func TestTransformer(t *testing.T) {
 						"staging":    "stagingmanifest",
 						"production": "stagingmanifest",
 					},
+					WriteCommitData: true,
 				},
 			},
 			Test: func(t *testing.T, s *State) {
@@ -4154,14 +4248,16 @@ spec:
 					Manifests: map[string]string{
 						"staging": "stagingmanifest",
 					},
-					Team: "team1",
+					Team:            "team1",
+					WriteCommitData: true,
 				},
 				&CreateApplicationVersion{
 					Application: "test2",
 					Manifests: map[string]string{
 						"staging": "stagingmanifest",
 					},
-					Team: "team2",
+					Team:            "team2",
+					WriteCommitData: true,
 				},
 			},
 			Test: func(t *testing.T, s *State) {
@@ -4268,6 +4364,7 @@ spec:
 					Manifests: map[string]string{
 						"staging": "stagingmanifest",
 					},
+					WriteCommitData: true,
 				},
 			},
 			Test: func(t *testing.T, s *State) {
@@ -4356,6 +4453,7 @@ spec:
 					Manifests: map[string]string{
 						"staging": "stagingmanifest",
 					},
+					WriteCommitData: true,
 				},
 			},
 			Test: func(t *testing.T, s *State) {
@@ -4494,6 +4592,7 @@ func makeTransformersDeployTestEnvLock(lock api.LockBehavior) []Transformer {
 			Manifests: map[string]string{
 				"production": "productionmanifest",
 			},
+			WriteCommitData: true,
 		},
 		&CreateEnvironmentLock{
 			Environment: "production",
@@ -4517,6 +4616,7 @@ func makeTransformersDeployTestAppLock(lock api.LockBehavior) []Transformer {
 			Manifests: map[string]string{
 				"production": "productionmanifest",
 			},
+			WriteCommitData: true,
 		},
 		&CreateEnvironmentApplicationLock{
 			Environment: "production",
@@ -4541,12 +4641,14 @@ func makeTransformersTwoDeploymentsWriteToQueue(lockA api.LockBehavior, lockB ap
 			Manifests: map[string]string{
 				"production": "productionmanifest",
 			},
+			WriteCommitData: true,
 		},
 		&CreateApplicationVersion{
 			Application: "test",
 			Manifests: map[string]string{
 				"production": "productionmanifest",
 			},
+			WriteCommitData: true,
 		},
 		&CreateEnvironmentLock{
 			Environment: "production",
@@ -4576,6 +4678,7 @@ func makeTransformersDoubleLock(lock api.LockBehavior, unlockBoth bool) []Transf
 			Manifests: map[string]string{
 				"production": "productionmanifest",
 			},
+			WriteCommitData: true,
 		},
 		&CreateEnvironmentLock{
 			Environment: "production",
@@ -4621,6 +4724,7 @@ func makeTransformersForDelete(numVersions uint64) []Transformer {
 			Manifests: map[string]string{
 				envProduction: "productionmanifest",
 			},
+			WriteCommitData: true,
 		})
 		res = append(res, &DeployApplicationVersion{
 			Environment:   envProduction,
@@ -4655,10 +4759,11 @@ func setupRepositoryTestWithPath(t *testing.T) (Repository, string) {
 	repo, err := New(
 		testutil.MakeTestContext(),
 		RepositoryConfig{
-			URL:            remoteDir,
-			Path:           localDir,
-			CommitterEmail: "kuberpult@freiheit.com",
-			CommitterName:  "kuberpult",
+			URL:             remoteDir,
+			Path:            localDir,
+			CommitterEmail:  "kuberpult@freiheit.com",
+			CommitterName:   "kuberpult",
+			WriteCommitData: true,
 		},
 	)
 	if err != nil {
@@ -4981,6 +5086,7 @@ func TestUpdateDatadogMetrics(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateEnvironmentApplicationLock{
 					Environment: "acceptance",
@@ -5003,6 +5109,7 @@ func TestUpdateDatadogMetrics(t *testing.T) {
 					Manifests: map[string]string{
 						envAcceptance: "acceptance",
 					},
+					WriteCommitData: true,
 				},
 				&CreateEnvironmentLock{
 					Environment: "acceptance",
@@ -5182,6 +5289,7 @@ func TestDeleteEnvFromApp(t *testing.T) {
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envProduction,
@@ -5210,6 +5318,7 @@ func TestDeleteEnvFromApp(t *testing.T) {
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envProduction,
@@ -5242,6 +5351,7 @@ func TestDeleteEnvFromApp(t *testing.T) {
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envProduction,
@@ -5269,6 +5379,7 @@ func TestDeleteEnvFromApp(t *testing.T) {
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
+					WriteCommitData: true,
 				},
 				&DeployApplicationVersion{
 					Environment:   envProduction,

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -32,9 +32,14 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type BatchServerConfig struct {
+	WriteCommitData bool
+}
+
 type BatchServer struct {
 	Repository repository.Repository
 	RBACConfig auth.RBACConfig
+	Config     BatchServerConfig
 }
 
 // see maxBatchActions in store.tsx
@@ -206,16 +211,17 @@ func (d *BatchServer) processAction(
 		in := action.CreateRelease
 		response := api.CreateReleaseResponseSuccess{}
 		return &repository.CreateApplicationVersion{
-				Version:        in.Version,
-				Application:    in.Application,
-				Manifests:      in.Manifests,
-				SourceCommitId: in.SourceCommitId,
-				SourceAuthor:   in.SourceAuthor,
-				SourceMessage:  in.SourceMessage,
-				SourceRepoUrl:  in.SourceRepoUrl,
-				Team:           in.Team,
-				DisplayVersion: in.DisplayVersion,
-				Authentication: repository.Authentication{RBACConfig: d.RBACConfig},
+				Version:         in.Version,
+				Application:     in.Application,
+				Manifests:       in.Manifests,
+				SourceCommitId:  in.SourceCommitId,
+				SourceAuthor:    in.SourceAuthor,
+				SourceMessage:   in.SourceMessage,
+				SourceRepoUrl:   in.SourceRepoUrl,
+				Team:            in.Team,
+				DisplayVersion:  in.DisplayVersion,
+				Authentication:  repository.Authentication{RBACConfig: d.RBACConfig},
+				WriteCommitData: d.Config.WriteCommitData,
 			}, &api.BatchResult{
 				Result: &api.BatchResult_CreateReleaseResponse{
 					CreateReleaseResponse: &api.CreateReleaseResponse{

--- a/services/cd-service/pkg/service/git.go
+++ b/services/cd-service/pkg/service/git.go
@@ -126,6 +126,10 @@ func (s *GitServer) GetProductSummary(ctx context.Context, in *api.GetProductSum
 }
 
 func (s *GitServer) GetCommitInfo(ctx context.Context, in *api.GetCommitInfoRequest) (*api.GetCommitInfoResponse, error) {
+	if !s.Config.WriteCommitData {
+		return nil, status.Error(codes.FailedPrecondition, "no written commit info available; set KUBERPULT_GIT_WRITE_COMMIT_DATA=true to enable")
+	}
+
 	fs := s.OverviewService.Repository.State().Filesystem
 
 	commitIDPrefix := in.CommitHash

--- a/services/cd-service/pkg/service/git.go
+++ b/services/cd-service/pkg/service/git.go
@@ -18,7 +18,9 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -144,6 +146,9 @@ func (s *GitServer) GetCommitInfo(ctx context.Context, in *api.GetCommitInfoRequ
 	sourceMessagePath := fs.Join(commitPath, "source_message")
 	var commitMessage string
 	if dat, err := util.ReadFile(fs, sourceMessagePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, status.Error(codes.NotFound, "commit info does not exist")
+		}
 		return nil, fmt.Errorf("could not open the source message file at %s, err: %w", sourceMessagePath, err)
 	} else {
 		commitMessage = string(dat)

--- a/services/cd-service/pkg/service/git_test.go
+++ b/services/cd-service/pkg/service/git_test.go
@@ -279,7 +279,7 @@ func TestGetCommitInfo(t *testing.T) {
 		name                  string
 		transformers          []rp.Transformer
 		request               *api.GetCommitInfoRequest
-		configWriteCommitData bool
+		allowReadingCommitData bool
 		expectedResponse      *api.GetCommitInfoResponse
 		expectedError         error
 	}

--- a/services/cd-service/pkg/service/git_test.go
+++ b/services/cd-service/pkg/service/git_test.go
@@ -502,7 +502,7 @@ func TestGetCommitInfo(t *testing.T) {
 			}
 
 			config := rp.RepositoryConfig{
-				WriteCommitData: tc.configWriteCommitData,
+				WriteCommitData: tc.allowReadingCommitData,
 			}
 			sv := &GitServer{
 				OverviewService: &OverviewServiceServer{Repository: repo, Shutdown: shutdown},

--- a/services/cd-service/pkg/service/git_test.go
+++ b/services/cd-service/pkg/service/git_test.go
@@ -276,12 +276,12 @@ func fixedTime() time.Time {
 func TestGetCommitInfo(t *testing.T) {
 
 	type TestCase struct {
-		name                  string
-		transformers          []rp.Transformer
-		request               *api.GetCommitInfoRequest
+		name                   string
+		transformers           []rp.Transformer
+		request                *api.GetCommitInfoRequest
 		allowReadingCommitData bool
-		expectedResponse      *api.GetCommitInfoResponse
-		expectedError         error
+		expectedResponse       *api.GetCommitInfoResponse
+		expectedError          error
 	}
 
 	tcs := []TestCase{
@@ -301,8 +301,8 @@ func TestGetCommitInfo(t *testing.T) {
 			request: &api.GetCommitInfoRequest{
 				CommitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
-			configWriteCommitData: true,
-			expectedError:         nil,
+			allowReadingCommitData: true,
+			expectedError:          nil,
 			expectedResponse: &api.GetCommitInfoResponse{
 				CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				CommitMessage: "some message",
@@ -355,8 +355,8 @@ func TestGetCommitInfo(t *testing.T) {
 			request: &api.GetCommitInfoRequest{
 				CommitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
-			configWriteCommitData: true,
-			expectedError:         nil,
+			allowReadingCommitData: true,
+			expectedError:          nil,
 			expectedResponse: &api.GetCommitInfoResponse{
 				CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				CommitMessage: "some message",
@@ -406,9 +406,9 @@ func TestGetCommitInfo(t *testing.T) {
 			request: &api.GetCommitInfoRequest{
 				CommitHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 			},
-			configWriteCommitData: true,
-			expectedError:         status.Error(codes.NotFound, "error: commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb was not found in the manifest repo"),
-			expectedResponse:      nil,
+			allowReadingCommitData: true,
+			expectedError:          status.Error(codes.NotFound, "error: commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb was not found in the manifest repo"),
+			expectedResponse:       nil,
 		},
 		{
 			name: "find a commit by prefix",
@@ -423,7 +423,7 @@ func TestGetCommitInfo(t *testing.T) {
 			request: &api.GetCommitInfoRequest{
 				CommitHash: "32a5b7b27",
 			},
-			configWriteCommitData: true,
+			allowReadingCommitData: true,
 			expectedResponse: &api.GetCommitInfoResponse{
 				CommitHash:    "32a5b7b27fe0e7c328e8ec4615cb34750bc328bd",
 				CommitMessage: "some message",
@@ -454,9 +454,9 @@ func TestGetCommitInfo(t *testing.T) {
 			request: &api.GetCommitInfoRequest{
 				CommitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
-			configWriteCommitData: false, // … but do not return it
-			expectedError:         status.Error(codes.FailedPrecondition, "no written commit info available; set KUBERPULT_GIT_WRITE_COMMIT_DATA=true to enable"),
-			expectedResponse:      nil,
+			allowReadingCommitData: false, // … but do not return it
+			expectedError:          status.Error(codes.FailedPrecondition, "no written commit info available; set KUBERPULT_GIT_WRITE_COMMIT_DATA=true to enable"),
+			expectedResponse:       nil,
 		},
 		{
 			name: "no commit info written if toggle not set",
@@ -474,9 +474,9 @@ func TestGetCommitInfo(t *testing.T) {
 			request: &api.GetCommitInfoRequest{
 				CommitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
-			configWriteCommitData: true, // … but attempt to read anyway
-			expectedError:         status.Error(codes.NotFound, "commit info does not exist"),
-			expectedResponse:      nil,
+			allowReadingCommitData: true, // … but attempt to read anyway
+			expectedError:          status.Error(codes.NotFound, "commit info does not exist"),
+			expectedResponse:       nil,
 		},
 	}
 

--- a/services/cd-service/pkg/service/git_test.go
+++ b/services/cd-service/pkg/service/git_test.go
@@ -19,10 +19,11 @@ package service
 import (
 	"errors"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository/testutil"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"testing"
 	"time"
+
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository/testutil"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
 	"google.golang.org/grpc/codes"
@@ -77,12 +78,13 @@ func TestGetProductOverview(t *testing.T) {
 					Manifests: map[string]string{
 						"development": "dev",
 					},
-					SourceAuthor:   "example <example@example.com>",
-					SourceCommitId: "testing25",
-					SourceMessage:  "changed something (#678)",
-					SourceRepoUrl:  "testing@testing.com/abc",
-					DisplayVersion: "v1.0.2",
-					Team:           "sre-team",
+					SourceAuthor:    "example <example@example.com>",
+					SourceCommitId:  "testing25",
+					SourceMessage:   "changed something (#678)",
+					SourceRepoUrl:   "testing@testing.com/abc",
+					DisplayVersion:  "v1.0.2",
+					Team:            "sre-team",
+					WriteCommitData: true,
 				},
 				&rp.DeployApplicationVersion{
 					Application: "test",
@@ -111,11 +113,12 @@ func TestGetProductOverview(t *testing.T) {
 					Manifests: map[string]string{
 						"development": "dev",
 					},
-					SourceAuthor:   "example <example@example.com>",
-					SourceCommitId: "testing25",
-					SourceMessage:  "changed something (#678)",
-					SourceRepoUrl:  "testing@testing.com/abc",
-					DisplayVersion: "v1.0.2",
+					SourceAuthor:    "example <example@example.com>",
+					SourceCommitId:  "testing25",
+					SourceMessage:   "changed something (#678)",
+					SourceRepoUrl:   "testing@testing.com/abc",
+					DisplayVersion:  "v1.0.2",
+					WriteCommitData: true,
 				},
 				&rp.DeployApplicationVersion{
 					Application: "test",
@@ -144,11 +147,12 @@ func TestGetProductOverview(t *testing.T) {
 					Manifests: map[string]string{
 						"development": "dev",
 					},
-					SourceAuthor:   "example <example@example.com>",
-					SourceCommitId: "testing25",
-					SourceMessage:  "changed something (#678)",
-					SourceRepoUrl:  "testing@testing.com/abc",
-					DisplayVersion: "v1.0.2",
+					SourceAuthor:    "example <example@example.com>",
+					SourceCommitId:  "testing25",
+					SourceMessage:   "changed something (#678)",
+					SourceRepoUrl:   "testing@testing.com/abc",
+					DisplayVersion:  "v1.0.2",
+					WriteCommitData: true,
 				},
 				&rp.DeployApplicationVersion{
 					Application: "test",
@@ -177,12 +181,13 @@ func TestGetProductOverview(t *testing.T) {
 					Manifests: map[string]string{
 						"development": "dev",
 					},
-					SourceAuthor:   "example <example@example.com>",
-					SourceCommitId: "testing25",
-					SourceMessage:  "changed something (#678)",
-					SourceRepoUrl:  "testing@testing.com/abc",
-					DisplayVersion: "v1.0.2",
-					Team:           "sre-team",
+					SourceAuthor:    "example <example@example.com>",
+					SourceCommitId:  "testing25",
+					SourceMessage:   "changed something (#678)",
+					SourceRepoUrl:   "testing@testing.com/abc",
+					DisplayVersion:  "v1.0.2",
+					Team:            "sre-team",
+					WriteCommitData: true,
 				},
 				&rp.DeployApplicationVersion{
 					Application: "test",
@@ -211,11 +216,12 @@ func TestGetProductOverview(t *testing.T) {
 					Manifests: map[string]string{
 						"development": "dev",
 					},
-					SourceAuthor:   "example <example@example.com>",
-					SourceCommitId: "testing25",
-					SourceMessage:  "changed something (#678)",
-					SourceRepoUrl:  "testing@testing.com/abc",
-					DisplayVersion: "v1.0.2",
+					SourceAuthor:    "example <example@example.com>",
+					SourceCommitId:  "testing25",
+					SourceMessage:   "changed something (#678)",
+					SourceRepoUrl:   "testing@testing.com/abc",
+					DisplayVersion:  "v1.0.2",
+					WriteCommitData: true,
 				},
 				&rp.DeployApplicationVersion{
 					Application: "test",
@@ -270,11 +276,12 @@ func fixedTime() time.Time {
 func TestGetCommitInfo(t *testing.T) {
 
 	type TestCase struct {
-		name             string
-		transformers     []rp.Transformer
-		request          *api.GetCommitInfoRequest
-		expectedResponse *api.GetCommitInfoResponse
-		expectedError    error
+		name                  string
+		transformers          []rp.Transformer
+		request               *api.GetCommitInfoRequest
+		configWriteCommitData bool
+		expectedResponse      *api.GetCommitInfoResponse
+		expectedError         error
 	}
 
 	tcs := []TestCase{
@@ -288,12 +295,14 @@ func TestGetCommitInfo(t *testing.T) {
 					Manifests: map[string]string{
 						"dev": "dev-manifest",
 					},
+					WriteCommitData: true,
 				},
 			},
 			request: &api.GetCommitInfoRequest{
 				CommitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
-			expectedError: nil,
+			configWriteCommitData: true,
+			expectedError:         nil,
 			expectedResponse: &api.GetCommitInfoResponse{
 				CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				CommitMessage: "some message",
@@ -322,6 +331,7 @@ func TestGetCommitInfo(t *testing.T) {
 					Manifests: map[string]string{
 						"dev": "dev-manifest1",
 					},
+					WriteCommitData: true,
 				},
 				&rp.CreateApplicationVersion{
 					Application:    "app2",
@@ -330,6 +340,7 @@ func TestGetCommitInfo(t *testing.T) {
 					Manifests: map[string]string{
 						"dev2": "dev-manifest2",
 					},
+					WriteCommitData: true,
 				},
 				&rp.CreateApplicationVersion{
 					Application:    "app3",
@@ -338,12 +349,14 @@ func TestGetCommitInfo(t *testing.T) {
 					Manifests: map[string]string{
 						"dev3": "dev-manifest3",
 					},
+					WriteCommitData: true,
 				},
 			},
 			request: &api.GetCommitInfoRequest{
 				CommitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
-			expectedError: nil,
+			configWriteCommitData: true,
+			expectedError:         nil,
 			expectedResponse: &api.GetCommitInfoResponse{
 				CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				CommitMessage: "some message",
@@ -384,29 +397,33 @@ func TestGetCommitInfo(t *testing.T) {
 			name: "create one commit with one app but get the info of a nonexistent commit",
 			transformers: []rp.Transformer{
 				&rp.CreateApplicationVersion{
-					Application:    "app",
-					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-					SourceMessage:  "some message",
+					Application:     "app",
+					SourceCommitId:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					SourceMessage:   "some message",
+					WriteCommitData: true,
 				},
 			},
 			request: &api.GetCommitInfoRequest{
 				CommitHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 			},
-			expectedError:    status.Error(codes.NotFound, "error: commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb was not found in the manifest repo"),
-			expectedResponse: nil,
+			configWriteCommitData: true,
+			expectedError:         status.Error(codes.NotFound, "error: commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb was not found in the manifest repo"),
+			expectedResponse:      nil,
 		},
 		{
 			name: "find a commit by prefix",
 			transformers: []rp.Transformer{
 				&rp.CreateApplicationVersion{
-					Application:    "app",
-					SourceCommitId: "32a5b7b27fe0e7c328e8ec4615cb34750bc328bd",
-					SourceMessage:  "some message",
+					Application:     "app",
+					SourceCommitId:  "32a5b7b27fe0e7c328e8ec4615cb34750bc328bd",
+					SourceMessage:   "some message",
+					WriteCommitData: true,
 				},
 			},
 			request: &api.GetCommitInfoRequest{
 				CommitHash: "32a5b7b27",
 			},
+			configWriteCommitData: true,
 			expectedResponse: &api.GetCommitInfoResponse{
 				CommitHash:    "32a5b7b27fe0e7c328e8ec4615cb34750bc328bd",
 				CommitMessage: "some message",
@@ -420,6 +437,26 @@ func TestGetCommitInfo(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "no commit info written if toggle not set",
+			transformers: []rp.Transformer{
+				&rp.CreateApplicationVersion{
+					Application:    "app",
+					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					SourceMessage:  "some message",
+					Manifests: map[string]string{
+						"dev": "dev-manifest",
+					},
+					WriteCommitData: true,
+				},
+			},
+			request: &api.GetCommitInfoRequest{
+				CommitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+			configWriteCommitData: false,
+			expectedError:         status.Error(codes.FailedPrecondition, "no written commit info available; set KUBERPULT_GIT_WRITE_COMMIT_DATA=true to enable"),
+			expectedResponse:      nil,
 		},
 	}
 
@@ -443,7 +480,14 @@ func TestGetCommitInfo(t *testing.T) {
 				// each consecutive transformer will get 1 second added:
 				variableTime = variableTime.Add(time.Second * time.Duration(1))
 			}
-			sv := &GitServer{OverviewService: &OverviewServiceServer{Repository: repo, Shutdown: shutdown}}
+
+			config := rp.RepositoryConfig{
+				WriteCommitData: tc.configWriteCommitData,
+			}
+			sv := &GitServer{
+				OverviewService: &OverviewServiceServer{Repository: repo, Shutdown: shutdown},
+				Config:          config,
+			}
 
 			ctx := testutil.MakeTestContext()
 			commitInfo, err := sv.GetCommitInfo(ctx, tc.request)


### PR DESCRIPTION
Introduces a new feature toggle via helm parameter `git.enableWritingCommitData`.
Only if it's set to true, kuberpult will write files in the `/commits`/ directory of the manifest repo. 

Rev: SRX-P6SHU8