### PR TITLE
fix: errors "was not wrapped in act(...)"

### DIFF
--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -38,6 +38,7 @@ import { GetFrontendConfigResponse } from '../../api/api';
 import { EnvironmentConfigDialog } from '../components/EnvironmentConfigDialog/EnvironmentConfigDialog';
 import { getOpenEnvironmentConfigDialog } from '../utils/Links';
 import { useSearchParams } from 'react-router-dom';
+import { TooltipProvider } from '../components/tooltip/tooltip';
 
 // retry strategy: retries the observable subscription with randomized exponential backoff
 // source: https://www.learnrxjs.io/learn-rxjs/operators/error_handling/retrywhen#examples
@@ -147,6 +148,7 @@ export const App: React.FC = () => {
                     <PageRoutes />
                     <Snackbar />
                 </div>
+                <TooltipProvider />
             </div>
         </AzureAuthProvider>
     );

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -107,29 +107,27 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                       >
                         <div
                           class="tooltip-container"
+                          data-tooltip-delay-hide="1000000"
+                          data-tooltip-html="<div><div>Environment locked by unknown</div><div>with Message: <b>envLock</b></div><div>ID: ui-envlock</div><div>Click to unlock.</div></div>"
+                          data-tooltip-id="kuberpult-tooltip"
+                          data-tooltip-place="bottom"
+                          id="tooltipenv-group-chip-id-ui-envlock"
                         >
-                          <a
-                            data-tooltip-delay-hide="50"
-                            data-tooltip-place="bottom"
-                            href="#"
-                            id="tooltipenv-group-chip-id-ui-envlock"
-                          >
-                            <div>
-                              <button
-                                aria-label=""
-                                class="mdc-button button-lock"
+                          <div>
+                            <button
+                              aria-label=""
+                              class="mdc-button button-lock"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <svg
+                                class="env-card-env-lock-icon fixed-size"
                               >
-                                <div
-                                  class="mdc-button__ripple"
-                                />
-                                <svg
-                                  class="env-card-env-lock-icon fixed-size"
-                                >
-                                  Locks_White.svg
-                                </svg>
-                              </button>
-                            </div>
-                          </a>
+                                Locks_White.svg
+                              </svg>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </span>
@@ -375,29 +373,27 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                       >
                         <div
                           class="tooltip-container"
+                          data-tooltip-delay-hide="1000000"
+                          data-tooltip-html="<div><div>Environment locked by unknown</div><div>with Message: <b>envLock</b></div><div>ID: ui-envlock</div><div>Click to unlock.</div></div>"
+                          data-tooltip-id="kuberpult-tooltip"
+                          data-tooltip-place="bottom"
+                          id="tooltipenv-group-chip-id-ui-envlock"
                         >
-                          <a
-                            data-tooltip-delay-hide="50"
-                            data-tooltip-place="bottom"
-                            href="#"
-                            id="tooltipenv-group-chip-id-ui-envlock"
-                          >
-                            <div>
-                              <button
-                                aria-label=""
-                                class="mdc-button button-lock"
+                          <div>
+                            <button
+                              aria-label=""
+                              class="mdc-button button-lock"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <svg
+                                class="env-card-env-lock-icon fixed-size"
                               >
-                                <div
-                                  class="mdc-button__ripple"
-                                />
-                                <svg
-                                  class="env-card-env-lock-icon fixed-size"
-                                >
-                                  Locks_White.svg
-                                </svg>
-                              </button>
-                            </div>
-                          </a>
+                                Locks_White.svg
+                              </svg>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </span>
@@ -649,29 +645,27 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                       >
                         <div
                           class="tooltip-container"
+                          data-tooltip-delay-hide="1000000"
+                          data-tooltip-html="<div><div>Environment locked by unknown</div><div>with Message: <b>envLock</b></div><div>ID: ui-envlock</div><div>Click to unlock.</div></div>"
+                          data-tooltip-id="kuberpult-tooltip"
+                          data-tooltip-place="bottom"
+                          id="tooltipenv-group-chip-id-ui-envlock"
                         >
-                          <a
-                            data-tooltip-delay-hide="50"
-                            data-tooltip-place="bottom"
-                            href="#"
-                            id="tooltipenv-group-chip-id-ui-envlock"
-                          >
-                            <div>
-                              <button
-                                aria-label=""
-                                class="mdc-button button-lock"
+                          <div>
+                            <button
+                              aria-label=""
+                              class="mdc-button button-lock"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <svg
+                                class="env-card-env-lock-icon fixed-size"
                               >
-                                <div
-                                  class="mdc-button__ripple"
-                                />
-                                <svg
-                                  class="env-card-env-lock-icon fixed-size"
-                                >
-                                  Locks_White.svg
-                                </svg>
-                              </button>
-                            </div>
-                          </a>
+                                Locks_White.svg
+                              </svg>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </span>
@@ -831,29 +825,27 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                       >
                         <div
                           class="tooltip-container"
+                          data-tooltip-delay-hide="1000000"
+                          data-tooltip-html="<div><div>Environment locked by unknown</div><div>with Message: <b>envLock</b></div><div>ID: ui-envlock</div><div>Click to unlock.</div></div>"
+                          data-tooltip-id="kuberpult-tooltip"
+                          data-tooltip-place="bottom"
+                          id="tooltipenv-group-chip-id-ui-envlock"
                         >
-                          <a
-                            data-tooltip-delay-hide="50"
-                            data-tooltip-place="bottom"
-                            href="#"
-                            id="tooltipenv-group-chip-id-ui-envlock"
-                          >
-                            <div>
-                              <button
-                                aria-label=""
-                                class="mdc-button button-lock"
+                          <div>
+                            <button
+                              aria-label=""
+                              class="mdc-button button-lock"
+                            >
+                              <div
+                                class="mdc-button__ripple"
+                              />
+                              <svg
+                                class="env-card-env-lock-icon fixed-size"
                               >
