### PR TITLE
fix: BREAKING CHANGE simplify helm chart by introducing .Chart.appVersion

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -115,7 +115,6 @@ integration-test:
     COPY pkg/ptr pkg/ptr
     
     RUN envsubst < Chart.yaml.tpl > Chart.yaml
-    RUN envsubst < values.yaml.tpl > values.yaml
 
     RUN gpg --keyring trustedkeys-kuberpult.gpg --no-default-keyring --batch --passphrase '' --quick-gen-key kuberpult-kind@example.com
     RUN gpg --keyring trustedkeys-kuberpult.gpg --armor --export kuberpult-kind@example.com > kuberpult-keyring.gpg

--- a/charts/kuberpult/.gitignore
+++ b/charts/kuberpult/.gitignore
@@ -1,6 +1,5 @@
 *.tgz
 Chart.yaml
-values.yaml
 ci/test-values.yaml
 tmp.tmpl
 vals.yaml

--- a/charts/kuberpult/Chart.yaml.tpl
+++ b/charts/kuberpult/Chart.yaml.tpl
@@ -1,3 +1,18 @@
+# This file is part of kuberpult.
+
+# Kuberpult is free software: you can redistribute it and/or modify
+# it under the terms of the Expat(MIT) License as published by
+# the Free Software Foundation.
+
+# Kuberpult is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MIT License for more details.
+
+# You should have received a copy of the MIT License
+# along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+# Copyright 2023 freiheit.com
 apiVersion: v2
 name: kuberpult
 description: freiheit.com contiuous delivery
@@ -15,13 +30,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: $VERSION
+version: "${VERSION}"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "$VERSION"
+appVersion: "${VERSION}"
 
 # This is the DEX helm chart which will only be installed if `auth.dexAuth.installDex.enabled` is true.
 # Dex is an identity service that uses OpenID Connect to drive authentication through other 

--- a/charts/kuberpult/Makefile
+++ b/charts/kuberpult/Makefile
@@ -32,11 +32,8 @@ CT := docker run --mount=type=bind,source=$(TOP_DIR),target=/src,readonly --work
 
 TGZ_FILE := kuberpult-$(VERSION).tgz
 
