### PR TITLE
fix: remove hardcoded retry limit from backoff

### DIFF
--- a/pkg/setup/health.go
+++ b/pkg/setup/health.go
@@ -232,7 +232,7 @@ func (h *HealthServer) Reporter(name string) *HealthReporter {
 	if h.BackOffFactory != nil {
 		bo = h.BackOffFactory()
 	} else {
-		bo = backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 5)
+		bo = backoff.NewExponentialBackOff()
 	}
 	r := &HealthReporter{
 		server:  h,


### PR DESCRIPTION
The fixed retry limit is causing the rollout service to get restarted whenver the cd-service is restarting.