### PR TITLE
feat: remove use of MDCTextField in top bar

### DIFF
--- a/services/frontend-service/src/ui/components/TopAppBar/TopAppBar.tsx
+++ b/services/frontend-service/src/ui/components/TopAppBar/TopAppBar.tsx
@@ -71,7 +71,7 @@ export const TopAppBar: React.FC<TopAppBarProps> = (props) => {
             <div className="mdc-top-app-bar__section top-app-bar--wide-filter">
                 <Textfield
                     className={'top-app-bar-search-field'}
-                    floatingLabel={'Application Name'}
+                    placeholder={'Application Name'}
                     value={appNameParam}
                     leadingIcon={'search'}
                 />
@@ -82,7 +82,7 @@ export const TopAppBar: React.FC<TopAppBarProps> = (props) => {
     const renderedTeamsFilter =
         props.showTeamFilter === true ? (
             <div className="mdc-top-app-bar__section top-app-bar--narrow-filter">
-                <Dropdown className={'top-app-bar-search-field'} floatingLabel={'Teams'} leadingIcon={'search'} />
+                <Dropdown className={'top-app-bar-search-field'} placeholder={'Teams'} leadingIcon={'search'} />
             </div>
         ) : (
             <div className="mdc-top-app-bar__section top-app-bar--narrow-filter"></div>

--- a/services/frontend-service/src/ui/components/TopAppBar/TopAppBar.tsx
+++ b/services/frontend-service/src/ui/components/TopAppBar/TopAppBar.tsx
@@ -66,6 +66,18 @@ export const TopAppBar: React.FC<TopAppBarProps> = (props) => {
             </div>
         );
 
+    const [searchParams, setSearchParams] = useSearchParams(
+        appNameParam === '' ? undefined : { application: `${appNameParam}` }
+    );
+    const onChangeApplication = useCallback(
+        (event: any) => {
+            if (event.target.value !== '') searchParams.set('application', event.target.value);
+            else searchParams.delete('application');
+            setSearchParams(searchParams);
+        },
+        [searchParams, setSearchParams]
+    );
+
     const renderedAppFilter =
         props.showAppFilter === true ? (
             <div className="mdc-top-app-bar__section top-app-bar--wide-filter">
@@ -74,6 +86,7 @@ export const TopAppBar: React.FC<TopAppBarProps> = (props) => {
                     placeholder={'Application Name'}
                     value={appNameParam}
                     leadingIcon={'search'}
+                    onChangeHandler={onChangeApplication}
                 />
             </div>
         ) : (

--- a/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
+++ b/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
@@ -24,7 +24,7 @@ import { Button } from '../button';
 
 export type DropdownProps = {
     className?: string;
-    floatingLabel?: string;
+    placeholder?: string;
     leadingIcon?: string;
 };
 
@@ -113,7 +113,7 @@ export const DropdownSelect: React.FC<DropdownSelectProps> = (props) => {
 };
 
 export const Dropdown = (props: DropdownProps): JSX.Element => {
-    const { className, floatingLabel, leadingIcon } = props;
+    const { className, placeholder, leadingIcon } = props;
     const control = useRef<HTMLDivElement>(null);
     const teams = useTeamNames();
     const [searchParams, setSearchParams] = useSearchParams();
@@ -122,7 +122,7 @@ export const Dropdown = (props: DropdownProps): JSX.Element => {
         'mdc-select',
         'mdc-select--outlined',
         {
-            'mdc-select--no-label': !floatingLabel,
+            'mdc-select--no-label': !placeholder,
             'mdc-select--with-leading-icon': leadingIcon,
         },
         className

--- a/services/frontend-service/src/ui/components/textfield/__snapshots__/textfield.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/textfield/__snapshots__/textfield.test.tsx.snap
@@ -2,24 +2,14 @@
 
 exports[`Textfield renders correctly using Snapshot 1`] = `
 <div
-  class="mdc-text-field mdc-text-field--outlined"
+  class="mdc-text-field mdc-text-field--outlined mdc-text-field--no-label"
 >
   <span
-    class="mdc-notched-outline mdc-notched-outline--upgraded"
+    class="mdc-notched-outline"
   >
     <span
       class="mdc-notched-outline__leading"
     />
-    <span
-      class="mdc-notched-outline__notch"
-    >
-      <span
-        class="mdc-floating-label"
-        style="transition-duration: 0s;"
-      >
-        Floating label
-      </span>
-    </span>
     <span
       class="mdc-notched-outline__trailing"
     />
@@ -27,7 +17,8 @@ exports[`Textfield renders correctly using Snapshot 1`] = `
   <input
     aria-label="Floating label"
     class="mdc-text-field__input"
-    type="text"
+    placeholder="Floating label"
+    type="search"
     value=""
   />
 </div>

--- a/services/frontend-service/src/ui/components/textfield/textfield.scss
+++ b/services/frontend-service/src/ui/components/textfield/textfield.scss
@@ -19,10 +19,3 @@ Copyright 2023 freiheit.com*/
 @use '@material/textfield/icon';
 
 @include icon.icon-core-styles;
-
-.mdc-text-field--outlined:not(.mdc-text-field--disabled):not(.mdc-text-field--focused):hover .mdc-notched-outline .mdc-notched-outline__leading,
-.mdc-text-field--outlined:not(.mdc-text-field--disabled):not(.mdc-text-field--focused):hover .mdc-notched-outline .mdc-notched-outline__notch,
-.mdc-text-field--outlined:not(.mdc-text-field--disabled):not(.mdc-text-field--focused):hover .mdc-notched-outline .mdc-notched-outline__trailing {
-    border-width: 2px;
-    border-color: var(--mdc-theme-primary);
-}

--- a/services/frontend-service/src/ui/components/textfield/textfield.scss
+++ b/services/frontend-service/src/ui/components/textfield/textfield.scss
@@ -19,15 +19,3 @@ Copyright 2023 freiheit.com*/
 @use '@material/textfield/icon';
 
 @include icon.icon-core-styles;
-
-.mdc-text-field {
-    width: 100%;
-}
-
-div.mdc-text-field.mdc-text-field--outlined span.mdc-floating-label.mdc-floating-label--float-above {
-    @extend .text-bold;
-}
-
-span.mdc-floating-label {
-    @extend .text-bold;
-}

--- a/services/frontend-service/src/ui/components/textfield/textfield.scss
+++ b/services/frontend-service/src/ui/components/textfield/textfield.scss
@@ -19,3 +19,10 @@ Copyright 2023 freiheit.com*/
 @use '@material/textfield/icon';
 
 @include icon.icon-core-styles;
+
+.mdc-text-field--outlined:not(.mdc-text-field--disabled):not(.mdc-text-field--focused):hover .mdc-notched-outline .mdc-notched-outline__leading,
+.mdc-text-field--outlined:not(.mdc-text-field--disabled):not(.mdc-text-field--focused):hover .mdc-notched-outline .mdc-notched-outline__notch,
+.mdc-text-field--outlined:not(.mdc-text-field--disabled):not(.mdc-text-field--focused):hover .mdc-notched-outline .mdc-notched-outline__trailing {
+    border-width: 2px;
+    border-color: var(--mdc-theme-primary);
+}

--- a/services/frontend-service/src/ui/components/textfield/textfield.test.tsx
+++ b/services/frontend-service/src/ui/components/textfield/textfield.test.tsx
@@ -24,7 +24,7 @@ describe('Textfield', () => {
         // given
         const { container } = render(
             <MemoryRouter>
-                <Textfield floatingLabel="Floating label" />
+                <Textfield placeholder="Floating label" />
             </MemoryRouter>
         );
         // when & then
@@ -45,7 +45,6 @@ describe('Textfield', () => {
         expect(container.querySelector('i')).toMatchInlineSnapshot(`
     <i
       class="material-icons mdc-text-field__icon mdc-text-field__icon--leading"
-      role="button"
       tabindex="0"
     >
       search
@@ -67,7 +66,7 @@ describe('Verify textfield content', () => {
         );
     };
 
-    const getWrapper = (overrides?: { floatingLabel: string; value: string; className: string }, entries?: string[]) =>
+    const getWrapper = (overrides?: { placeholder: string; value: string; className: string }, entries?: string[]) =>
         render(getNode(overrides));
 
     it(`Renders a navigation item base`, () => {
@@ -80,7 +79,7 @@ describe('Verify textfield content', () => {
     interface dataT {
         name: string;
         className: string;
-        floatingLabel: string;
+        placeholder: string;
         value: string;
         expect: (container: HTMLElement) => void;
     }
@@ -89,7 +88,7 @@ describe('Verify textfield content', () => {
         {
             name: 'Empty textfield',
             className: 'top-app-bar-search-field',
-            floatingLabel: 'Search',
+            placeholder: 'Search',
             value: '',
             expect: (container) =>
                 expect(container.getElementsByClassName('mdc-text-field__input')[0]).toHaveTextContent(''),
@@ -97,7 +96,7 @@ describe('Verify textfield content', () => {
         {
             name: 'Textfield with content',
             className: 'top-app-bar-search-field',
-            floatingLabel: 'Search',
+            placeholder: 'Search',
             value: 'test-search',
             expect: (container) => {
                 const input = getElementsByClassNameSafe(container, 'mdc-text-field__input')[0];
@@ -111,9 +110,9 @@ describe('Verify textfield content', () => {
 
     describe.each(data)(`Renders a navigation item with selected`, (testcase) => {
         it(testcase.name, () => {
-            const { className, floatingLabel, value } = testcase;
+            const { className, placeholder, value } = testcase;
             // when
-            const { container } = getWrapper({ floatingLabel, className, value });
+            const { container } = getWrapper({ placeholder, className, value });
             // then
             testcase.expect(container);
         });

--- a/services/frontend-service/src/ui/components/textfield/textfield.tsx
+++ b/services/frontend-service/src/ui/components/textfield/textfield.tsx
@@ -13,45 +13,29 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import classNames from 'classnames';
-import { MDCTextField } from '@material/textfield';
 import { useSearchParams } from 'react-router-dom';
 
 export type TextfieldProps = {
     className?: string;
-    floatingLabel?: string;
+    placeholder?: string;
     value?: string | number;
     leadingIcon?: string;
 };
 
 export const Textfield = (props: TextfieldProps): JSX.Element => {
-    const { className, floatingLabel, leadingIcon, value } = props;
-    const control = useRef<HTMLDivElement>(null);
-    const input = useRef<HTMLInputElement>(null);
-    const MDComponent = useRef<MDCTextField>();
+    const { className, placeholder, leadingIcon, value } = props;
 
-    useEffect(() => {
-        if (control.current) {
-            MDComponent.current = new MDCTextField(control.current);
-        }
-        return (): void => MDComponent.current?.destroy();
-    }, []);
-
-    useEffect(() => {
-        if (floatingLabel) {
-            MDComponent.current?.layout();
-        }
-    });
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [searchParams, setSearchParams] = useSearchParams();
+    const [searchParams, setSearchParams] = useSearchParams(
+        value === undefined || value === '' ? undefined : { application: `${value}` }
+    );
 
     const allClassName = classNames(
         'mdc-text-field',
         'mdc-text-field--outlined',
+        'mdc-text-field--no-label',
         {
-            'mdc-text-field--no-label': !floatingLabel,
             'mdc-text-field--with-leading-icon': leadingIcon,
         },
         className
@@ -67,22 +51,9 @@ export const Textfield = (props: TextfieldProps): JSX.Element => {
     );
 
     return (
-        <div className={allClassName} ref={control}>
+        <div className={allClassName}>
             <span className="mdc-notched-outline">
                 <span className="mdc-notched-outline__leading" />
-                {!!floatingLabel && (
-                    <span className="mdc-notched-outline__notch">
-                        <span
-                            className={classNames('mdc-floating-label', {
-                                'mdc-floating-label--float-above':
-                                    !!value ||
-                                    (input.current && input.current.value !== '') ||
-                                    input.current === document.activeElement,
-                            })}>
-                            {floatingLabel}
-                        </span>
-                    </span>
-                )}
                 <span className="mdc-notched-outline__trailing" />
             </span>
             {leadingIcon && (
@@ -91,12 +62,11 @@ export const Textfield = (props: TextfieldProps): JSX.Element => {
                 </i>
             )}
             <input
-                type="text"
+                type="search"
                 className="mdc-text-field__input"
-                defaultValue={value}
-                ref={input}
-                aria-label={floatingLabel}
-                disabled={window.location.href.includes('environments')}
+                value={searchParams.get('application') ?? ''}
+                placeholder={placeholder}
+                aria-label={placeholder}
                 onChange={setQueryParam}
             />
         </div>

--- a/services/frontend-service/src/ui/components/textfield/textfield.tsx
+++ b/services/frontend-service/src/ui/components/textfield/textfield.tsx
@@ -13,23 +13,19 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-import { useCallback } from 'react';
+import { ChangeEventHandler } from 'react';
 import classNames from 'classnames';
-import { useSearchParams } from 'react-router-dom';
 
 export type TextfieldProps = {
     className?: string;
     placeholder?: string;
     value?: string | number;
     leadingIcon?: string;
+    onChangeHandler?: ChangeEventHandler;
 };
 
 export const Textfield = (props: TextfieldProps): JSX.Element => {
-    const { className, placeholder, leadingIcon, value } = props;
-
-    const [searchParams, setSearchParams] = useSearchParams(
-        value === undefined || value === '' ? undefined : { application: `${value}` }
-    );
+    const { className, placeholder, leadingIcon, value, onChangeHandler } = props;
 
     const allClassName = classNames(
         'mdc-text-field',
@@ -39,15 +35,6 @@ export const Textfield = (props: TextfieldProps): JSX.Element => {
             'mdc-text-field--with-leading-icon': leadingIcon,
         },
         className
-    );
-
-    const setQueryParam = useCallback(
-        (event: any) => {
-            if (event.target.value !== '') searchParams.set('application', event.target.value);
-            else searchParams.delete('application');
-            setSearchParams(searchParams);
-        },
-        [searchParams, setSearchParams]
     );
 
     return (
@@ -64,10 +51,10 @@ export const Textfield = (props: TextfieldProps): JSX.Element => {
             <input
                 type="search"
                 className="mdc-text-field__input"
-                value={searchParams.get('application') ?? ''}
+                defaultValue={value}
                 placeholder={placeholder}
                 aria-label={placeholder}
-                onChange={setQueryParam}
+                onChange={onChangeHandler}
             />
         </div>
     );

--- a/services/frontend-service/src/ui/components/textfield/textfield.tsx
+++ b/services/frontend-service/src/ui/components/textfield/textfield.tsx
@@ -13,7 +13,7 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright 2023 freiheit.com*/
-import { ChangeEventHandler } from 'react';
+import { ChangeEventHandler, useCallback, useState } from 'react';
 import classNames from 'classnames';
 
 export type TextfieldProps = {
@@ -27,12 +27,18 @@ export type TextfieldProps = {
 export const Textfield = (props: TextfieldProps): JSX.Element => {
     const { className, placeholder, leadingIcon, value, onChangeHandler } = props;
 
+    const [hasFocus, setFocus] = useState(false);
+
+    const onFocus = useCallback((): void => setFocus(true), [setFocus]);
+    const onBlur = useCallback((): void => setFocus(false), [setFocus]);
+
     const allClassName = classNames(
         'mdc-text-field',
         'mdc-text-field--outlined',
         'mdc-text-field--no-label',
         {
             'mdc-text-field--with-leading-icon': leadingIcon,
+            'mdc-text-field--focused': hasFocus,
         },
         className
     );
@@ -55,6 +61,8 @@ export const Textfield = (props: TextfieldProps): JSX.Element => {
                 placeholder={placeholder}
                 aria-label={placeholder}
                 onChange={onChangeHandler}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </div>
     );


### PR DESCRIPTION
* get rid of floating label transitions
* rename `floatingLabel` parameter to better reflect what it does

Comparison:
* Before  
  ![image](https://github.com/freiheit-com/kuberpult/assets/123140/0a900ad2-5718-4567-83c6-df59488b1245)
  ![image](https://github.com/freiheit-com/kuberpult/assets/123140/70b330e7-b122-4454-bdca-bf8f79264f3f)
* After
  ![image](https://github.com/freiheit-com/kuberpult/assets/123140/4ab52839-091b-45a2-91d3-ef001c429a2b)
  ![image](https://github.com/freiheit-com/kuberpult/assets/123140/e3ad2d1f-94f0-4c7f-9be0-67cf40734b2a)


Rev: SRX-53N7TA