### PR TITLE
feat: Add release train to sideBar

### DIFF
--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -208,7 +208,6 @@ func (d *BatchServer) processAction(
 				CommitHash:      in.CommitHash,
 				WriteCommitData: d.Config.WriteCommitData,
 				Authentication:  repository.Authentication{RBACConfig: d.RBACConfig},
-				Repo:            d.Repository,
 			}, &api.BatchResult{
 				Result: &api.BatchResult_ReleaseTrain{
 					ReleaseTrain: &api.ReleaseTrainResponse{Target: in.Target, Team: in.Team},

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -208,6 +208,7 @@ func (d *BatchServer) processAction(
 				CommitHash:      in.CommitHash,
 				WriteCommitData: d.Config.WriteCommitData,
 				Authentication:  repository.Authentication{RBACConfig: d.RBACConfig},
+				Repo:            d.Repository,
 			}, &api.BatchResult{
 				Result: &api.BatchResult_ReleaseTrain{
 					ReleaseTrain: &api.ReleaseTrainResponse{Target: in.Target, Team: in.Team},

--- a/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.test.tsx
+++ b/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.test.tsx
@@ -23,19 +23,6 @@ const mock_UseEnvGroups = Spy('envGroup');
 const mock_UseTags = Spy('Overview');
 const mock_UseSummaryDisplay = Spy('Status');
 
-const localStorageMock = (() => {
-    const store: { [key: string]: string } = {};
-    return {
-        getItem: (key: string) => store[key] || null,
-        setItem: (key: string, value: string) => {
-            store[key] = value.toString();
-        },
-    };
-})();
-Object.defineProperty(window, 'localStorage', {
-    value: localStorageMock,
-});
-
 jest.mock('../../utils/store', () => ({
     getSummary() {
         return {};
@@ -84,7 +71,6 @@ describe('Product Version Data', () => {
         expectedDropDown: string;
         tags: TagData[];
         productSummary: ProductSummary[];
-        localStorageVal: string;
     };
     const data: TestData[] = [
         {
@@ -101,7 +87,6 @@ describe('Product Version Data', () => {
                     priority: Priority.UNRECOGNIZED,
                 },
             ],
-            localStorageVal: '',
         },
         {
             name: 'tags to Display with summary',
@@ -126,7 +111,6 @@ describe('Product Version Data', () => {
                     priority: Priority.UNRECOGNIZED,
                 },
             ],
-            localStorageVal: '',
         },
         {
             name: 'table to be displayed with multiple rows of data',
@@ -155,32 +139,6 @@ describe('Product Version Data', () => {
                     priority: Priority.UNRECOGNIZED,
                 },
             ],
-            localStorageVal: '',
-        },
-        {
-            name: 'test the release train button shown',
-            environmentName: 'tester',
-            tags: [{ commitId: '123', tag: 'refs/tags/dummyTag' }],
-            expectedDropDown: 'dummyTag',
-            productSummary: [
-                {
-                    app: 'testing-app',
-                    version: '4',
-                    commitId: '123',
-                    displayVersion: 'v1.2.3',
-                    environment: 'dev',
-                    team: 'sre-team',
-                },
-            ],
-            environmentGroups: [
-                {
-                    environments: [sampleEnvsA[0]],
-                    distanceToUpstream: 1,
-                    environmentGroupName: 'g1',
-                    priority: Priority.UNRECOGNIZED,
-                },
-            ],
-            localStorageVal: 'testing',
         },
     ];
 
@@ -188,7 +146,6 @@ describe('Product Version Data', () => {
         // given
         it(testCase.name, () => {
             // replicate api calls
-            localStorage.setItem(testCase.localStorageVal, testCase.localStorageVal);
             mock_UseEnvGroups.returns(testCase.environmentGroups);
             mock_UseTags.returns({ response: { tagData: testCase.tags }, tagsReady: true });
             mock_UseSummaryDisplay.returns({
@@ -214,10 +171,8 @@ describe('Product Version Data', () => {
                 );
             }
             const releaseTrainButton = screen.queryByText('Run Release Train');
-            if (testCase.localStorageVal !== '') {
+            if (testCase.tags.length > 0) {
                 expect(releaseTrainButton).toBeInTheDocument();
-            } else {
-                expect(releaseTrainButton).toBeNull();
             }
         });
     });

--- a/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.tsx
+++ b/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.tsx
@@ -158,21 +158,21 @@ export const ProductVersion: React.FC = () => {
                             releaseTrain: { target: env, commitHash: selectedTag, team: '' },
                         },
                     });
-                });
-            } else {
-                if (teams.length > 1) {
-                    showSnackbarError('Can only run one release train action at a time, should only select one team');
                     return;
-                }
-                selectedEnvs.forEach((env) => {
-                    addAction({
-                        action: {
-                            $case: 'releaseTrain',
-                            releaseTrain: { target: env, commitHash: selectedTag, team: teams[0] },
-                        },
-                    });
                 });
             }
+            if (teams.length > 1) {
+                showSnackbarError('Can only run one release train action at a time, should only select one team');
+                return;
+            }
+            selectedEnvs.forEach((env) => {
+                addAction({
+                    action: {
+                        $case: 'releaseTrain',
+                        releaseTrain: { target: env, commitHash: selectedTag, team: teams[0] },
+                    },
+                });
+            });
             return;
         },
         [selectedTag, teams]

--- a/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.tsx
+++ b/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.tsx
@@ -158,8 +158,8 @@ export const ProductVersion: React.FC = () => {
                             releaseTrain: { target: env, commitHash: selectedTag, team: '' },
                         },
                     });
-                    return;
                 });
+                return;
             }
             if (teams.length > 1) {
                 showSnackbarError('Can only run one release train action at a time, should only select one team');

--- a/services/frontend-service/src/ui/components/ProductVersion/__snapshots__/ProductVersion.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ProductVersion/__snapshots__/ProductVersion.test.tsx.snap
@@ -89,6 +89,19 @@ exports[`Product Version Data Displays Product Version Page table to be displaye
             </option>
           </select>
         </div>
+        <button
+          aria-label="Run Release Train"
+          class="mdc-button release_train_button"
+        >
+          <div
+            class="mdc-button__ripple"
+          />
+          <span
+            class="mdc-button__label"
+          >
+            Run Release Train
+          </span>
+        </button>
       </div>
       <div>
         <div
@@ -164,121 +177,6 @@ exports[`Product Version Data Displays Product Version Page table to be displaye
 `;
 
 exports[`Product Version Data Displays Product Version Page tags to Display with summary 1`] = `
-<body>
-  <div>
-    <div
-      class="product_version"
-    >
-      <h1
-        class="environment_name"
-      >
-        Product Version Page
-      </h1>
-      <div
-        class=""
-      />
-      <div
-        class="space_apart_row"
-      >
-        <div
-          class="dropdown_div"
-        >
-          <select
-            class="drop_down"
-            data-testid="drop_down"
-          >
-            <option
-              disabled=""
-              value="default"
-            >
-              Select a Tag
-            </option>
-            <option
-              value="123"
-            >
-              dummyTag
-            </option>
-          </select>
-          <select
-            class="env_drop_down"
-          >
-            <option
-              disabled=""
-              value="default"
-            >
-              Select an Environment or Environment Group
-            </option>
-            <option
-              value="g1"
-            >
-              g1
-            </option>
-            <option
-              value="g1/tester"
-            >
-              g1/tester
-            </option>
-          </select>
-        </div>
-      </div>
-      <div>
-        <div
-          class="table_padding"
-        >
-          <table
-            class="table"
-          >
-            <tbody>
-              <tr
-                class="table_title"
-              >
-                <th>
-                  App Name
-                </th>
-                <th>
-                  Version
-                </th>
-                <th>
-                  Environment
-                </th>
-                <th>
-                  Team
-                </th>
-                <th>
-                  ManifestRepoLink
-                </th>
-                <th>
-                  SourceRepoLink
-                </th>
-              </tr>
-              <tr
-                class="table_data"
-              >
-                <td>
-                  testing-app
-                </td>
-                <td>
-                  v1.2.3
-                </td>
-                <td>
-                  dev
-                </td>
-                <td>
-                  sre-team
-                </td>
-                <td />
-                <td />
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`Product Version Data Displays Product Version Page test the release train button shown 1`] = `
 <body>
   <div>
     <div

--- a/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.test.tsx
@@ -162,7 +162,7 @@ const dataCallbacks: TestDataCallbacks[] = [
         },
         clickThis: confirmButtonSelector,
         expectedCancelCallCount: 0,
-        expectedSubmitCallCount: 1,
+        expectedSubmitCallCount: 0,
     },
 ];
 

--- a/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.test.tsx
@@ -22,8 +22,10 @@ type TestDataSelection = {
     input: EnvSelectionDialogProps;
     expectedNumItems: number;
     clickOnButton: string;
+    secondClick: string;
     expectedNumSelectedAfterClick: number;
     expectedNumDeselectedAfterClick: number;
+    expectedNumSelectedAfterSecondClick: number;
 };
 
 const mySubmitSpy = jest.fn();
@@ -45,6 +47,8 @@ const dataSelection: TestDataSelection[] = [
         clickOnButton: 'dev',
         expectedNumSelectedAfterClick: 1,
         expectedNumDeselectedAfterClick: 1,
+        secondClick: 'staging',
+        expectedNumSelectedAfterSecondClick: 2,
     },
     {
         name: 'renders 3 item list',
@@ -59,6 +63,40 @@ const dataSelection: TestDataSelection[] = [
         clickOnButton: 'staging',
         expectedNumSelectedAfterClick: 1,
         expectedNumDeselectedAfterClick: 2,
+        secondClick: 'prod',
+        expectedNumSelectedAfterSecondClick: 2,
+    },
+    {
+        name: 'only one item allowed for release trains',
+        input: {
+            environments: ['dev', 'staging', 'prod'],
+            open: true,
+            onSubmit: mySubmitSpy,
+            onCancel: myCancelSpy,
+            envSelectionDialog: false,
+        },
+        expectedNumItems: 3,
+        clickOnButton: 'staging',
+        expectedNumSelectedAfterClick: 1,
+        expectedNumDeselectedAfterClick: 2,
+        secondClick: 'prod',
+        expectedNumSelectedAfterSecondClick: 1,
+    },
+    {
+        name: 'renders empty item list',
+        input: {
+            environments: [],
+            open: true,
+            onSubmit: mySubmitSpy,
+            onCancel: myCancelSpy,
+            envSelectionDialog: true,
+        },
+        expectedNumItems: 0,
+        clickOnButton: '',
+        expectedNumSelectedAfterClick: 0,
+        expectedNumDeselectedAfterClick: 0,
+        secondClick: '',
+        expectedNumSelectedAfterSecondClick: 0,
     },
 ];
 
@@ -144,15 +182,30 @@ describe('EnvSelectionDialog', () => {
             expect(document.querySelectorAll('.envs-dropdown-select .test-button-checkbox').length).toEqual(
                 testcase.expectedNumItems
             );
-            const result = documentQuerySelectorSafe('.id-' + testcase.clickOnButton);
-            act(() => {
-                result.click();
-            });
+            if (testcase.clickOnButton !== '') {
+                const result = documentQuerySelectorSafe('.id-' + testcase.clickOnButton);
+                act(() => {
+                    result.click();
+                });
+            } else {
+                expect(document.querySelector('.env-selection-dialog')?.textContent).toContain(
+                    'There are no environments'
+                );
+            }
             expect(document.querySelectorAll('.test-button-checkbox.enabled').length).toEqual(
                 testcase.expectedNumSelectedAfterClick
             );
             expect(document.querySelectorAll('.test-button-checkbox.disabled').length).toEqual(
                 testcase.expectedNumDeselectedAfterClick
+            );
+            if (testcase.secondClick !== '') {
+                const result = documentQuerySelectorSafe('.id-' + testcase.secondClick);
+                act(() => {
+                    result.click();
+                });
+            }
+            expect(document.querySelectorAll('.test-button-checkbox.enabled').length).toEqual(
+                testcase.expectedNumSelectedAfterSecondClick
             );
         });
     });

--- a/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.tsx
@@ -17,6 +17,7 @@ import * as React from 'react';
 import { useState } from 'react';
 import { Checkbox } from '../dropdown/checkbox';
 import { ConfirmationDialog } from '../dialog/ConfirmationDialog';
+import { showSnackbarError } from '../../utils/store';
 
 export type EnvSelectionDialogProps = {
     environments: string[];
@@ -30,6 +31,10 @@ export const EnvSelectionDialog: React.FC<EnvSelectionDialogProps> = (props) => 
     const [selectedEnvs, setSelectedEnvs] = useState<string[]>([]);
 
     const onConfirm = React.useCallback(() => {
+        if (selectedEnvs.length < 1) {
+            showSnackbarError('There needs to be at least one environment selected to perform this action');
+            return;
+        }
         props.onSubmit(selectedEnvs);
         setSelectedEnvs([]);
     }, [props, selectedEnvs]);
@@ -41,16 +46,16 @@ export const EnvSelectionDialog: React.FC<EnvSelectionDialogProps> = (props) => 
 
     const addTeam = React.useCallback(
         (env: string) => {
-            const newTeam = env;
-            const indexOf = selectedEnvs.indexOf(newTeam);
+            const newEnv = env;
+            const indexOf = selectedEnvs.indexOf(newEnv);
             if (indexOf >= 0) {
                 const copy = selectedEnvs.concat();
                 copy.splice(indexOf, 1);
                 setSelectedEnvs(copy);
             } else if (!props.envSelectionDialog) {
-                setSelectedEnvs([newTeam]);
+                setSelectedEnvs([newEnv]);
             } else {
-                setSelectedEnvs(selectedEnvs.concat(newTeam));
+                setSelectedEnvs(selectedEnvs.concat(newEnv));
             }
         },
         [props.envSelectionDialog, selectedEnvs]
@@ -91,8 +96,8 @@ export const EnvSelectionDialog: React.FC<EnvSelectionDialogProps> = (props) => 
                         <div id="missing_envs">There are no environments to list</div>
                     ) : (
                         <div id="missing_envs">
-                            There are no environments that have the selected environment as the upstream target or you
-                            are attempting with an environment group
+                            There are no available environments to run a release train to based on the current
+                            environment/environmentGroup
                         </div>
                     )}
                 </div>

--- a/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/EnvSelectionDialog.tsx
@@ -47,11 +47,13 @@ export const EnvSelectionDialog: React.FC<EnvSelectionDialogProps> = (props) => 
                 const copy = selectedEnvs.concat();
                 copy.splice(indexOf, 1);
                 setSelectedEnvs(copy);
+            } else if (!props.envSelectionDialog) {
+                setSelectedEnvs([newTeam]);
             } else {
                 setSelectedEnvs(selectedEnvs.concat(newTeam));
             }
         },
-        [selectedEnvs]
+        [props.envSelectionDialog, selectedEnvs]
     );
 
     return (
@@ -66,22 +68,35 @@ export const EnvSelectionDialog: React.FC<EnvSelectionDialogProps> = (props) => 
                     : 'Select which environments to run release train to:'
             }
             confirmLabel={props.envSelectionDialog ? 'Remove app from environments' : 'Release Train'}>
-            <div className="envs-dropdown-select">
-                {props.environments.map((env: string, index: number) => {
-                    const enabled = selectedEnvs.includes(env);
-                    return (
-                        <div key={env}>
-                            <Checkbox
-                                enabled={enabled}
-                                onClick={addTeam}
-                                id={String(env)}
-                                label={env}
-                                classes={'env' + env}
-                            />
+            {props.environments.length > 0 ? (
+                <div className="envs-dropdown-select">
+                    {props.environments.map((env: string, index: number) => {
+                        const enabled = selectedEnvs.includes(env);
+                        return (
+                            <div key={env}>
+                                <Checkbox
+                                    enabled={enabled}
+                                    onClick={addTeam}
+                                    id={String(env)}
+                                    label={env}
+                                    classes={'env' + env}
+                                />
+                            </div>
+                        );
+                    })}
+                </div>
+            ) : (
+                <div className="envs-dropdown-select">
+                    {props.envSelectionDialog ? (
+                        <div id="missing_envs">There are no environments to list</div>
+                    ) : (
+                        <div id="missing_envs">
+                            There are no environments that have the selected environment as the upstream target or you
+                            are attempting with an environment group
                         </div>
-                    );
-                })}
-            </div>
+                    )}
+                </div>
+            )}
         </ConfirmationDialog>
     );
 };

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.test.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.test.tsx
@@ -593,7 +593,7 @@ describe('Action details', () => {
                 type: ActionTypes.ReleaseTrain,
                 name: 'Release Train',
                 dialogTitle: 'Are you sure you want to run a Release Train',
-                summary: 'Run release train for environment dev',
+                summary: 'Run release train to environment dev',
                 tooltip: '',
                 environment: 'dev',
             },

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.test.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.test.tsx
@@ -577,6 +577,27 @@ describe('Action details', () => {
                 application: 'foo',
             },
         },
+        {
+            name: 'test releaseTrain action',
+            action: {
+                action: {
+                    $case: 'releaseTrain',
+                    releaseTrain: {
+                        target: 'dev',
+                        team: '',
+                        commitHash: '',
+                    },
+                },
+            },
+            expectedDetails: {
+                type: ActionTypes.ReleaseTrain,
+                name: 'Release Train',
+                dialogTitle: 'Are you sure you want to run a Release Train',
+                summary: 'Run release train for environment dev',
+                tooltip: '',
+                environment: 'dev',
+            },
+        },
     ];
 
     describe.each(data)('Test getActionDetails function', (testcase) => {

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -50,6 +50,7 @@ export enum ActionTypes {
     CreateApplicationLock,
     DeleteApplicationLock,
     DeleteEnvFromApp,
+    ReleaseTrain,
     UNKNOWN,
 }
 
@@ -186,6 +187,15 @@ export const getActionDetails = (
                     action.deleteEnvFromApp.application +
                     '"',
                 application: action.deleteEnvFromApp.application,
+            };
+        case 'releaseTrain':
+            return {
+                type: ActionTypes.ReleaseTrain,
+                name: 'Release Train',
+                dialogTitle: 'Are you sure you want to run a Release Train',
+                tooltip: '',
+                summary: 'Run release train for environment ' + action.releaseTrain.target,
+                environment: action.releaseTrain.target,
             };
         default:
             return {

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -194,7 +194,7 @@ export const getActionDetails = (
                 name: 'Release Train',
                 dialogTitle: 'Are you sure you want to run a Release Train',
                 tooltip: '',
-                summary: 'Run release train for environment ' + action.releaseTrain.target,
+                summary: 'Run release train to environment ' + action.releaseTrain.target,
                 environment: action.releaseTrain.target,
             };
         default:

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -249,10 +249,11 @@ export const addAction = (action: BatchAction): void => {
             if (
                 actions.some(
                     (act) =>
-                        act.action?.$case === 'deploy' &&
-                        action.action?.$case === 'deploy' &&
-                        act.action.deploy.application === action.action.deploy.application &&
-                        act.action.deploy.environment === action.action.deploy.environment
+                        (act.action?.$case === 'deploy' &&
+                            action.action?.$case === 'deploy' &&
+                            act.action.deploy.application === action.action.deploy.application &&
+                            act.action.deploy.environment === action.action.deploy.environment) ||
+                        act.action?.$case === 'releaseTrain'
                     // version, lockBehavior and ignoreAllLocks are ignored
                 )
             )
@@ -279,6 +280,16 @@ export const addAction = (action: BatchAction): void => {
                 )
             )
                 return;
+            break;
+        case 'releaseTrain':
+            // only allow one release train at a time to avoid conflicts or if there are existing deploy actions
+            if (actions.some((act) => act.action?.$case === 'releaseTrain' || act.action?.$case === 'deploy')) {
+                showSnackbarError(
+                    'Can only have one release train action at a time and can not have deploy actions in parrallel'
+                );
+                return;
+            }
+
             break;
     }
     UpdateAction.set({ actions: [...UpdateAction.get().actions, action] });


### PR DESCRIPTION
- Adding the action of a release train is blocked if there is a release train or deployment already in the list of actions
- Adding the action of a deployment is blocked if there is a release train already in the list of actions
- Add release train to sideBar via Release Train button on Product Version Page
- Only one environment selectable in popup from Release Train button


![Screenshot 2024-03-01 at 17 50 00](https://github.com/freiheit-com/kuberpult/assets/47796934/e8f25672-acd6-4104-acba-a904a96ed828)
Example of release train


REV: DSN-3ZRNTG