### PR TITLE
feat: Limit the age of events being sent to DORA

### DIFF
--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -147,6 +147,8 @@ spec:
             secretKeyRef:
               name: kuberpult-rollout-service
               key: KUBERPULT_REVOLUTION_DORA_TOKEN
+        - name: KUBERPULT_REVOLUTION_DORA_MAX_EVENT_AGE
+          value: "2h"
         volumeMounts:
         # We need to mount a writeable tmp directory for argocd connections to work correctly. https://github.com/argoproj/argo-cd/issues/14115
         - name: tmp

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	argoio "github.com/argoproj/argo-cd/v2/util/io"
@@ -59,10 +60,11 @@ type Config struct {
 	ArgocdRefreshEnabled     bool   `split_words:"true"`
 	ArgocdRefreshConcurrency int    `default:"50" split_words:"true"`
 
-	RevolutionDoraEnabled     bool   `split_words:"true"`
-	RevolutionDoraUrl         string `split_words:"true" default:""`
-	RevolutionDoraToken       string `split_words:"true" default:""`
-	RevolutionDoraConcurrency int    `default:"10" split_words:"true"`
+	RevolutionDoraEnabled     bool          `split_words:"true"`
+	RevolutionDoraUrl         string        `split_words:"true" default:""`
+	RevolutionDoraToken       string        `split_words:"true" default:""`
+	RevolutionDoraConcurrency int           `default:"10" split_words:"true"`
+	RevolutionDoraMaxEventAge time.Duration `default:"0" split_words:"true"`
 
 	ManageArgoApplicationsEnabled bool     `split_words:"true" default:"true"`
 	ManageArgoApplicationsFilter  []string `split_words:"true" default:"sreteam"`
@@ -97,6 +99,7 @@ func (config *Config) RevolutionConfig() (revolution.Config, error) {
 		URL:         config.RevolutionDoraUrl,
 		Token:       []byte(config.RevolutionDoraToken),
 		Concurrency: config.RevolutionDoraConcurrency,
+		MaxEventAge: config.RevolutionDoraMaxEventAge,
 	}, nil
 }
 


### PR DESCRIPTION
You can now set the environment variable REVOLUTION_DORA_MAX_EVENT_AGE to a duration like "2h" or "30m" to only send the most recent events to DORA.