### PR TITLE
fix: Implement GetRevisionMetadata

### DIFF
--- a/services/cd-service/pkg/argocd/reposerver/reposerver.go
+++ b/services/cd-service/pkg/argocd/reposerver/reposerver.go
@@ -116,8 +116,9 @@ func (*reposerver) GetHelmCharts(context.Context, *argorepo.HelmChartsRequest) (
 }
 
 // GetRevisionMetadata implements apiclient.RepoServerServiceServer.
-func (*reposerver) GetRevisionMetadata(context.Context, *argorepo.RepoServerRevisionMetadataRequest) (*v1alpha1.RevisionMetadata, error) {
-	return nil, notImplemented
+func (*reposerver) GetRevisionMetadata(ctx context.Context, req *argorepo.RepoServerRevisionMetadataRequest) (*v1alpha1.RevisionMetadata, error) {
+	// It doesn't matter too much what is in here as long as we don't give an error.
+	return &v1alpha1.RevisionMetadata{}, nil
 }
 
 // ListApps implements apiclient.RepoServerServiceServer.

--- a/services/cd-service/pkg/argocd/reposerver/reposerver_test.go
+++ b/services/cd-service/pkg/argocd/reposerver/reposerver_test.go
@@ -448,6 +448,30 @@ func TestResolveRevision(t *testing.T) {
 	}
 }
 
+func TestGetRevisionMetadata(t *testing.T) {
+	tcs := []struct {
+		Name string
+	}{
+		{
+			Name: "returns a dummy",
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			srv := (*reposerver)(nil)
+			req := argorepo.RepoServerRevisionMetadataRequest{}
+			_, err := srv.GetRevisionMetadata(
+				context.Background(),
+				&req,
+			)
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+		})
+	}
+}
+
 func testRepository(t *testing.T) (repository.Repository, repository.RepositoryConfig) {
 	dir := t.TempDir()
 	remoteDir := path.Join(dir, "remote")


### PR DESCRIPTION
The errors from that endpoint are currenlty spamming but it's not an actual issue. The data returned by this endpoint is only informational in the argocd ui.