### PR TITLE
fix: Event refactor

### DIFF
--- a/services/cd-service/pkg/event/event.go
+++ b/services/cd-service/pkg/event/event.go
@@ -22,8 +22,9 @@ import (
 	"slices"
 
 	"github.com/freiheit-com/kuberpult/pkg/api/v1"
+	"github.com/freiheit-com/kuberpult/pkg/uuid"
 	"github.com/go-git/go-billy/v5"
-	"google.golang.org/protobuf/types/known/timestamppb"
+	"github.com/onokonem/sillyQueueServer/timeuuid"
 )
 
 type eventType struct {
@@ -130,9 +131,10 @@ func Write(filesystem billy.Filesystem, eventDir string, event Event) error {
 }
 
 // Convert an event to its protobuf representation
-func ToProto(ev Event, createdAt *timestamppb.Timestamp) *api.Event {
+func ToProto(eventID timeuuid.UUID, ev Event) *api.Event {
 	result := &api.Event{
-		CreatedAt: createdAt,
+		CreatedAt: uuid.GetTime(&eventID),
+		Uuid:      eventID.String(),
 	}
 	ev.toProto(result)
 	return result

--- a/services/cd-service/pkg/event/event.go
+++ b/services/cd-service/pkg/event/event.go
@@ -15,7 +15,125 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright 2023 freiheit.com*/
 package event
 
-const (
-	NewReleaseEventName = "new-release"
-	DeploymentEventName = "deployment"
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"slices"
+
+	"github.com/freiheit-com/kuberpult/pkg/api/v1"
+	"github.com/go-git/go-billy/v5"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+type eventType struct {
+	EventType string `fs:"eventType"`
+}
+
+// NewRelease is an event that denotes that a commit has been released
+// for the first time.
+type NewRelease struct {
+	Environments map[string]struct{} `fs:"environments"`
+}
+
+func (_ *NewRelease) eventType() string {
+	return "new-release"
+}
+
+func (ev *NewRelease) toProto(trg *api.Event) {
+	envs := make([]string, 0, len(ev.Environments))
+	for env := range ev.Environments {
+		envs = append(envs, env)
+	}
+	slices.Sort(envs)
+	trg.EventType = &api.Event_CreateReleaseEvent{
+		CreateReleaseEvent: &api.CreateReleaseEvent{
+			EnvironmentNames: envs,
+		},
+	}
+}
+
+// Deployment is an event that denotes that an application of a commit
+// has been released to an environment.
+type Deployment struct {
+	Application                 string  `fs:"application"`
+	Environment                 string  `fs:"environment"`
+	SourceTrainEnvironmentGroup *string `fs:"source_train_environment_group"`
+	SourceTrainUpstream         *string `fs:"source_train_upstream"`
+}
+
+func (_ *Deployment) eventType() string {
+	return "deployment"
+}
+
+func (ev *Deployment) toProto(trg *api.Event) {
+	var releaseTrainSource *api.DeploymentEvent_ReleaseTrainSource
+	if ev.SourceTrainEnvironmentGroup != nil {
+		releaseTrainSource = &api.DeploymentEvent_ReleaseTrainSource{
+			TargetEnvironmentGroup: ev.SourceTrainEnvironmentGroup,
+		}
+	}
+	if ev.SourceTrainUpstream != nil {
+		if releaseTrainSource == nil {
+			releaseTrainSource = new(api.DeploymentEvent_ReleaseTrainSource)
+		}
+		releaseTrainSource.UpstreamEnvironment = *ev.SourceTrainUpstream
+	}
+	trg.EventType = &api.Event_DeploymentEvent{
+		DeploymentEvent: &api.DeploymentEvent{
+			Application:        ev.Application,
+			TargetEnvironment:  ev.Environment,
+			ReleaseTrainSource: releaseTrainSource,
+		},
+	}
+}
+
+// Event is a commit-releated event
+type Event interface {
+	eventType() string
+	toProto(*api.Event)
+}
+
+// Read an event from a filesystem.
+func Read(fs billy.Filesystem, eventDir string) (Event, error) {
+	var tp eventType
+	if err := read(fs, eventDir, &tp); err != nil {
+		return nil, err
+	}
+	var result Event
+	switch tp.EventType {
+	case "new-release":
+		result = &NewRelease{}
+	case "deployment":
+		result = &Deployment{}
+	default:
+		return nil, fmt.Errorf("unknown event type: %q", tp.EventType)
+	}
+	if err := read(fs, eventDir, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// Write an event to a filesystem
+func Write(filesystem billy.Filesystem, eventDir string, event Event) error {
+	_, err := filesystem.Stat(eventDir)
+	if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("event file already exists: %w", err)
+	}
+	if err := write(filesystem, eventDir, eventType{
+		EventType: event.eventType(),
+	}); err != nil {
+		return err
+	}
+	return write(filesystem, eventDir, event)
+}
+
+// Convert an event to its protobuf representation
+func ToProto(ev Event, createdAt *timestamppb.Timestamp) *api.Event {
+	result := &api.Event{
+		CreatedAt: createdAt,
+	}
+	ev.toProto(result)
+	return result
+}

--- a/services/cd-service/pkg/event/event_test.go
+++ b/services/cd-service/pkg/event/event_test.go
@@ -1,3 +1,18 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
 package event
 
 import (

--- a/services/cd-service/pkg/event/event_test.go
+++ b/services/cd-service/pkg/event/event_test.go
@@ -1,0 +1,69 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_roundtrip(t *testing.T) {
+	for _, test := range []struct {
+		Name  string
+		Event Event
+	}{
+		{
+			Name: "new-release",
+			Event: &NewRelease{
+				Environments: map[string]struct{}{
+					"env1": {},
+					"env2": {},
+				},
+			},
+		},
+		{
+			Name: "deployment-basic",
+			Event: &Deployment{
+				Application: "app",
+				Environment: "env",
+			},
+		},
+		{
+			Name: "deployment-1",
+			Event: &Deployment{
+				Application:                 "app1",
+				Environment:                 "env1",
+				SourceTrainEnvironmentGroup: ptr("A"),
+			},
+		},
+		{
+			Name: "deployment-2",
+			Event: &Deployment{
+				Application:                 "app1",
+				Environment:                 "env1",
+				SourceTrainEnvironmentGroup: ptr("A"),
+				SourceTrainUpstream:         ptr("B"),
+			},
+		},
+	} {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			fs := memfs.New()
+			if err := Write(fs, "test", test.Event); err != nil {
+				t.Fatal("writing event:", err)
+			}
+			result, err := Read(fs, "test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.Event, result); diff != "" {
+				t.Error("wrong result:\n", diff)
+			}
+		})
+	}
+}
+
+func ptr[T any](x T) *T {
+	return &x
+}

--- a/services/cd-service/pkg/event/reader.go
+++ b/services/cd-service/pkg/event/reader.go
@@ -1,3 +1,18 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
 package event
 
 import (

--- a/services/cd-service/pkg/event/reader.go
+++ b/services/cd-service/pkg/event/reader.go
@@ -1,0 +1,96 @@
+package event
+
+import (
+	"errors"
+	"fmt"
+	fserr "io/fs"
+	"reflect"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/util"
+)
+
+func read(
+	filesystem billy.Filesystem,
+	dir string,
+	val any,
+) error {
+	v := reflect.ValueOf(val)
+	return readFile(filesystem, dir, v.Elem(), v.Elem().Type(), encodingDefault)
+}
+
+func readFile(
+	fs billy.Filesystem,
+	file string,
+	value reflect.Value,
+	tp reflect.Type,
+	encoding encoding,
+) error {
+	switch tp.Kind() {
+	case reflect.Pointer:
+		_, err := fs.Stat(file)
+		if err != nil {
+			if errors.Is(err, fserr.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if value.IsNil() {
+			value.Set(reflect.New(tp.Elem()))
+		}
+		return readFile(fs, file, value.Elem(), tp.Elem(), encoding)
+	case reflect.String:
+		cont, err := util.ReadFile(fs, file)
+		if err != nil {
+			return err
+		}
+		value.SetString(string(cont))
+		return nil
+	case reflect.Struct:
+		for i := 0; i < tp.NumField(); i++ {
+			f := tp.Field(i)
+			name, enc := parseTag(f.Tag.Get("fs"))
+			if name == "" {
+				name = f.Name
+			}
+			if err := readFile(fs,
+				fs.Join(file, name),
+				value.Field(i),
+				f.Type,
+				enc,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.Map:
+		if tp.Key().Kind() != reflect.String {
+			return fmt.Errorf("can only use maps with strings as keys")
+		}
+		files, err := fs.ReadDir(file)
+		if err != nil {
+			return err
+		}
+		if value.IsNil() {
+			value.Set(reflect.MakeMapWithSize(tp, len(files)))
+		}
+		for _, sub := range files {
+			if sub.Name() == ".gitkeep" {
+				continue
+			}
+			val := reflect.New(tp.Elem()).Elem()
+			if err := readFile(fs,
+				fs.Join(file, sub.Name()),
+				val,
+				tp.Elem(),
+				encodingDefault,
+			); err != nil {
+				return err
+			}
+			value.SetMapIndex(reflect.ValueOf(sub.Name()), val)
+		}
+		return nil
+	default:
+		return fmt.Errorf("cannot read type %v", tp)
+	}
+}

--- a/services/cd-service/pkg/event/writer.go
+++ b/services/cd-service/pkg/event/writer.go
@@ -1,3 +1,18 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
 package event
 
 import (

--- a/services/cd-service/pkg/event/writer.go
+++ b/services/cd-service/pkg/event/writer.go
@@ -1,0 +1,124 @@
+package event
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/util"
+)
+
+func write(
+	filesystem billy.Filesystem,
+	dir string,
+	val any,
+) error {
+	return writeFile(filesystem, dir, reflect.ValueOf(val), encodingDefault)
+}
+
+func writeFile(
+	fs billy.Filesystem,
+	file string,
+	value reflect.Value,
+	encoding encoding,
+) error {
+	tp := value.Type()
+	switch tp.Kind() {
+	case reflect.Pointer:
+		if value.IsNil() {
+			return nil
+		}
+		return writeFile(fs, file, value.Elem(), encoding)
+	case reflect.String:
+		val := value.Interface().(string)
+		return util.WriteFile(fs, file, []byte(val), 0666)
+	case reflect.Struct:
+		if err := fs.MkdirAll(file, 0777); err != nil {
+			return err
+		}
+		if tp.NumField() == 0 {
+			return util.WriteFile(fs, fs.Join(file, ".gitkeep"), []byte{}, 0666)
+		}
+		for i := 0; i < tp.NumField(); i++ {
+			f := tp.Field(i)
+			name, enc := parseTag(f.Tag.Get("fs"))
+			if name == "" {
+				name = f.Name
+			}
+			if err := writeFile(fs,
+				fs.Join(file, name),
+				value.Field(i),
+				enc,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.Map:
+		if tp.Key().Kind() != reflect.String {
+			return fmt.Errorf("can only use maps with strings as keys")
+		}
+		if err := fs.MkdirAll(file, 0777); err != nil {
+			return err
+		}
+		if value.Len() == 0 {
+			return util.WriteFile(fs, fs.Join(file, ".gitkeep"), []byte{}, 0666)
+		}
+		iter := value.MapRange()
+		for iter.Next() {
+			fileName := iter.Key().Interface().(string)
+			if err := writeFile(fs,
+				fs.Join(file, fileName),
+				iter.Value(),
+				encodingDefault,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.Slice:
+		if err := fs.MkdirAll(file, 0777); err != nil {
+			return err
+		}
+		if value.Len() == 0 {
+			return util.WriteFile(fs, fs.Join(file, ".gitkeep"), []byte{}, 0666)
+		}
+		for i := 0; i < value.Len(); i++ {
+			if err := writeFile(fs,
+				fs.Join(file, fmt.Sprintf("%d", i)),
+				value.Index(i),
+				encodingDefault,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("cannot write type %v", tp)
+	}
+}
+
+type encoding int
+
+const (
+	encodingDefault encoding = iota
+)
+
+func parseTag(tag string) (name string, encoding encoding) {
+	elems := strings.Split(tag, ",")
+	if len(elems) == 0 {
+		return "", encodingDefault
+	}
+	name = elems[0]
+	if len(elems) == 1 {
+		return name, encodingDefault
+	}
+	switch elems[1] {
+	case "default", "":
+		encoding = encodingDefault
+	default:
+		panic(fmt.Sprintf("unknown encoding: %q", elems[1]))
+	}
+	return name, encoding
+}

--- a/services/cd-service/pkg/event/writer_test.go
+++ b/services/cd-service/pkg/event/writer_test.go
@@ -1,3 +1,18 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
 package event
 
 import (

--- a/services/cd-service/pkg/event/writer_test.go
+++ b/services/cd-service/pkg/event/writer_test.go
@@ -1,0 +1,84 @@
+package event
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_write(t *testing.T) {
+
+	type named struct {
+		Field string
+	}
+
+	example := "test"
+
+	for _, test := range []struct {
+		Name  string
+		Event any
+	}{
+		{
+			Name:  "string",
+			Event: "hello",
+		},
+		{
+			Name: "struct",
+			Event: struct {
+				Field1 string `fs:"field1"`
+				Field2 string
+			}{
+				Field1: "f1",
+				Field2: "f2",
+			},
+		},
+		{
+			Name: "map",
+			Event: map[string]string{
+				"file1": "content1",
+				"file2": "content2",
+			},
+		},
+		{
+			Name: "named",
+			Event: named{
+				Field: "test",
+			},
+		},
+		{
+			Name: "map-empty",
+			Event: map[string]struct{}{
+				"x": {},
+				"y": {},
+			},
+		},
+		{
+			Name:  "pointer",
+			Event: &example,
+		},
+		{
+			Name:  "nil-pointer",
+			Event: (*string)(nil),
+		},
+	} {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			fs := memfs.New()
+			err := write(fs, "test", test.Event)
+			if err != nil {
+				t.Fatal("writing event:", err)
+			}
+			result := reflect.New(reflect.TypeOf(test.Event))
+			err = read(fs, "test", result.Interface())
+			if err != nil {
+				t.Fatal("reading event:", err)
+			}
+			if diff := cmp.Diff(test.Event, result.Elem().Interface()); diff != "" {
+				t.Error("wrong result:\n", diff)
+			}
+		})
+	}
+}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -547,43 +547,28 @@ func writeCommitData(ctx context.Context, sourceCommitId string, sourceMessage s
 	if err := util.WriteFile(fs, fs.Join(commitAppDir, ".gitkeep"), make([]byte, 0), 0666); err != nil {
 		return GetCreateReleaseGeneralFailure(err)
 	}
-	err := writeNewReleaseEvent(ctx, eventId, sourceCommitId, fs, environments)
+	envMap := make(map[string]struct{}, len(environments))
+	for _, env := range environments {
+		envMap[env] = struct{}{}
+	}
+	err := writeEvent(eventId, sourceCommitId, fs, &event.NewRelease{
+		Environments: envMap,
+	})
 	if err != nil {
 		return fmt.Errorf("error while writing event: %v", err)
 	}
 	return nil
 }
 
-func writeNewReleaseEvent(ctx context.Context, eventId string, sourceCommitId string, filesystem billy.Filesystem, envs []string) error {
+func writeEvent(
+	eventId string,
+	sourceCommitId string,
+	filesystem billy.Filesystem,
+	ev event.Event,
+) error {
 	eventDir := commitEventDir(filesystem, sourceCommitId, eventId)
-	_, err := filesystem.Stat(eventDir)
-	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			// anything except "not exists" is an error:
-			return fmt.Errorf("event directory %s already existed: %v", eventDir, err)
-		}
-	}
-	if err := filesystem.MkdirAll(eventDir, 0777); err != nil {
-		return fmt.Errorf("could not create directory %s: %v", eventDir, err)
-	}
-	for i := range envs {
-		env := envs[i]
-		environmentDir := filesystem.Join(eventDir, "environments", env)
-		if err := filesystem.MkdirAll(environmentDir, 0777); err != nil {
-			return fmt.Errorf("could not create directory %s: %v", environmentDir, err)
-		}
-		environmentNamePath := filesystem.Join(environmentDir, ".gitkeep")
-		if err := util.WriteFile(filesystem, environmentNamePath, make([]byte, 0), 0666); err != nil {
-			return fmt.Errorf("could not write file %s: %v", environmentNamePath, err)
-		}
-	}
-	eventTypePath := filesystem.Join(eventDir, "eventType")
-	if err := util.WriteFile(filesystem, eventTypePath, []byte(event.NewReleaseEventName), 0666); err != nil {
-		return fmt.Errorf("could not write file %s: %v", eventTypePath, err)
-	}
-
 	// Note: we do not store the "createAt" date here, because we use UUIDs with timestamp information
-	return nil
+	return event.Write(filesystem, eventDir, ev)
 }
 
 func (c *CreateApplicationVersion) calculateVersion(state *State) (uint64, error) {
@@ -1687,41 +1672,17 @@ func (c *DeployApplicationVersion) Transform(
 }
 
 func writeDeploymentEvent(fs billy.Filesystem, commitId, eventId, application, environment string, sourceTrain *DeployApplicationVersionSource) error {
-	eventPath := commitEventDir(fs, commitId, eventId)
-
-	if err := fs.MkdirAll(eventPath, 0777); err != nil {
-		return fmt.Errorf("could not create event directory at %s, error: %w", eventPath, err)
+	ev := event.Deployment{
+		Application: application,
+		Environment: environment,
 	}
-
-	eventTypePath := fs.Join(eventPath, "eventType")
-	if err := util.WriteFile(fs, eventTypePath, []byte(event.DeploymentEventName), 0666); err != nil {
-		return fmt.Errorf("could not write the event type file at %s, error: %w", eventTypePath, err)
-	}
-
-	eventApplicationPath := fs.Join(eventPath, "application")
-	if err := util.WriteFile(fs, eventApplicationPath, []byte(application), 0666); err != nil {
-		return fmt.Errorf("could not write the application file at %s, error: %w", eventApplicationPath, err)
-	}
-
-	eventEnvironmentPath := fs.Join(eventPath, "environment")
-	if err := util.WriteFile(fs, eventEnvironmentPath, []byte(environment), 0666); err != nil {
-		return fmt.Errorf("could not write the environment file at %s, error: %w", eventEnvironmentPath, err)
-	}
-
 	if sourceTrain != nil {
 		if sourceTrain.TargetGroup != nil {
-			eventTrainGroupPath := fs.Join(eventPath, "source_train_environment_group")
-			if err := util.WriteFile(fs, eventTrainGroupPath, []byte(*sourceTrain.TargetGroup), 0666); err != nil {
-				return fmt.Errorf("could not write source train group file at %s, error: %w", eventTrainGroupPath, err)
-			}
+			ev.SourceTrainEnvironmentGroup = sourceTrain.TargetGroup
 		}
-		eventTrainUpstreamPath := fs.Join(eventPath, "source_train_upstream")
-		if err := util.WriteFile(fs, eventTrainUpstreamPath, []byte(sourceTrain.Upstream), 0666); err != nil {
-			return fmt.Errorf("could not write source train upstream file at %s, error: %w", eventTrainUpstreamPath, err)
-		}
+		ev.SourceTrainUpstream = &sourceTrain.Upstream
 	}
-
-	return nil
+	return writeEvent(eventId, commitId, fs, &ev)
 }
 
 type ReleaseTrain struct {

--- a/services/cd-service/pkg/service/git.go
+++ b/services/cd-service/pkg/service/git.go
@@ -27,7 +27,6 @@ import (
 
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
 	grpcErrors "github.com/freiheit-com/kuberpult/pkg/grpc"
-	"github.com/freiheit-com/kuberpult/pkg/uuid"
 	"github.com/freiheit-com/kuberpult/pkg/valid"
 	eventmod "github.com/freiheit-com/kuberpult/services/cd-service/pkg/event"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
@@ -212,7 +211,7 @@ func (s *GitServer) ReadEvent(ctx context.Context, fs billy.Filesystem, eventPat
 	if err != nil {
 		return nil, err
 	}
-	return eventmod.ToProto(event, uuid.GetTime(&eventId)), nil
+	return eventmod.ToProto(eventId, event), nil
 }
 
 // findCommitID checks if the "commits" directory in the given

--- a/services/cd-service/pkg/service/git.go
+++ b/services/cd-service/pkg/service/git.go
@@ -27,8 +27,6 @@ import (
 
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
 	grpcErrors "github.com/freiheit-com/kuberpult/pkg/grpc"
-	"github.com/freiheit-com/kuberpult/pkg/logger"
-	"github.com/freiheit-com/kuberpult/pkg/ptr"
 	"github.com/freiheit-com/kuberpult/pkg/uuid"
 	"github.com/freiheit-com/kuberpult/pkg/valid"
 	eventmod "github.com/freiheit-com/kuberpult/services/cd-service/pkg/event"
@@ -210,94 +208,11 @@ func (s *GitServer) GetEvents(ctx context.Context, fs billy.Filesystem, commitPa
 }
 
 func (s *GitServer) ReadEvent(ctx context.Context, fs billy.Filesystem, eventPath string, eventId timeuuid.UUID) (*api.Event, error) {
-	eventTypePath := fs.Join(eventPath, "eventType")
-	eventTypeRaw, err := util.ReadFile(fs, eventTypePath) // full path: commits/<commitHash2>/<commitHash38>/events/<eventUUID>/eventType
+	event, err := eventmod.Read(fs, eventPath)
 	if err != nil {
-		return nil, fmt.Errorf("could not read eventType in path %s - %v", eventTypePath, err)
+		return nil, err
 	}
-	var eventType = string(eventTypeRaw)
-
-	if eventType == eventmod.NewReleaseEventName {
-		eventEnvsPath := fs.Join(eventPath, "environments")
-
-		potentialEnvironmentDirs, err := fs.ReadDir(eventEnvsPath)
-		if err != nil {
-			return nil, fmt.Errorf("could not read events environments directory '%s' - %v", eventEnvsPath, err)
-		}
-
-		var envs []string = nil
-		for i := range potentialEnvironmentDirs {
-			envDir := potentialEnvironmentDirs[i]
-			fileName := envDir.Name()
-			if envDir.IsDir() {
-				envs = append(envs, fileName)
-			} else {
-				logger.FromContext(ctx).Sugar().Warnf(
-					"found entry in %s that was not an environment directory", fs.Join(eventEnvsPath, fileName))
-			}
-		}
-
-		var result = &api.Event{
-			Uuid: eventId.String(),
-			CreatedAt: uuid.GetTime(&eventId),
-			EventType: &api.Event_CreateReleaseEvent{
-				CreateReleaseEvent: &api.CreateReleaseEvent{
-					EnvironmentNames: envs,
-				},
-			},
-		}
-		return result, nil
-	}
-	if eventType == eventmod.DeploymentEventName {
-		deploymentEvent := api.DeploymentEvent{}
-
-		applicationNamePath := fs.Join(eventPath, "application")
-		if data, err := util.ReadFile(fs, applicationNamePath); err != nil {
-			return nil, fmt.Errorf("could not read the application name file at %s, error: %w", applicationNamePath, err)
-		} else {
-			deploymentEvent.Application = string(data)
-		}
-
-		environmentNamePath := fs.Join(eventPath, "environment")
-		if data, err := util.ReadFile(fs, environmentNamePath); err != nil {
-			return nil, fmt.Errorf("could not read the environment name file at %s, error: %w", environmentNamePath, err)
-		} else {
-			deploymentEvent.TargetEnvironment = string(data)
-		}
-
-		upstreamNamePath := fs.Join(eventPath, "source_train_upstream")
-		if data, err := util.ReadFile(fs, upstreamNamePath); err != nil {
-			if !errors.Is(err, os.ErrNotExist) { // something is wrong
-				return nil, fmt.Errorf("an unexpected error occured when reading the upstream file at %s, error: %w", upstreamNamePath, err)
-			}
-			// everything okay, deployment not triggered by release train
-		} else { // deployment triggered by release train
-			deploymentEvent.ReleaseTrainSource = &api.DeploymentEvent_ReleaseTrainSource{}
-
-			deploymentEvent.ReleaseTrainSource.UpstreamEnvironment = string(data)
-			
-			targetGroupPath := fs.Join(eventPath, "source_train_environment_group")
-			if data, err := util.ReadFile(fs, targetGroupPath); err != nil {
-				if !errors.Is(err, os.ErrNotExist) { // something is wrong
-					return nil, fmt.Errorf("an unexpected error occured when reading the target group file at %s, error: %w", targetGroupPath, err)
-				}
-				// everything okay, deployment not triggered by release train on an environment group
-			} else { // deployment triggered by release train on an environment group
-				deploymentEvent.ReleaseTrainSource.TargetEnvironmentGroup = ptr.FromString(string(data))
-			}
-		}
-
-		result := &api.Event{
-			Uuid: eventId.String(),
-			CreatedAt: uuid.GetTime(&eventId),
-			EventType: &api.Event_DeploymentEvent{
-				DeploymentEvent: &deploymentEvent,
-			},
-		}
-
-		return result, nil
-	}
-	return nil, fmt.Errorf("could not read event, did not recognize event type '%s'", eventType)
+	return eventmod.ToProto(event, uuid.GetTime(&eventId)), nil
 }
 
 // findCommitID checks if the "commits" directory in the given


### PR DESCRIPTION
Create a reflection-based reader/writer for events which converts a Go-struct from/into a filesystem structure. Reflection is used here since it is the most straight-forward approach to handle generic en-/decoding functions.