### PR TITLE
feat: limit number of batched commits per push

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -187,6 +187,8 @@ spec:
           value: "{{ .Values.git.networkTimeout }}"
         - name: KUBERPULT_GIT_WRITE_COMMIT_DATA
           value: "{{ .Values.git.enableWritingCommitData }}"
+        - name: KUBERPULT_GIT_MAXIMUM_COMMITS_PER_PUSH
+          value: "{{ .Values.git.maximumCommitsPerPush }}"
         volumeMounts:
         - name: repository
           mountPath: /repository

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -53,6 +53,9 @@ git:
   enableWritingCommitData: false
 
   # Kuberpult tries to reduce the number of pushes and can bundle concurrent commits into a single push.
+  # This can reduce the time it takes to process requests ariving at the same time and improve throughput.
+  # The correct number largely depends on the performance of the git host and repository size. For small to medium sized deployments the default is good.
+  # We recommend values between 1 and 20.
   maximumCommitsPerPush: 5
 
 hub: europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -52,6 +52,9 @@ git:
   # Disabling this option does not delete the `/commit` directory.
   enableWritingCommitData: false
 
+  # Kuberpult tries to reduce the number of pushes and can bundle concurrent commits into a single push.
+  maximumCommitsPerPush: 5
+
 hub: europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
 
 log:

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -74,7 +74,7 @@ type Config struct {
 	ArgoCdServer             string        `default:"" split_words:"true"`
 	ArgoCdInsecure           bool          `default:"false" split_words:"true"`
 	GitWebUrl                string        `default:"" split_words:"true"`
-	GitMaximumCommitsPerPush uint          `default:"0" split_words:"true"`
+	GitMaximumCommitsPerPush uint          `default:"1" split_words:"true"`
 }
 
 func (c *Config) storageBackend() repository.StorageBackend {
@@ -176,7 +176,11 @@ func RunServer() {
 				zap.String("url", c.GitUrl),
 				zap.String("details", "https is not supported for git communication, only ssh is supported"))
 		}
