### PR TITLE
fix: introduce TransformerBatchApplyError ...

### DIFF
--- a/services/cd-service/pkg/repository/error.go
+++ b/services/cd-service/pkg/repository/error.go
@@ -98,24 +98,6 @@ func GetCreateReleaseAppNameTooLong(appName string, regExp string, maxLen uint32
 	}
 }
 
-type InternalError struct {
-	inner error
-}
-
-func (i *InternalError) String() string {
-	return fmt.Sprintf("repository internal: %s", i.inner)
-}
-
-func (i *InternalError) Unwrap() error {
-	return i.inner
-}
-
-func (i *InternalError) Error() string {
-	return i.String()
-}
-
-var _ error = (*InternalError)(nil)
-
 type LockedError struct {
 	EnvironmentApplicationLocks map[string]Lock
 	EnvironmentLocks            map[string]Lock

--- a/services/cd-service/pkg/repository/queue.go
+++ b/services/cd-service/pkg/repository/queue.go
@@ -19,7 +19,7 @@ package repository
 /**
 This queue contains transformers. Do not confuse with the "queuedVersion" field in protobuf (api.proto).
 The queue here is used because applying a change to git (pushing) takes some time.
-Still, every request waits for the transformer AND push to finish (that's what the `result` channel is for in the "element struct" below).
+Still, every request waits for the transformer AND push to finish (that's what the `result` channel is for in the "transformerBatch struct" below).
 This queue improves the throughput when there are many parallel requests, because the "push" operation is done only once for multiple requests (a request here is essentially the same as a transformer).
 Many parallel requests can happen in a CI with many microservices that all call the "release" endpoint almost at the same time.
 This queue does not improve the latency, because each request still waits for the push to finish.
@@ -30,10 +30,10 @@ import (
 )
 
 type queue struct {
-	elements chan element
+	transformerBatches chan transformerBatch
 }
 
-type element struct {
+type transformerBatch struct {
 	ctx          context.Context
 	transformers []Transformer
 	result       chan error
@@ -41,13 +41,13 @@ type element struct {
 
 func (q *queue) add(ctx context.Context, transformers []Transformer) <-chan error {
 	resultChannel := make(chan error, 1)
-	e := element{
+	e := transformerBatch{
 		ctx:          ctx,
 		transformers: transformers,
 		result:       resultChannel,
 	}
 	select {
-	case q.elements <- e:
+	case q.transformerBatches <- e:
 		return resultChannel
 	case <-ctx.Done():
 		resultChannel <- ctx.Err()
@@ -57,6 +57,6 @@ func (q *queue) add(ctx context.Context, transformers []Transformer) <-chan erro
 
 func makeQueue() queue {
 	return queue{
-		elements: make(chan element, 5),
+		transformerBatches: make(chan transformerBatch, 5),
 	}
 }

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -1728,7 +1728,7 @@ func TestDeleteDirIfEmpty(t *testing.T) {
 func TestProcessQueueOnce(t *testing.T) {
 	tcs := []struct {
 		Name           string
-		Element        element
+		Element        transformerBatch
 		PushUpdateFunc PushUpdateFunc
 		PushActionFunc PushActionCallbackFunc
 		ExpectedError  error
@@ -1737,7 +1737,7 @@ func TestProcessQueueOnce(t *testing.T) {
 			Name:           "success",
 			PushUpdateFunc: defaultPushUpdate,
 			PushActionFunc: DefaultPushActionCallback,
-			Element: element{
+			Element: transformerBatch{
 				ctx: testutil.MakeTestContext(),
 				transformers: []Transformer{
 					&EmptyTransformer{},
@@ -1753,7 +1753,7 @@ func TestProcessQueueOnce(t *testing.T) {
 				return nil
 			},
 			PushActionFunc: DefaultPushActionCallback,
-			Element: element{
+			Element: transformerBatch{
 				ctx: testutil.MakeTestContext(),
 				transformers: []Transformer{
 					&EmptyTransformer{},
@@ -1772,7 +1772,7 @@ func TestProcessQueueOnce(t *testing.T) {
 					return git.MakeGitError(1)
 				}
 			},
-			Element: element{
+			Element: transformerBatch{
 				ctx: testutil.MakeTestContext(),
 				transformers: []Transformer{
 					&EmptyTransformer{},

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -1363,7 +1363,7 @@ func TestApplyQueue(t *testing.T) {
 			Name: "error at the start",
 			Actions: []action{
 				{
-					ExpectedError: TransformerError,
+					ExpectedError: &TransformerBatchApplyError{TransformerError: TransformerError, Index: 0},
 					Transformer:   &ErrorTransformer{},
 				}, {}, {},
 			},
@@ -1376,7 +1376,7 @@ func TestApplyQueue(t *testing.T) {
 			Actions: []action{
 				{},
 				{
-					ExpectedError: TransformerError,
+					ExpectedError: &TransformerBatchApplyError{TransformerError: TransformerError, Index: 0},
 					Transformer:   &ErrorTransformer{},
 				}, {},
 			},
@@ -1389,7 +1389,7 @@ func TestApplyQueue(t *testing.T) {
 			Actions: []action{
 				{}, {},
 				{
-					ExpectedError: TransformerError,
+					ExpectedError: &TransformerBatchApplyError{TransformerError: TransformerError, Index: 0},
 					Transformer:   &ErrorTransformer{},
 				},
 			},
@@ -1401,7 +1401,7 @@ func TestApplyQueue(t *testing.T) {
 			Name: "Invalid json error at start",
 			Actions: []action{
 				{
-					ExpectedError: InvalidJson,
+					ExpectedError: &TransformerBatchApplyError{TransformerError: InvalidJson, Index: 0},
 					Transformer:   &InvalidJsonTransformer{},
 				},
 				{}, {},
@@ -1415,7 +1415,7 @@ func TestApplyQueue(t *testing.T) {
 			Actions: []action{
 				{},
 				{
-					ExpectedError: InvalidJson,
+					ExpectedError: &TransformerBatchApplyError{TransformerError: InvalidJson, Index: 0},
 					Transformer:   &InvalidJsonTransformer{},
 				},
 				{},
@@ -1429,7 +1429,7 @@ func TestApplyQueue(t *testing.T) {
 			Actions: []action{
 				{}, {},
 				{
-					ExpectedError: InvalidJson,
+					ExpectedError: &TransformerBatchApplyError{TransformerError: InvalidJson, Index: 0},
 					Transformer:   &InvalidJsonTransformer{},
 				},
 			},
@@ -1494,7 +1494,7 @@ func TestApplyQueue(t *testing.T) {
 			finished <- struct{}{}
 			// Check for the correct errors
 			for i, action := range tc.Actions {
-				if err := <-results[i]; err != action.ExpectedError {
+				if err := <-results[i]; err != nil && err.Error() != action.ExpectedError.Error() {
 					t.Errorf("result[%d] error is not \"%v\" but got \"%v\"", i, action.ExpectedError, err)
 				}
 			}

--- a/services/cd-service/pkg/repository/testrepository/testrepository.go
+++ b/services/cd-service/pkg/repository/testrepository/testrepository.go
@@ -42,8 +42,8 @@ func (fr *failingRepository) Push(ctx context.Context, pushAction func() error) 
 	return fr.err
 }
 
-func (fr *failingRepository) ApplyTransformersInternal(ctx context.Context, transformers ...repository.Transformer) ([]string, *repository.State, []*repository.TransformerResult, error) {
-	return nil, nil, nil, fr.err
+func (fr *failingRepository) ApplyTransformersInternal(ctx context.Context, transformers ...repository.Transformer) ([]string, *repository.State, []*repository.TransformerResult, *repository.TransformerBatchApplyError) {
+	return nil, nil, nil, &repository.TransformerBatchApplyError{TransformerError: fr.err, Index: 0}
 }
 
 func (fr *failingRepository) State() *repository.State {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -783,7 +783,7 @@ func TestCreateApplicationVersionIdempotency(t *testing.T) {
 					WriteCommitData: true,
 				},
 			},
-			expectedErrorMsg: `error at index 2 of transformer batch: already_exists_different:{first_differing_field:MANIFESTS diff:"--- acceptance-existing\n+++ acceptance-request\n@@ -1 +1 @@\n-{}\n\\ No newline at end of file\n+{ \"different\": \"yes\" }\n\\ No newline at end of file\n"}`,
+			expectedErrorMsg: `error at index 2 of transformer batch: already_exists_different:{first_differing_field:MANIFESTS  diff:"--- acceptance-existing\n+++ acceptance-request\n@@ -1 +1 @@\n-{}\n\\ No newline at end of file\n+{ \"different\": \"yes\" }\n\\ No newline at end of file\n"}`,
 		},
 		{
 			Name: "recreate same version with idempotence, but different formatting of yaml",


### PR DESCRIPTION
- to allow to forward, which transformer of a batch failed
- use it in ApplyTransformers and ApplyTransformersInternal
- remove grcp errors in low level repository: grpc errors should only be
  created on a high level at the endpoint
- try to remove (now?) rather pointless internal error type
- close the result channel and ensure only one error or nil is send
- rename too generic type element to transformerBatchrename, and applyElement to applyTransformerBatches