### PR TITLE
fix: Render CommitInfoPage nicer

### DIFF
--- a/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.scss
+++ b/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.scss
@@ -23,7 +23,7 @@ Copyright 2023 freiheit.com*/
             padding: 4px;
         }
     }
-    .commit-page-message div {
+    .commit-page-message span {
         margin-left: 10px;
     }
 }

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.scss
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.scss
@@ -14,7 +14,6 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 
-
 .commit-page {
     .next-prev-buttons {
         display: flex;
@@ -26,7 +25,9 @@ Copyright 2023 freiheit.com*/
         padding: 5px;
     }
 
-    table, th, td {
+    table,
+    th,
+    td {
         border: 1px solid var(--mdc-theme-primary);
         border-collapse: collapse;
     }
@@ -62,6 +63,4 @@ Copyright 2023 freiheit.com*/
             width: 25%;
         }
     }
-
-
 }

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.scss
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.scss
@@ -14,12 +14,54 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright 2023 freiheit.com*/
 
-.next-prev-buttons {
-    display: flex;
-    flex-direction: row;
-}
 
-.history-button-container {
-    width: auto;
-    padding: 5px;
+.commit-page {
+    .next-prev-buttons {
+        display: flex;
+        flex-direction: row;
+    }
+
+    .history-button-container {
+        width: auto;
+        padding: 5px;
+    }
+
+    table, th, td {
+        border: 1px solid var(--mdc-theme-primary);
+        border-collapse: collapse;
+    }
+
+    table {
+        width: 100%;
+    }
+
+    .metadata {
+        th.hash {
+            width: 25%;
+        }
+
+        th.message {
+            width: 50%;
+        }
+
+        th.apps {
+            width: 25%;
+        }
+    }
+
+    .events {
+        th.date {
+            width: 25%;
+        }
+
+        th.description {
+            width: 50%;
+        }
+
+        th.environments {
+            width: 25%;
+        }
+    }
+
+
 }

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.test.tsx
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.test.tsx
@@ -130,7 +130,7 @@ test('CommitInfo component renders commit info when the response is valid', () =
                     },
                 ],
             },
