### PR TITLE
fix: repair datadog metrics

### DIFF
--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -51,7 +51,7 @@ const datadogNameCd = "kuberpult-cd-service"
 
 type contextKey string
 
-const ddMetricsKey contextKey = "ddMetrics"
+const DdMetricsKey contextKey = "ddMetrics"
 
 type Config struct {
 	// these will be mapped to "KUBERPULT_GIT_URL", etc.
@@ -172,7 +172,7 @@ func RunServer() {
 			if err != nil {
 				logger.FromContext(ctx).Fatal("datadog.metrics.error", zap.Error(err))
 			}
-			ctx = context.WithValue(ctx, ddMetricsKey, ddMetrics)
+			ctx = context.WithValue(ctx, DdMetricsKey, ddMetrics)
 		}
 
 		// If the tracer is not started, calling this function is a no-op.

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -49,10 +49,6 @@ import (
 
 const datadogNameCd = "kuberpult-cd-service"
 
-type contextKey string
-
-const DdMetricsKey contextKey = "ddMetrics"
-
 type Config struct {
 	// these will be mapped to "KUBERPULT_GIT_URL", etc.
 	GitUrl                   string        `required:"true" split_words:"true"`
@@ -172,7 +168,7 @@ func RunServer() {
 			if err != nil {
 				logger.FromContext(ctx).Fatal("datadog.metrics.error", zap.Error(err))
 			}
-			ctx = context.WithValue(ctx, DdMetricsKey, ddMetrics)
+			ctx = context.WithValue(ctx, repository.DdMetricsKey, ddMetrics)
 		}
 
 		// If the tracer is not started, calling this function is a no-op.

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/cmd"
 	"io"
 	"net/http"
 	"os"
@@ -334,9 +335,11 @@ func New(ctx context.Context, cfg RepositoryConfig) (Repository, error) {
 func New2(ctx context.Context, cfg RepositoryConfig) (Repository, setup.BackgroundFunc, error) {
 	logger := logger.FromContext(ctx)
 
-	ddMetricsFromCtx := ctx.Value("ddMetrics")
+	ddMetricsFromCtx := ctx.Value(cmd.DdMetricsKey)
 	if ddMetricsFromCtx != nil {
 		ddMetrics = ddMetricsFromCtx.(statsd.ClientInterface)
+	} else {
+		logger.Sugar().Warnf("could not load ddmetrics from context - running without datadog metrics")
 	}
 
 	if cfg.Branch == "" {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/cmd"
 	"io"
 	"net/http"
 	"os"
@@ -61,6 +60,10 @@ import (
 	"github.com/go-git/go-billy/v5/util"
 	git "github.com/libgit2/git2go/v34"
 )
+
+type contextKey string
+
+const DdMetricsKey contextKey = "ddMetrics"
 
 // A Repository provides a multiple reader / single writer access to a git repository.
 type Repository interface {
@@ -335,7 +338,7 @@ func New(ctx context.Context, cfg RepositoryConfig) (Repository, error) {
 func New2(ctx context.Context, cfg RepositoryConfig) (Repository, setup.BackgroundFunc, error) {
 	logger := logger.FromContext(ctx)
 
-	ddMetricsFromCtx := ctx.Value(cmd.DdMetricsKey)
+	ddMetricsFromCtx := ctx.Value(DdMetricsKey)
 	if ddMetricsFromCtx != nil {
 		ddMetrics = ddMetricsFromCtx.(statsd.ClientInterface)
 	} else {


### PR DESCRIPTION
the context was used with a different type on accident, so metrics were effectively always disabled