### PR TITLE
feat: implement endpoint to retrieve manifests

### DIFF
--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -118,6 +118,10 @@ spec:
           value: "https://{{ .Values.ingress.domainName }}"
         - name: KUBERPULT_GIT_BRANCH
           value: {{ .Values.git.branch | quote }}
+        - name: KUBERPULT_IAP_ENABLED
+          value: {{ .Values.ingress.iap.enabled | quote }}
+        - name: KUBERPULT_API_ENABLE_DESPITE_NO_AUTH
+          value: {{ .Values.auth.api.enableDespiteNoAuth | quote }}
 {{- if .Values.datadogTracing.enabled }}
         - name: DD_AGENT_HOST
           valueFrom:

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -270,7 +270,7 @@ auth:
     # As of now this applies only to the manifest endpoint <insert rest pattern here>
     # If you do not have Googles IAP enabled, but still want to use the API, be aware that it is publicly available,
     # so you would need a protection outside of kuberpult (e.g. a VPN).
-    # If `enableDespiteNoAuth=true`, then the API will only respond, if IAP is enabled in this helm chart (`ingress.iap.enabled=true`).
+    # If `enableDespiteNoAuth=true`, then the API will respond, even if IAP is disabled in this helm chart (`ingress.iap.enabled=true`).
     enableDespiteNoAuth: false
 
 # The Dex configuration values. For more information please check the Dex repository https://github.com/dexidp/dex

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -267,7 +267,7 @@ auth:
     scopes: ""
   api:
     # New api endpoints (starting with `/api/`), are by default only turned on when IAP is enabled.
-    # As of now this applies only to the manifest endpoint <insert rest pattern here>
+    # As of now this applies only to the manifest endpoint `/api/application/<application>/release/<release>/manifests`.
     # If you do not have Googles IAP enabled, but still want to use the API, be aware that it is publicly available,
     # so you would need a protection outside of kuberpult (e.g. a VPN).
     # If `enableDespiteNoAuth=true`, then the API will respond, even if IAP is disabled in this helm chart (`ingress.iap.enabled=true`).

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -265,6 +265,13 @@ auth:
     baseURL: ""
     # List of scopes to validate the token. Please add them as comma separated values.
     scopes: ""
+  api:
+    # New api endpoints (starting with `/api/`), are by default only turned on when IAP is enabled.
+    # As of now this applies only to the manifest endpoint <insert rest pattern here>
+    # If you do not have Googles IAP enabled, but still want to use the API, be aware that it is publicly available,
+    # so you would need a protection outside of kuberpult (e.g. a VPN).
+    # If `enableDespiteNoAuth=true`, then the API will only respond, if IAP is enabled in this helm chart (`ingress.iap.enabled=true`).
+    enableDespiteNoAuth: false
 
 # The Dex configuration values. For more information please check the Dex repository https://github.com/dexidp/dex
 dex:

--- a/docker-compose-earthly.yml
+++ b/docker-compose-earthly.yml
@@ -31,6 +31,7 @@ services:
       - KUBERPULT_SOURCE_REPO_URL=https://github.com/freiheit-com/kuberpult/commit/{commit}
       - KUBERPULT_MANIFEST_REPO_URL=https://github.com/freiheit-com/fdc-standard-setup-dev-env-manifest/tree/{branch}/{dir}
       - KUBERPULT_GIT_BRANCH=main
+      - KUBERPULT_API_ENABLED_DESPITE_NO_AUTH=false
     ports:
       - "8081:8081"
     depends_on:

