### PR TITLE
feat: Add lock-prevented-deployment commit event

### DIFF
--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -62,6 +62,7 @@ message Event {
   oneof event_type {
     CreateReleaseEvent create_release_event = 3;
     DeploymentEvent deployment_event = 4;
+    LockPreventedDeploymentEvent lock_prevented_deployment_event = 5;
   }
 }
 
@@ -77,6 +78,18 @@ message DeploymentEvent {
   string application = 1;
   string target_environment = 2;
   optional ReleaseTrainSource release_train_source = 3;
+}
+
+message LockPreventedDeploymentEvent {
+  enum LockType {
+    LOCK_TYPE_UNKNOWN = 0;
+    LOCK_TYPE_ENV = 1;
+    LOCK_TYPE_APP = 2;
+  }
+  string application = 1;
+  string environment = 2;
+  string lock_message = 3;
+  LockType lock_type = 4;
 }
 
 message TagData {

--- a/services/cd-service/pkg/event/event_test.go
+++ b/services/cd-service/pkg/event/event_test.go
@@ -60,6 +60,15 @@ func Test_roundtrip(t *testing.T) {
 				SourceTrainUpstream:         ptr("B"),
 			},
 		},
+		{
+			Name: "lock-prevented-deployment",
+			Event: &LockPreventedDeployment{
+				Application: "app",
+				Environment: "env",
+				LockMessage: "msg",
+				LockType:    "application",
+			},
+		},
 	} {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.test.tsx
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.test.tsx
@@ -16,7 +16,7 @@ Copyright 2023 freiheit.com*/
 import { render } from '@testing-library/react';
 import { CommitInfo } from './CommitInfo';
 import { MemoryRouter } from 'react-router-dom';
-import { GetCommitInfoResponse } from '../../../api/api';
+import { GetCommitInfoResponse, LockPreventedDeploymentEvent_LockType } from '../../../api/api';
 
 test('CommitInfo component does not render commit info when the response is undefined', () => {
     const { container } = render(
@@ -101,6 +101,19 @@ test('CommitInfo component renders commit info when the response is valid', () =
                             },
                         },
                     },
+                    {
+                        uuid: '00000000-0000-0000-0000-000000000004',
+                        createdAt: new Date('2024-02-13T09:46:00Z'),
+                        eventType: {
+                            $case: 'lockPreventedDeploymentEvent',
+                            lockPreventedDeploymentEvent: {
+                                application: 'app',
+                                environment: 'dev',
+                                lockMessage: 'locked',
+                                lockType: LockPreventedDeploymentEvent_LockType.LOCK_TYPE_ENV,
+                            },
+                        },
+                    },
                 ],
             },
             expectedTitle: 'Commit tomato',
@@ -122,6 +135,11 @@ test('CommitInfo component renders commit info when the response is valid', () =
                         '2024-02-12T09:46:00',
                         'Release train deployment of application app on environment group staging-group from environment dev to environment staging',
                         'staging',
+                    ],
+                    [
+                        '2024-02-13T09:46:00',
+                        'Application app was blocked from deploying due to an environment lock with message "locked"',
+                        'dev',
                     ],
                 ],
             },

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
@@ -16,7 +16,7 @@ Copyright 2023 freiheit.com*/
 
 import { TopAppBar } from '../TopAppBar/TopAppBar';
 import React from 'react';
-import { GetCommitInfoResponse, Event } from '../../../api/api';
+import { GetCommitInfoResponse, Event, LockPreventedDeploymentEvent_LockType } from '../../../api/api';
 
 type CommitInfoProps = {
     commitInfo: GetCommitInfoResponse | undefined;
@@ -134,5 +134,25 @@ const eventDescription = (event: Event): [JSX.Element, string] => {
                     );
             }
             return [description, de.targetEnvironment];
+        case 'lockPreventedDeploymentEvent':
+            const inner = tp.lockPreventedDeploymentEvent;
+            return [
+                <span>
+                    Application <b>{inner.application}</b> was blocked from deploying due to{' '}
+                    {lockTypeName(inner.lockType)} with message "{inner.lockMessage}"
+                </span>,
+                inner.environment,
+            ];
+    }
+};
+
+const lockTypeName = (tp: LockPreventedDeploymentEvent_LockType): string => {
+    switch (tp) {
+        case LockPreventedDeploymentEvent_LockType.LOCK_TYPE_APP:
+            return 'an application lock';
+        case LockPreventedDeploymentEvent_LockType.LOCK_TYPE_ENV:
+            return 'an environment lock';
+        case LockPreventedDeploymentEvent_LockType.LOCK_TYPE_UNKNOWN:
+            return 'an unknown lock';
     }
 };


### PR DESCRIPTION
Whenever a lock (application or environment) blocks the deployment of an app, this event is created.