### PR TITLE
feat: make batchClient timeout configurable

### DIFF
--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -94,6 +94,8 @@ spec:
           value: kuberpult-cd-service:8443
         - name: KUBERPULT_ARGOCD_BASE_URL
           value: {{ .Values.argocd.baseUrl | quote }}
+        - name: KUBERPULT_BATCH_CLIENT_TIMEOUT
+          value: {{ .Values.frontend.service.batchClient.timeout | quote }}
         - name: KUBERPULT_VERSION
           value: {{ $.Chart.AppVersion | quote}}
         - name: KUBERPULT_SOURCE_REPO_URL

--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -95,7 +95,7 @@ spec:
         - name: KUBERPULT_ARGOCD_BASE_URL
           value: {{ .Values.argocd.baseUrl | quote }}
         - name: KUBERPULT_BATCH_CLIENT_TIMEOUT
-          value: {{ .Values.frontend.service.batchClient.timeout | quote }}
+          value: {{ .Values.frontend.batchClient.timeout | quote }}
         - name: KUBERPULT_VERSION
           value: {{ $.Chart.AppVersion | quote}}
         - name: KUBERPULT_SOURCE_REPO_URL

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -102,6 +102,7 @@ frontend:
 # This MUST be lower than the combined timeouts of ALL http proxies in use.
   maxWaitDuration: 10m
   batchClient:
+    # This value needs to be higher than the network timeout for git
     timeout: 2m
 rollout:
   enabled: false

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -91,6 +91,8 @@ frontend:
 # See frontend-service.yaml for automatically added annotations.
   service:
     annotations: {}
+    batchClient:
+      timeout: 2m
   resources:
     limits:
       cpu: 500m

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -91,8 +91,6 @@ frontend:
 # See frontend-service.yaml for automatically added annotations.
   service:
     annotations: {}
-    batchClient:
-      timeout: 2m
   resources:
     limits:
       cpu: 500m
@@ -103,6 +101,8 @@ frontend:
 # Limit for the wait time for resources that support waiting on conditions ( e.g. rollout-status ).
 # This MUST be lower than the combined timeouts of ALL http proxies in use.
   maxWaitDuration: 10m
+  batchClient:
+    timeout: 2m
 rollout:
   enabled: false
   image: kuberpult-rollout-service

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -21,13 +21,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	grpcerrors "github.com/freiheit-com/kuberpult/pkg/grpc"
 	"io"
 	"net/http"
 	"os"
 	"strings"
-	"time"
-
-	grpcerrors "github.com/freiheit-com/kuberpult/pkg/grpc"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/freiheit-com/kuberpult/services/frontend-service/pkg/interceptors"
@@ -221,7 +219,7 @@ func runServer(ctx context.Context) error {
 
 	batchClient := &service.BatchServiceWithDefaultTimeout{
 		Inner:          api.NewBatchServiceClient(cdCon),
-		DefaultTimeout: 2 * time.Minute,
+		DefaultTimeout: c.BatchClientTimeout,
 	}
 	gproxy := &GrpcProxy{
 		OverviewClient:           api.NewOverviewServiceClient(cdCon),

--- a/services/frontend-service/pkg/config/config.go
+++ b/services/frontend-service/pkg/config/config.go
@@ -45,6 +45,7 @@ type ServerConfig struct {
 	AllowedOrigins      string        `default:"" split_words:"true"`
 	GitAuthorName       string        `default:"" split_words:"true"`
 	GitAuthorEmail      string        `default:"" split_words:"true"`
+	BatchClientTimeout  time.Duration `default:"2m" split_words:"true"`
 	MaxWaitDuration     time.Duration `default:"10m" split_words:"true"`
 }
 


### PR DESCRIPTION
The batchClient can timeout with the static value we use. Therefore we should make the timeout configurable in the chart.