### PR TITLE
fix: make colors between `EnvironmentCard` and `EnvironmentChip` consistent

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -16,11 +16,10 @@ Copyright 2023 freiheit.com*/
 import { EnvironmentListItem, ReleaseDialog, ReleaseDialogProps } from './ReleaseDialog';
 import { fireEvent, render } from '@testing-library/react';
 import { UpdateAction, UpdateOverview, UpdateRolloutStatus, UpdateSidebar } from '../../utils/store';
-import { Environment, Priority, Release, RolloutStatus, UndeploySummary } from '../../../api/api';
+import { Environment, EnvironmentGroup, Priority, Release, RolloutStatus, UndeploySummary } from '../../../api/api';
 import { Spy } from 'spy4js';
 import { SideBar } from '../SideBar/SideBar';
 import { MemoryRouter } from 'react-router-dom';
-
 
 const mock_FormattedDate = Spy.mockModule('../FormattedDate/FormattedDate', 'FormattedDate');
 
@@ -37,6 +36,7 @@ describe('Release Dialog', () => {
         props: ReleaseDialogProps;
         rels: Release[];
         envs: Environment[];
+        envGroups: EnvironmentGroup[];
         expect_message: boolean;
         expect_queues: number;
         data_length: number;
@@ -53,6 +53,7 @@ describe('Release Dialog', () => {
         props: ReleaseDialogProps;
         rels: Release[];
         envs: Environment[];
+        envGroups: EnvironmentGroup[];
         expect_message: boolean;
         expect_queues: number;
         data_length: number;
@@ -91,6 +92,15 @@ describe('Release Dialog', () => {
                         },
                     },
                     distanceToUpstream: 0,
+                    priority: Priority.UPSTREAM,
+                },
+            ],
+            envGroups: [
+                {
+                    // this data should never appear (group with no envs with a well-defined priority), but we'll make it for the sake of the test.
+                    distanceToUpstream: 0,
+                    environmentGroupName: 'prod',
+                    environments: [],
                     priority: Priority.UPSTREAM,
                 },
             ],
@@ -136,6 +146,15 @@ describe('Release Dialog', () => {
                     priority: Priority.UPSTREAM,
                 },
             ],
+            envGroups: [
+                {
+                    // this data should never appear (group with no envs with a well-defined priority), but we'll make it for the sake of the test.
+                    distanceToUpstream: 0,
+                    environmentGroupName: 'prod',
+                    environments: [],
+                    priority: Priority.UPSTREAM,
+                },
+            ],
             expect_message: true,
             expect_queues: 0,
             data_length: 2,
@@ -174,6 +193,15 @@ describe('Release Dialog', () => {
                         },
                     },
                     distanceToUpstream: 0,
+                    priority: Priority.UPSTREAM,
+                },
+            ],
+            envGroups: [
+                {
+                    // this data should never appear (group with no envs with a well-defined priority), but we'll make it for the sake of the test.
+                    distanceToUpstream: 0,
+                    environmentGroupName: 'prod',
+                    environments: [],
                     priority: Priority.UPSTREAM,
                 },
             ],
@@ -217,6 +245,15 @@ describe('Release Dialog', () => {
                         },
                     },
                     distanceToUpstream: 0,
+                    priority: Priority.UPSTREAM,
+                },
+            ],
+            envGroups: [
+                {
+                    // this data should never appear (group with no envs with a well-defined priority), but we'll make it for the sake of the test.
+                    distanceToUpstream: 0,
+                    environmentGroupName: 'prod',
+                    environments: [],
                     priority: Priority.UPSTREAM,
                 },
             ],
@@ -280,6 +317,7 @@ describe('Release Dialog', () => {
                 },
             ],
             envs: [],
+            envGroups: [],
             expect_message: false,
             expect_queues: 0,
             data_length: 0,
