### PR TITLE
chore: initialize all struct in rollout service

### DIFF
--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -306,16 +306,16 @@ func CreateArgoApplication(overview *api.GetOverviewResponse, app *api.Environme
 	}
 	//exhaustruct:ignore
 	Spec := v1alpha1.ApplicationSpec{
-		Source: Source,
-		SyncPolicy: SyncPolicy,
-		Project: env.Name,
-		Destination: applicationDestination,
+		Source:            Source,
+		SyncPolicy:        SyncPolicy,
+		Project:           env.Name,
+		Destination:       applicationDestination,
 		IgnoreDifferences: ignoreDifferences,
 	}
 	//exhaustruct:ignore
 	deployApp := &v1alpha1.Application{
 		ObjectMeta: ObjectMeta,
-		Spec: Spec,
+		Spec:       Spec,
 	}
 
 	return deployApp

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -51,6 +51,7 @@ type ArgoAppProcessor struct {
 
 func New(appClient application.ApplicationServiceClient, manageArgoApplicationEnabled bool, manageArgoApplicationFilter []string) ArgoAppProcessor {
 	return ArgoAppProcessor{
+		lastOverview:          nil,
 		ApplicationClient:     appClient,
 		ManageArgoAppsEnabled: manageArgoApplicationEnabled,
 		ManageArgoAppsFilter:  manageArgoApplicationFilter,
@@ -141,9 +142,12 @@ func (a ArgoAppProcessor) CreateOrUpdateApp(ctx context.Context, overview *api.G
 			upsert := false
 			validate := false
 			appCreateRequest := &application.ApplicationCreateRequest{
-				Application: appToCreate,
-				Upsert:      &upsert,
-				Validate:    &validate,
+				XXX_NoUnkeyedLiteral: struct{}{},
+				XXX_unrecognized:     nil,
+				XXX_sizecache:        0,
+				Application:          appToCreate,
+				Upsert:               &upsert,
+				Validate:             &validate,
 			}
 			_, err := a.ApplicationClient.Create(ctx, appCreateRequest)
 			if err != nil {
@@ -156,9 +160,12 @@ func (a ArgoAppProcessor) CreateOrUpdateApp(ctx context.Context, overview *api.G
 			validate := false
 			appToUpdate := CreateArgoApplication(overview, app, k.Environment)
 			appUpdateRequest := &application.ApplicationUpdateRequest{
-				Validate:    ptr.Bool(validate),
-				Application: appToUpdate,
-				Project:     ptr.FromString(appToUpdate.Spec.Project),
+				XXX_NoUnkeyedLiteral: struct{}{},
+				XXX_unrecognized:     nil,
+				XXX_sizecache:        0,
+				Validate:             ptr.Bool(validate),
+				Application:          appToUpdate,
+				Project:              ptr.FromString(appToUpdate.Spec.Project),
 			}
 			_, err := a.ApplicationClient.Update(ctx, appUpdateRequest)
 			if err != nil {
@@ -170,6 +177,7 @@ func (a ArgoAppProcessor) CreateOrUpdateApp(ctx context.Context, overview *api.G
 
 func (a *ArgoAppProcessor) ConsumeArgo(ctx context.Context, hlth *setup.HealthReporter) error {
 	return hlth.Retry(ctx, func() error {
+		//exhaustruct:ignore
 		watch, err := a.ApplicationClient.Watch(ctx, &application.ApplicationQuery{})
 		if err != nil {
 			if status.Code(err) == codes.Canceled {
@@ -213,7 +221,14 @@ func (a ArgoAppProcessor) DeleteArgoApps(ctx context.Context, argoApps map[strin
 
 	for i := range toDelete {
 		_, err := a.ApplicationClient.Delete(ctx, &application.ApplicationDeleteRequest{
-			Name: ptr.FromString(toDelete[i].Name),
+			Cascade:              nil,
+			PropagationPolicy:    nil,
+			AppNamespace:         nil,
+			Project:              nil,
+			XXX_NoUnkeyedLiteral: struct{}{},
+			XXX_unrecognized:     nil,
+			XXX_sizecache:        0,
+			Name:                 ptr.FromString(toDelete[i].Name),
 		})
 
 		if err != nil {

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -125,6 +125,7 @@ func getGrpcClients(ctx context.Context, config Config) (api.OverviewServiceClie
 			msg := "failed to read CA certificates"
 			return nil, nil, fmt.Errorf(msg)
 		}
+		//exhaustruct:ignore
 		cred = credentials.NewTLS(&tls.Config{
 			RootCAs: systemRoots,
 		})
@@ -208,39 +209,45 @@ func runServer(ctx context.Context, config Config) error {
 	dispatcher := service.NewDispatcher(broadcast, versionC)
 	backgroundTasks := []setup.BackgroundTaskConfig{
 		{
-			Name: "consume argocd events",
+			Shutdown: nil,
+			Name:     "consume argocd events",
 			Run: func(ctx context.Context, health *setup.HealthReporter) error {
 				return service.ConsumeEvents(ctx, appClient, dispatcher, health)
 			},
 		},
 		{
-			Name: "consume kuberpult events",
+			Shutdown: nil,
+			Name:     "consume kuberpult events",
 			Run: func(ctx context.Context, health *setup.HealthReporter) error {
 				return versionC.ConsumeEvents(ctx, broadcast, health)
 			},
 		},
 		{
-			Name: "consume self-manage events",
+			Shutdown: nil,
+			Name:     "consume self-manage events",
 			Run: func(ctx context.Context, health *setup.HealthReporter) error {
 				return versionC.GetArgoProcessor().Consume(ctx, health)
 			},
 		},
 		{
-			Name: "consume argo events",
+			Shutdown: nil,
+			Name:     "consume argo events",
 			Run: func(ctx context.Context, health *setup.HealthReporter) error {
 				return versionC.GetArgoProcessor().ConsumeArgo(ctx, health)
 			},
 		},
 		{
-			Name: "dispatch argocd events",
-			Run:  dispatcher.Work,
+			Shutdown: nil,
+			Name:     "dispatch argocd events",
+			Run:      dispatcher.Work,
 		},
 	}
 
 	if config.ArgocdRefreshEnabled {
 
 		backgroundTasks = append(backgroundTasks, setup.BackgroundTaskConfig{
-			Name: "refresh argocd",
+			Shutdown: nil,
+			Name:     "refresh argocd",
 			Run: func(ctx context.Context, health *setup.HealthReporter) error {
 				notify := notifier.New(appClient, config.ArgocdRefreshConcurrency)
 				return notifier.Subscribe(ctx, notify, broadcast, health)
@@ -255,7 +262,8 @@ func runServer(ctx context.Context, config Config) error {
 		}
 		revolutionDora := revolution.New(revolutionConfig)
 		backgroundTasks = append(backgroundTasks, setup.BackgroundTaskConfig{
-			Name: "revolution dora",
+			Shutdown: nil,
+			Name:     "revolution dora",
 			Run: func(ctx context.Context, health *setup.HealthReporter) error {
 				health.ReportReady("pushing")
 				return revolutionDora.Subscribe(ctx, broadcast)
@@ -264,7 +272,8 @@ func runServer(ctx context.Context, config Config) error {
 	}
 
 	backgroundTasks = append(backgroundTasks, setup.BackgroundTaskConfig{
-		Name: "create metrics",
+		Shutdown: nil,
+		Name:     "create metrics",
 		Run: func(ctx context.Context, health *setup.HealthReporter) error {
 			health.ReportReady("reporting")
 			return metrics.Metrics(ctx, broadcast, pkgmetrics.FromContext(ctx), nil, func() {})
@@ -274,12 +283,16 @@ func runServer(ctx context.Context, config Config) error {
 	setup.Run(ctx, setup.ServerConfig{
 		HTTP: []setup.HTTPConfig{
 			{
-				Port: "8080",
+				Register:  nil,
+				BasicAuth: nil,
+				Shutdown:  nil,
+				Port:      "8080",
 			},
 		},
 		Background: backgroundTasks,
 		GRPC: &setup.GRPCConfig{
-			Port: "8443",
+			Shutdown: nil,
+			Port:     "8443",
 			Opts: []grpc.ServerOption{
 				grpc.ChainStreamInterceptor(grpcStreamInterceptors...),
 				grpc.ChainUnaryInterceptor(grpcUnaryInterceptors...),

--- a/services/rollout-service/pkg/notifier/notifier.go
+++ b/services/rollout-service/pkg/notifier/notifier.go
@@ -59,7 +59,7 @@ func (n *notifier) NotifyArgoCd(ctx context.Context, environment, application st
 		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 		defer cancel()
 		l := logger.FromContext(ctx).With(zap.String("environment", environment), zap.String("application", application))
-
+		//exhaustruct:ignore
 		_, err = n.client.Get(ctx, &argoapplication.ApplicationQuery{
 			Name:    ptr.FromString(fmt.Sprintf("%s-%s", environment, application)),
 			Refresh: ptr.FromString(string(argoappv1.RefreshTypeNormal)),

--- a/services/rollout-service/pkg/revolution/revolution.go
+++ b/services/rollout-service/pkg/revolution/revolution.go
@@ -43,7 +43,13 @@ type Config struct {
 
 func New(config Config) *Subscriber {
 	sub := &Subscriber{
-		group: errgroup.Group{},
+		token:  nil,
+		url:    "",
+		ready:  nil,
+		state:  nil,
+		maxAge: 0,
+		now:    nil,
+		group:  errgroup.Group{},
 	}
 	sub.group.SetLimit(config.Concurrency)
 	sub.url = config.URL
@@ -142,6 +148,7 @@ type kuberpultEvent struct {
 
 func (s *Subscriber) notify(ctx context.Context, ev *service.BroadcastEvent) func() error {
 	event := kuberpultEvent{
+		URL:         "",
 		Id:          uuidFor(ev.Application, ev.ArgocdVersion.SourceCommitId, ev.ArgocdVersion.DeployedAt.String()),
 		CommitHash:  ev.ArgocdVersion.SourceCommitId,
 		EventTime:   ev.ArgocdVersion.DeployedAt.Format(time.RFC3339),

--- a/services/rollout-service/pkg/service/broadcast.go
+++ b/services/rollout-service/pkg/service/broadcast.go
@@ -100,6 +100,8 @@ type Broadcast struct {
 
 func New() *Broadcast {
 	return &Broadcast{
+		mx:       sync.Mutex{},
+		waiting:  nil,
 		state:    map[Key]*appState{},
 		listener: map[chan *BroadcastEvent]struct{}{},
 	}
@@ -114,6 +116,7 @@ func (b *Broadcast) ProcessArgoEvent(ctx context.Context, ev ArgoEvent) {
 		Environment: ev.Environment,
 	}
 	if b.state[k] == nil {
+		//exhaustruct:ignore
 		b.state[k] = &appState{}
 	}
 	msg := b.state[k].applyArgoEvent(&ev)
@@ -142,6 +145,7 @@ func (b *Broadcast) ProcessKuberpultEvent(ctx context.Context, ev versions.Kuber
 		Environment: ev.Environment,
 	}
 	if b.state[k] == nil {
+		//exhaustruct:ignore
 		b.state[k] = &appState{}
 	}
 	msg := b.state[k].applyKuberpultEvent(&ev)

--- a/services/rollout-service/pkg/service/dispatcher.go
+++ b/services/rollout-service/pkg/service/dispatcher.go
@@ -51,6 +51,7 @@ func NewDispatcher(sink ArgoEventProcessor, vc versions.VersionClient) *Dispatch
 	bo.MaxElapsedTime = 0
 	bo.MaxInterval = 5 * time.Minute
 	rs := &Dispatcher{
+		mx:            sync.Mutex{},
 		sink:          sink,
 		versionClient: vc,
 		known:         map[Key]*knownRevision{},

--- a/services/rollout-service/pkg/service/service.go
+++ b/services/rollout-service/pkg/service/service.go
@@ -48,6 +48,7 @@ type ArgoEventProcessor interface {
 
 func ConsumeEvents(ctx context.Context, appClient SimplifiedApplicationServiceClient, dispatcher *Dispatcher, hlth *setup.HealthReporter) error {
 	return hlth.Retry(ctx, func() error {
+		//exhaustruct:ignore
 		watch, err := appClient.Watch(ctx, &application.ApplicationQuery{})
 		if err != nil {
 			if status.Code(err) == codes.Canceled {

--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -38,8 +38,9 @@ import (
 // This is a the user that the rollout service uses to query the versions.
 // It is not written to the repository.
 var RolloutServiceUser auth.User = auth.User{
-	Email: "kuberpult-rollout-service@local",
-	Name:  "kuberpult-rollout-service",
+	DexAuthContext: nil,
+	Email:          "kuberpult-rollout-service@local",
+	Name:           "kuberpult-rollout-service",
 }
 
 type VersionClient interface {
@@ -182,7 +183,9 @@ func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEven
 	environmentGroups := map[key]string{}
 	teams := map[key]string{}
 	return hr.Retry(ctx, func() error {
-		client, err := v.overviewClient.StreamOverview(ctx, &api.GetOverviewRequest{})
+		client, err := v.overviewClient.StreamOverview(ctx, &api.GetOverviewRequest{
+			GitRevision: "",
+		})
 		if err != nil {
 			return fmt.Errorf("overview.connect: %w", err)
 		}
@@ -246,11 +249,16 @@ func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEven
 			for k := range versions {
 				if seen[k] == 0 {
 					processor.ProcessKuberpultEvent(ctx, KuberpultEvent{
+						IsProduction:     false,
 						Application:      k.Application,
 						Environment:      k.Environment,
 						EnvironmentGroup: environmentGroups[k],
 						Team:             teams[k],
-						Version:          &VersionInfo{},
+						Version: &VersionInfo{
+							Version:        0,
+							SourceCommitId: "",
+							DeployedAt:     time.Time{},
+						},
 					})
 				}
 			}
@@ -261,10 +269,12 @@ func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEven
 
 func New(oclient api.OverviewServiceClient, vclient api.VersionServiceClient, appClient application.ApplicationServiceClient, manageArgoApplicationEnabled bool, manageArgoApplicationFilter []string) VersionClient {
 	result := &versionClient{
-		cache:          lru.New(20),
-		overviewClient: oclient,
-		versionClient:  vclient,
-		ArgoProcessor:  argo.New(appClient, manageArgoApplicationEnabled, manageArgoApplicationFilter),
+		manageArgoAppsEnabled: false,
+		manageArgoAppsFilter:  "",
+		cache:                 lru.New(20),
+		overviewClient:        oclient,
+		versionClient:         vclient,
+		ArgoProcessor:         argo.New(appClient, manageArgoApplicationEnabled, manageArgoApplicationFilter),
 	}
 	return result
 }

--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -269,8 +269,6 @@ func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEven
 
 func New(oclient api.OverviewServiceClient, vclient api.VersionServiceClient, appClient application.ApplicationServiceClient, manageArgoApplicationEnabled bool, manageArgoApplicationFilter []string) VersionClient {
 	result := &versionClient{
-		manageArgoAppsEnabled: false,
-		manageArgoAppsFilter:  "",
 		cache:                 lru.New(20),
 		overviewClient:        oclient,
 		versionClient:         vclient,

--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -269,10 +269,10 @@ func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEven
 
 func New(oclient api.OverviewServiceClient, vclient api.VersionServiceClient, appClient application.ApplicationServiceClient, manageArgoApplicationEnabled bool, manageArgoApplicationFilter []string) VersionClient {
 	result := &versionClient{
-		cache:                 lru.New(20),
-		overviewClient:        oclient,
-		versionClient:         vclient,
-		ArgoProcessor:         argo.New(appClient, manageArgoApplicationEnabled, manageArgoApplicationFilter),
+		cache:          lru.New(20),
+		overviewClient: oclient,
+		versionClient:  vclient,
+		ArgoProcessor:  argo.New(appClient, manageArgoApplicationEnabled, manageArgoApplicationFilter),
 	}
 	return result
 }


### PR DESCRIPTION
This is a prerequisite PR for #1396 

Here we address or silence all the errors generated by exhaustruct in the CD service. The decision for whether to address or silence an error was the mere convenience; if a struct initialization seemed too large or too complicated, the error was silenced, otherwise it was addressed.