### PR TITLE
fix: add tracing for root app rendering

### DIFF
--- a/services/cd-service/pkg/argocd/render.go
+++ b/services/cd-service/pkg/argocd/render.go
@@ -17,7 +17,9 @@ Copyright 2023 freiheit.com*/
 package argocd
 
 import (
+	"context"
 	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"path/filepath"
 	"strings"
 
@@ -36,9 +38,10 @@ type AppData struct {
 	TeamName string
 }
 
-var ApiVersions []ApiVersion = []ApiVersion{V1Alpha1}
+func Render(ctx context.Context, gitUrl string, gitBranch string, config config.EnvironmentConfig, env string, appsData []AppData) (map[ApiVersion][]byte, error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "Render")
+	defer span.Finish()
 
-func Render(gitUrl string, gitBranch string, config config.EnvironmentConfig, env string, appsData []AppData) (map[ApiVersion][]byte, error) {
 	if config.ArgoCd == nil {
 		return nil, fmt.Errorf("no ArgoCd configured for environment %s", env)
 	}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -1156,8 +1156,8 @@ func (r *repository) updateArgoCdApps(ctx context.Context, state *State, env str
 	if apps, err := state.GetEnvironmentApplications(env); err != nil {
 		return err
 	} else {
-		span, _ := tracer.StartSpanFromContext(ctx, "collectData")
-		defer span.Finish()
+		spanCollectData, _ := tracer.StartSpanFromContext(ctx, "collectData")
+		defer spanCollectData.Finish()
 		appData := []argocd.AppData{}
 		sort.Strings(apps)
 		for _, appName := range apps {
@@ -1186,15 +1186,15 @@ func (r *repository) updateArgoCdApps(ctx context.Context, state *State, env str
 				TeamName: team,
 			})
 		}
-		span.Finish()
+		spanCollectData.Finish()
 
-		span, ctx = tracer.StartSpanFromContext(ctx, "RenderAndWrite")
-		defer span.Finish()
+		spanRenderAndWrite, ctx := tracer.StartSpanFromContext(ctx, "RenderAndWrite")
+		defer spanRenderAndWrite.Finish()
 		if manifests, err := argocd.Render(ctx, r.config.URL, r.config.Branch, config, env, appData); err != nil {
 			return err
 		} else {
-			span, ctx = tracer.StartSpanFromContext(ctx, "Write")
-			defer span.Finish()
+			spanWrite, _ := tracer.StartSpanFromContext(ctx, "Write")
+			defer spanWrite.Finish()
 			for apiVersion, content := range manifests {
 				if err := fs.MkdirAll(fs.Join("argocd", string(apiVersion)), 0777); err != nil {
 					return err

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -1156,7 +1156,7 @@ func (r *repository) updateArgoCdApps(ctx context.Context, state *State, env str
 	if apps, err := state.GetEnvironmentApplications(env); err != nil {
 		return err
 	} else {
-		span, ctx := tracer.StartSpanFromContext(ctx, "collectData")
+		span, _ := tracer.StartSpanFromContext(ctx, "collectData")
 		defer span.Finish()
 		appData := []argocd.AppData{}
 		sort.Strings(apps)


### PR DESCRIPTION
A first look at profiling data indicates that the rendering of the root apps takes quite a lot of time. This adds more detailed traces for the rendering.