### PR TITLE
chore: initialize all struct in `pkg`

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -132,6 +132,7 @@ func (x *DexGrpcContextReader) ReadUserFromGrpcContext(ctx context.Context) (*Us
 	logger.FromContext(ctx).Info(fmt.Sprintf("Extract: original mail %s. Decoded: %s", originalEmail, userMail))
 	logger.FromContext(ctx).Info(fmt.Sprintf("Extract: original name %s. Decoded: %s", originalName, userName))
 	u := &User{
+		DexAuthContext: nil,
 		Email: userMail,
 		Name:  userName,
 	}
@@ -204,6 +205,7 @@ func WriteUserRoleToHttpHeader(r *http.Request, role string) {
 
 func GetUserOrDefault(u *User, defaultUser User) User {
 	var userAdapted = User{
+		DexAuthContext: nil,
 		Email: defaultUser.Email,
 		Name:  defaultUser.Name,
 	}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -133,8 +133,8 @@ func (x *DexGrpcContextReader) ReadUserFromGrpcContext(ctx context.Context) (*Us
 	logger.FromContext(ctx).Info(fmt.Sprintf("Extract: original name %s. Decoded: %s", originalName, userName))
 	u := &User{
 		DexAuthContext: nil,
-		Email: userMail,
-		Name:  userName,
+		Email:          userMail,
+		Name:           userName,
 	}
 	if u.Email == "" || u.Name == "" {
 		return nil, grpc.AuthError(ctx, errors.New("email and name in grpc context cannot both be empty"))
@@ -206,8 +206,8 @@ func WriteUserRoleToHttpHeader(r *http.Request, role string) {
 func GetUserOrDefault(u *User, defaultUser User) User {
 	var userAdapted = User{
 		DexAuthContext: nil,
-		Email: defaultUser.Email,
-		Name:  defaultUser.Name,
+		Email:          defaultUser.Email,
+		Name:           defaultUser.Name,
 	}
 	if u != nil && u.Email != "" {
 		userAdapted.Email = u.Email

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -47,6 +47,7 @@ func JWKSInitAzureFromJson() (*keyfunc.JWKS, error) {
 
 func JWKSInitAzure(ctx context.Context) (*keyfunc.JWKS, error) {
 	jwksURL := "https://login.microsoftonline.com/common/discovery/v2.0/keys"
+	//exhaustruct:ignore
 	options := keyfunc.Options{
 		Ctx: ctx,
 		RefreshErrorHandler: func(err error) {

--- a/pkg/auth/dex.go
+++ b/pkg/auth/dex.go
@@ -76,7 +76,7 @@ const (
 // NewDexAppClient a Dex Client.
 func NewDexAppClient(clientID, clientSecret, baseURL string, scopes []string) (*DexAppClient, error) {
 	a := DexAppClient{
-		Client: nil,
+		Client:       nil,
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		Scopes:       scopes,

--- a/pkg/auth/dex.go
+++ b/pkg/auth/dex.go
@@ -76,6 +76,7 @@ const (
 // NewDexAppClient a Dex Client.
 func NewDexAppClient(clientID, clientSecret, baseURL string, scopes []string) (*DexAppClient, error) {
 	a := DexAppClient{
+		Client: nil,
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		Scopes:       scopes,
@@ -83,9 +84,11 @@ func NewDexAppClient(clientID, clientSecret, baseURL string, scopes []string) (*
 		RedirectURI:  baseURL + callbackPATH,
 		IssuerURL:    baseURL + issuerPATH,
 	}
+	//exhaustruct:ignore
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 	}
+	//exhaustruct:ignore
 	a.Client = &http.Client{
 		Transport: transport,
 	}
@@ -222,6 +225,7 @@ func (a *DexAppClient) handleCallback(w http.ResponseWriter, r *http.Request) {
 	// Stores the oauth token into the cookie.
 	if idTokenRAW != "" {
 		expiration := time.Now().Add(time.Duration(expirationDays) * 24 * time.Hour)
+		//exhaustruct:ignore
 		cookie := http.Cookie{
 			Name:    dexOAUTHTokenName,
 			Value:   idTokenRAW,
@@ -240,6 +244,7 @@ func ValidateOIDCToken(ctx context.Context, issuerURL, rawToken string, allowedA
 	}
 
 	// Token must be verified against an allowed audience.
+	//exhaustruct:ignore
 	config := oidc.Config{ClientID: allowedAudience}
 	verifier := p.Verifier(&config)
 	idToken, err := verifier.Verify(ctx, rawToken)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -46,6 +46,7 @@ func Init() (metric.MeterProvider, http.Handler, error) {
 		sdkmetric.WithReader(promExp),
 	)
 
+	//exhaustruct:ignore
 	return meterProvider, promhttp.HandlerFor(reg, promhttp.HandlerOpts{}), nil
 }
 

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -107,6 +107,7 @@ type ServerConfig struct {
 }
 
 func Run(ctx context.Context, config ServerConfig) {
+	//exhaustruct:ignore
 	s := &setup{}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -235,6 +236,7 @@ func runHTTPHandler(ctx context.Context, s *setup, handler http.Handler, port st
 		handler = NewBasicAuthHandler(basicAuth, handler)
 	}
 
+	//exhaustruct:ignore
 	httpS := &http.Server{
 		Handler: handler,
 	}

--- a/pkg/testfs/testfs.go
+++ b/pkg/testfs/testfs.go
@@ -90,7 +90,9 @@ func (u *UsageCollector) used(op Operation, filename string) {
 	}
 	_, ok := u.usage[FileOperation{op, filename}]
 	if !ok {
-		u.usage[FileOperation{op, filename}] = value{}
+		u.usage[FileOperation{op, filename}] = value{
+			errored: false,
+		}
 	}
 }
 
@@ -139,6 +141,7 @@ func (uc *UsageCollector) WithError(fs billy.Filesystem, op Operation, filename 
 	return &Filesystem{
 		Inner: fs,
 		errorInjector: errorInjector{
+			used:      false,
 			operation: op,
 			filename:  filename,
 			err:       err,

--- a/tests/integration-tests/main_test.go
+++ b/tests/integration-tests/main_test.go
@@ -1,5 +1,4 @@
-/*
-This file is part of kuberpult.
+/*This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -13,8 +12,7 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright 2023 freiheit.com
-*/
+Copyright 2023 freiheit.com*/
 package integration_tests
 
 import (

--- a/tests/integration-tests/main_test.go
+++ b/tests/integration-tests/main_test.go
@@ -1,4 +1,5 @@
-/*This file is part of kuberpult.
+/*
+This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -12,7 +13,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright 2023 freiheit.com*/
+Copyright 2023 freiheit.com
+*/
 package integration_tests
 
 import (
@@ -22,7 +24,6 @@ import (
 	"strconv"
 	"testing"
 )
-
 
 // The appSuffix is a unique string consisting of only characters that are valid app names.
 // This is used to make tests repeatable.


### PR DESCRIPTION
This is a prerequisite PR for #1396 

Here we address or silence all the errors generated by exhaustruct in the CD service. The decision for whether to address or silence an error was the mere convenience; if a struct initialization seemed too large or too complicated, the error was silenced, otherwise it was addressed.