### PR TITLE
feat:  generating environments for local test data is done through rest endpoint

### DIFF
--- a/infrastructure/scripts/create-testdata/Readme.md
+++ b/infrastructure/scripts/create-testdata/Readme.md
@@ -13,8 +13,10 @@ You can check this repo out like this:
 You now have a repo.
 you still need to fill it with some basic data:
 environments and releases.
-For environments, just copy`testdata_template` to the root of your manifest repo.
-Commit and push (you may need `--force` to push).
+For environments, ensure that kuberpult is running (use the docker-compose file),
+and then run `./create-environments.sh` to create environments. This defaults to the 
+environments inside tesdata_template/environments, but you can also provide your own
+enviroments and respective configurations by running `./create-environments.sh /path/to/envs`
 
 For releases, ensure kuberpult is running (use the docker-compose file),
 and then run `./create-release.sh my-service my-team` to create releases

--- a/infrastructure/scripts/create-testdata/Readme.md
+++ b/infrastructure/scripts/create-testdata/Readme.md
@@ -16,7 +16,7 @@ environments and releases.
 For environments, ensure that kuberpult is running (use the docker-compose file),
 and then run `./create-environments.sh` to create environments. This defaults to the 
 environments inside tesdata_template/environments, but you can also provide your own
-enviroments and respective configurations by running `./create-environments.sh /path/to/envs`
+environments and respective configurations by running `./create-environments.sh /path/to/envs`
 
 For releases, ensure kuberpult is running (use the docker-compose file),
 and then run `./create-release.sh my-service my-team` to create releases

--- a/infrastructure/scripts/create-testdata/create-environments.sh
+++ b/infrastructure/scripts/create-testdata/create-environments.sh
@@ -4,10 +4,8 @@ set -o pipefail
 #set -x
 
 # usage
-# ./create-release.sh my-service-name [my-team-name]
+# ./create-environments.sh [path/to/envs]
 # Note that this just creates files, it doesn't push in git
-
-
 
 FRONTEND_PORT=8081 # see docker-compose.yml
 
