### PR TITLE
feat: commit history button

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -29,7 +29,13 @@ import { Button } from '../button';
 import { Close, Locks } from '../../../images';
 import { EnvironmentChip } from '../chip/EnvironmentGroupChip';
 import { FormattedDate } from '../FormattedDate/FormattedDate';
-import { ArgoAppLink, ArgoTeamLink, DisplayManifestLink, DisplaySourceLink } from '../../utils/Links';
+import {
+    ArgoAppLink,
+    ArgoTeamLink,
+    DisplayManifestLink,
+    DisplaySourceLink,
+    DisplayCommitHistoryLink,
+} from '../../utils/Links';
 import { ReleaseVersion } from '../ReleaseVersion/ReleaseVersion';
 import { PlainDialog } from '../dialog/ConfirmationDialog';
 import { ExpandButton } from '../button/ExpandButton';
@@ -307,6 +313,11 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                                 <DisplaySourceLink commitId={release.sourceCommitId} displayString={'Source'} />
                                 &nbsp;
                                 <DisplayManifestLink app={app} version={release.version} displayString="Manifest" />
+                                &nbsp;
+                                <DisplayCommitHistoryLink
+                                    commitId={release.sourceCommitId}
+                                    displayString={'Commit History'}
+                                />
                             </span>
                         </div>
                         <div className={classNames('release-dialog-app', className)}>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -41,6 +41,13 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                   class="links"
                 >
                    
+                   
+                  <a
+                    href="/ui/commits/commit"
+                    title="Opens the commit history"
+                  >
+                    Commit History
+                  </a>
                 </span>
               </div>
               <div
@@ -302,6 +309,13 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                   class="links"
                 >
                    
+                   
+                  <a
+                    href="/ui/commits/commit"
+                    title="Opens the commit history"
+                  >
+                    Commit History
+                  </a>
                 </span>
               </div>
               <div
@@ -566,6 +580,13 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                   class="links"
                 >
                    
+                   
+                  <a
+                    href="/ui/commits/cafe"
+                    title="Opens the commit history"
+                  >
+                    Commit History
+                  </a>
                 </span>
               </div>
               <div
@@ -1017,6 +1038,7 @@ exports[`Release Dialog Renders the environment locks undeploy version release 1
                 <span
                   class="links"
                 >
+                   
                    
                 </span>
               </div>

--- a/services/frontend-service/src/ui/utils/Links.test.tsx
+++ b/services/frontend-service/src/ui/utils/Links.test.tsx
@@ -15,7 +15,14 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright 2023 freiheit.com*/
 import { render } from '@testing-library/react';
 import React from 'react';
-import { ArgoAppEnvLink, ArgoAppLink, ArgoTeamLink, DisplayManifestLink, DisplaySourceLink } from './Links';
+import {
+    ArgoAppEnvLink,
+    ArgoAppLink,
+    ArgoTeamLink,
+    DisplayManifestLink,
+    DisplaySourceLink,
+    DisplayCommitHistoryLink,
+} from './Links';
 import { GetFrontendConfigResponse_ArgoCD } from '../../api/api';
 import { UpdateFrontendConfig } from './store';
 import { elementQuerySelectorSafe } from '../../setupTests';
@@ -271,6 +278,47 @@ describe('DisplaySourceLink', () => {
         const getWrapper = () => render(getNode());
         it(testcase.name, () => {
             setupSourceRepo(testcase.sourceRepo);
+            const { container } = getWrapper();
+
+            if (testcase.expectedLink) {
+                // Either render the link:
+                const aElem = elementQuerySelectorSafe(container, 'a');
+                expect(aElem.attributes.getNamedItem('href')?.value).toBe(testcase.expectedLink);
+            } else {
+                // or render nothing:
+                expect(document.body.textContent).toBe('');
+            }
+        });
+    });
+});
+
+describe('DisplayCommitHistoryLink', () => {
+    const cases: {
+        name: string;
+        commitId: string;
+        expectedLink: string | undefined;
+    }[] = [
+        {
+            name: 'Test with displayString',
+            commitId: '123',
+            expectedLink: '/ui/commits/123',
+        },
+        {
+            name: 'Test without displayString',
+            commitId: '123',
+            expectedLink: '/ui/commits/123',
+        },
+        {
+            name: 'Test Without commit should render nothing',
+            commitId: '',
+            expectedLink: undefined,
+        },
+    ];
+
+    describe.each(cases)('RendersProperly', (testcase) => {
+        const getNode = () => <DisplayCommitHistoryLink displayString={''} commitId={testcase.commitId} />;
+        const getWrapper = () => render(getNode());
+        it(testcase.name, () => {
             const { container } = getWrapper();
 
             if (testcase.expectedLink) {

--- a/services/frontend-service/src/ui/utils/Links.test.tsx
+++ b/services/frontend-service/src/ui/utils/Links.test.tsx
@@ -304,11 +304,6 @@ describe('DisplayCommitHistoryLink', () => {
             expectedLink: '/ui/commits/123',
         },
         {
-            name: 'Test without displayString',
-            commitId: '123',
-            expectedLink: '/ui/commits/123',
-        },
-        {
             name: 'Test Without commit should render nothing',
             commitId: '',
             expectedLink: undefined,

--- a/services/frontend-service/src/ui/utils/Links.tsx
+++ b/services/frontend-service/src/ui/utils/Links.tsx
@@ -67,6 +67,13 @@ export const deriveReleaseDirLink = (
     return undefined;
 };
 
+export const getCommitHistoryLink = (commitId: string | undefined): string | undefined => {
+    if (commitId) {
+        return '/ui/commits/' + commitId;
+    }
+    return undefined;
+};
+
 export const ArgoTeamLink: React.FC<{ team: string | undefined }> = (props): JSX.Element | null => {
     const { team } = props;
     const argoBaseUrl = useArgoCdBaseUrl();
@@ -144,6 +151,22 @@ export const DisplayManifestLink: React.FC<{ displayString: string; app: string;
             </a>
         );
     }
+    return null;
+};
+
+export const DisplayCommitHistoryLink: React.FC<{ displayString: string; commitId: string }> = (
+    props
+): JSX.Element | null => {
+    const { displayString, commitId } = props;
+    if (commitId) {
+        const listLink = getCommitHistoryLink(commitId);
+        return (
+            <a title={'Opens the commit history'} href={listLink}>
+                {displayString}
+            </a>
+        );
+    }
+
     return null;
 };
 


### PR DESCRIPTION
This PR introduces a new button on a release dialog that redirects the user to the new commit page, highlighted  in the picture.
![Screenshot 2024-03-06 at 17 40 51](https://github.com/freiheit-com/kuberpult/assets/162333021/73b7e9b5-1952-437c-aa79-f0bbe3a5d830)