-
+		if c.GitMaximumCommitsPerPush == 0 {
+			logger.FromContext(ctx).Fatal("git.config",
+				zap.String("details", "the maximum number of commits per push must be at least 1"),
+			)
+		}
 		cfg := repository.RepositoryConfig{
 			WebhookResolver: nil,
 			URL:             c.GitUrl,

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -49,31 +49,32 @@ const datadogNameCd = "kuberpult-cd-service"
 
 type Config struct {
 	// these will be mapped to "KUBERPULT_GIT_URL", etc.
-	GitUrl                string        `required:"true" split_words:"true"`
-	GitBranch             string        `default:"master" split_words:"true"`
-	BootstrapMode         bool          `default:"false" split_words:"true"`
-	GitCommitterEmail     string        `default:"kuberpult@freiheit.com" split_words:"true"`
-	GitCommitterName      string        `default:"kuberpult" split_words:"true"`
-	GitSshKey             string        `default:"/etc/ssh/identity" split_words:"true"`
-	GitSshKnownHosts      string        `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
-	GitNetworkTimeout     time.Duration `default:"1m" split_words:"true"`
-	GitWriteCommitData    bool          `default:"false" split_words:"true"`
-	PgpKeyRingPath        string        `split_words:"true"`
-	AzureEnableAuth       bool          `default:"false" split_words:"true"`
-	DexEnabled            bool          `default:"false" split_words:"true"`
-	DexRbacPolicyPath     string        `split_words:"true"`
-	EnableTracing         bool          `default:"false" split_words:"true"`
-	EnableMetrics         bool          `default:"false" split_words:"true"`
-	EnableEvents          bool          `default:"false" split_words:"true"`
-	DogstatsdAddr         string        `default:"127.0.0.1:8125" split_words:"true"`
-	EnableProfiling       bool          `default:"false" split_words:"true"`
-	DatadogApiKeyLocation string        `default:"" split_words:"true"`
-	EnableSqlite          bool          `default:"true" split_words:"true"`
-	DexMock               bool          `default:"false" split_words:"true"`
-	DexMockRole           string        `default:"Developer" split_words:"true"`
-	ArgoCdServer          string        `default:"" split_words:"true"`
-	ArgoCdInsecure        bool          `default:"false" split_words:"true"`
-	GitWebUrl             string        `default:"" split_words:"true"`
+	GitUrl                   string        `required:"true" split_words:"true"`
+	GitBranch                string        `default:"master" split_words:"true"`
+	BootstrapMode            bool          `default:"false" split_words:"true"`
+	GitCommitterEmail        string        `default:"kuberpult@freiheit.com" split_words:"true"`
+	GitCommitterName         string        `default:"kuberpult" split_words:"true"`
+	GitSshKey                string        `default:"/etc/ssh/identity" split_words:"true"`
+	GitSshKnownHosts         string        `default:"/etc/ssh/ssh_known_hosts" split_words:"true"`
+	GitNetworkTimeout        time.Duration `default:"1m" split_words:"true"`
+	GitWriteCommitData       bool          `default:"false" split_words:"true"`
+	PgpKeyRingPath           string        `split_words:"true"`
+	AzureEnableAuth          bool          `default:"false" split_words:"true"`
+	DexEnabled               bool          `default:"false" split_words:"true"`
+	DexRbacPolicyPath        string        `split_words:"true"`
+	EnableTracing            bool          `default:"false" split_words:"true"`
+	EnableMetrics            bool          `default:"false" split_words:"true"`
+	EnableEvents             bool          `default:"false" split_words:"true"`
+	DogstatsdAddr            string        `default:"127.0.0.1:8125" split_words:"true"`
+	EnableProfiling          bool          `default:"false" split_words:"true"`
+	DatadogApiKeyLocation    string        `default:"" split_words:"true"`
+	EnableSqlite             bool          `default:"true" split_words:"true"`
+	DexMock                  bool          `default:"false" split_words:"true"`
+	DexMockRole              string        `default:"Developer" split_words:"true"`
+	ArgoCdServer             string        `default:"" split_words:"true"`
+	ArgoCdInsecure           bool          `default:"false" split_words:"true"`
+	GitWebUrl                string        `default:"" split_words:"true"`
+	GitMaximumCommitsPerPush uint          `default:"0" split_words:"true"`
 }
 
 func (c *Config) storageBackend() repository.StorageBackend {

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -200,6 +200,7 @@ func RunServer() {
 			NetworkTimeout:         c.GitNetworkTimeout,
 			DogstatsdEvents:        c.EnableMetrics,
 			WriteCommitData:        c.GitWriteCommitData,
+			MaximumCommitsPerPush:  c.GitMaximumCommitsPerPush,
 		}
 		repo, repoQueue, err := repository.New2(ctx, cfg)
 		if err != nil {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -348,6 +348,9 @@ func New2(ctx context.Context, cfg RepositoryConfig) (Repository, setup.Backgrou
 	if cfg.NetworkTimeout == 0 {
 		cfg.NetworkTimeout = time.Minute
 	}
+	if cfg.MaximumCommitsPerPush == 0 {
+		cfg.MaximumCommitsPerPush = 1
+	}
 	var credentials *credentialsStore
 	var certificates *certificateStore
 	var err error
@@ -534,7 +537,7 @@ func (r *repository) useRemote(ctx context.Context, callback func(*git.Remote) e
 }
 
 func (r *repository) drainQueue() []transformerBatch {
-	if r.config.MaximumCommitsPerPush == 0 {
+	if r.config.MaximumCommitsPerPush < 2 {
 		return nil
 	}
 	limit := r.config.MaximumCommitsPerPush - 1

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -1141,8 +1141,9 @@ func TestApplyQueuePanic(t *testing.T) {
 			repo, processQueue, err := New2(
 				testutil.MakeTestContext(),
 				RepositoryConfig{
-					URL:  "file://" + remoteDir,
-					Path: localDir,
+					URL:                   "file://" + remoteDir,
+					Path:                  localDir,
+					MaximumCommitsPerPush: 3,
 				},
 			)
 			if err != nil {
@@ -1466,8 +1467,9 @@ func TestApplyQueue(t *testing.T) {
 			repo, err := New(
 				testutil.MakeTestContext(),
 				RepositoryConfig{
-					URL:  "file://" + remoteDir,
-					Path: localDir,
+					URL:                   "file://" + remoteDir,
+					Path:                  localDir,
+					MaximumCommitsPerPush: 10,
 				},
 			)
 			if err != nil {

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -1528,22 +1528,22 @@ func TestMaximumCommitsPerPush(t *testing.T) {
 	tcs := []struct {
 		NumberOfCommits       uint
 		MaximumCommitsPerPush uint
-		ExpectedPushes        uint
+		ExpectedAtLeastPushes uint
 	}{
 		{
 			NumberOfCommits:       7,
 			MaximumCommitsPerPush: 5,
-			ExpectedPushes:        2,
+			ExpectedAtLeastPushes: 2,
 		},
 		{
 			NumberOfCommits:       5,
 			MaximumCommitsPerPush: 0,
-			ExpectedPushes:        5,
+			ExpectedAtLeastPushes: 5,
 		},
 		{
 			NumberOfCommits:       5,
 			MaximumCommitsPerPush: 10,
-			ExpectedPushes:        1,
+			ExpectedAtLeastPushes: 1,
 		},
 	}
 
@@ -1591,8 +1591,8 @@ func TestMaximumCommitsPerPush(t *testing.T) {
 				processor(ctx, nil)
 			}()
 			eg.Wait()
-			if ts.Pushes != tc.ExpectedPushes {
-				t.Errorf("expected %d pushes, but %d happened", tc.ExpectedPushes, ts.Pushes)
+			if ts.Pushes < tc.ExpectedAtLeastPushes {
+				t.Errorf("expected at least %d pushes, but %d happened", tc.ExpectedAtLeastPushes, ts.Pushes)
 			}
 
 		})

--- a/services/cd-service/pkg/repository/testssh/server.go
+++ b/services/cd-service/pkg/repository/testssh/server.go
@@ -38,6 +38,7 @@ type TestServer struct {
 	KnownHosts string
 	ClientKey  string
 	Url        string
+	Pushes     uint
 	l          net.Listener
 	execDelay  time.Duration
 }
@@ -137,6 +138,9 @@ func (ts *TestServer) handleConn(con net.Conn, workdir string, sc *ssh.ServerCon
 					req.Reply(false, nil)
 					ch.Close()
 					return
+				}
+				if args[0] == "git-receive-pack" {
+					ts.Pushes = ts.Pushes + 1
 				}
 				args[1] = filepath.Join(workdir, args[1])
 				cmd := exec.Command(args[0], args[1:len(args)]...)


### PR DESCRIPTION
Theoretically we could end up in a situation where we are trying to fit an infinite amount of commits in one push. That is probably not an ideal thing to do. There should be a limit on this, especially in environments with high concurrency.

This change adds a new config option `.git.maximumCommitsPerPush` to the helm chart that is used as an upper limit for the number of commits per push.