### PR TITLE
fix: verify validity of next and prev commit IDs

### DIFF
--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -101,8 +101,8 @@ func manifestDirectoryWithReleasesVersion(fs billy.Filesystem, application strin
 }
 
 func commitDirectory(fs billy.Filesystem, commit string) string {
-	if !valid.SHA1CommitID(commit) { //Verification should be
-		return fs.Join("commits", "") //Throw error?
+	if !valid.SHA1CommitID(commit) {
+		return fs.Join("commits", "")
 	}
 	return fs.Join("commits", commit[:2], commit[2:])
 }

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -101,8 +101,8 @@ func manifestDirectoryWithReleasesVersion(fs billy.Filesystem, application strin
 }
 
 func commitDirectory(fs billy.Filesystem, commit string) string {
-	if !valid.SHA1CommitID(commit) {
-		return fs.Join("commits", "")
+	if !valid.SHA1CommitID(commit) { //Verification should be
+		return fs.Join("commits", "") //Throw error?
 	}
 	return fs.Join("commits", commit[:2], commit[2:])
 }

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -101,7 +101,6 @@ func manifestDirectoryWithReleasesVersion(fs billy.Filesystem, application strin
 }
 
 func commitDirectory(fs billy.Filesystem, commit string) string {
-	}
 	return fs.Join("commits", commit[:2], commit[2:])
 }
 

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -101,8 +101,6 @@ func manifestDirectoryWithReleasesVersion(fs billy.Filesystem, application strin
 }
 
 func commitDirectory(fs billy.Filesystem, commit string) string {
-	if !valid.SHA1CommitID(commit) {
-		return fs.Join("commits", "")
 	}
 	return fs.Join("commits", commit[:2], commit[2:])
 }

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -101,6 +101,9 @@ func manifestDirectoryWithReleasesVersion(fs billy.Filesystem, application strin
 }
 
 func commitDirectory(fs billy.Filesystem, commit string) string {
+	if !valid.SHA1CommitID(commit) {
+		return fs.Join("commits", "")
+	}
 	return fs.Join("commits", commit[:2], commit[2:])
 }
 

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -562,12 +562,12 @@ func writeCommitData(ctx context.Context, sourceCommitId string, sourceMessage s
 		return GetCreateReleaseGeneralFailure(err)
 	}
 
-	if previousCommitId != "" {
+	if previousCommitId != "" && valid.SHA1CommitID(previousCommitId) {
 		if err := writeNextPrevInfo(ctx, sourceCommitId, strings.ToLower(previousCommitId), fieldPreviousCommitId, app, fs); err != nil {
 			return GetCreateReleaseGeneralFailure(err)
 		}
 	}
-	if nextCommitId != "" {
+	if nextCommitId != "" && valid.SHA1CommitID(nextCommitId) {
 		if err := writeNextPrevInfo(ctx, sourceCommitId, strings.ToLower(nextCommitId), fieldNextCommidId, app, fs); err != nil {
 			return GetCreateReleaseGeneralFailure(err)
 		}

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1724,7 +1724,6 @@ func TestNextAndPreviousCommitCreation(t *testing.T) {
 					Content: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 			},
-			expectedError: nil,
 		},
 		{
 			Name: "Create a circle of next and prev",
@@ -1787,7 +1786,6 @@ func TestNextAndPreviousCommitCreation(t *testing.T) {
 					Content: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
 				},
 			},
-			expectedError: nil,
 		},
 		{
 			Name: "New Release overwrites",
@@ -1838,7 +1836,6 @@ func TestNextAndPreviousCommitCreation(t *testing.T) {
 					Content: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac",
 				},
 			},
-			expectedError: nil,
 		},
 		{
 			Name: "Invalid commit IDS do not create files",
@@ -1877,16 +1874,14 @@ func TestNextAndPreviousCommitCreation(t *testing.T) {
 			repo := setupRepositoryTest(t)
 			_, updatedState, _, err := repo.ApplyTransformersInternal(ctx, tc.Transformers...)
 			if err != nil {
-
 				t.Fatalf("encountered error but no error is expected here: %v", err)
-
 			}
 			fs := updatedState.Filesystem
 
 			verErr := verifyContent(fs, tc.expectedContent)
+
 			if diff := cmp.Diff(tc.expectedError, verErr, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("error mismatch (-want, +got):\n%s", diff)
-				t.Fatalf("Error while verifying content of : %v. Filesystem content:\n%s", verErr, strings.Join(listFiles(fs), "\n"))
+				t.Fatalf("error mismatch (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -2019,7 +2014,7 @@ func TestReplacedByEvent(t *testing.T) {
 
 			verErr := verifyContent(fs, tc.expectedContent)
 			if diff := cmp.Diff(tc.ExpectedError, verErr, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("error mismatch (-want, +got):\n%s", diff)
+				t.Fatalf("error mismatch (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -2014,7 +2014,7 @@ func TestReplacedByEvent(t *testing.T) {
 
 			verErr := verifyContent(fs, tc.expectedContent)
 			if diff := cmp.Diff(tc.ExpectedError, verErr, cmpopts.EquateErrors()); diff != "" {
-				t.Fatalf("error mismatch (-want, +got):\n%s", diff)
+				t.Errorf("error mismatch (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1886,6 +1886,7 @@ func TestNextAndPreviousCommitCreation(t *testing.T) {
 			verErr := verifyContent(fs, tc.expectedContent)
 			if diff := cmp.Diff(tc.expectedError, verErr, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("error mismatch (-want, +got):\n%s", diff)
+				t.Fatalf("Error while verifying content of : %v. Filesystem content:\n%s", verErr, strings.Join(listFiles(fs), "\n"))
 			}
 		})
 	}


### PR DESCRIPTION
If next and prev commits were invalid, they could end up crashing cd-service (i.e id = 1)