### PR TITLE
fix: change base64 input parameter from '-b0' to 'b 0'

### DIFF
--- a/infrastructure/scripts/create-testdata/create-release.sh
+++ b/infrastructure/scripts/create-testdata/create-release.sh
@@ -89,8 +89,8 @@ FRONTEND_PORT=8081 # see docker-compose.yml
 
 if [[ $(uname -o) == Darwin ]];
 then
-  EMAIL=$(echo -n "script-user@example.com" | base64 -b0)
-  AUTHOR=$(echo -n "script-user" | base64 -b0)
+  EMAIL=$(echo -n "script-user@example.com" | base64 -b 0)
+  AUTHOR=$(echo -n "script-user" | base64 -b 0)
 else
   EMAIL=$(echo -n "script-user@example.com" | base64 -w 0)
   AUTHOR=$(echo -n "script-user" | base64 -w 0)


### PR DESCRIPTION
base64 command wasn't setup properly for macOS. make kuberpult-earthly would fail on macOS.