### PR TITLE
feat: link readme in UI

### DIFF
--- a/services/frontend-service/src/ui/components/TopAppBar/TopAppBar.tsx
+++ b/services/frontend-service/src/ui/components/TopAppBar/TopAppBar.tsx
@@ -30,7 +30,7 @@ import {
     useSidebarShown,
 } from '../../utils/store';
 import { Warning } from '../../../api/api';
-import { hideWithoutWarnings, setHideWithoutWarnings } from '../../utils/Links';
+import { hideWithoutWarnings, KuberpultGitHubLink, setHideWithoutWarnings } from '../../utils/Links';
 
 export type TopAppBarProps = {
     showAppFilter: boolean;
@@ -46,7 +46,7 @@ export const TopAppBar: React.FC<TopAppBarProps> = (props) => {
     const appNameParam = params.get('application') || '';
     const teamsParam = (params.get('teams') || '').split(',').filter((val) => val !== '');
 
-    const version = useKuberpultVersion();
+    const version = useKuberpultVersion() || '2.6.0';
 
     const hideWithoutWarningsValue = hideWithoutWarnings(params);
     const allWarnings: Warning[] = useAllWarnings();
@@ -101,11 +101,14 @@ export const TopAppBar: React.FC<TopAppBarProps> = (props) => {
         ) : (
             <div className="mdc-top-app-bar__section top-app-bar--narrow-filter"></div>
         );
+
     return (
         <div className="mdc-top-app-bar">
             <div className="mdc-top-app-bar__row">
                 <div className="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
-                    <span className="mdc-top-app-bar__title">Kuberpult {version}</span>
+                    <span className="mdc-top-app-bar__title">
+                        Kuberpult <KuberpultGitHubLink version={version} />
+                    </span>
                 </div>
                 {renderedAppFilter}
                 {renderedTeamsFilter}

--- a/services/frontend-service/src/ui/utils/Links.test.tsx
+++ b/services/frontend-service/src/ui/utils/Links.test.tsx
@@ -22,6 +22,7 @@ import {
     DisplayManifestLink,
     DisplaySourceLink,
     DisplayCommitHistoryLink,
+    KuberpultGitHubLink,
 } from './Links';
 import { GetFrontendConfigResponse_ArgoCD } from '../../api/api';
 import { UpdateFrontendConfig } from './store';
@@ -324,6 +325,34 @@ describe('DisplayCommitHistoryLink', () => {
                 // or render nothing:
                 expect(document.body.textContent).toBe('');
             }
+        });
+    });
+});
+
+describe('KuberpultGitHubLink', () => {
+    const cases: {
+        version: string;
+        expectedLink: string;
+    }[] = [
+        {
+            version: '2.6.0',
+            expectedLink: 'https://github.com/freiheit-com/kuberpult/blob/v2.6.0/README.md',
+        },
+        {
+            version: '6.6.6',
+            expectedLink: 'https://github.com/freiheit-com/kuberpult/blob/v6.6.6/README.md',
+        },
+    ];
+    describe.each(cases)('Renders properly', (testcase) => {
+        const getNode = () => <KuberpultGitHubLink version={testcase.version} />;
+        const getWrapper = () => render(getNode());
+        it(testcase.version, () => {
+            //given
+            const { container } = getWrapper();
+            // when
+            const aElem = elementQuerySelectorSafe(container, 'a');
+            // then
+            expect(aElem.attributes.getNamedItem('href')?.value).toBe(testcase.expectedLink);
         });
     });
 });

--- a/services/frontend-service/src/ui/utils/Links.tsx
+++ b/services/frontend-service/src/ui/utils/Links.tsx
@@ -208,6 +208,18 @@ export const ProductVersionLink: React.FC<{ env: string; groupName: string }> = 
     );
 };
 
+export const KuberpultGitHubLink: React.FC<{ version: string }> = (props): JSX.Element | null => {
+    const { version } = props;
+    const vversion = 'v' + version;
+    return (
+        <a
+            title={'Opens the Kuberpult Readme for the current version ' + vversion}
+            href={'https://github.com/freiheit-com/kuberpult/blob/v' + version + '/README.md'}>
+            {vversion}
+        </a>
+    );
+};
+
 const hideWithoutWarningsParamName = 'hideWithoutWarnings';
 const hideWithoutWarningsParamEnabledValue = 'Y';
 export const hideWithoutWarnings = (params: URLSearchParams): boolean => {


### PR DESCRIPTION
This adds a link to the Readme of the current version of kuberpult to version link that is displayed at the top left of the main page.


Before:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/a9af8970-0b7a-4068-ae8d-5ce519bd43d7)


Now:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/7036985b-f483-452c-a246-823cdb805b16)

Reference: SRX-7X37EW