### PR TITLE
chore: initialize all struct in CD service

### DIFF
--- a/services/cd-service/pkg/argocd/render.go
+++ b/services/cd-service/pkg/argocd/render.go
@@ -98,7 +98,10 @@ func RenderV1Alpha1(gitUrl string, gitBranch string, config config.EnvironmentCo
 	project := v1alpha1.AppProject{
 		TypeMeta: v1alpha1.AppProjectTypeMeta,
 		ObjectMeta: v1alpha1.ObjectMeta{
-			Name: env,
+			Annotations: nil,
+			Labels:      nil,
+			Finalizers:  nil,
+			Name:        env,
 		},
 		Spec: v1alpha1.AppProjectSpec{
 			Description:              env,

--- a/services/cd-service/pkg/argocd/reposerver/reposerver.go
+++ b/services/cd-service/pkg/argocd/reposerver/reposerver.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"time"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	argorepo "github.com/argoproj/argo-cd/v2/reposerver/apiclient"
@@ -34,6 +35,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type reposerver struct {
@@ -93,9 +95,15 @@ func (r *reposerver) GenerateManifest(ctx context.Context, req *argorepo.Manifes
 		return nil, err
 	}
 	resp := &argorepo.ManifestResponse{
-		Manifests:  mn,
-		Revision:   state.Commit.Id().String(),
-		SourceType: "Directory",
+		Namespace:            "",
+		Server:               "",
+		VerifyResult:         "",
+		XXX_NoUnkeyedLiteral: struct{}{},
+		XXX_unrecognized:     nil,
+		XXX_sizecache:        0,
+		Manifests:            mn,
+		Revision:             state.Commit.Id().String(),
+		SourceType:           "Directory",
 	}
 	return resp, nil
 }
@@ -118,7 +126,15 @@ func (*reposerver) GetHelmCharts(context.Context, *argorepo.HelmChartsRequest) (
 // GetRevisionMetadata implements apiclient.RepoServerServiceServer.
 func (*reposerver) GetRevisionMetadata(ctx context.Context, req *argorepo.RepoServerRevisionMetadataRequest) (*v1alpha1.RevisionMetadata, error) {
 	// It doesn't matter too much what is in here as long as we don't give an error.
-	return &v1alpha1.RevisionMetadata{}, nil
+	return &v1alpha1.RevisionMetadata{
+		Author: "",
+		Date: v1.Time{
+			Time: time.Time{},
+		},
+		Tags:          nil,
+		Message:       "",
+		SignatureInfo: "",
+	}, nil
 }
 
 // ListApps implements apiclient.RepoServerServiceServer.
@@ -143,15 +159,21 @@ func (r *reposerver) ResolveRevision(ctx context.Context, req *argorepo.ResolveR
 		// This looks a bit strange but argocd actually responds with a succes response if the ambiguous ref can be parsed as a git commit id even if that commit does not exists at all.
 		if serr, ok := status.FromError(err); ok && serr.Code() == codes.NotFound && oid != nil {
 			return &argorepo.ResolveRevisionResponse{
-				Revision:          oid.String(),
-				AmbiguousRevision: fmt.Sprintf("%s (%s)", req.AmbiguousRevision, oid),
+				XXX_NoUnkeyedLiteral: struct{}{},
+				XXX_unrecognized:     nil,
+				XXX_sizecache:        0,
+				Revision:             oid.String(),
+				AmbiguousRevision:    fmt.Sprintf("%s (%s)", req.AmbiguousRevision, oid),
 			}, nil
 		}
 		return nil, err
 	}
 	resp := argorepo.ResolveRevisionResponse{
-		Revision:          state.Commit.Id().String(),
-		AmbiguousRevision: fmt.Sprintf("%s (%s)", req.AmbiguousRevision, state.Commit.Id()),
+		XXX_NoUnkeyedLiteral: struct{}{},
+		XXX_unrecognized:     nil,
+		XXX_sizecache:        0,
+		Revision:             state.Commit.Id().String(),
+		AmbiguousRevision:    fmt.Sprintf("%s (%s)", req.AmbiguousRevision, state.Commit.Id()),
 	}
 	return &resp, nil
 }

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -154,10 +154,11 @@ func RunServer() {
 		}
 
 		cfg := repository.RepositoryConfig{
-			URL:            c.GitUrl,
-			Path:           "./repository",
-			CommitterEmail: c.GitCommitterEmail,
-			CommitterName:  c.GitCommitterName,
+			WebhookResolver: repository.DefaultWebhookResolver{},
+			URL:             c.GitUrl,
+			Path:            "./repository",
+			CommitterEmail:  c.GitCommitterEmail,
+			CommitterName:   c.GitCommitterName,
 			Credentials: repository.Credentials{
 				SshKey: c.GitSshKey,
 			},
@@ -191,6 +192,7 @@ func RunServer() {
 		shutdownCh := make(chan struct{})
 		setup.Run(ctx, setup.ServerConfig{
 			HTTP: []setup.HTTPConfig{
+				//exhaustruct:ignore
 				{
 					Port: "8080",
 					Register: func(mux *http.ServeMux) {
@@ -203,7 +205,8 @@ func RunServer() {
 				},
 			},
 			GRPC: &setup.GRPCConfig{
-				Port: "8443",
+				Shutdown: nil,
+				Port:     "8443",
 				Opts: []grpc.ServerOption{
 					grpc.ChainStreamInterceptor(grpcStreamInterceptors...),
 					grpc.ChainUnaryInterceptor(grpcUnaryInterceptors...),
@@ -236,7 +239,8 @@ func RunServer() {
 			},
 			Background: []setup.BackgroundTaskConfig{
 				{
-					Name: "ddmetrics",
+					Shutdown: nil,
+					Name:     "ddmetrics",
 					Run: func(ctx context.Context, reporter *setup.HealthReporter) error {
 						reporter.ReportReady("sending metrics")
 						repository.RegularlySendDatadogMetrics(repo, 300, func(repository2 repository.Repository) {
@@ -246,8 +250,9 @@ func RunServer() {
 					},
 				},
 				{
-					Name: "push queue",
-					Run:  repoQueue,
+					Shutdown: nil,
+					Name:     "push queue",
+					Run:      repoQueue,
 				},
 			},
 			Shutdown: func(ctx context.Context) error {

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -154,7 +154,7 @@ func RunServer() {
 		}
 
 		cfg := repository.RepositoryConfig{
-			WebhookResolver: repository.DefaultWebhookResolver{},
+			WebhookResolver: nil,
 			URL:             c.GitUrl,
 			Path:            "./repository",
 			CommitterEmail:  c.GitCommitterEmail,

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -192,8 +192,9 @@ func RunServer() {
 		shutdownCh := make(chan struct{})
 		setup.Run(ctx, setup.ServerConfig{
 			HTTP: []setup.HTTPConfig{
-				//exhaustruct:ignore
 				{
+					BasicAuth: nil,
+					Shutdown: nil,
 					Port: "8080",
 					Register: func(mux *http.ServeMux) {
 						handler := logger.WithHttpLogger(httpServerLogger, repositoryService)

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -194,8 +194,8 @@ func RunServer() {
 			HTTP: []setup.HTTPConfig{
 				{
 					BasicAuth: nil,
-					Shutdown: nil,
-					Port: "8080",
+					Shutdown:  nil,
+					Port:      "8080",
 					Register: func(mux *http.ServeMux) {
 						handler := logger.WithHttpLogger(httpServerLogger, repositoryService)
 						if c.EnableTracing {

--- a/services/cd-service/pkg/event/event.go
+++ b/services/cd-service/pkg/event/event.go
@@ -72,6 +72,7 @@ func (ev *Deployment) toProto(trg *api.Event) {
 	var releaseTrainSource *api.DeploymentEvent_ReleaseTrainSource
 	if ev.SourceTrainEnvironmentGroup != nil {
 		releaseTrainSource = &api.DeploymentEvent_ReleaseTrainSource{
+			UpstreamEnvironment:    "",
 			TargetEnvironmentGroup: ev.SourceTrainEnvironmentGroup,
 		}
 	}
@@ -136,10 +137,13 @@ func Read(fs billy.Filesystem, eventDir string) (Event, error) {
 	var result Event
 	switch tp.EventType {
 	case "new-release":
+		//exhaustruct:ignore
 		result = &NewRelease{}
 	case "deployment":
+		//exhaustruct:ignore
 		result = &Deployment{}
 	case "lock-prevented-deployment":
+		//exhaustruct:ignore
 		result = &LockPreventedDeployment{}
 	default:
 		return nil, fmt.Errorf("unknown event type: %q", tp.EventType)
@@ -167,6 +171,7 @@ func Write(filesystem billy.Filesystem, eventDir string, event Event) error {
 // Convert an event to its protobuf representation
 func ToProto(eventID timeuuid.UUID, ev Event) *api.Event {
 	result := &api.Event{
+		EventType: nil,
 		CreatedAt: uuid.GetTime(&eventID),
 		Uuid:      eventID.String(),
 	}

--- a/services/cd-service/pkg/mapper/environments_config.go
+++ b/services/cd-service/pkg/mapper/environments_config.go
@@ -37,14 +37,19 @@ func MapEnvironmentsToGroups(envs map[string]config.EnvironmentConfig) []*api.En
 		var bucket, ok = buckets[groupName]
 		if !ok {
 			bucket = &api.EnvironmentGroup{
+				DistanceToUpstream:   0,
+				Priority:             api.Priority_PROD,
 				EnvironmentGroupName: groupNameCopy,
 				Environments:         []*api.Environment{},
 			}
 			buckets[groupNameCopy] = bucket
 		}
 		var newEnv = &api.Environment{
-			Name: envName,
+			DistanceToUpstream: 0,
+			Priority:           api.Priority_PROD,
+			Name:               envName,
 			Config: &api.EnvironmentConfig{
+				Argocd:           nil,
 				Upstream:         TransformUpstream(env.Upstream),
 				EnvironmentGroup: &groupNameCopy,
 			},
@@ -301,11 +306,13 @@ func TransformUpstream(upstream *config.EnvironmentConfigUpstream) *api.Environm
 	}
 	if upstream.Latest {
 		return &api.EnvironmentConfig_Upstream{
-			Latest: &upstream.Latest,
+			Environment: nil,
+			Latest:      &upstream.Latest,
 		}
 	}
 	if upstream.Environment != "" {
 		return &api.EnvironmentConfig_Upstream{
+			Latest:      nil,
 			Environment: &upstream.Environment,
 		}
 	}

--- a/services/cd-service/pkg/repository/credentials.go
+++ b/services/cd-service/pkg/repository/credentials.go
@@ -43,7 +43,10 @@ func base64encode(c []byte) string {
 }
 
 func (c *Credentials) load() (*credentialsStore, error) {
-	store := &credentialsStore{}
+	store := &credentialsStore{
+		sshPrivateKey: "",
+		sshPublicKey:  "",
+	}
 	if c.SshKey != "" {
 		pkey, err := os.Open(c.SshKey)
 		if err != nil {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -228,8 +228,14 @@ func GetTags(cfg RepositoryConfig, repoName string, ctx context.Context) (tags [
 		CredentialsCallback:      credentials.CredentialsCallback(ctx),
 		CertificateCheckCallback: certificates.CertificateCheckCallback(ctx),
 	}
-	//exhaustruct:ignore
 	fetchOptions := git.FetchOptions{
+		Prune: git.FetchPruneUnspecified,
+		UpdateFetchhead: false,
+		Headers: nil,
+		ProxyOptions: git.ProxyOptions{
+			Type: git.ProxyTypeNone,
+			Url: "",
+		},
 		RemoteCallbacks: RemoteCallbacks,
 		DownloadTags:    git.DownloadTagsAll,
 	}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -118,13 +118,18 @@ type WebhookResolver interface {
 type DefaultWebhookResolver struct{}
 
 func (r DefaultWebhookResolver) Resolve(insecure bool, req *http.Request) (*http.Response, error) {
-	tr := &http.Transport{
-		// we reach argo from within the cluster, so there's no ssl:
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: insecure,
-		},
+	//exhaustruct:ignore
+	TLSClientConfig := &tls.Config{
+		InsecureSkipVerify: insecure,
 	}
-	client := &http.Client{Transport: tr}
+	//exhaustruct:ignore
+	tr := &http.Transport{
+		TLSClientConfig: TLSClientConfig,
+	}
+	//exhaustruct:ignore
+	client := &http.Client{
+		Transport: tr,
+	}
 	return client.Do(req)
 }
 
@@ -218,12 +223,15 @@ func GetTags(cfg RepositoryConfig, repoName string, ctx context.Context) (tags [
 	}
 
 	fetchSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", cfg.Branch, cfg.Branch)
+	//exhaustruct:ignore
+	RemoteCallbacks := git.RemoteCallbacks{
+		CredentialsCallback:      credentials.CredentialsCallback(ctx),
+		CertificateCheckCallback: certificates.CertificateCheckCallback(ctx),
+	}
+	//exhaustruct:ignore
 	fetchOptions := git.FetchOptions{
-		RemoteCallbacks: git.RemoteCallbacks{
-			CredentialsCallback:      credentials.CredentialsCallback(ctx),
-			CertificateCheckCallback: certificates.CertificateCheckCallback(ctx),
-		},
-		DownloadTags: git.DownloadTagsAll,
+		RemoteCallbacks: RemoteCallbacks,
+		DownloadTags:    git.DownloadTagsAll,
 	}
 	remote, err := repo.Remotes.CreateAnonymous(cfg.URL)
 	if err != nil {
@@ -323,6 +331,10 @@ func New2(ctx context.Context, cfg RepositoryConfig) (Repository, setup.Backgrou
 			return nil, nil, err
 		} else {
 			result := &repository{
+				writesDone:      0,
+				headLock:        sync.Mutex{},
+				notify:          notify.Notify{},
+				writeLock:       sync.Mutex{},
 				config:          &cfg,
 				credentials:     credentials,
 				certificates:    certificates,
@@ -334,18 +346,28 @@ func New2(ctx context.Context, cfg RepositoryConfig) (Repository, setup.Backgrou
 
 			defer result.headLock.Unlock()
 			fetchSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", cfg.Branch, cfg.Branch)
-			fetchOptions := git.FetchOptions{
-				RemoteCallbacks: git.RemoteCallbacks{
-					UpdateTipsCallback: func(refname string, a *git.Oid, b *git.Oid) error {
-						logger.Debug("git.fetched",
-							zap.String("refname", refname),
-							zap.String("revision.new", b.String()),
-						)
-						return nil
-					},
-					CredentialsCallback:      credentials.CredentialsCallback(ctx),
-					CertificateCheckCallback: certificates.CertificateCheckCallback(ctx),
+			//exhaustruct:ignore
+			RemoteCallbacks := git.RemoteCallbacks{
+				UpdateTipsCallback: func(refname string, a *git.Oid, b *git.Oid) error {
+					logger.Debug("git.fetched",
+						zap.String("refname", refname),
+						zap.String("revision.new", b.String()),
+					)
+					return nil
 				},
+				CredentialsCallback:      credentials.CredentialsCallback(ctx),
+				CertificateCheckCallback: certificates.CertificateCheckCallback(ctx),
+			}
+			fetchOptions := git.FetchOptions{
+				Prune:           git.FetchPruneUnspecified,
+				UpdateFetchhead: false,
+				DownloadTags:    git.DownloadTagsUnspecified,
+				Headers:         nil,
+				ProxyOptions: git.ProxyOptions{
+					Type: git.ProxyTypeNone,
+					Url:  "",
+				},
+				RemoteCallbacks: RemoteCallbacks,
 			}
 			err := remote.Fetch([]string{fetchSpec}, &fetchOptions, "fetching")
 			if err != nil {
@@ -418,6 +440,7 @@ func (r *repository) ProcessQueue(ctx context.Context, health *setup.HealthRepor
 }
 
 func (r *repository) applyElements(elements []element, allowFetchAndReset bool) ([]element, error, *TransformerResult) {
+	//exhaustruct:ignore
 	var changes = &TransformerResult{}
 	for i := 0; i < len(elements); {
 		e := elements[i]
@@ -533,12 +556,21 @@ func (r *repository) ProcessQueueOnce(ctx context.Context, e element, callback P
 	elements = append(elements, r.drainQueue()...)
 
 	var pushSuccess = true
+
+	//exhaustruct:ignore
+	RemoteCallbacks := git.RemoteCallbacks{
+		CredentialsCallback:         r.credentials.CredentialsCallback(e.ctx),
+		CertificateCheckCallback:    r.certificates.CertificateCheckCallback(e.ctx),
+		PushUpdateReferenceCallback: callback(r.config.Branch, &pushSuccess),
+	}
 	pushOptions := git.PushOptions{
-		RemoteCallbacks: git.RemoteCallbacks{
-			CredentialsCallback:         r.credentials.CredentialsCallback(e.ctx),
-			CertificateCheckCallback:    r.certificates.CertificateCheckCallback(e.ctx),
-			PushUpdateReferenceCallback: callback(r.config.Branch, &pushSuccess),
+		PbParallelism: 0,
+		Headers:       nil,
+		ProxyOptions: git.ProxyOptions{
+			Type: git.ProxyTypeNone,
+			Url:  "",
 		},
+		RemoteCallbacks: RemoteCallbacks,
 	}
 
 	// Apply the items
@@ -621,7 +653,8 @@ func (r *repository) sendWebhookToArgoCd(ctx context.Context, logger *zap.Logger
 		htmlUrl:  r.config.WebURL, // if this does not match, argo will completely ignore the request and return 200
 		revision: "refs/heads/" + r.config.Branch,
 		change: changeInfo{
-			payloadAfter: changes.Commits.Current.String(),
+			payloadBefore: "",
+			payloadAfter:  changes.Commits.Current.String(),
 		},
 		defaultBranch: r.config.Branch, // this is questionable, because we don't actually know the default branch, but it seems to work fine in practice
 		Commits: []commit{
@@ -681,15 +714,18 @@ func doWebhookPostRequest(ctx context.Context, data ArgoWebhookData, repoConfig 
 	l := logger.FromContext(ctx)
 	l.Info(fmt.Sprintf("doWebhookPostRequest: URL: %s", url))
 
+	//exhaustruct:ignore
+	Repository := v1alpha1.Repository{
+		HTMLURL:       data.htmlUrl,
+		DefaultBranch: data.defaultBranch,
+	}
+	//exhaustruct:ignore
 	var argoFormat = v1alpha1.PushPayload{
-		Ref:    data.revision,
-		Before: data.change.payloadBefore,
-		After:  data.change.payloadAfter,
-		Repository: v1alpha1.Repository{
-			HTMLURL:       data.htmlUrl,
-			DefaultBranch: data.defaultBranch,
-		},
-		Commits: toArgoCommits(data.Commits),
+		Ref:        data.revision,
+		Before:     data.change.payloadBefore,
+		After:      data.change.payloadAfter,
+		Repository: Repository,
+		Commits:    toArgoCommits(data.Commits),
 	}
 
 	jsonBytes, err := json.MarshalIndent(argoFormat, " ", " ")
@@ -753,12 +789,12 @@ func toArgoCommits(commits []commit) []v1alpha1.Commit {
 				Name     string `json:"name"`
 				Email    string `json:"email"`
 				Username string `json:"username"`
-			}{},
+			}{Name: "", Email: "", Username: ""},
 			Committer: struct {
 				Name     string `json:"name"`
 				Email    string `json:"email"`
 				Username string `json:"username"`
-			}{},
+			}{Name: "", Email: "", Username: ""},
 			Added:    c.Added,
 			Removed:  c.Removed,
 			Modified: c.Modified,
@@ -858,6 +894,7 @@ func (r *TransformerResult) Combine(other *TransformerResult) {
 }
 
 func CombineArray(others []*TransformerResult) *TransformerResult {
+	//exhaustruct:ignore
 	var r *TransformerResult = &TransformerResult{}
 	for i := range others {
 		r.Combine(others[i])
@@ -928,18 +965,28 @@ func (r *repository) ApplyTransformers(ctx context.Context, transformers ...Tran
 func (r *repository) FetchAndReset(ctx context.Context) error {
 	fetchSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", r.config.Branch, r.config.Branch)
 	logger := logger.FromContext(ctx)
-	fetchOptions := git.FetchOptions{
-		RemoteCallbacks: git.RemoteCallbacks{
-			UpdateTipsCallback: func(refname string, a *git.Oid, b *git.Oid) error {
-				logger.Debug("git.fetched",
-					zap.String("refname", refname),
-					zap.String("revision.new", b.String()),
-				)
-				return nil
-			},
-			CredentialsCallback:      r.credentials.CredentialsCallback(ctx),
-			CertificateCheckCallback: r.certificates.CertificateCheckCallback(ctx),
+	//exhaustruct:ignore
+	RemoteCallbacks := git.RemoteCallbacks{
+		UpdateTipsCallback: func(refname string, a *git.Oid, b *git.Oid) error {
+			logger.Debug("git.fetched",
+				zap.String("refname", refname),
+				zap.String("revision.new", b.String()),
+			)
+			return nil
 		},
+		CredentialsCallback:      r.credentials.CredentialsCallback(ctx),
+		CertificateCheckCallback: r.certificates.CertificateCheckCallback(ctx),
+	}
+	fetchOptions := git.FetchOptions{
+		Prune:           git.FetchPruneUnspecified,
+		UpdateFetchhead: false,
+		DownloadTags:    git.DownloadTagsUnspecified,
+		Headers:         nil,
+		ProxyOptions: git.ProxyOptions{
+			Type: git.ProxyTypeNone,
+			Url:  "",
+		},
+		RemoteCallbacks: RemoteCallbacks,
 	}
 	err := r.useRemote(ctx, func(remote *git.Remote) error {
 		return remote.Fetch([]string{fetchSpec}, &fetchOptions, "fetching")
@@ -971,6 +1018,7 @@ func (r *repository) FetchAndReset(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	//exhaustruct:ignore
 	err = r.repository.ResetToCommit(commit, git.ResetSoft, &git.CheckoutOptions{Strategy: git.CheckoutForce})
 	if err != nil {
 		return err
@@ -1105,6 +1153,7 @@ func (r *repository) StateAt(oid *git.Oid) (*State, error) {
 			if errors.As(err, &gerr) {
 				if gerr.Code == git.ErrNotFound {
 					return &State{
+						Commit:                 nil,
 						Filesystem:             fs.NewEmptyTreeBuildFS(r.repository),
 						BootstrapMode:          r.config.BootstrapMode,
 						EnvironmentConfigsPath: r.config.EnvironmentConfigsPath,
@@ -1266,7 +1315,14 @@ type Lock struct {
 }
 
 func readLock(fs billy.Filesystem, lockDir string) (*Lock, error) {
-	lock := &Lock{}
+	lock := &Lock{
+		Message: "",
+		CreatedBy: Actor{
+			Name:  "",
+			Email: "",
+		},
+		CreatedAt: time.Time{},
+	}
 
 	if cnt, err := readFile(fs, fs.Join(lockDir, "message")); err != nil {
 		if !os.IsNotExist(err) {
@@ -1640,7 +1696,15 @@ func (s *State) GetApplicationRelease(application string, version uint64) (*Rele
 	if err != nil {
 		return nil, wrapFileError(err, base, "could not call stat")
 	}
-	release := Release{Version: version}
+	release := Release{
+		Version:         version,
+		UndeployVersion: false,
+		SourceAuthor:    "",
+		SourceCommitId:  "",
+		SourceMessage:   "",
+		CreatedAt:       time.Time{},
+		DisplayVersion:  "",
+	}
 	if cnt, err := readFile(s.Filesystem, s.Filesystem.Join(base, "source_commit_id")); err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -796,8 +796,8 @@ func toArgoCommits(commits []commit) []v1alpha1.Commit {
 				Email    string `json:"email"`
 				Username string `json:"username"`
 			}{
-				Name: "",
-				Email: "",
+				Name:     "",
+				Email:    "",
 				Username: "",
 			},
 			Committer: struct {
@@ -805,8 +805,8 @@ func toArgoCommits(commits []commit) []v1alpha1.Commit {
 				Email    string `json:"email"`
 				Username string `json:"username"`
 			}{
-				Name: "",
-				Email: "",
+				Name:     "",
+				Email:    "",
 				Username: "",
 			},
 			Added:    c.Added,

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -795,12 +795,20 @@ func toArgoCommits(commits []commit) []v1alpha1.Commit {
 				Name     string `json:"name"`
 				Email    string `json:"email"`
 				Username string `json:"username"`
-			}{Name: "", Email: "", Username: ""},
+			}{
+				Name: "",
+				Email: "",
+				Username: "",
+			},
 			Committer: struct {
 				Name     string `json:"name"`
 				Email    string `json:"email"`
 				Username string `json:"username"`
-			}{Name: "", Email: "", Username: ""},
+			}{
+				Name: "",
+				Email: "",
+				Username: "",
+			},
 			Added:    c.Added,
 			Removed:  c.Removed,
 			Modified: c.Modified,

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -229,12 +229,12 @@ func GetTags(cfg RepositoryConfig, repoName string, ctx context.Context) (tags [
 		CertificateCheckCallback: certificates.CertificateCheckCallback(ctx),
 	}
 	fetchOptions := git.FetchOptions{
-		Prune: git.FetchPruneUnspecified,
+		Prune:           git.FetchPruneUnspecified,
 		UpdateFetchhead: false,
-		Headers: nil,
+		Headers:         nil,
 		ProxyOptions: git.ProxyOptions{
 			Type: git.ProxyTypeNone,
-			Url: "",
+			Url:  "",
 		},
 		RemoteCallbacks: RemoteCallbacks,
 		DownloadTags:    git.DownloadTagsAll,

--- a/services/cd-service/pkg/repository/testrepository/testrepository.go
+++ b/services/cd-service/pkg/repository/testrepository/testrepository.go
@@ -25,6 +25,7 @@ import (
 )
 
 func Failing(err error) repository.Repository {
+	//exhaustruct:ignore
 	return &failingRepository{err: err}
 }
 
@@ -46,10 +47,12 @@ func (fr *failingRepository) ApplyTransformersInternal(ctx context.Context, tran
 }
 
 func (fr *failingRepository) State() *repository.State {
+	//exhaustruct:ignore
 	return &repository.State{}
 }
 
 func (fr *failingRepository) StateAt(oid *git.Oid) (*repository.State, error) {
+	//exhaustruct:ignore
 	return &repository.State{}, nil
 }
 

--- a/services/cd-service/pkg/repository/testssh/server.go
+++ b/services/cd-service/pkg/repository/testssh/server.go
@@ -56,8 +56,10 @@ type exitReq struct {
 }
 
 func New(workdir string) *TestServer {
+	//exhaustruct:ignore
 	ts := TestServer{}
 	// Allocate a new listening port
+	//exhaustruct:ignore
 	ts.l, _ = net.ListenTCP("tcp", &net.TCPAddr{})
 	ts.Port = ts.l.Addr().(*net.TCPAddr).Port
 
@@ -67,8 +69,10 @@ func New(workdir string) *TestServer {
 	kh := knownhosts.Line([]string{fmt.Sprintf("127.0.0.1")}, ps.PublicKey())
 	ts.KnownHosts = filepath.Join(workdir, "known_hosts")
 	os.WriteFile(ts.KnownHosts, []byte(kh), 0644)
+	//exhaustruct:ignore
 	sc := &ssh.ServerConfig{
 		PublicKeyCallback: func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			//exhaustruct:ignore
 			return &ssh.Permissions{}, nil
 		},
 	}
@@ -78,8 +82,9 @@ func New(workdir string) *TestServer {
 	_, clientPriv, _ := ed25519.GenerateKey(nil)
 	ts.ClientKey = filepath.Join(workdir, "id_ed25519")
 	key := pem.EncodeToMemory(&pem.Block{
-		Type:  "OPENSSH PRIVATE KEY",
-		Bytes: edkey.MarshalED25519PrivateKey(clientPriv),
+		Headers: nil,
+		Type:    "OPENSSH PRIVATE KEY",
+		Bytes:   edkey.MarshalED25519PrivateKey(clientPriv),
 	})
 	os.WriteFile(ts.ClientKey, key, 0600)
 

--- a/services/cd-service/pkg/repository/testutil/testutil.go
+++ b/services/cd-service/pkg/repository/testutil/testutil.go
@@ -32,8 +32,9 @@ import (
 
 func MakeTestContext() context.Context {
 	u := auth.User{
-		Email: "testmail@example.com",
-		Name:  "test tester",
+		DexAuthContext: nil,
+		Email:          "testmail@example.com",
+		Name:           "test tester",
 	}
 	ctx := auth.WriteUserToContext(context.Background(), u)
 
@@ -73,7 +74,8 @@ func MakeEnvConfigLatest(argoCd *config.EnvironmentConfigArgoCd) config.Environm
 func MakeEnvConfigLatestWithGroup(argoCd *config.EnvironmentConfigArgoCd, envGroup *string) config.EnvironmentConfig {
 	return config.EnvironmentConfig{
 		Upstream: &config.EnvironmentConfigUpstream{
-			Latest: true,
+			Environment: "",
+			Latest:      true,
 		},
 		ArgoCd:           argoCd,
 		EnvironmentGroup: envGroup,
@@ -118,7 +120,9 @@ func (gen IncrementalUUID) Generate() string {
 }
 
 func NewIncrementalUUIDGenerator() uuid.GenerateUUIDs {
-	fakeGenBase := IncrementalUUIDBase{}
+	fakeGenBase := IncrementalUUIDBase{
+		count: 0,
+	}
 	fakeGen := IncrementalUUID{
 		gen: &fakeGenBase,
 	}

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -178,6 +178,7 @@ func (d *BatchServer) processAction(
 			b = api.LockBehavior_IGNORE
 		}
 		return &repository.DeployApplicationVersion{
+			SourceTrain:     nil,
 			Environment:     act.Environment,
 			Application:     act.Application,
 			Version:         act.Version,
@@ -201,6 +202,7 @@ func (d *BatchServer) processAction(
 			return nil, nil, status.Error(codes.InvalidArgument, "invalid Team name")
 		}
 		return &repository.ReleaseTrain{
+				Repo:            d.Repository,
 				Target:          in.Target,
 				Team:            in.Team,
 				CommitHash:      in.CommitHash,
@@ -239,6 +241,7 @@ func (d *BatchServer) processAction(
 		in := action.CreateEnvironment
 		conf := in.Config
 		if conf == nil {
+			//exhaustruct:ignore
 			conf = &api.EnvironmentConfig{}
 		}
 		var argocd *config.EnvironmentConfigArgoCd

--- a/services/cd-service/pkg/service/environment.go
+++ b/services/cd-service/pkg/service/environment.go
@@ -56,11 +56,13 @@ func transformUpstreamToConfig(upstream *api.EnvironmentConfig_Upstream) *config
 	}
 	if upstream.GetLatest() {
 		return &config.EnvironmentConfigUpstream{
-			Latest: true,
+			Environment: "",
+			Latest:      true,
 		}
 	}
 	if upstream.GetEnvironment() != "" {
 		return &config.EnvironmentConfigUpstream{
+			Latest:      false,
 			Environment: upstream.GetEnvironment(),
 		}
 	}
@@ -82,9 +84,12 @@ func transformArgoCdToApi(in *config.EnvironmentConfigArgoCd) *api.EnvironmentCo
 		return nil
 	}
 	return &api.EnvironmentConfig_ArgoCD{
-		SyncWindows: transformSyncWindowsToApi(in.SyncWindows),
-		Destination: transformDestinationToApi(&in.Destination),
-		AccessList:  transformAccessEntryToApi(in.ClusterResourceWhitelist),
+		ApplicationAnnotations: nil,
+		IgnoreDifferences:      nil,
+		SyncOptions:            nil,
+		SyncWindows:            transformSyncWindowsToApi(in.SyncWindows),
+		Destination:            transformDestinationToApi(&in.Destination),
+		AccessList:             transformAccessEntryToApi(in.ClusterResourceWhitelist),
 	}
 }
 
@@ -105,9 +110,10 @@ func transformSyncWindowsToApi(in []config.ArgoCdSyncWindow) []*api.EnvironmentC
 	var out []*api.EnvironmentConfig_ArgoCD_SyncWindows
 	for _, syncWindow := range in {
 		out = append(out, &api.EnvironmentConfig_ArgoCD_SyncWindows{
-			Kind:     syncWindow.Kind,
-			Schedule: syncWindow.Schedule,
-			Duration: syncWindow.Duration,
+			Applications: nil,
+			Kind:         syncWindow.Kind,
+			Schedule:     syncWindow.Schedule,
+			Duration:     syncWindow.Duration,
 		})
 	}
 	return out
@@ -169,6 +175,7 @@ func transformIgnoreDifferencesToApi(in []*config.ArgoCdIgnoreDifference) []api.
 
 func transformDestinationToConfig(in *api.EnvironmentConfig_ArgoCD_Destination) config.ArgoCdDestination {
 	if in == nil {
+		//exhaustruct:ignore
 		return config.ArgoCdDestination{}
 	}
 	return config.ArgoCdDestination{
@@ -182,6 +189,7 @@ func transformDestinationToConfig(in *api.EnvironmentConfig_ArgoCD_Destination) 
 
 func transformDestinationToApi(in *config.ArgoCdDestination) *api.EnvironmentConfig_ArgoCD_Destination {
 	if in == nil {
+		//exhaustruct:ignore
 		return &api.EnvironmentConfig_ArgoCD_Destination{}
 	}
 	return &api.EnvironmentConfig_ArgoCD_Destination{

--- a/services/cd-service/pkg/service/git.go
+++ b/services/cd-service/pkg/service/git.go
@@ -74,13 +74,22 @@ func (s *GitServer) GetProductSummary(ctx context.Context, in *api.GetProductSum
 			for _, env := range group.Environments {
 				if env.Name == *in.Environment {
 					for _, app := range env.Applications {
-						summaryFromEnv = append(summaryFromEnv, api.ProductSummary{App: app.Name, Version: strconv.FormatUint(app.Version, 10), Environment: *in.Environment})
+						summaryFromEnv = append(summaryFromEnv, api.ProductSummary{
+							CommitId:       "",
+							DisplayVersion: "",
+							Team:           "",
+							App:            app.Name,
+							Version:        strconv.FormatUint(app.Version, 10),
+							Environment:    *in.Environment,
+						})
 					}
 				}
 			}
 		}
 		if len(summaryFromEnv) == 0 {
-			return &api.GetProductSummaryResponse{}, nil
+			return &api.GetProductSummaryResponse{
+				ProductSummary: nil,
+			}, nil
 		}
 		sort.Slice(summaryFromEnv, func(i, j int) bool {
 			a := summaryFromEnv[i].App
@@ -93,7 +102,14 @@ func (s *GitServer) GetProductSummary(ctx context.Context, in *api.GetProductSum
 				for _, env := range group.Environments {
 					var singleEnvSummary []api.ProductSummary
 					for _, app := range env.Applications {
-						singleEnvSummary = append(singleEnvSummary, api.ProductSummary{App: app.Name, Version: strconv.FormatUint(app.Version, 10), Environment: env.Name})
+						singleEnvSummary = append(singleEnvSummary, api.ProductSummary{
+							CommitId:       "",
+							DisplayVersion: "",
+							Team:           "",
+							App:            app.Name,
+							Version:        strconv.FormatUint(app.Version, 10),
+							Environment:    env.Name,
+						})
 					}
 					sort.Slice(singleEnvSummary, func(i, j int) bool {
 						a := singleEnvSummary[i].App

--- a/services/cd-service/pkg/service/version.go
+++ b/services/cd-service/pkg/service/version.go
@@ -54,6 +54,7 @@ func (o *VersionServiceServer) GetVersion(
 		}
 		return nil, err
 	}
+	//exhaustruct:ignore
 	res := api.GetVersionResponse{}
 	version, err := state.GetEnvironmentApplicationVersion(in.Environment, in.Application)
 	if version != nil {


### PR DESCRIPTION
This is a prerequisite PR for #1396 

Here we address or silence all the errors generated by `exhaustruct` in the CD service. The decision for whether to address or silence an error was the mere convenience; if a struct initialization seemed too large or too complicated, the error was silenced, otherwise it was addressed.