@@ -419,6 +457,7 @@ describe('Release Dialog', () => {
                 render(
                     <EnvironmentListItem
                         env={testcase.envs[0]}
+                        envGroup={testcase.envGroups[0]}
                         app={testcase.props.app}
                         queuedVersion={0}
                         release={{ ...testcase.rels[0], version: 3 }}
@@ -464,6 +503,7 @@ describe('Release Dialog', () => {
             render(
                 <EnvironmentListItem
                     env={testcase.envs[0]}
+                    envGroup={testcase.envGroups[0]}
                     app={testcase.props.app}
                     queuedVersion={0}
                     release={testcase.rels[0]}

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -21,6 +21,7 @@ import { Spy } from 'spy4js';
 import { SideBar } from '../SideBar/SideBar';
 import { MemoryRouter } from 'react-router-dom';
 
+
 const mock_FormattedDate = Spy.mockModule('../FormattedDate/FormattedDate', 'FormattedDate');
 
 describe('Release Dialog', () => {

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -71,6 +71,7 @@ export const AppLock: React.FC<{
 
 export type EnvironmentListItemProps = {
     env: Environment;
+    envGroup: EnvironmentGroup;
     app: string;
     release: Release;
     queuedVersion: number;
@@ -103,6 +104,7 @@ const DeployedVersion: React.FC<CommitIdProps> = ({ application, app, env, other
 
 export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
     env,
+    envGroup,
     app,
     release,
     queuedVersion,
@@ -185,6 +187,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                 <EnvironmentChip
                     env={env}
                     app={app}
+                    envGroup={envGroup}
                     className={'release-environment'}
                     key={env.name}
                     groupNameOverride={undefined}
@@ -258,6 +261,7 @@ export const EnvironmentList: React.FC<{
                         <EnvironmentListItem
                             key={env.name}
                             env={env}
+                            envGroup={envGroup}
                             app={app}
                             release={release}
                             className={className}

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                   class="env-card-header"
                 >
                   <div
-                    class="mdc-evolution-chip release-environment environment-priority-upstream"
+                    class="mdc-evolution-chip release-environment environment-priority-unrecognized"
                     role="row"
                   >
                     <span
@@ -352,7 +352,7 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                   class="env-card-header"
                 >
                   <div
-                    class="mdc-evolution-chip release-environment environment-priority-upstream"
+                    class="mdc-evolution-chip release-environment environment-priority-unrecognized"
                     role="row"
                   >
                     <span
@@ -626,7 +626,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                   class="env-card-header"
                 >
                   <div
-                    class="mdc-evolution-chip release-environment environment-priority-upstream"
+                    class="mdc-evolution-chip release-environment environment-priority-unrecognized"
                     role="row"
                   >
                     <span
@@ -808,7 +808,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                   class="env-card-header"
                 >
                   <div
-                    class="mdc-evolution-chip release-environment environment-priority-upstream"
+                    class="mdc-evolution-chip release-environment environment-priority-unrecognized"
                     role="row"
                   >
                     <span

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
@@ -14,7 +14,7 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 import classNames from 'classnames';
-import { Environment } from '../../../api/api';
+import { Environment, EnvironmentGroup } from '../../../api/api';
 import React from 'react';
 import { EnvironmentGroupExtended, getPriorityClassName, useCurrentlyDeployedAtGroup } from '../../utils/store';
 import { LocksWhite } from '../../../images';
@@ -41,6 +41,7 @@ export const AppLockSummary: React.FC<{
 export type EnvironmentChipProps = {
     className: string;
     env: Environment;
+    envGroup: EnvironmentGroup;
     app: string;
     groupNameOverride?: string;
     numberEnvsDeployed?: number;
@@ -49,8 +50,8 @@ export type EnvironmentChipProps = {
 };
 
 export const EnvironmentChip = (props: EnvironmentChipProps): JSX.Element => {
-    const { className, env, smallEnvChip, app } = props;
-    const priorityClassName = getPriorityClassName(env);
+    const { className, env, envGroup, smallEnvChip, app } = props;
+    const priorityClassName = getPriorityClassName(envGroup);
     const name = props.groupNameOverride ? props.groupNameOverride : env.name;
     const numberString =
         props.numberEnvsDeployed && props.numberEnvsInGroup
@@ -107,6 +108,7 @@ export const EnvironmentGroupChip = (props: {
                 <EnvironmentChip
                     className={className}
                     env={envGroup.environments[0]}
+                    envGroup={envGroup}
                     app={app}
                     groupNameOverride={envGroup.environmentGroupName}
                     numberEnvsDeployed={envGroup.environments.length}
@@ -121,6 +123,7 @@ export const EnvironmentGroupChip = (props: {
         <EnvironmentChip
             className={className}
             env={envGroup.environments[0]}
+            envGroup={envGroup}
             app={app}
             groupNameOverride={undefined}
             numberEnvsDeployed={1}


### PR DESCRIPTION
Currently environment colors are inconsistent between the environments page and the release dialogue, as shown below.

| ![](https://i.imgur.com/LchXL1G.png) |
| :---: |
| _Figure 1: the environments page (left) and the release dialogue for an arbitrary app (right). Note that `development` has different colors in the two pages_|

These colors are determined by the `priority` field of `Environment` and `EnvironmentGroup` types; the environments page refers to the `EnvironmentGroup` type, while the release dialogue refers to the `Environment` type. This inconsistency was introduced in #1321.

This PR fixes this by modifying the logic of calculating the CSS style in the `EnvironmentChip` component (which consequently determines the CSS style for the color) to be similar to that of the `EnvironmentCard` component by referring to the `priority` field of the group of the environment rather than the environment itself.

Now it looks like this:

| ![](https://i.imgur.com/lj59pGu.png)|
| :---: |
| _Figure 2: the colors now_ |