### PR TITLE
fix: improve check for non-existing argo apps

### DIFF
--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -130,7 +130,7 @@ func (a ArgoAppProcessor) CreateOrUpdateApp(ctx context.Context, overview *api.G
 
 		appExists := false
 		for _, argoApp := range appsKnownToArgo {
-			if argoApp.Annotations["com.freiheit.kuberpult/application"] != "" {
+			if argoApp.Name == app.Name && argoApp.Annotations["com.freiheit.kuberpult/application"] != "" {
 				appExists = true
 				break
 			}

--- a/services/rollout-service/pkg/argo/argo_test.go
+++ b/services/rollout-service/pkg/argo/argo_test.go
@@ -212,7 +212,6 @@ func (m *mockApplicationServiceClient) Create(ctx context.Context, req *applicat
 }
 
 func (m *mockApplicationServiceClient) testAllConsumed(t *testing.T, expectedConsumed int) {
-	fmt.Println(m.Apps)
 	for _, app := range m.Apps {
 		if !app.App.Spec.SyncPolicy.Automated.SelfHeal {
 			t.Errorf("expected app %s to have selfHeal enabled", app.App.Name)
@@ -638,7 +637,6 @@ func TestArgoConsume(t *testing.T) {
 				trigger:           make(chan *api.GetOverviewResponse, 10),
 				argoApps:          make(chan *v1alpha1.ApplicationWatchEvent, 10),
 			}
-			fmt.Println(argoProcessor.argoApps)
 			hlth.BackOffFactory = func() backoff.BackOff { return backoff.NewConstantBackOff(0) }
 			errCh := make(chan error)
 			go func() {


### PR DESCRIPTION
Creating new apps could fail because we were considering that an application exists in argo if there is at least one application that is self-managed. Also more testing was done to not only check the number of events in the argo processor, but also the types.