### PR TITLE
chore: initialize all struct in frontend service

### DIFF
--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -125,6 +125,7 @@ func runServer(ctx context.Context) error {
 			msg := "failed to read CA certificates"
 			return fmt.Errorf(msg)
 		}
+		//exhaustruct:ignore
 		cred = credentials.NewTLS(&tls.Config{
 			RootCAs: systemRoots,
 		})
@@ -156,8 +157,9 @@ func runServer(ctx context.Context) error {
 	}
 
 	var defaultUser = auth.User{
-		Email: c.GitAuthorEmail,
-		Name:  c.GitAuthorName,
+		DexAuthContext: nil,
+		Email:          c.GitAuthorEmail,
+		Name:           c.GitAuthorName,
 	}
 
 	if c.AzureEnableAuth {
@@ -357,6 +359,7 @@ func runServer(ctx context.Context) error {
 	corsHandler := &setup.CORSMiddleware{
 		PolicyFor: func(r *http.Request) *setup.CORSPolicy {
 			return &setup.CORSPolicy{
+				MaxAge:           0,
 				AllowMethods:     "POST",
 				AllowHeaders:     "content-type,x-grpc-web,authorization",
 				AllowOrigin:      c.AllowedOrigins,
@@ -367,9 +370,14 @@ func runServer(ctx context.Context) error {
 	}
 
 	setup.Run(ctx, setup.ServerConfig{
+		GRPC:       nil,
+		Background: nil,
+		Shutdown:   nil,
 		HTTP: []setup.HTTPConfig{
 			{
-				Port: "8081",
+				BasicAuth: nil,
+				Shutdown:  nil,
+				Port:      "8081",
 				Register: func(mux *http.ServeMux) {
 					mux.Handle("/", corsHandler)
 				},
@@ -412,7 +420,9 @@ func getRequestAuthorFromGoogleIAP(ctx context.Context, r *http.Request) *auth.U
 
 	// get the authenticated email
 	u := &auth.User{
-		Email: payload.Claims["email"].(string),
+		Name:           "",
+		DexAuthContext: nil,
+		Email:          payload.Claims["email"].(string),
 	}
 	return u
 }

--- a/services/frontend-service/pkg/handler/environments.go
+++ b/services/frontend-service/pkg/handler/environments.go
@@ -44,6 +44,7 @@ func (s Server) handleCreateEnvironment(w http.ResponseWriter, req *http.Request
 	}
 
 	form := req.MultipartForm
+	//exhaustruct:ignore
 	envConfig := api.EnvironmentConfig{}
 
 	config, ok := form.Value["config"]

--- a/services/frontend-service/pkg/handler/release.go
+++ b/services/frontend-service/pkg/handler/release.go
@@ -84,6 +84,15 @@ func (s Server) HandleRelease(w http.ResponseWriter, r *http.Request, tail strin
 	}
 
 	tf := api.CreateReleaseRequest{
+		Environment: "",
+		Application: "",
+		Team: "",
+		Version: 0,
+		SourceCommitId: "",
+		SourceAuthor: "",
+		SourceMessage: "",
+		SourceRepoUrl: "",
+		DisplayVersion: "",
 		Manifests: map[string]string{},
 	}
 	if err := r.ParseMultipartForm(MAXIMUM_MULTIPART_SIZE); err != nil {

--- a/services/frontend-service/pkg/handler/release.go
+++ b/services/frontend-service/pkg/handler/release.go
@@ -84,16 +84,16 @@ func (s Server) HandleRelease(w http.ResponseWriter, r *http.Request, tail strin
 	}
 
 	tf := api.CreateReleaseRequest{
-		Environment: "",
-		Application: "",
-		Team: "",
-		Version: 0,
+		Environment:    "",
+		Application:    "",
+		Team:           "",
+		Version:        0,
 		SourceCommitId: "",
-		SourceAuthor: "",
-		SourceMessage: "",
-		SourceRepoUrl: "",
+		SourceAuthor:   "",
+		SourceMessage:  "",
+		SourceRepoUrl:  "",
 		DisplayVersion: "",
-		Manifests: map[string]string{},
+		Manifests:      map[string]string{},
 	}
 	if err := r.ParseMultipartForm(MAXIMUM_MULTIPART_SIZE); err != nil {
 		w.WriteHeader(400)

--- a/services/frontend-service/pkg/handler/releasetrain.go
+++ b/services/frontend-service/pkg/handler/releasetrain.go
@@ -76,8 +76,8 @@ func (s Server) handleReleaseTrain(w http.ResponseWriter, req *http.Request, tar
 			{Action: &api.BatchAction_ReleaseTrain{
 				ReleaseTrain: &api.ReleaseTrainRequest{
 					CommitHash: "",
-					Target: target,
-					Team:   teamParam,
+					Target:     target,
+					Team:       teamParam,
 				}}},
 		},
 		})

--- a/services/frontend-service/pkg/handler/releasetrain.go
+++ b/services/frontend-service/pkg/handler/releasetrain.go
@@ -75,6 +75,7 @@ func (s Server) handleReleaseTrain(w http.ResponseWriter, req *http.Request, tar
 		&api.BatchRequest{Actions: []*api.BatchAction{
 			{Action: &api.BatchAction_ReleaseTrain{
 				ReleaseTrain: &api.ReleaseTrainRequest{
+					CommitHash: "",
 					Target: target,
 					Team:   teamParam,
 				}}},

--- a/services/frontend-service/pkg/interceptors/interceptors.go
+++ b/services/frontend-service/pkg/interceptors/interceptors.go
@@ -53,8 +53,8 @@ func authorize(ctx context.Context, jwks *keyfunc.JWKS, clientId string, tenantI
 	if _, ok := claims["aud"]; ok && claims["aud"] == clientId {
 		u = &auth.User{
 			DexAuthContext: nil,
-			Email: claims["email"].(string),
-			Name:  claims["name"].(string),
+			Email:          claims["email"].(string),
+			Name:           claims["name"].(string),
 		}
 	}
 

--- a/services/frontend-service/pkg/interceptors/interceptors.go
+++ b/services/frontend-service/pkg/interceptors/interceptors.go
@@ -52,6 +52,7 @@ func authorize(ctx context.Context, jwks *keyfunc.JWKS, clientId string, tenantI
 	var u *auth.User = nil
 	if _, ok := claims["aud"]; ok && claims["aud"] == clientId {
 		u = &auth.User{
+			DexAuthContext: nil,
 			Email: claims["email"].(string),
 			Name:  claims["name"].(string),
 		}


### PR DESCRIPTION
This is a prerequisite PR for #1396 

Here we address or silence all the errors generated by exhaustruct in the CD service. The decision for whether to address or silence an error was the mere convenience; if a struct initialization seemed too large or too complicated, the error was silenced, otherwise it was addressed.