### PR TITLE
fix: Add maximum team name size to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The `/release` endpoint accepts several parameters:
 * `source_message` git commit message of the new change.
 * `author-email` and `author-name` are base64 encoded http headers. They define the `git author` that pushes to the manifest repository.
 * `version` (optional, but recommended) If not set, Kuberpult will just use `last release number + 1`. It is recommended to set this to a unique number, for example the number of commits in your git main branch. This way, if you have parallel executions of `/release` for the same service, Kuberpult will sort them in the right order.
-* `team` (optional) team name of the microservice. Used to filter more easily for relevant services in kuberpult's UI and also written as label to the Argo CD app to allow filtering in the Argo CD UI.
+* `team` (optional) team name of the microservice. Used to filter more easily for relevant services in kuberpult's UI and also written as label to the Argo CD app to allow filtering in the Argo CD UI. The team name has a maximum size of 20 characters.
 
 Caveats:
 * Note that the `/release` endpoint can be rather slow. This is because it involves running `git push` to a real repository, which in itself is a slow operation. Usually this takes about 1 second, but it highly depends on your Git Hosting Provider. This applies to all endpoints that have to write to the git repo (which is most of the endpoints).


### PR DESCRIPTION
Currently the maximum is 20 characters. Check https://github.com/freiheit-com/kuberpult/blob/bca7caa8931f5d5db56026f59545ad9016d78c0e/pkg/valid/validations.go#L48