### PR TITLE
fix: add Earthly to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ jobs:
     name: Release kuberpult with semantic versioning
     runs-on: ubuntu-latest
     steps:
+      - name: Install earthly
+        uses: earthly/actions-setup@v1
+        with:
+            version: v0.8.4
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # needed for git describe/VERSION in Makefile


### PR DESCRIPTION
Due to #1378 the release workflow fails as Earthly is not installed there, this should fix that.