### PR TITLE
feat: Add annotations option to kuberpult-frontend-service helm chart

### DIFF
--- a/charts/kuberpult/Makefile
+++ b/charts/kuberpult/Makefile
@@ -40,7 +40,7 @@ values.yaml: values.yaml.tpl
 
 $(TGZ_FILE): Chart.yaml values.yaml templates/*
 	helm dependency update
-	(rm -rf charts && helm dep update && cd charts && for filename in *.tgz; do tar -xvzf $$filename && rm -f $$filename; done;)
+	(rm -rf charts && helm dep update && cd charts && find ./ -type f -name "*.tgz" -exec sh -c 'tar -xzvf "$0" && rm "$0"' {} \;)
 	helm package .
 
 ci/test-values.yaml: Chart.yaml values.yaml

--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -182,9 +182,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kuberpult-frontend-service
-{{- if .Values.ingress.iap.enabled }}
   annotations:
+{{- if .Values.ingress.iap.enabled }}
     cloud.google.com/backend-config: '{"default": "kuberpult"}'
+{{- end }}
+{{- range $key, $value := .Values.frontend.service.annotations }}
+    {{ $key | quote}}: {{ $value | quote}}
 {{- end }}
 spec:
   ports:

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -73,6 +73,7 @@ frontend:
 # For testing purposes, we allow to overwrite the tags individually, to test an old frontend service with a new cd service.
   tag: "$VERSION"
 # Annotations given here will be added to kuberpult-frontend-service annotations.
+# See frontend-service.yaml for automatically added annotations.
   service:
     annotations: {}
   resources:

--- a/charts/kuberpult/values.yaml.tpl
+++ b/charts/kuberpult/values.yaml.tpl
@@ -72,6 +72,9 @@ frontend:
 # In general, kuberpult only guarantees that running with the same version of frontend and cd service will work.
 # For testing purposes, we allow to overwrite the tags individually, to test an old frontend service with a new cd service.
   tag: "$VERSION"
+# Annotations given here will be added to kuberpult-frontend-service annotations.
+  service:
+    annotations: {}
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
Add the option to add additional annotations to the `kuberpult-frontend-service`. 

Rev: [DSN-FCTBUB](https://revolution.dev/app/-JqFGExX46gs9mH7vxR5/-NQPLdkfXUNc4bE9KOiO/STORY/-Np4ZYgecd7kNdYWMnVu/)
Jira: OTOP-734