### PR TITLE
feat: add `exhaustruct` to CI

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -28,7 +28,7 @@ deps:
     RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@$GO_CI_LINT_VERSION
 
     RUN wget https://github.com/GaijinEntertainment/go-exhaustruct/archive/refs/tags/v3.2.0.tar.gz -O exhaustruct.tar.gz
-    RUN echo 511d0ba05092386a59dca74b6cbeb99f510b814261cc04b68213a9ae31cf8bf6  exchaustruct.tar.gz | sha256sum -c
+    RUN echo 511d0ba05092386a59dca74b6cbeb99f510b814261cc04b68213a9ae31cf8bf6  exhaustruct.tar.gz | sha256sum -c
     RUN tar xzf exhaustruct.tar.gz
     WORKDIR go-exhaustruct-3.2.0
     RUN go build ./cmd/exhaustruct

--- a/Earthfile
+++ b/Earthfile
@@ -27,6 +27,13 @@ deps:
     ARG GO_CI_LINT_VERSION="v1.51.2"
     RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@$GO_CI_LINT_VERSION
 
+    RUN wget https://github.com/GaijinEntertainment/go-exhaustruct/archive/refs/tags/v3.2.0.tar.gz -O exhaustruct.tar.gz
+    RUN tar xzf exhaustruct.tar.gz
+    WORKDIR go-exhaustruct-3.2.0
+    RUN go build ./cmd/exhaustruct
+    RUN echo c1378c7cd853e989854022fdab1fe4f4a634c22a54f1f255f07cfff1e81b378a  exhaustruct | sha256sum -c
+    RUN mv exhaustruct /usr/local/bin/exhaustruct
+
     WORKDIR /kp
     COPY go.mod go.sum ./
     RUN go mod download

--- a/Earthfile
+++ b/Earthfile
@@ -28,10 +28,10 @@ deps:
     RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@$GO_CI_LINT_VERSION
 
     RUN wget https://github.com/GaijinEntertainment/go-exhaustruct/archive/refs/tags/v3.2.0.tar.gz -O exhaustruct.tar.gz
+    RUN echo 511d0ba05092386a59dca74b6cbeb99f510b814261cc04b68213a9ae31cf8bf6  exchaustruct.tar.gz | sha256sum -c
     RUN tar xzf exhaustruct.tar.gz
     WORKDIR go-exhaustruct-3.2.0
     RUN go build ./cmd/exhaustruct
-    RUN echo c1378c7cd853e989854022fdab1fe4f4a634c22a54f1f255f07cfff1e81b378a  exhaustruct | sha256sum -c
     RUN mv exhaustruct /usr/local/bin/exhaustruct
 
     WORKDIR /kp

--- a/infrastructure/earthly/go/Earthfile
+++ b/infrastructure/earthly/go/Earthfile
@@ -45,6 +45,8 @@ LINT:
         RUN echo "Formatting required for:\n$FILES_TO_FORMAT\nRun \"go fmt ./...\" to fix the errors" && exit 1
     END
 
+    RUN exhaustruct ./...
+
 DOCKER:
     FUNCTION
     ARG UID=1000


### PR DESCRIPTION
Here we add the [`exhaustruct`](https://github.com/GaijinEntertainment/go-exhaustruct) linter to CI. The CI will fail if there are uninitialized struct fields in Go code (excluding test and generated files).

Note that `golangci-lint`, which is currently executed in the CI, does [support](https://golangci-lint.run/usage/linters/#exhaustruct) `exhaustruct`. However, there seems to be an issue when running `exhaustruct` through `golangci-lint`: it doesn't respect the `//exhaustruct:ignore` comments. Therefore, we will stick to running `exhaustruct` separately.