-            expectedTitle: 'Commit tomato',
+            expectedTitle: 'Commit: tomato',
             expectedCommitDescriptionTable: {
                 head: ['Commit Hash:', 'Commit Message:', 'Touched apps:'],
                 body: [['potato', `tomato Commit message body line 1 Commit message body line 2`, 'google, windows']],
@@ -200,9 +200,9 @@ test('CommitInfo component renders commit info when the response is valid', () =
             </MemoryRouter>
         );
 
-        // first h1 is "Planned Actions", second h1 is "This page is still in beta", and we need the 3rd
-        expect(container.getElementsByTagName('h1').length).toBeGreaterThan(2);
-        expect(container.getElementsByTagName('h1')[2]).toHaveTextContent(testCase.expectedTitle);
+        // first h1 is "Planned Actions", second h1 is actually our CommitInfo component:
+        expect(container.getElementsByTagName('h1').length).toEqual(2);
+        expect(container.getElementsByTagName('h1')[1]).toHaveTextContent(testCase.expectedTitle);
 
         const tables = container.getElementsByTagName('table');
 
@@ -245,7 +245,7 @@ describe('CommitInfo component renders next and previous buttons correctly', () 
                 previousCommitHash: '987654321',
                 events: [],
             },
-            expectedTitle: 'Commit tomato',
+            expectedTitle: 'Commit: tomato',
             expectedCommitDescriptionTable: {
                 head: ['Commit Hash:', 'Commit Message:', 'Touched apps:'],
                 body: [['potato', `tomato Commit message body line 1 Commit message body line 2`, 'google']],
@@ -265,7 +265,7 @@ describe('CommitInfo component renders next and previous buttons correctly', () 
                 previousCommitHash: '',
                 events: [],
             },
-            expectedTitle: 'Commit tomato',
+            expectedTitle: 'Commit: tomato',
             expectedCommitDescriptionTable: {
                 head: ['Commit Hash:', 'Commit Message:', 'Touched apps:'],
                 body: [['potato', `tomato Commit message body line 1 Commit message body line 2`, 'google']],
@@ -285,7 +285,7 @@ describe('CommitInfo component renders next and previous buttons correctly', () 
                 previousCommitHash: '987654321',
                 events: [],
             },
-            expectedTitle: 'Commit tomato',
+            expectedTitle: 'Commit: tomato',
             expectedCommitDescriptionTable: {
                 head: ['Commit Hash:', 'Commit Message:', 'Touched apps:'],
                 body: [['potato', `tomato Commit message body line 1 Commit message body line 2`, 'google']],
@@ -305,7 +305,7 @@ describe('CommitInfo component renders next and previous buttons correctly', () 
                 previousCommitHash: '',
                 events: [],
             },
-            expectedTitle: 'Commit tomato',
+            expectedTitle: 'Commit: tomato',
             expectedCommitDescriptionTable: {
                 head: ['Commit Hash:', 'Commit Message:', 'Touched apps:'],
                 body: [['potato', `tomato Commit message body line 1 Commit message body line 2`, 'google']],
@@ -325,7 +325,7 @@ describe('CommitInfo component renders next and previous buttons correctly', () 
                 previousCommitHash: '987654321',
                 events: [],
             },
-            expectedTitle: 'Commit tomato',
+            expectedTitle: 'Commit: tomato',
             expectedCommitDescriptionTable: {
                 head: ['Commit Hash:', 'Commit Message:', 'Touched apps:'],
                 body: [['potato', `tomato Commit message body line 1 Commit message body line 2`, 'google']],

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
@@ -32,20 +32,25 @@ export const CommitInfo: React.FC<CommitInfoProps> = (props) => {
             </div>
         );
     }
+    // most commit messages and with "/n" but that looks odd when rendered in a table:
+    const msgWithoutTrailingN = commitInfo.commitMessage.trimEnd();
+    const nextPrevMessage =
+        'Note that kuberpult links to the next commit in the repository that it is aware of.' +
+        'This is not necessarily the next/previous commit that touches the desired microservice.';
+    const tooltipMsg = ' Limitation: Currently only commits that touch exactly one app are linked.';
+    const showInfo = !commitInfo.nextCommitHash || !commitInfo.previousCommitHash;
     return (
         <div>
             <TopAppBar showAppFilter={false} showTeamFilter={false} showWarningFilter={false} />
             <main className="main-content commit-page">
-                <h1>This page is still in beta</h1>
-                <br />
-                <h1> Commit {commitInfo.commitMessage.split('\n')[0]} </h1>
+                <h1> Commit: {commitInfo.commitMessage.split('\n')[0]} </h1>
                 <div>
-                    <table border={1}>
+                    <table className={'metadata'} border={1}>
                         <thead>
                             <tr>
-                                <th>Commit Hash:</th>
-                                <th>Commit Message:</th>
-                                <th>Touched apps:</th>
+                                <th className={'hash'}>Commit Hash:</th>
+                                <th className={'message'}>Commit Message:</th>
+                                <th className={'apps'}>Touched apps:</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -53,8 +58,11 @@ export const CommitInfo: React.FC<CommitInfoProps> = (props) => {
                                 <td>{commitInfo.commitHash}</td>
                                 <td>
                                     <div className={'commit-page-message'}>
-                                        {commitInfo.commitMessage.split('\n').map((msg, index) => (
-                                            <div key={index}>{msg} &nbsp;</div>
+                                        {msgWithoutTrailingN.split('\n').map((msg, index) => (
+                                            <div key={index}>
+                                                <span>{msg}</span>
+                                                <br />
+                                            </div>
                                         ))}
                                     </div>
                                 </td>
@@ -67,15 +75,23 @@ export const CommitInfo: React.FC<CommitInfoProps> = (props) => {
                             <div className="next-prev-buttons">
                                 {commitInfo.previousCommitHash !== '' && (
                                     <div className="history-button-container">
-                                        <a href={'/ui/commits/' + commitInfo.previousCommitHash}>Previous Commit</a>
+                                        <a
+                                            href={'/ui/commits/' + commitInfo.previousCommitHash}
+                                            title={nextPrevMessage}>
+                                            Previous Commit
+                                        </a>
                                     </div>
                                 )}
 
                                 {commitInfo.nextCommitHash !== '' && (
                                     <div className="history-button-container">
-                                        <a href={'/ui/commits/' + commitInfo.nextCommitHash}>Next Commit</a>
+                                        <a href={'/ui/commits/' + commitInfo.nextCommitHash} title={nextPrevMessage}>
+                                            Next Commit
+                                        </a>
                                     </div>
                                 )}
+
+                                {showInfo && <div title={tooltipMsg}> ⓘ </div>}
                             </div>
                         )}
                     </div>
@@ -88,17 +104,17 @@ export const CommitInfo: React.FC<CommitInfoProps> = (props) => {
 };
 
 const CommitInfoEvents: React.FC<{ events: Event[] }> = (props) => (
-    <table border={1}>
+    <table className={'events'} border={1}>
         <thead>
             <tr>
-                <th>Date:</th>
-                <th>Event Description:</th>
-                <th>Environments:</th>
+                <th className={'date'}>Date:</th>
+                <th className={'description'}>Event Description:</th>
+                <th className={'environments'}>Environments:</th>
             </tr>
         </thead>
         <tbody>
-            {props.events.map((event, eventIdx) => {
-                const createdAt = event.createdAt?.toISOString() || '';
+            {props.events.map((event, _) => {
+                const createdAt = event.createdAt?.toLocaleString() || '';
                 const [description, environments] = eventDescription(event);
                 return (
                     <tr key={event.uuid}>

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
@@ -114,7 +114,7 @@ const CommitInfoEvents: React.FC<{ events: Event[] }> = (props) => (
         </thead>
         <tbody>
             {props.events.map((event, _) => {
-                const createdAt = event.createdAt?.toLocaleString() || '';
+                const createdAt = event.createdAt?.toISOString() || '';
                 const [description, environments] = eventDescription(event);
                 return (
                     <tr key={event.uuid}>


### PR DESCRIPTION
* removed beta header
* added (i) info icon
* added tooltips for next/prev commit
* Table styling: adapted with of columns and border
* Improved "\n" rendering in commit message

New:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/c31217f7-bbe1-4a2f-b732-3633c3803435)

Old:
![image](https://github.com/freiheit-com/kuberpult/assets/3481382/dd87ba9a-632d-4d19-b1c8-2088378f831f)