@@ -22,6 +20,4 @@ for filename in "$testData"/*; do
          http://localhost:${FRONTEND_PORT}/environments/${env}
 done
 
-
 echo # curl sometimes does not print a trailing \n
-

--- a/infrastructure/scripts/create-testdata/create-environments.sh
+++ b/infrastructure/scripts/create-testdata/create-environments.sh
@@ -6,8 +6,9 @@ set -o pipefail
 # Note that this just creates files, it doesn't push in git
 
 FRONTEND_PORT=8081 # see docker-compose.yml
-
+cd $(dirname $0)
 testData=${1:-"./testdata_template/environments"}
+
 for filename in "$testData"/*; do
   configFile="$filename"/config.json
   env=$(basename -- "$filename")

--- a/infrastructure/scripts/create-testdata/create-environments.sh
+++ b/infrastructure/scripts/create-testdata/create-environments.sh
@@ -7,99 +7,20 @@ set -o pipefail
 # ./create-release.sh my-service-name [my-team-name]
 # Note that this just creates files, it doesn't push in git
 
-configFile=$1
-applicationOwnerTeam=${2:-sreteam}
-name=${2:-sreteam}
-commit_id=$(LC_CTYPE=C tr -dc a-f0-9 </dev/urandom | head -c 40 ; echo '')
-authors[0]="urbansky"
-authors[1]="Medo"
-authors[2]="Hannes"
-authors[3]="Mouhsen"
-authors[4]="Tamer"
-authors[5]="Ahmed"
-authors[6]="João"
-authors[7]="Leandro"
-sizeAuthors=${#authors[@]}
-index=$(($RANDOM % $sizeAuthors))
-echo ${authors[$index]}
-author="${authors[$index]}"
-commit_message_file="$(mktemp "${TMPDIR:-/tmp}/publish.XXXXXX")"
-trap "rm -f ""$commit_message_file" INT TERM HUP EXIT
-displayVersion=
-if ((RANDOM % 2)); then
-  displayVersion=$(( $RANDOM % 100)).$(( $RANDOM % 100)).$(( $RANDOM % 100))
-fi
 
-msgs[0]="Added new eslint rule"
-msgs[1]="Fix annotations in helm templates"
-msgs[2]="Improve performance with gitLib2"
-msgs[3]="Add colors to new UI"
-msgs[4]="Release trains for env groups"
-msgs[5]="Fix whitespace in ReleaseDialog"
-msgs[6]="Add Snackbar Notifications"
-msgs[7]="Rephrase ReleaseDialog text"
-msgs[8]="Change renovate schedule"
-msgs[9]="Fix bug in distanceToUpstream calculation"
-msgs[10]="Allow deleting locks on locks page"
-sizeMsgs=${#msgs[@]}
-index=$(($RANDOM % $sizeMsgs))
-echo $index
-echo "${msgs[$index]}" > "${commit_message_file}"
-
-ls "${commit_message_file}"
-
-release_version=''
-case "${RELEASE_VERSION:-}" in
-	'') echo "No RELEASE_VERSION set. Using non-idempotent versioning scheme";;
-	*[!0-9]*) echo "Please set the env variable RELEASE_VERSION to a number"; exit 1;;
-	*) release_version='--form-string '"version=${RELEASE_VERSION:-}";;
-esac
-
-echo "release version:" "${release_version}"
-
-configuration=()
-configuration+=("--form" "team=${applicationOwnerTeam}")
-
-manifests=()
-for env in development_1
-do
-  file=$(mktemp "${TMPDIR:-/tmp}/$env.XXXXXX")
-  signatureFile=$(mktemp "${TMPDIR:-/tmp}/$env.XXXXXX")
-  randomValue=$(LC_CTYPE=C tr -dc a-f0-9 </dev/urandom | head -c 12 ; echo '')
-cat <<EOF > "${file}"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: $name-dummy-config-map
-  namespace: "$env"
-data:
-  key: value
-  random: "${randomValue}"
----
-EOF
-  echo "wrote file ${file}"
-  manifests+=("--form" "manifests[${env}]=@${file}")
-  #gpg  --keyring trustedkeys-kuberpult.gpg --local-user kuberpult-kind@example.com --detach --sign --armor < "${file}" > "${signatureFile}"
-  manifests+=("--form" "signatures[${env}]=@${signatureFile}")
-done
-echo commit id: "${commit_id}"
 
 FRONTEND_PORT=8081 # see docker-compose.yml
 
-if [[ $(uname -o) == Darwin ]];
-then
-  EMAIL=$(echo -n "script-user@example.com" | base64 -b0)
-  AUTHOR=$(echo -n "script-user" | base64 -b0)
-else
-  EMAIL=$(echo -n "script-user@example.com" | base64 -w 0)
-  AUTHOR=$(echo -n "script-user" | base64 -w 0)
-fi
-
-DATA=$(cat $1)
-curl  -f -X POST -H "multipart/form-data" \
-      --form-string "config=${DATA}" \
-       http://localhost:${FRONTEND_PORT}/environments/development_1
+testData=${1:-"./testdata_template/environments"}
+for filename in "$testData"/*; do
+  configFile="$filename"/config.json
+  env=$(basename -- "$filename")
+  echo Writing $env...
+  DATA=$(cat $configFile)
+  curl  -f -X POST -H "multipart/form-data" \
+        --form-string "config=${DATA}" \
+         http://localhost:${FRONTEND_PORT}/environments/${env}
+done
 
 
 echo # curl sometimes does not print a trailing \n

--- a/infrastructure/scripts/create-testdata/create-environments.sh
+++ b/infrastructure/scripts/create-testdata/create-environments.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+#set -x
+
+# usage
+# ./create-release.sh my-service-name [my-team-name]
+# Note that this just creates files, it doesn't push in git
+
+configFile=$1
+applicationOwnerTeam=${2:-sreteam}
+name=${2:-sreteam}
+commit_id=$(LC_CTYPE=C tr -dc a-f0-9 </dev/urandom | head -c 40 ; echo '')
+authors[0]="urbansky"
+authors[1]="Medo"
+authors[2]="Hannes"
+authors[3]="Mouhsen"
+authors[4]="Tamer"
+authors[5]="Ahmed"
+authors[6]="João"
+authors[7]="Leandro"
+sizeAuthors=${#authors[@]}
+index=$(($RANDOM % $sizeAuthors))
+echo ${authors[$index]}
+author="${authors[$index]}"
+commit_message_file="$(mktemp "${TMPDIR:-/tmp}/publish.XXXXXX")"
+trap "rm -f ""$commit_message_file" INT TERM HUP EXIT
+displayVersion=
+if ((RANDOM % 2)); then
+  displayVersion=$(( $RANDOM % 100)).$(( $RANDOM % 100)).$(( $RANDOM % 100))
+fi
+
+msgs[0]="Added new eslint rule"
+msgs[1]="Fix annotations in helm templates"
+msgs[2]="Improve performance with gitLib2"
+msgs[3]="Add colors to new UI"
+msgs[4]="Release trains for env groups"
+msgs[5]="Fix whitespace in ReleaseDialog"
+msgs[6]="Add Snackbar Notifications"
+msgs[7]="Rephrase ReleaseDialog text"
+msgs[8]="Change renovate schedule"
+msgs[9]="Fix bug in distanceToUpstream calculation"
+msgs[10]="Allow deleting locks on locks page"
+sizeMsgs=${#msgs[@]}
+index=$(($RANDOM % $sizeMsgs))
+echo $index
+echo "${msgs[$index]}" > "${commit_message_file}"
+
+ls "${commit_message_file}"
+
+release_version=''
+case "${RELEASE_VERSION:-}" in
+	'') echo "No RELEASE_VERSION set. Using non-idempotent versioning scheme";;
+	*[!0-9]*) echo "Please set the env variable RELEASE_VERSION to a number"; exit 1;;
+	*) release_version='--form-string '"version=${RELEASE_VERSION:-}";;
+esac
+
+echo "release version:" "${release_version}"
+
+configuration=()
+configuration+=("--form" "team=${applicationOwnerTeam}")
+
+manifests=()
+for env in development_1
+do
+  file=$(mktemp "${TMPDIR:-/tmp}/$env.XXXXXX")
+  signatureFile=$(mktemp "${TMPDIR:-/tmp}/$env.XXXXXX")
+  randomValue=$(LC_CTYPE=C tr -dc a-f0-9 </dev/urandom | head -c 12 ; echo '')
+cat <<EOF > "${file}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: $name-dummy-config-map
+  namespace: "$env"
+data:
+  key: value
+  random: "${randomValue}"
+---
+EOF
+  echo "wrote file ${file}"
+  manifests+=("--form" "manifests[${env}]=@${file}")
+  #gpg  --keyring trustedkeys-kuberpult.gpg --local-user kuberpult-kind@example.com --detach --sign --armor < "${file}" > "${signatureFile}"
+  manifests+=("--form" "signatures[${env}]=@${signatureFile}")
+done
+echo commit id: "${commit_id}"
+
+FRONTEND_PORT=8081 # see docker-compose.yml
+
+if [[ $(uname -o) == Darwin ]];
+then
+  EMAIL=$(echo -n "script-user@example.com" | base64 -b0)
+  AUTHOR=$(echo -n "script-user" | base64 -b0)
+else
+  EMAIL=$(echo -n "script-user@example.com" | base64 -w 0)
+  AUTHOR=$(echo -n "script-user" | base64 -w 0)
+fi
+
+DATA=$(cat $1)
+curl  -f -X POST -H "multipart/form-data" \
+      --form-string "config=${DATA}" \
+       http://localhost:${FRONTEND_PORT}/environments/development_1
+
+
+echo # curl sometimes does not print a trailing \n
+

--- a/infrastructure/scripts/create-testdata/create-environments.sh
+++ b/infrastructure/scripts/create-testdata/create-environments.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -eu
 set -o pipefail
-#set -x
-
 # usage
 # ./create-environments.sh [path/to/envs]
 # Note that this just creates files, it doesn't push in git


### PR DESCRIPTION
You no longer need to copy the environments inside the test_data_template folder into the manifest repo and push the changes. Kuberpult now receives all environment data and configurations through the rest endpoint, by running the new create-environments.sh script