### PR TITLE
fix: warning when can't find prev or next commit ID

### DIFF
--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -559,12 +559,12 @@ func writeCommitData(ctx context.Context, sourceCommitId string, sourceMessage s
 	}
 
 	if previousCommitId != "" {
-		if err := writeNextPrevInfo(sourceCommitId, strings.ToLower(previousCommitId), fieldPreviousCommitId, fs); err != nil {
+		if err := writeNextPrevInfo(ctx, sourceCommitId, strings.ToLower(previousCommitId), fieldPreviousCommitId, app, fs); err != nil {
 			return GetCreateReleaseGeneralFailure(err)
 		}
 	}
 	if nextCommitId != "" {
-		if err := writeNextPrevInfo(sourceCommitId, strings.ToLower(nextCommitId), fieldNextCommidId, fs); err != nil {
+		if err := writeNextPrevInfo(ctx, sourceCommitId, strings.ToLower(nextCommitId), fieldNextCommidId, app, fs); err != nil {
 			return GetCreateReleaseGeneralFailure(err)
 		}
 	}
@@ -596,7 +596,7 @@ func writeCommitData(ctx context.Context, sourceCommitId string, sourceMessage s
 	return nil
 }
 
-func writeNextPrevInfo(sourceCommitId string, otherCommitId string, fieldSource string, fs billy.Filesystem) error {
+func writeNextPrevInfo(ctx context.Context, sourceCommitId string, otherCommitId string, fieldSource string, application string, fs billy.Filesystem) error {
 
 	otherCommitId = strings.ToLower(otherCommitId)
 	sourceCommitDir := commitDirectory(fs, sourceCommitId)
@@ -604,7 +604,9 @@ func writeNextPrevInfo(sourceCommitId string, otherCommitId string, fieldSource 
 	otherCommitDir := commitDirectory(fs, otherCommitId)
 
 	if _, err := fs.Stat(otherCommitDir); err != nil {
-		return err
+		logger.FromContext(ctx).Sugar().Warnf(
+			"%s application does not contain any commit with the provided id (%s). Ignoring provided information.", application, otherCommitId)
+		return nil
 	}
 
 	if err := util.WriteFile(fs, fs.Join(sourceCommitDir, fieldSource), []byte(otherCommitId), 0666); err != nil {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -605,7 +605,7 @@ func writeNextPrevInfo(ctx context.Context, sourceCommitId string, otherCommitId
 
 	if _, err := fs.Stat(otherCommitDir); err != nil {
 		logger.FromContext(ctx).Sugar().Warnf(
-			"%s application does not contain any commit with the provided id (%s). Ignoring provided information.", application, otherCommitId)
+			"Could not find the previous commit while trying to create a new release for commit %s and application %s. This is expected when `git.enableWritingCommitData` was just turned on, however it should not happen multiple times.", otherCommitId, application, otherCommitDir)
 		return nil
 	}
 


### PR DESCRIPTION
When previous or next commit id is provided but kuberpult does not find the folder for those commits, previously we were throwing an error. Now we simply log a warning and move on.