### PR TITLE
fix: Add argoCds revision to span

### DIFF
--- a/services/rollout-service/pkg/service/dispatcher.go
+++ b/services/rollout-service/pkg/service/dispatcher.go
@@ -75,12 +75,11 @@ func (r *Dispatcher) Dispatch(ctx context.Context, k Key, ev *v1alpha1.Applicati
 func (r *Dispatcher) tryResolve(ctx context.Context, k Key, ev *v1alpha1.ApplicationWatchEvent) *versions.VersionInfo {
 	r.mx.Lock()
 	defer r.mx.Unlock()
-	ddSpan, ok := tracer.SpanFromContext(ctx)
+	ddSpan, ctx := tracer.StartSpanFromContext(ctx, "tryResolve")
+	defer ddSpan.Finish()
 	revision := ev.Application.Status.Sync.Revision
-	if ok && ddSpan != nil {
-		ddSpan.SetTag("argoSyncRevision", revision)
-	}
-	// 0. Check if this is delete event, if yes then we can delete the entry right away
+	ddSpan.SetTag("argoSyncRevision", revision)
+	// 0. Check if this is the delete event, if yes then we can delete the entry right away
 	if ev.Type == "DELETED" {
 		version := &versions.ZeroVersion
 		r.known[k] = &knownRevision{


### PR DESCRIPTION
we got some errors (especially when restarting the rollout-service) that are indicating the revision is not a valid commit hash, so with this change we add it to the span to allow better debugging.