### PR TITLE
fix: stabilize order of events by sorting the manifests

### DIFF
--- a/pkg/sorting/sorting.go
+++ b/pkg/sorting/sorting.go
@@ -1,0 +1,36 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package sorting
+
+import (
+	"cmp"
+	"sort"
+)
+
+// SortKeys sorts the map by the keys
+// We should always avoid iterating over a map without sorting it first,
+// in order to get a deterministic order of operations.
+func SortKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	keys := make([]K, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	return keys
+}

--- a/pkg/sorting/sorting_test.go
+++ b/pkg/sorting/sorting_test.go
@@ -1,0 +1,63 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright 2023 freiheit.com*/
+
+package sorting
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func TestSortKeys(t *testing.T) {
+	tcs := []struct {
+		Name         string
+		Input        map[string]string
+		ExpectedKeys []string
+	}{
+		{
+			Name:         "empty map",
+			Input:        map[string]string{},
+			ExpectedKeys: []string{},
+		},
+		{
+			Name: "one element",
+			Input: map[string]string{
+				"a": "one",
+			},
+			ExpectedKeys: []string{"a"},
+		},
+		{
+			Name: "many elements",
+			Input: map[string]string{
+				"a": "x",
+				"d": "y",
+				"c": "z",
+				"b": "w",
+			},
+			ExpectedKeys: []string{"a", "b", "c", "d"},
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			actualKeys := SortKeys(tc.Input)
+			if diff := cmp.Diff(tc.ExpectedKeys, actualKeys); diff != "" {
+				t.Errorf("error mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/services/cd-service/pkg/mapper/environments_config.go
+++ b/services/cd-service/pkg/mapper/environments_config.go
@@ -264,6 +264,7 @@ func max(a uint32, b uint32) uint32 {
 	return b
 }
 
+// EnvironmentByDistance is there to sort by distance first and by name second
 type EnvironmentByDistance []*api.Environment
 
 func (s EnvironmentByDistance) Len() int {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -21,10 +21,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/pkg/sorting"
 	"io"
 	"io/fs"
 	"os"
 	"path"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -478,6 +480,8 @@ func (c *CreateApplicationVersion) Transform(
 	for env := range c.Manifests {
 		allEnvsOfThisApp = append(allEnvsOfThisApp, env)
 	}
+	slices.Sort(allEnvsOfThisApp)
+
 	gen := getGenerator(ctx)
 	eventUuid := gen.Generate()
 	if c.WriteCommitData {
@@ -486,8 +490,11 @@ func (c *CreateApplicationVersion) Transform(
 			return "", GetCreateReleaseGeneralFailure(err)
 		}
 	}
+	sortedKeys := sorting.SortKeys(c.Manifests)
+	for i := range sortedKeys {
+		env := sortedKeys[i]
+		man := c.Manifests[env]
 
-	for env, man := range c.Manifests {
 		err := state.checkUserPermissions(ctx, env, c.Application, auth.PermissionCreateRelease, c.Team, c.RBACConfig)
 		if err != nil {
 			return "", GetCreateReleaseGeneralFailure(err)


### PR DESCRIPTION
The ID of events written to the /commits/ directory were nondeterministic, because we iterate over a map. This sorts the keys of the map before iterating.