### PR TITLE
fix: Adapt Release train endpoint to take commitHash as optional input

### DIFF
--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -236,6 +236,7 @@ message DeleteEnvironmentFromAppRequest {
 message ReleaseTrainRequest {
   string target = 1;
   string team = 2;
+  string commitHash = 3;
 }
 
 message ReleaseTrainResponse {

--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -236,7 +236,7 @@ message DeleteEnvironmentFromAppRequest {
 message ReleaseTrainRequest {
   string target = 1;
   string team = 2;
-  string commitHash = 3;
+  string commit_hash = 3;
 }
 
 message ReleaseTrainResponse {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1657,6 +1657,105 @@ type ReleaseTrain struct {
 	CommitHash string
 	Repo       Repository
 }
+type Overview struct {
+	App     string
+	Version uint64
+}
+
+func getEnvironmentInGroup(groups []*api.EnvironmentGroup, groupNameToReturn string, envNameToReturn string) *api.Environment {
+	for _, currentGroup := range groups {
+		if currentGroup.EnvironmentGroupName == groupNameToReturn {
+			for _, currentEnv := range currentGroup.Environments {
+				if currentEnv.Name == envNameToReturn {
+					return currentEnv
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func getOverrideVersions(commitHash, upstreamEnvName string, repo Repository) (resp []Overview, err error) {
+	oid, err := git.NewOid(commitHash)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating new oid for commitHash %s: %w", commitHash, err)
+	}
+	s, err := repo.StateAt(oid)
+	if err != nil {
+		var gerr *git.GitError
+		if errors.As(err, &gerr) {
+			if gerr.Code == git.ErrNotFound {
+				return nil, fmt.Errorf("ErrNotFound: %w", err)
+			}
+		}
+		return nil, fmt.Errorf("unable to get oid: %w", err)
+	}
+	envs, err := s.GetEnvironmentConfigs()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get EnvironmentConfigs for %s: %w", commitHash, err)
+	}
+	result := mapper.MapEnvironmentsToGroups(envs)
+	for envName, config := range envs {
+		var groupName = mapper.DeriveGroupName(config, envName)
+		var envInGroup = getEnvironmentInGroup(result, groupName, envName)
+		if upstreamEnvName != envInGroup.Name || upstreamEnvName != groupName {
+			continue
+		}
+		apps, err := s.GetEnvironmentApplications(envName)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get EnvironmentApplication for env %s: %w", envName, err)
+		}
+		for _, appName := range apps {
+			app := api.Environment_Application{
+				Name: appName,
+			}
+			version, err := s.GetEnvironmentApplicationVersion(envName, appName)
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("unable to get EnvironmentApplicationVersion for %s: %w", appName, err)
+			}
+			if version == nil {
+				continue
+			}
+			app.Version = *version
+			resp = append(resp, Overview{App: app.Name, Version: app.Version})
+		}
+	}
+	return resp, nil
+}
+
+func (c *ReleaseTrain) getUpstreamLatestApp(upstreamLatest bool, state *State, ctx context.Context, upstreamEnvName, source, commitHash string) (apps []string, appVersions []Overview, err error) {
+	if commitHash != "" {
+		appVersions, err := getOverrideVersions(c.CommitHash, upstreamEnvName, c.Repo)
+		if err != nil {
+			return nil, nil, grpc.PublicError(ctx, fmt.Errorf("could not get app version for commitHash %s for %s: %w", c.CommitHash, c.Target, err))
+		}
+		// check that commit hash is not older than 20 commits in the past
+		for _, app := range appVersions {
+			apps = append(apps, app.App)
+			versions, err := findOldApplicationVersions(state, app.App)
+			if err != nil {
+				return nil, nil, grpc.PublicError(ctx, fmt.Errorf("unable to find findOldApplicationVersions for app %s: %w", app.App, err))
+			}
+			if len(versions) > 0 && versions[0] > app.Version {
+				return nil, nil, grpc.PublicError(ctx, fmt.Errorf("Version for app %s is older than 20 commits when running release train to commitHash %s: %w", app.App, c.CommitHash, err))
+			}
+
+		}
+		return apps, appVersions, nil
+	}
+	if upstreamLatest {
+		apps, err = state.GetApplications()
+		if err != nil {
+			return nil, nil, grpc.PublicError(ctx, fmt.Errorf("could not get all applications for %q: %w", source, err))
+		}
+		return apps, nil, nil
+	}
+	apps, err = state.GetEnvironmentApplications(upstreamEnvName)
+	if err != nil {
+		return nil, nil, grpc.PublicError(ctx, fmt.Errorf("upstream environment (%q) does not have applications: %w", upstreamEnvName, err))
+	}
+	return apps, nil, nil
+}
 
 func getEnvironmentGroupsEnvironmentsOrEnvironment(configs map[string]config.EnvironmentConfig, targetGroupName string) map[string]config.EnvironmentConfig {
 
@@ -1777,9 +1876,10 @@ func (c *envReleaseTrain) Transform(
 			"Target Environment '%s' is locked - skipping.",
 			c.Env), nil
 	}
-	apps, overrideVersions, err := c.getUpstreamLatestApp(upstreamLatest, state, ctx, upstreamEnvName, source, c.CommitHash)
+	apps, overrideVersions, err := c.Parent.getUpstreamLatestApp(upstreamLatest, state, ctx, upstreamEnvName, source, c.Parent.CommitHash)
 	if err != nil {
-		return "", nil, err
+		return "", err
+	}
 	sort.Strings(apps)
 	// now iterate over all apps, deploying all that are not locked
 	numServices := 0
@@ -1797,7 +1897,13 @@ func (c *envReleaseTrain) Transform(
 			return "", grpc.PublicError(ctx, fmt.Errorf("application %q in env %q does not have a version deployed: %w", appName, c.Env, err))
 		}
 		var versionToDeploy uint64
-		if upstreamLatest {
+		if overrideVersions != nil {
+			for _, override := range overrideVersions {
+				if override.App == appName {
+					versionToDeploy = override.Version
+				}
+			}
+		} else if upstreamLatest {
 			versionToDeploy, err = GetLastRelease(state.Filesystem, appName)
 			if err != nil {
 				return "", grpc.PublicError(ctx, fmt.Errorf("application %q does not have a latest deployed: %w", appName, err))

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -2094,7 +2094,7 @@ func TestReleaseTrainWithCommit(t *testing.T) {
 			ReleaseTrainEnv:    "staging",
 			shouldSucceed:      true,
 			expectedError:      "",
-			expectedCommitMsg:  "Release Train to environment/environment group 'staging':\n\nRelease Train to 'staging' environment:\n\nThe release train deployed 1 services from 'dev' to 'staging'\ndeployed version 1 of \"test\" to \"staging\"\n\n\n\n\n",
+			expectedCommitMsg:  "Release Train to environment/environment group 'staging':\n\nRelease Train to 'staging' environment:\n\nThe release train deployed 1 services from 'dev' to 'staging'\ndeployed version 1 of \"test\" to \"staging\"",
 			overrideCommitHash: "",
 		},
 		{
@@ -2136,12 +2136,7 @@ func TestReleaseTrainWithCommit(t *testing.T) {
 Release Train to 'staging' environment:
 
 The release train deployed 1 services from 'dev' to 'staging'
-deployed version 1 of "test" to "staging"
-
-
-
-
-`,
+deployed version 1 of "test" to "staging"`,
 		},
 		{
 			Name: "Release train done with commit but nothing to deploy",
@@ -2171,11 +2166,7 @@ deployed version 1 of "test" to "staging"
 
 Release Train to 'dev' environment:
 
-The release train deployed 0 services from 'latest' to 'dev'
-
-
-
-`,
+The release train deployed 0 services from 'latest' to 'dev'`,
 		},
 		{
 			Name: "Release train with invalid commitHash",

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -2094,7 +2094,7 @@ func TestReleaseTrainWithCommit(t *testing.T) {
 			ReleaseTrainEnv:    "staging",
 			shouldSucceed:      true,
 			expectedError:      "",
-			expectedCommitMsg:  "Release Train to environment/environment group 'staging':\n\nRelease Train to 'staging' environment for 1 apps:\n\nThe release train deployed 1 services from 'dev' to 'staging'\ndeployed version 1 of \"test\" to \"staging\"\n\n\n\n\n",
+			expectedCommitMsg:  "Release Train to environment/environment group 'staging':\n\nRelease Train to 'staging' environment:\n\nThe release train deployed 1 services from 'dev' to 'staging'\ndeployed version 1 of \"test\" to \"staging\"\n\n\n\n\n",
 			overrideCommitHash: "",
 		},
 		{
@@ -2127,12 +2127,13 @@ func TestReleaseTrainWithCommit(t *testing.T) {
 					Version:     1,
 				},
 			},
-			ReleaseTrainEnv: "staging",
-			shouldSucceed:   true,
-			expectedError:   "",
+			ReleaseTrainEnv:    "staging",
+			shouldSucceed:      true,
+			expectedError:      "",
+			overrideCommitHash: "TO_BE_REPLACED",
 			expectedCommitMsg: `Release Train to environment/environment group 'staging':
 
-Release Train to 'staging' environment for 1 apps:
+Release Train to 'staging' environment:
 
 The release train deployed 1 services from 'dev' to 'staging'
 deployed version 1 of "test" to "staging"
@@ -2162,12 +2163,13 @@ deployed version 1 of "test" to "staging"
 					Version:     1,
 				},
 			},
-			ReleaseTrainEnv: "dev",
-			shouldSucceed:   true,
-			expectedError:   "",
+			ReleaseTrainEnv:    "dev",
+			shouldSucceed:      true,
+			expectedError:      "",
+			overrideCommitHash: "TO_BE_REPLACED",
 			expectedCommitMsg: `Release Train to environment/environment group 'dev':
 
-Release Train to 'dev' environment for 0 apps:
+Release Train to 'dev' environment:
 
 The release train deployed 0 services from 'latest' to 'dev'
 
@@ -2274,7 +2276,7 @@ The release train deployed 0 services from 'latest' to 'dev'
 				Target:     tc.ReleaseTrainEnv,
 				Repo:       repo,
 			}
-			if tc.overrideCommitHash != "" {
+			if tc.overrideCommitHash != "TO_BE_REPLACED" {
 				releaseTrain = &ReleaseTrain{
 					CommitHash: tc.overrideCommitHash,
 					Target:     tc.ReleaseTrainEnv,

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -2271,18 +2271,15 @@ The release train deployed 0 services from 'latest' to 'dev'
 				}
 				t.Fatal(err)
 			}
-			releaseTrain := &ReleaseTrain{
-				CommitHash: strings.TrimSpace(string(out2)),
-				Target:     tc.ReleaseTrainEnv,
-				Repo:       repo,
-			}
+			commitHash:=strings.TrimSpace(string(out2))
 			if tc.overrideCommitHash != "TO_BE_REPLACED" {
-				releaseTrain = &ReleaseTrain{
-					CommitHash: tc.overrideCommitHash,
-					Target:     tc.ReleaseTrainEnv,
-					Repo:       repo,
-				}
+        			commitHash:=tc.overrideCommitHash
 			}
+		        releaseTrain = &ReleaseTrain{
+			        CommitHash: commitHash,
+			        Target:     tc.ReleaseTrainEnv,
+			        Repo:       repo,
+	        	}
 			commitMsg, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), releaseTrain)
 
 			if tc.shouldSucceed {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -2271,15 +2271,15 @@ The release train deployed 0 services from 'latest' to 'dev'
 				}
 				t.Fatal(err)
 			}
-			commitHash:=strings.TrimSpace(string(out2))
+			commitHash := strings.TrimSpace(string(out2))
 			if tc.overrideCommitHash != "TO_BE_REPLACED" {
-        			commitHash:=tc.overrideCommitHash
+				commitHash = tc.overrideCommitHash
 			}
-		        releaseTrain = &ReleaseTrain{
-			        CommitHash: commitHash,
-			        Target:     tc.ReleaseTrainEnv,
-			        Repo:       repo,
-	        	}
+			releaseTrain := &ReleaseTrain{
+				CommitHash: commitHash,
+				Target:     tc.ReleaseTrainEnv,
+				Repo:       repo,
+			}
 			commitMsg, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), releaseTrain)
 
 			if tc.shouldSucceed {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"io"
 	"math/rand"
 	"os/exec"
@@ -33,6 +32,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository/testutil"
 
@@ -2033,6 +2034,255 @@ Environment "acceptance-de" has both upstream.latest and upstream.environment co
 			repo := setupRepositoryTest(t)
 			commitMsg, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), tc.Transformers...)
 			// note that we only check the LAST error here:
+			if tc.shouldSucceed {
+				if err != nil {
+					t.Fatalf("Expected no error: %v", err)
+				}
+				actualMsg := commitMsg[len(commitMsg)-1]
+				if diff := cmp.Diff(actualMsg, tc.expectedCommitMsg); diff != "" {
+					t.Errorf("got \n%s\n, want \n%s\n, diff (-want +got)\n%s\n", actualMsg, tc.expectedCommitMsg, diff)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("Expected an error but got none")
+				} else {
+					actualMsg := err.Error()
+					if actualMsg != tc.expectedError {
+						t.Fatalf("expected a different error.\nExpected: %q\nGot %q", tc.expectedError, actualMsg)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestReleaseTrainWithCommit(t *testing.T) {
+	tcs := []struct {
+		Name               string
+		SetupTransformers  []Transformer
+		ReleaseTrainEnv    string
+		expectedError      string
+		expectedCommitMsg  string
+		shouldSucceed      bool
+		overrideCommitHash string
+	}{
+		{
+			Name: "Release train done without commit Hash",
+			SetupTransformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "dev",
+					Config:      testutil.MakeEnvConfigLatest(nil),
+				},
+				&CreateApplicationVersion{
+					Application: "test",
+					Version:     1,
+					Manifests: map[string]string{
+						"dev":     "dev",
+						"staging": "staging",
+					},
+				},
+				&CreateEnvironment{
+					Environment: "staging",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Latest:      false,
+							Environment: "dev",
+						},
+					},
+				},
+			},
+			ReleaseTrainEnv:    "staging",
+			shouldSucceed:      true,
+			expectedError:      "",
+			expectedCommitMsg:  "Release Train to environment/environment group 'staging':\n\nRelease Train to 'staging' environment for 1 apps:\n\nThe release train deployed 1 services from 'dev' to 'staging'\ndeployed version 1 of \"test\" to \"staging\"\n\n\n\n\n",
+			overrideCommitHash: "",
+		},
+		{
+			Name: "Release train done with commit Hash",
+			SetupTransformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "dev",
+					Config:      testutil.MakeEnvConfigLatest(nil),
+				},
+				&CreateApplicationVersion{
+					Application: "test",
+					Version:     1,
+					Manifests: map[string]string{
+						"dev":     "dev",
+						"staging": "staging",
+					},
+				},
+				&CreateEnvironment{
+					Environment: "staging",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Latest:      false,
+							Environment: "dev",
+						},
+					},
+				},
+				&DeployApplicationVersion{
+					Application: "test",
+					Environment: "dev",
+					Version:     1,
+				},
+			},
+			ReleaseTrainEnv: "staging",
+			shouldSucceed:   true,
+			expectedError:   "",
+			expectedCommitMsg: `Release Train to environment/environment group 'staging':
+
+Release Train to 'staging' environment for 1 apps:
+
+The release train deployed 1 services from 'dev' to 'staging'
+deployed version 1 of "test" to "staging"
+
+
+
+
+`,
+		},
+		{
+			Name: "Release train done with commit but nothing to deploy",
+			SetupTransformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "dev",
+					Config:      testutil.MakeEnvConfigLatest(nil),
+				},
+				&CreateApplicationVersion{
+					Application: "test",
+					Version:     1,
+					Manifests: map[string]string{
+						"dev": "dev",
+					},
+				},
+				&DeployApplicationVersion{
+					Application: "test",
+					Environment: "dev",
+					Version:     1,
+				},
+			},
+			ReleaseTrainEnv: "dev",
+			shouldSucceed:   true,
+			expectedError:   "",
+			expectedCommitMsg: `Release Train to environment/environment group 'dev':
+
+Release Train to 'dev' environment for 0 apps:
+
+The release train deployed 0 services from 'latest' to 'dev'
+
+
+
+`,
+		},
+		{
+			Name: "Release train with invalid commitHash",
+			SetupTransformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "dev",
+					Config:      testutil.MakeEnvConfigLatest(nil),
+				},
+				&CreateApplicationVersion{
+					Application: "test",
+					Version:     1,
+					Manifests: map[string]string{
+						"dev": "dev",
+					},
+				},
+				&DeployApplicationVersion{
+					Application: "test",
+					Environment: "dev",
+					Version:     1,
+				},
+			},
+			ReleaseTrainEnv:    "dev",
+			shouldSucceed:      false,
+			expectedError:      "rpc error: code = InvalidArgument desc = error: could not get app version for commitHash 3f1debc97f5880c59caab9b36ad31f52604ce4dd for dev: ErrNotFound: object not found - no match for id (3f1debc97f5880c59caab9b36ad31f52604ce4dd)",
+			overrideCommitHash: "3f1debc97f5880c59caab9b36ad31f52604ce4dd",
+		},
+		{
+			Name: "Release train with invalid oid value",
+			SetupTransformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "dev",
+					Config:      testutil.MakeEnvConfigLatest(nil),
+				},
+				&CreateApplicationVersion{
+					Application: "test",
+					Version:     1,
+					Manifests: map[string]string{
+						"dev": "dev",
+					},
+				},
+				&DeployApplicationVersion{
+					Application: "test",
+					Environment: "dev",
+					Version:     1,
+				},
+			},
+			ReleaseTrainEnv:    "dev",
+			shouldSucceed:      false,
+			expectedError:      "rpc error: code = InvalidArgument desc = error: could not get app version for commitHash aa for dev: Error creating new oid for commitHash aa: invalid oid",
+			overrideCommitHash: "aa",
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			remoteDir := path.Join(dir, "remote")
+			localDir := path.Join(dir, "local")
+			cmd := exec.Command("git", "init", "--bare", remoteDir)
+			err := cmd.Start()
+			if err != nil {
+				t.Errorf("could not start git init")
+			}
+			err = cmd.Wait()
+			if err != nil {
+				t.Errorf("could not wait for git init to finish")
+			}
+			ctx := testutil.MakeTestContext()
+			repo, err := New(
+				ctx,
+				RepositoryConfig{
+					URL:            "file://" + remoteDir,
+					Path:           localDir,
+					CommitterEmail: "kuberpult@freiheit.com",
+					CommitterName:  "kuberpult",
+					Branch:         "main",
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = repo.Apply(ctx, tc.SetupTransformers...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd2 := exec.Command("git", "-C", remoteDir, "rev-parse", "main")
+			out2, err := cmd2.Output()
+			if err != nil {
+				if exitErr, ok := err.(*exec.ExitError); ok {
+					t.Logf("stderr: %s\n", exitErr.Stderr)
+				}
+				t.Fatal(err)
+			}
+			releaseTrain := &ReleaseTrain{
+				CommitHash: strings.TrimSpace(string(out2)),
+				Target:     tc.ReleaseTrainEnv,
+				Repo:       repo,
+			}
+			if tc.overrideCommitHash != "" {
+				releaseTrain = &ReleaseTrain{
+					CommitHash: tc.overrideCommitHash,
+					Target:     tc.ReleaseTrainEnv,
+					Repo:       repo,
+				}
+			}
+			commitMsg, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), releaseTrain)
+
 			if tc.shouldSucceed {
 				if err != nil {
 					t.Fatalf("Expected no error: %v", err)

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -202,6 +202,8 @@ func (d *BatchServer) processAction(
 				Target:         in.Target,
 				Team:           in.Team,
 				Authentication: repository.Authentication{RBACConfig: d.RBACConfig},
+				Repo:           d.Repository,
+				CommitHash:     in.CommitHash,
 			}, &api.BatchResult{
 				Result: &api.BatchResult_ReleaseTrain{
 					ReleaseTrain: &api.ReleaseTrainResponse{Target: in.Target, Team: in.Team},


### PR DESCRIPTION
Release Train now run release train to specific commit hash instead of always to latest changes

REV: DSN-BADARR