-                                <div
-                                  class="mdc-button__ripple"
-                                />
-                                <svg
-                                  class="env-card-env-lock-icon fixed-size"
-                                >
-                                  Locks_White.svg
-                                </svg>
-                              </button>
-                            </div>
-                          </a>
+                                Locks_White.svg
+                              </svg>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </span>

--- a/services/frontend-service/src/ui/components/tooltip/__snapshots__/tooltip.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/tooltip/__snapshots__/tooltip.test.tsx.snap
@@ -3,16 +3,14 @@
 exports[`Tooltip Renders a tooltip 1`] = `
 <div
   class="tooltip-container"
+  data-tooltip-delay-hide="1000000"
+  data-tooltip-html="<div>I&#x27;m inside the tooltip</div>"
+  data-tooltip-id="kuberpult-tooltip"
+  data-tooltip-place="bottom"
+  id="tooltiptest-tooltip"
 >
-  <a
-    data-tooltip-delay-hide="50"
-    data-tooltip-place="bottom"
-    href="#"
-    id="tooltiptest-tooltip"
-  >
-    <button>
-      click me
-    </button>
-  </a>
+  <button>
+    click me
+  </button>
 </div>
 `;

--- a/services/frontend-service/src/ui/components/tooltip/tooltip.scss
+++ b/services/frontend-service/src/ui/components/tooltip/tooltip.scss
@@ -15,22 +15,17 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright 2023 freiheit.com*/
 @use '../../../../node_modules/@material/tooltip/styles';
 
-.tooltip-container {
-    a {
-        text-decoration: none;
-    }
-    .tooltip {
-        z-index: 1000;
-        background-color: white;
-        color: black;
-        font-size: 14px;
-        border-radius: 8px;
-        .release__hash--container {
-            padding: 2px 0px 0px 0px;
+#kuberpult-tooltip {
+    z-index: 1000;
+    background-color: white;
+    color: black;
+    font-size: 14px;
+    border-radius: 8px;
+    .release__hash--container {
+        padding: 2px 0px 0px 0px;
 
-            .release__hash {
-                padding: 0;
-            }
+        .release__hash {
+            padding: 0;
         }
     }
 }

--- a/services/frontend-service/src/ui/components/tooltip/tooltip.tsx
+++ b/services/frontend-service/src/ui/components/tooltip/tooltip.tsx
@@ -14,21 +14,50 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 import { Tooltip as TooltipReact } from 'react-tooltip';
+import ReactDOMServer from 'react-dom/server';
 
-export const Tooltip = (props: { children: JSX.Element; tooltipContent: JSX.Element; id: string }): JSX.Element => {
-    const { children, tooltipContent, id } = props;
+// As long as there is only a single global provider, there is no need to sync its id manually.
+// We currently only provide styling for the default tooltip.
+export const tooltipProviderGlobalID = 'kuberpult-tooltip';
+
+export type TooltipProps = {
+    children: JSX.Element;
+    id: string;
+    tooltipContent: JSX.Element;
+    tooltipProviderID: string;
+};
+
+export const Tooltip = (overrides?: Partial<TooltipProps>): JSX.Element => {
+    const props: TooltipProps = {
+        tooltipProviderID: tooltipProviderGlobalID,
+        children: <></>,
+        id: '',
+        tooltipContent: <></>,
+        ...overrides,
+    };
+
+    const { children, tooltipContent, id, tooltipProviderID } = props;
     const delayHide = 50; // for debugging the css, increase this to 1000000
 
     // The React tooltip really wants us to use a href, but also we don't want to do anything on click:
-    const href = '#';
     return (
-        <div className={'tooltip-container'}>
-            <a href={href} id={'tooltip' + id} data-tooltip-place="bottom" data-tooltip-delay-hide={delayHide}>
-                {children}
-            </a>
-            <TooltipReact className={'tooltip'} anchorSelect={'#tooltip' + id} border={'2px solid lightgray'}>
-                {tooltipContent}
-            </TooltipReact>
+        <div
+            className={'tooltip-container'}
+            id={'tooltip' + id}
+            data-tooltip-place="bottom"
+            data-tooltip-delay-hide={delayHide}
+            data-tooltip-id={tooltipProviderID}
+            data-tooltip-html={ReactDOMServer.renderToStaticMarkup(tooltipContent)}>
+            {children}
         </div>
     );
+};
+
+export type TooltipProviderProps = { id: string; className: string };
+
+// The tooltip provider handles displaying of all tool tips with one sprt of styling.
+// It should always be rendered and hence present at root of the DOM (preferably in App.tsx).
+export const TooltipProvider = (overwrites?: Partial<TooltipProviderProps>): JSX.Element => {
+    const props: TooltipProviderProps = { className: 'tooltip', id: tooltipProviderGlobalID, ...overwrites };
+    return <TooltipReact className={props.className} id={props.id} border={'2px solid lightgray'}></TooltipReact>;
 };


### PR DESCRIPTION
The underyling issue was a misuse of `react-tooltip`:
Instead of instantiating one `react.Tooltip`-component per tooltip to be
displayed, there should an always-rendered component while the content
to display is supplied via `data-` attributes on the components itself.

`react-tooltip` seems to do some "magic" DOM manipulations under the
hood which causes warnings when executing tests.

On the plus side, accoring to `react-tooltip`'s documentaiton this
should also increase performance, though I cannot confirm this from
running on dev environments.

Rev: SRX-CXV1V1