--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -335,6 +335,7 @@ message GetVersionResponse {
 
 service VersionService {
   rpc GetVersion (GetVersionRequest) returns (GetVersionResponse) {}
+  rpc GetManifests (GetManifestsRequest) returns (GetManifestsResponse) {}
 }
 
 service OverviewService {
@@ -589,4 +590,19 @@ message GetStatusResponse {
   }
   RolloutStatus status = 1;
   repeated ApplicationStatus applications = 2;
+}
+
+message GetManifestsRequest {
+  string application = 1;
+  string release = 2;
+}
+
+message Manifest {
+  string environment = 1;
+  string content = 2;
+}
+
+message GetManifestsResponse {
+  Release release = 1;
+  map<string, Manifest> manifests = 2;
 }

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -96,6 +96,10 @@ func releasesDirectoryWithVersion(fs billy.Filesystem, application string, versi
 	return fs.Join(releasesDirectory(fs, application), versionToString(version))
 }
 
+func manifestDirectoryWithReleasesVersion(fs billy.Filesystem, application string, version uint64) string {
+	return fs.Join(releasesDirectoryWithVersion(fs, application, version), "environments")
+}
+
 func commitDirectory(fs billy.Filesystem, commit string) string {
 	return fs.Join("commits", commit[:2], commit[2:])
 }

--- a/services/cd-service/pkg/service/version_test.go
+++ b/services/cd-service/pkg/service/version_test.go
@@ -18,9 +18,17 @@ package service
 
 import (
 	"context"
-	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository/testutil"
+	"crypto/md5"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository/testutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/config"
@@ -162,6 +170,176 @@ func TestVersion(t *testing.T) {
 				if ev.ExpectedSourceCommitId != res.SourceCommitId {
 					t.Errorf("go wrong source commit id, expected %q, got %q", ev.ExpectedSourceCommitId, res.SourceCommitId)
 				}
+			}
+		})
+	}
+}
+
+func TestGetManifests(t *testing.T) {
+	type testCase struct {
+		name    string
+		setup   []repository.Transformer
+		req     *api.GetManifestsRequest
+		want    *api.GetManifestsResponse
+		wantErr error
+	}
+
+	appName := "app-default"
+	appNameOther := "app-other"
+	fixtureRequest := func(mods ...func(*api.GetManifestsRequest)) *api.GetManifestsRequest {
+		req := &api.GetManifestsRequest{
+			Application: appName,
+			Release:     "latest",
+		}
+		for _, m := range mods {
+			m(req)
+		}
+		return req
+	}
+	fixtureSetupEnv := func() []repository.Transformer {
+		return []repository.Transformer{
+			&repository.CreateEnvironment{
+				Environment: "development",
+				Config: config.EnvironmentConfig{
+					Upstream: &config.EnvironmentConfigUpstream{
+						Latest: true,
+					},
+				},
+			},
+			&repository.CreateEnvironment{
+				Environment: "staging",
+				Config: config.EnvironmentConfig{
+					Upstream: &config.EnvironmentConfigUpstream{
+						Latest: true,
+					},
+				},
+			},
+		}
+	}
+	fixtureRelease := func(application string, release uint64) *repository.CreateApplicationVersion {
+		return &repository.CreateApplicationVersion{
+			Application: application,
+			Version:     release,
+			Manifests: map[string]string{
+				"development": fmt.Sprintf("dev-manifest for %s in release %d", application, release),
+				"staging":     fmt.Sprintf("staging-manifest for %s in release %d", application, release),
+			},
+			SourceCommitId: fmt.Sprintf("%x",
+				md5.Sum(
+					[]byte(
+						fmt.Sprintf("source commit id for app %s and release %d", application, release),
+					),
+				),
+			),
+		}
+	}
+
+	fixtureReleaseToManifests := func(release *repository.CreateApplicationVersion) *api.GetManifestsResponse {
+		return &api.GetManifestsResponse{
+			Release: &api.Release{
+				Version:        release.Version,
+				SourceCommitId: release.SourceCommitId,
+			},
+			Manifests: map[string]*api.Manifest{
+				"development": {
+					Environment: "development",
+					Content:     release.Manifests["development"],
+				},
+				"staging": {
+					Environment: "staging",
+					Content:     release.Manifests["staging"],
+				},
+			},
+		}
+	}
+
+	for _, tc := range []*testCase{
+		func() *testCase {
+			release := fixtureRelease(appName, 3)
+
+			return &testCase{
+				name: "happy path",
+				setup: append(fixtureSetupEnv(),
+					fixtureRelease(appNameOther, 1),
+					fixtureRelease(appNameOther, 2),
+					fixtureRelease(appName, 1),
+					fixtureRelease(appName, 2),
+					release,
+				),
+				req:  fixtureRequest(),
+				want: fixtureReleaseToManifests(release),
+			}
+		}(),
+		func() *testCase {
+			release := fixtureRelease(appName, 2)
+
+			return &testCase{
+				name: "request specific release",
+				setup: append(fixtureSetupEnv(),
+					fixtureRelease(appName, 1),
+					fixtureRelease(appNameOther, 1),
+					release,
+					fixtureRelease(appName, 3),
+					fixtureRelease(appNameOther, 2),
+				),
+				req:  fixtureRequest(func(req *api.GetManifestsRequest) { req.Release = "2" }),
+				want: fixtureReleaseToManifests(release),
+			}
+		}(),
+		{
+			name: "no release specified",
+			setup: append(fixtureSetupEnv(),
+				fixtureRelease(appName, 1),
+				fixtureRelease(appName, 2),
+				fixtureRelease(appName, 3),
+			),
+			req:     fixtureRequest(func(req *api.GetManifestsRequest) { req.Release = "" }),
+			wantErr: status.Error(codes.InvalidArgument, "invalid release number, expected uint or 'latest'"),
+		},
+		{
+			name: "no application specified",
+			setup: append(fixtureSetupEnv(),
+				fixtureRelease(appName, 1),
+				fixtureRelease(appName, 2),
+				fixtureRelease(appName, 3),
+			),
+			req:     fixtureRequest(func(req *api.GetManifestsRequest) { req.Application = "" }),
+			wantErr: status.Error(codes.InvalidArgument, "no application specified"),
+		},
+		{
+			name: "no releases for application",
+			setup: append(fixtureSetupEnv(),
+				fixtureRelease(appNameOther, 1),
+				fixtureRelease(appNameOther, 2),
+				fixtureRelease(appNameOther, 3),
+			),
+			req:     fixtureRequest(),
+			wantErr: status.Errorf(codes.NotFound, "no releases found for application %s", appName),
+		},
+	} {
+		tc := tc // TODO SRX-SRRONB: Remove after switching to go v1.22
+		t.Run(tc.name, func(t *testing.T) {
+			repo, err := setupRepositoryTest(t)
+			if err != nil {
+				t.Fatalf("error setting up repository test: %v", err)
+			}
+			sv := &VersionServiceServer{Repository: repo}
+
+			for i, transformer := range tc.setup {
+				now := time.Unix(int64(i), 0)
+				ctx := repository.WithTimeNow(testutil.MakeTestContext(), now)
+				err := repo.Apply(ctx, transformer)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got, err := sv.GetManifests(context.Background(), tc.req)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("error mismatch (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform(), protocmp.IgnoreFields(&api.Release{}, "created_at")); diff != "" {
+				t.Errorf("response mismatch (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -313,32 +313,50 @@ func runServer(ctx context.Context) error {
 	httpHandler := handler.Server{
 		BatchClient:   batchClient,
 		RolloutClient: rolloutClient,
+		VersionClient: api.NewVersionServiceClient(cdCon),
 		Config:        c,
 		KeyRing:       pgpKeyRing,
 		AzureAuth:     c.AzureEnableAuth,
 	}
 	mux := http.NewServeMux()
-	mux.Handle("/environments/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	restHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer readAllAndClose(req.Body, 1024)
 		if c.DexEnabled {
-			interceptors.DexLoginInterceptor(w, req, httpHandler, c.DexClientId, c.DexClientSecret)
+			interceptors.DexLoginInterceptor(w, req, httpHandler.Handle, c.DexClientId, c.DexClientSecret)
+			return
 		}
 		httpHandler.Handle(w, req)
-	}))
-	mux.Handle("/environment-groups/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	})
+	for _, endpoint := range []string{
+		"/environments",
+		"/environments/",
+		"/environment-groups",
+		"/environment-groups/",
+		"/release",
+	} {
+		mux.Handle(endpoint, restHandler)
+	}
+
+	// api is only accessible via IAP for now unless explicitly disabled
+	restApiHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer readAllAndClose(req.Body, 1024)
-		if c.DexEnabled {
-			interceptors.DexLoginInterceptor(w, req, httpHandler, c.DexClientId, c.DexClientSecret)
+		if c.ApiEnableDespiteNoAuth {
+			httpHandler.HandleAPI(w, req)
+			return
 		}
-		httpHandler.Handle(w, req)
-	}))
-	mux.Handle("/release", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		defer readAllAndClose(req.Body, 1024)
-		if c.DexEnabled {
-			interceptors.DexLoginInterceptor(w, req, httpHandler, c.DexClientId, c.DexClientSecret)
+
+		if !c.IapEnabled {
+			http.Error(w, "IAP not enabled, /api unavailable.", http.StatusUnauthorized)
+			return
 		}
-		httpHandler.Handle(w, req)
-	}))
+		interceptors.GoogleIAPInterceptor(w, req, httpHandler.HandleAPI, backendServiceId, c.GKEBackendServiceID)
+	})
+	for _, endpoint := range []string{
+		"/api",
+		"/api/",
+	} {
+		mux.Handle(endpoint, restApiHandler)
+	}
 
 	mux.Handle("/", http.FileServer(http.Dir("build")))
 	// Split HTTP REST from gRPC Web requests, as suggested in the documentation:
@@ -520,6 +538,8 @@ func (p *Auth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // GrpcProxy passes through gRPC messages to another server.
+// This is needed for the UI to communicate with other services via gRPC over web.
+// The UI _only_ communicates via gRPC over web (+ static files), while the REST API is only intended for automated processes like build pipelines.
 // An alternative to the more generic methods proposed in
 // https://github.com/grpc/grpc-go/issues/2297
 type GrpcProxy struct {

--- a/services/frontend-service/pkg/config/config.go
+++ b/services/frontend-service/pkg/config/config.go
@@ -19,36 +19,38 @@ package config
 import "time"
 
 type ServerConfig struct {
-	CdServer              string        `default:"kuberpult-cd-service:8443"`
-	CdServerSecure        bool          `default:"false" split_words:"true"`
-	RolloutServer         string        `default:""`
-	HttpCdServer          string        `default:"http://kuberpult-cd-service:80" split_words:"true"`
-	GKEProjectNumber      string        `default:"" split_words:"true"`
-	GKEBackendServiceID   string        `default:"" split_words:"true"`
-	GKEBackendServiceName string        `default:"" split_words:"true"`
-	EnableTracing         bool          `default:"false" split_words:"true"`
-	ArgocdBaseUrl         string        `default:"" split_words:"true"`
-	ArgocdNamespace       string        `default:"tools" split_words:"true"`
-	PgpKeyRingPath        string        `split_words:"true"`
-	AzureEnableAuth       bool          `default:"false" split_words:"true"`
-	AzureCloudInstance    string        `default:"https://login.microsoftonline.com/" split_words:"true"`
-	AzureClientId         string        `default:"" split_words:"true"`
-	AzureTenantId         string        `default:"" split_words:"true"`
-	AzureRedirectUrl      string        `default:"" split_words:"true"`
-	DexEnabled            bool          `default:"false" split_words:"true"`
-	DexClientId           string        `default:"" split_words:"true"`
-	DexClientSecret       string        `default:"" split_words:"true"`
-	DexBaseURL            string        `default:"" split_words:"true"`
-	DexScopes             string        `default:"" split_words:"true"`
-	Version               string        `default:""`
-	SourceRepoUrl         string        `default:"" split_words:"true"`
-	ManifestRepoUrl       string        `default:"" split_words:"true"`
-	GitBranch             string        `default:"" split_words:"true"`
-	AllowedOrigins        string        `default:"" split_words:"true"`
-	GitAuthorName         string        `default:"" split_words:"true"`
-	GitAuthorEmail        string        `default:"" split_words:"true"`
-	BatchClientTimeout    time.Duration `default:"2m" split_words:"true"`
-	MaxWaitDuration       time.Duration `default:"10m" split_words:"true"`
+	CdServer               string        `default:"kuberpult-cd-service:8443"`
+	CdServerSecure         bool          `default:"false" split_words:"true"`
+	RolloutServer          string        `default:""`
+	HttpCdServer           string        `default:"http://kuberpult-cd-service:80" split_words:"true"`
+	GKEProjectNumber       string        `default:"" split_words:"true"`
+	GKEBackendServiceID    string        `default:"" split_words:"true"`
+	GKEBackendServiceName  string        `default:"" split_words:"true"`
+	EnableTracing          bool          `default:"false" split_words:"true"`
+	ArgocdBaseUrl          string        `default:"" split_words:"true"`
+	ArgocdNamespace        string        `default:"tools" split_words:"true"`
+	PgpKeyRingPath         string        `split_words:"true"`
+	AzureEnableAuth        bool          `default:"false" split_words:"true"`
+	AzureCloudInstance     string        `default:"https://login.microsoftonline.com/" split_words:"true"`
+	AzureClientId          string        `default:"" split_words:"true"`
+	AzureTenantId          string        `default:"" split_words:"true"`
+	AzureRedirectUrl       string        `default:"" split_words:"true"`
+	DexEnabled             bool          `default:"false" split_words:"true"`
+	DexClientId            string        `default:"" split_words:"true"`
+	DexClientSecret        string        `default:"" split_words:"true"`
+	DexBaseURL             string        `default:"" split_words:"true"`
+	DexScopes              string        `default:"" split_words:"true"`
+	Version                string        `default:""`
+	SourceRepoUrl          string        `default:"" split_words:"true"`
+	ManifestRepoUrl        string        `default:"" split_words:"true"`
+	GitBranch              string        `default:"" split_words:"true"`
+	AllowedOrigins         string        `default:"" split_words:"true"`
+	GitAuthorName          string        `default:"" split_words:"true"`
+	GitAuthorEmail         string        `default:"" split_words:"true"`
+	BatchClientTimeout     time.Duration `default:"2m" split_words:"true"`
+	MaxWaitDuration        time.Duration `default:"10m" split_words:"true"`
+	ApiEnableDespiteNoAuth bool          `default:"false" split_words:"true"`
+	IapEnabled             bool          `default:"false" split_words:"true"`
 }
 
 type FrontendConfig struct {

--- a/services/frontend-service/pkg/handler/applications.go
+++ b/services/frontend-service/pkg/handler/applications.go
@@ -140,8 +140,7 @@ func (s Server) handleApplicationRelease(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	var group string
-	group, tail = xpath.Shift(tail)
+	group, _ := xpath.Shift(tail)
 	switch group {
 	case "manifests":
 		s.handleApplicationReleaseManifests(w, req, applicationID, releaseNum)

--- a/services/frontend-service/pkg/handler/applications.go
+++ b/services/frontend-service/pkg/handler/applications.go
@@ -140,7 +140,8 @@ func (s Server) handleApplicationRelease(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	group, tail := xpath.Shift(tail)
+	var group string
+	group, tail = xpath.Shift(tail)
 	switch group {
 	case "manifests":
 		s.handleApplicationReleaseManifests(w, req, applicationID, releaseNum)

--- a/services/frontend-service/pkg/handler/applications.go
+++ b/services/frontend-service/pkg/handler/applications.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
 	xpath "github.com/freiheit-com/kuberpult/pkg/path"
 )
 
@@ -110,4 +111,64 @@ func (s Server) handleDeleteApplicationLock(w http.ResponseWriter, req *http.Req
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+type ApplicationID = string
+
+func (s Server) handleApiApplication(w http.ResponseWriter, req *http.Request, tail string) {
+	applicationID, tail := xpath.Shift(tail)
+	if applicationID == "" {
+		http.Error(w, "missing application ID", http.StatusNotFound)
+		return
+	}
+	applicationID = ApplicationID(applicationID)
+
+	group, tail := xpath.Shift(tail)
+	switch group {
+	case "release":
+		s.handleApplicationRelease(w, req, tail, applicationID)
+	default:
+		http.Error(w, fmt.Sprintf("unknown endpoint 'api/application/%s/%s'", applicationID, group), http.StatusNotFound)
+	}
+}
+
+func (s Server) handleApplicationRelease(w http.ResponseWriter, req *http.Request, tail string, applicationID ApplicationID) {
+	releaseNum, tail := xpath.Shift(tail)
+
+	if releaseNum == "" {
+		http.Error(w, "missing release number", http.StatusNotFound)
+		return
+	}
+
+	group, tail := xpath.Shift(tail)
+	switch group {
+	case "manifests":
+		s.handleApplicationReleaseManifests(w, req, applicationID, releaseNum)
+	default:
+		http.Error(w, fmt.Sprintf("unknown endpoint 'api/application/%s/%s'", releaseNum, group), http.StatusNotFound)
+	}
+}
+
+func (s Server) handleApplicationReleaseManifests(w http.ResponseWriter, req *http.Request, applicationID ApplicationID, releaseNum string) {
+	resp, err := s.VersionClient.GetManifests(req.Context(), &api.GetManifestsRequest{
+		Application: string(applicationID),
+		Release:     releaseNum,
+	})
+	if err != nil {
+		handleGRPCError(req.Context(), w, err)
+		return
+	}
+	encoded, err := json.Marshal(resp)
+	if err != nil {
+		logger.FromContext(req.Context()).Error("GetManifests: encoding response")
+		http.Error(w, "GetManifests: encoding response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(encoded)
+	if err != nil {
+		logger.FromContext(req.Context()).Error("GetManifests: writing response")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
 }

--- a/services/frontend-service/pkg/handler/grpc.go
+++ b/services/frontend-service/pkg/handler/grpc.go
@@ -30,7 +30,9 @@ func handleGRPCError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch s.Code() {
 	case codes.InvalidArgument:
 		http.Error(w, s.Message(), http.StatusBadRequest)
-	case codes.FailedPrecondition:
+	case codes.Unimplemented:
+		http.Error(w, s.Message(), http.StatusNotImplemented)
+	case codes.FailedPrecondition, codes.NotFound:
 		// This is a bit of a shortcut.
 		// We probably do not want to return NotFound for any failed precondition.
 		// For now, this is only used when deleting locks that are non-existent.

--- a/services/frontend-service/pkg/handler/handle.go
+++ b/services/frontend-service/pkg/handler/handle.go
@@ -30,6 +30,7 @@ import (
 type Server struct {
 	BatchClient   api.BatchServiceClient
 	RolloutClient api.RolloutServiceClient
+	VersionClient api.VersionServiceClient
 	Config        config.ServerConfig
 	KeyRing       openpgp.KeyRing
 	AzureAuth     bool
@@ -46,5 +47,20 @@ func (s Server) Handle(w http.ResponseWriter, req *http.Request) {
 		s.HandleRelease(w, req, tail)
 	default:
 		http.Error(w, fmt.Sprintf("unknown endpoint '%s'", group), http.StatusNotFound)
+	}
+}
+
+func (s Server) HandleAPI(w http.ResponseWriter, req *http.Request) {
+	group, tail := xpath.Shift(req.URL.Path)
+	if group != "api" {
+		http.Error(w, fmt.Sprintf("unknown endpoint '%s'", group), http.StatusNotFound)
+	}
+
+	group, tail = xpath.Shift(tail)
+	switch group {
+	case "application":
+		s.handleApiApplication(w, req, tail)
+	default:
+		http.Error(w, fmt.Sprintf("unknown endpoint 'api/%s'", group), http.StatusNotFound)
 	}
 }

--- a/services/frontend-service/pkg/handler/release.go
+++ b/services/frontend-service/pkg/handler/release.go
@@ -84,7 +84,18 @@ func (s Server) HandleRelease(w http.ResponseWriter, r *http.Request, tail strin
 	}
 
 	tf := api.CreateReleaseRequest{
-		Manifests: map[string]string{},
+		Environment:      "",
+		Application:      "",
+		Team:             "",
+		Version:          0,
+		SourceCommitId:   "",
+		SourceAuthor:     "",
+		SourceMessage:    "",
+		SourceRepoUrl:    "",
+		PreviousCommitId: "",
+		NextCommitId:     "",
+		DisplayVersion:   "",
+		Manifests:        map[string]string{},
 	}
 	if err := r.ParseMultipartForm(MAXIMUM_MULTIPART_SIZE); err != nil {
 		w.WriteHeader(400)

--- a/services/frontend-service/pkg/handler/release.go
+++ b/services/frontend-service/pkg/handler/release.go
@@ -84,18 +84,7 @@ func (s Server) HandleRelease(w http.ResponseWriter, r *http.Request, tail strin
 	}
 
 	tf := api.CreateReleaseRequest{
-		Environment:      "",
-		Application:      "",
-		Team:             "",
-		Version:          0,
-		SourceCommitId:   "",
-		SourceAuthor:     "",
-		SourceMessage:    "",
-		SourceRepoUrl:    "",
-		PreviousCommitId: "",
-		NextCommitId:     "",
-		DisplayVersion:   "",
-		Manifests:        map[string]string{},
+		Manifests: map[string]string{},
 	}
 	if err := r.ParseMultipartForm(MAXIMUM_MULTIPART_SIZE); err != nil {
 		w.WriteHeader(400)

--- a/services/frontend-service/pkg/interceptors/interceptors.go
+++ b/services/frontend-service/pkg/interceptors/interceptors.go
@@ -97,9 +97,7 @@ func StreamAuthInterceptor(
 }
 
 // GoogleIAPInterceptor intercepts HTTP calls to the frontend service.
-// DexLoginInterceptor must only be used if dex is enabled.
-// If the user us not logged in, it redirected the calls to the Dex login page.
-// If the user is already logged in, proceeds with the request.
+// If the user us not logged in or no JWT is found, an Unauthenticated error is returned.
 func GoogleIAPInterceptor(
 	w http.ResponseWriter,
 	req *http.Request,

--- a/services/frontend-service/pkg/interceptors/interceptors.go
+++ b/services/frontend-service/pkg/interceptors/interceptors.go
@@ -96,7 +96,7 @@ func StreamAuthInterceptor(
 	return handler(srv, stream)
 }
 
-// DexLoginInterceptor intercepts HTTP calls to the frontend service.
+// GoogleIAPInterceptor intercepts HTTP calls to the frontend service.
 // DexLoginInterceptor must only be used if dex is enabled.
 // If the user us not logged in, it redirected the calls to the Dex login page.
 // If the user is already logged in, proceeds with the request.

--- a/services/rollout-service/pkg/versions/versions_test.go
+++ b/services/rollout-service/pkg/versions/versions_test.go
@@ -133,6 +133,10 @@ func (m *mockVersionClient) GetVersion(ctx context.Context, in *api.GetVersionRe
 	return res.response, res.err
 }
 
+func (m *mockVersionClient) GetManifests(ctx context.Context, in *api.GetManifestsRequest, opts ...grpc.CallOption) (*api.GetManifestsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "unimplemented")
+}
+
 type mockVersionEventProcessor struct {
 	events []KuberpultEvent
 }


### PR DESCRIPTION
* add new endpoint `/api/application/<app>/release/<release>/manifests`
* `/api` is protected via IAP by default
* set `KUBERPULT_API_ENABLE_DESPITE_NO_AUTH=true` to disable IAP protection (only recommended for local dev)

Rev: SRX-MJL1MD