### PR TITLE
fix: use fixed version for msal packages

### DIFF
--- a/services/frontend-service/package.json
+++ b/services/frontend-service/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@azure/msal-browser": "^2.28.3",
-    "@azure/msal-react": "^1.4.5",
-    "@emotion/react": "^11.1.5",
+    "@azure/msal-browser": "2.38.3",
+    "@azure/msal-react": "1.5.12",
+    "@emotion/react": "11.11.3",
     "@emotion/styled": "^11.1.5",
     "@improbable-eng/grpc-web": "^0.15.0",
     "@material-ui/core": "5.0.0-alpha.34",


### PR DESCRIPTION
Note that the selected versions are the currently installed ones.
So effectively, this should not change anything.