### PR TITLE
fix: productversion cleanup (SRX-AX9683)

### DIFF
--- a/services/frontend-service/src/setupTests.ts
+++ b/services/frontend-service/src/setupTests.ts
@@ -16,7 +16,7 @@ Copyright 2023 freiheit.com*/
 import '@testing-library/jest-dom';
 import 'react-use-sub/test-util';
 import { Lock, Release } from './api/api';
-import { DisplayLock, UpdateFrontendConfig, UpdateOverview, updateSummary, updateTag } from './ui/utils/store';
+import { DisplayLock, UpdateFrontendConfig, UpdateOverview, updateTag } from './ui/utils/store';
 
 // test utility to await all running promises
 global.nextTick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
@@ -108,8 +108,5 @@ export const fakeLoadEverything = (load: boolean): void => {
     });
     updateTag.set({
         tagsReady: load,
-    });
-    updateSummary.set({
-        summaryReady: load,
     });
 };

--- a/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.test.tsx
+++ b/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.test.tsx
@@ -13,7 +13,7 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { Environment, EnvironmentGroup, Priority, ProductSummary, TagData } from '../../../api/api';
 import { ProductVersion, TableFiltered } from './ProductVersion';
@@ -21,12 +21,8 @@ import { Spy } from 'spy4js';
 
 const mock_UseEnvGroups = Spy('envGroup');
 const mock_UseTags = Spy('Overview');
-const mock_UseSummaryDisplay = Spy('Status');
 
 jest.mock('../../utils/store', () => ({
-    getSummary() {
-        return {};
-    },
     refreshTags() {
         return {};
     },
@@ -36,12 +32,10 @@ jest.mock('../../utils/store', () => ({
     useTags() {
         return mock_UseTags();
     },
-    useSummaryDisplay() {
-        return mock_UseSummaryDisplay();
-    },
     useEnvironments() {
         return [];
     },
+    showSnackbarError() {},
 }));
 
 jest.mock('../../utils/Links', () => ({
@@ -53,6 +47,17 @@ jest.mock('../../utils/Links', () => ({
     },
 }));
 
+const mockGetProductSummary = jest.fn();
+
+jest.mock('../../utils/GrpcApi', () => ({
+    get useApi() {
+        return {
+            gitService: () => ({
+                GetProductSummary: () => mockGetProductSummary(),
+            }),
+        };
+    },
+}));
 const sampleEnvsA: Environment[] = [
     {
         name: 'tester',
@@ -144,19 +149,17 @@ describe('Product Version Data', () => {
 
     describe.each(data)(`Displays Product Version Page`, (testCase) => {
         // given
-        it(testCase.name, () => {
+        it(testCase.name, async () => {
             // replicate api calls
             mock_UseEnvGroups.returns(testCase.environmentGroups);
             mock_UseTags.returns({ response: { tagData: testCase.tags }, tagsReady: true });
-            mock_UseSummaryDisplay.returns({
-                response: { productSummary: testCase.productSummary },
-                summaryReady: true,
-            });
+            mockGetProductSummary.mockResolvedValue({ productSummary: testCase.productSummary });
             render(
                 <MemoryRouter>
                     <ProductVersion />
                 </MemoryRouter>
             );
+            await act(global.nextTick);
             expect(document.body).toMatchSnapshot();
             if (testCase.expectedDropDown !== '') {
                 expect(document.querySelector('.drop_down')?.textContent).toContain(testCase.expectedDropDown);

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -27,7 +27,6 @@ import {
     StreamStatusResponse,
     Warning,
     GetGitTagsResponse,
-    GetProductSummaryResponse,
     RolloutStatus,
     GetCommitInfoResponse,
     GetEnvironmentConfigResponse,
@@ -72,10 +71,6 @@ type TagsResponse = {
     response: GetGitTagsResponse;
     tagsReady: boolean;
 };
-type ProductSummaryResponse = {
-    response: GetProductSummaryResponse;
-    summaryReady: boolean;
-};
 
 export enum CommitInfoState {
     LOADING,
@@ -103,24 +98,6 @@ export const refreshTags = (): void => {
         });
 };
 export const [useTag, updateTag] = createStore<TagsResponse>({ response: tagsResponse, tagsReady: false });
-
-const summaryResponse: GetProductSummaryResponse = { productSummary: [] };
-export const getSummary = (commitHash: string, environment: string, environmentGroup: string): void => {
-    updateSummary.set({ summaryReady: false });
-    const api = useApi;
-    api.gitService()
-        .GetProductSummary({ commitHash: commitHash, environment: environment, environmentGroup: environmentGroup })
-        .then((result: GetProductSummaryResponse) => {
-            updateSummary.set({ response: result, summaryReady: true });
-        })
-        .catch((e) => {
-            showSnackbarError(e.message);
-        });
-};
-export const [useSummary, updateSummary] = createStore<ProductSummaryResponse>({
-    response: summaryResponse,
-    summaryReady: false,
-});
 
 export const getCommitInfo = (commitHash: string): void => {
     const api = useApi;
@@ -151,7 +128,6 @@ export const randomLockId = (): string => 'ui-v2-' + randBase36();
 
 export const useActions = (): BatchAction[] => useAction(({ actions }) => actions);
 export const useTags = (): TagsResponse => useTag((res) => res);
-export const useSummaryDisplay = (): ProductSummaryResponse => useSummary((res) => res);
 
 export const [useSidebar, UpdateSidebar] = createStore({ shown: false });
 


### PR DESCRIPTION
- store.tsx:
  * remove getSummary, useDisplaySummary, useSummary, updateSummary,
    GetSummaryResponse
  * those all use one global store for one summary, thus the summary
    would not be usable from different component at the same time
  * also they tightly coupled with UI (snackbar, loading state) which is
    break separation
- ProductVersion.tsx:
  * separate the state of product version into two clear booleans
    instead of ambiguous displaySummary/response.summaryReady):
    - showSummary: should a product version be shown at all?
    - summaryLoading: is the version info still loading?
  * rename tag change handler to onChangeTag (from non-obvious
    openClose)
    - also remove superfluous onSelect handler
    - also dont try to load summaries here -- updating the search params
      will take care of that already, dont duplicate it here
  * store summaries to display in the local productSummaries state
- ProductVersion.test.tsx/setupTests.tsx
  * adapt to changes