-Chart.yaml: Chart.yaml.tpl 
-	env VERSION="$(VERSION)" envsubst < Chart.yaml.tpl > $@
-
-values.yaml: values.yaml.tpl 
-	env VERSION="$(VERSION)" envsubst < values.yaml.tpl > $@
+Chart.yaml: Chart.yaml.tpl
+	env VERSION="$(VERSION)" envsubst < $< > $@
 
 $(TGZ_FILE): Chart.yaml values.yaml templates/*
 	helm dependency update
@@ -64,7 +61,7 @@ test-ci: test-helm
 test: ct-test test-helm
 
 clean:
-	rm -f Chart.yaml values.yaml
+	rm -f Chart.yaml
 	rm -f kuberpult-*.tgz
 	rm -f ci/test-values.yaml
 	rm -fr ./charts/
@@ -74,4 +71,4 @@ release-tag: $(TGZ_FILE)
 
 .PHONY: clean
 
-all: Chart.yaml values.yaml
+all: Chart.yaml

--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -269,7 +269,6 @@ cd:
     requests:
       memory: 200Mi
       cpu: 0.05
-  tag: "${IMAGE_TAG_KUBERPULT}"
 frontend:
   resources:
     limits:
@@ -278,7 +277,6 @@ frontend:
     requests:
       memory: 200Mi
       cpu: 0.05
-  tag: "${IMAGE_TAG_KUBERPULT}"
 rollout:
   enabled: true
   resources:
@@ -288,7 +286,6 @@ rollout:
     requests:
       memory: 200Mi
       cpu: 0.05
-  tag: "${IMAGE_TAG_KUBERPULT}"
 ingress:
   domainName: kuberpult.example.com
 log:

--- a/charts/kuberpult/templates/_helpers.tpl
+++ b/charts/kuberpult/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "rollout-podAnnotations" }}
 {{- if .Values.datadogTracing.enabled }}
-apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-rollout-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ .Values.rollout.tag }}"}'
+apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-rollout-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
 {{- end }}
 {{- end }}

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -29,8 +29,8 @@
 
 # Copyright 2023 freiheit.com
 
-{{- if .Values.tag }}
-{{ fail "Values.tag cannot be used anymore. If you have to overwrite the tag, use cd.tag or frontend.tag instead"}}
+{{- if .Values.cd.tag }}
+{{ fail "Values.cd.tag cannot be used anymore. We only support the same appVersion for all services at this point."}}
 {{ end -}}
 
 ---
@@ -42,7 +42,7 @@ metadata:
     app: kuberpult-cd-service
 {{- if .Values.datadogTracing.enabled }}
     tags.datadoghq.com/service: kuberpult-cd-service
-    tags.datadoghq.com/version: {{ .Values.cd.tag }}
+    tags.datadoghq.com/version: {{ $.Chart.AppVersion }}
     tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
 {{- end }}
 spec:
@@ -64,9 +64,9 @@ spec:
 {{- if .Values.datadogTracing.enabled }}
         tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
         tags.datadoghq.com/service: kuberpult-cd-service
-        tags.datadoghq.com/version: {{ .Values.cd.tag }}
+        tags.datadoghq.com/version: {{ $.Chart.AppVersion }}
       annotations:
-        apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-cd-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ .Values.cd.tag }}"}'
+        apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-cd-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
 {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -75,7 +75,7 @@ spec:
       {{- end }}
       containers:
       - name: service
-        image: "{{ .Values.hub }}/{{ .Values.cd.image }}:{{ .Values.cd.tag }}"
+        image: "{{ .Values.hub }}/{{ .Values.cd.image }}:{{ $.Chart.AppVersion }}"
         ports:
           - name: http
             containerPort: 8080

--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -29,6 +29,9 @@
 
 # Copyright 2023 freiheit.com
 
+{{- if .Values.frontend.tag }}
+{{ fail "Values.frontend.tag cannot be used anymore. We only support the same appVersion for all services at this point."}}
+{{ end -}}
 
 ---
 apiVersion: apps/v1
@@ -49,9 +52,9 @@ spec:
 {{- if .Values.datadogTracing.enabled }}
         tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
         tags.datadoghq.com/service: kuberpult-frontend-service
-        tags.datadoghq.com/version: {{ .Values.frontend.tag }}
+        tags.datadoghq.com/version: {{ $.Chart.AppVersion }}
       annotations:
-        apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-frontend-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ .Values.frontend.tag }}"}'
+        apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-frontend-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
 {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -60,7 +63,7 @@ spec:
       {{- end }}
       containers:
       - name: service
-        image: "{{ .Values.hub }}/{{ .Values.frontend.image }}:{{ .Values.frontend.tag }}"
+        image: "{{ .Values.hub }}/{{ .Values.frontend.image }}:{{ $.Chart.AppVersion }}"
         ports:
           - name: http
             containerPort: 8081
@@ -92,7 +95,7 @@ spec:
         - name: KUBERPULT_ARGOCD_BASE_URL
           value: {{ .Values.argocd.baseUrl | quote }}
         - name: KUBERPULT_VERSION
-          value: {{ .Values.frontend.tag | quote}}
+          value: {{ $.Chart.AppVersion | quote}}
         - name: KUBERPULT_SOURCE_REPO_URL
           value: {{ .Values.git.sourceRepoUrl | quote}}
         - name: KUBERPULT_MANIFEST_REPO_URL

--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -14,6 +14,10 @@
 
 # Copyright 2023 freiheit.com
 # This file is part of kuberpult.
+{{- if .Values.rollout.tag }}
+{{ fail "Values.rollout.tag cannot be used anymore. We only support the same appVersion for all services at this point."}}
+{{ end -}}
+
 {{- if .Values.rollout.enabled }}
 {{- if not (regexMatch "^https?://[^:]+:[0-9]+$" .Values.argocd.server) -}}
 {{ fail "argocd.server must be a valid http/https url including the port"}}
@@ -31,7 +35,7 @@ metadata:
     app: kuberpult-rollout-service
 {{- if .Values.datadogTracing.enabled }}
     tags.datadoghq.com/service: kuberpult-rollout-service
-    tags.datadoghq.com/version: {{ .Values.rollout.tag }}
+    tags.datadoghq.com/version: {{ $.Chart.AppVersion }}
     tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
 {{- end }}
 spec:
@@ -46,7 +50,7 @@ spec:
 {{- if .Values.datadogTracing.enabled }}
         tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
         tags.datadoghq.com/service: kuberpult-rollout-service
-        tags.datadoghq.com/version: {{ .Values.rollout.tag }}
+        tags.datadoghq.com/version: {{ $.Chart.AppVersion }}
 {{- end }}
       annotations:
 {{ $podAnnotations | toYaml | indent 8}}
@@ -57,7 +61,7 @@ spec:
       {{- end }}
       containers:
       - name: service
-        image: "{{ .Values.hub }}/{{ .Values.rollout.image }}:{{ .Values.rollout.tag }}"
+        image: "{{ .Values.hub }}/{{ .Values.rollout.image }}:{{ $.Chart.AppVersion }}"
         ports:
           - name: http
             containerPort: 8080

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -1,3 +1,18 @@
+# This file is part of kuberpult.
+
+# Kuberpult is free software: you can redistribute it and/or modify
+# it under the terms of the Expat(MIT) License as published by
+# the Free Software Foundation.
+
+# Kuberpult is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MIT License for more details.
+
+# You should have received a copy of the MIT License
+# along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+# Copyright 2023 freiheit.com
 # Default values for ..
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -46,10 +61,6 @@ log:
   level: "WARN"
 cd:
   image: kuberpult-cd-service
-# In MOST cases, do NOT overwrite the "tag".
-# In general, kuberpult only guarantees that running with the same version of frontend and cd service will work.
-# For testing purposes, we allow to overwrite the tags individually, to test an old frontend service with a new cd service.
-  tag: "$VERSION"
   backendConfig:
     create: false   # Add backend config for health checks on GKE only
     timeoutSec: 300  # 30sec is the default on gcp loadbalancers, however kuberpult needs more with parallel requests. It is the time how long the loadbalancer waits for kuberpult to finish calls to the rest endpoint "release"
@@ -68,10 +79,6 @@ cd:
       initialDelaySeconds: 5
 frontend:
   image: kuberpult-frontend-service
-# In MOST cases, do NOT overwrite the "tag".
-# In general, kuberpult only guarantees that running with the same version of frontend and cd service will work.
-# For testing purposes, we allow to overwrite the tags individually, to test an old frontend service with a new cd service.
-  tag: "$VERSION"
 # Annotations given here will be added to kuberpult-frontend-service annotations.
 # See frontend-service.yaml for automatically added annotations.
   service:
@@ -89,10 +96,6 @@ frontend:
 rollout:
   enabled: false
   image: kuberpult-rollout-service
-# In MOST cases, do NOT overwrite the "tag".
-# In general, kuberpult only guarantees that running with the same version of frontend and cd service will work.
-# For testing purposes, we allow to overwrite the tags individually, to test an old frontend service with a new cd service.
-  tag: "$VERSION"
   resources:
     limits:
       cpu: 500m

--- a/tests/integration-tests/cluster-setup/argocd-kuberpult.sh
+++ b/tests/integration-tests/cluster-setup/argocd-kuberpult.sh
@@ -137,7 +137,6 @@ cd:
     requests:
       memory: 200Mi
       cpu: 0.05
-  tag: "${VERSION}"
 frontend:
   resources:
     limits:
@@ -146,7 +145,6 @@ frontend:
     requests:
       memory: 200Mi
       cpu: 0.05
-  tag: "${VERSION}"
 rollout:
   enabled: true
   resources:
@@ -156,7 +154,6 @@ rollout:
     requests:
       memory: 200Mi
       cpu: 0.05
-  tag: "${VERSION}"
 ingress:
   domainName: kuberpult.example.com
 log:


### PR DESCRIPTION
- use unified .Charts.appVersion
- drop:
  * .Values.cd.tag
  * .Values.frontend.tag
  * .Values.rollout.tag
- You need to replace cd.tag etc, with appVersion. Note that only the SAME version for ALL services is supported!

Reference: SRX-GH80MS

BREAKING CHANGE: removes/replaces helm chart parameters