### PR TITLE
fix: do not create commits if the option is disabled

### DIFF
--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -519,6 +519,9 @@ func writeCommitData(ctx context.Context, sourceCommitId string, sourceMessage s
 		return nil
 	}
 	commitDir := commitDirectory(fs, sourceCommitId)
+	if err := fs.MkdirAll(commitDir, 0777); err != nil {
+		return GetCreateReleaseGeneralFailure(err)
+	}
 	if err := util.WriteFile(fs, fs.Join(commitDir, ".empty"), make([]byte, 0), 0666); err != nil {
 		return GetCreateReleaseGeneralFailure(err)
 	}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -397,12 +397,6 @@ func (c *CreateApplicationVersion) Transform(
 		if err := util.WriteFile(fs, fs.Join(releaseDir, fieldSourceCommitId), []byte(c.SourceCommitId), 0666); err != nil {
 			return "", GetCreateReleaseGeneralFailure(err)
 		}
-		if valid.SHA1CommitID(c.SourceCommitId) {
-			commitDir := commitApplicationDirectory(fs, c.SourceCommitId, c.Application)
-			if err := fs.MkdirAll(commitDir, 0777); err != nil {
-				return "", GetCreateReleaseGeneralFailure(err)
-			}
-		}
 	}
 	if c.SourceAuthor != "" {
 		if err := util.WriteFile(fs, fs.Join(releaseDir, fieldSourceAuthor), []byte(c.SourceAuthor), 0666); err != nil {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -434,7 +434,11 @@ func TestCreateApplicationVersionEvents(t *testing.T) {
 			Name: "createRelease event should write files",
 			Transformers: []Transformer{
 				&CreateEnvironment{
-					Environment: "acceptance",
+					Environment: envAcceptance,
+					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: envAcceptance, Latest: false}},
+				},
+				&CreateEnvironment{
+					Environment: envProduction,
 					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: envAcceptance, Latest: false}},
 				},
 				&CreateApplicationVersion{

--- a/services/cd-service/pkg/service/git_test.go
+++ b/services/cd-service/pkg/service/git_test.go
@@ -475,7 +475,7 @@ func TestGetCommitInfo(t *testing.T) {
 				CommitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
 			allowReadingCommitData: true, // … but attempt to read anyway
-			expectedError:          status.Error(codes.NotFound, "commit info does not exist"),
+			expectedError:          status.Error(codes.NotFound, "error: commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa was not found in the manifest repo"),
 			expectedResponse:       nil,
 		},
 	}


### PR DESCRIPTION
This was just a left-over from a merge. We are already doing the same thing in `writeCommitData`.
However, in `writeCommitData` we are correctly checking the feature flag.