### PR TITLE
feat(frontend, dex): Add correct setup for dex in the  frontend

### DIFF
--- a/pkg/auth/dex.go
+++ b/pkg/auth/dex.go
@@ -60,7 +60,7 @@ type DexAppClient struct {
 
 const (
 	// Dex service internal URL. Used to connect to dex internally in the cluster.
-	dexServiceURL = "http://kuberpult-dex-service:5556"
+	dexServiceURL = "http://kuberpult-dex:5556"
 	// Dex issuer path. Needs to be match the dex issuer helm config.
 	issuerPATH = "/dex"
 	// Dex callback path. Needs to be match the dex staticClients.redirectURIs helm config.

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -233,6 +233,8 @@ func runServer(ctx context.Context) error {
 		grpcStreamInterceptors = append(grpcStreamInterceptors, AzureStreamInterceptor)
 	}
 
+	mux := http.NewServeMux()
+	http.DefaultServeMux = mux
 	if c.DexEnabled {
 		// Registers Dex handlers.
 		_, err := auth.NewDexAppClient(c.DexClientId, c.DexClientSecret, c.DexBaseURL, auth.ReadScopes(c.DexScopes))
@@ -323,7 +325,6 @@ func runServer(ctx context.Context) error {
 		KeyRing:                     pgpKeyRing,
 		AzureAuth:                   c.AzureEnableAuth,
 	}
-	mux := http.NewServeMux()
 	restHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer readAllAndClose(req.Body, 1024)
 		if c.DexEnabled {


### PR DESCRIPTION
- The dex service is called `kuberpult-dex`
- The dex routes are now added to the mux which is served -> before they were implicitly added to `http.DefaultServeMux` but the mux which was served was `http.NewServeMux()`

Now when you try to access any of
```
		"/environments",
		"/environments/",
		"/environment-groups",
		"/environment-groups/",
		"/release",
```
if `c.DexEnabled` you should get forwarded.

For setup of the values.yaml (I only paste dex-relevant stuff, of course you'd also need a manifest repo connected etc.):

```YAML
auth:
  dexAuth:
    baseURL: https://kuberpult.example.com
    clientId: sample-id-kuberpult-dex
    clientSecret: sample-secret-kuberpult-dex
    enabled: true
    installDex: true
    policy_csv: |
      p, role:Developer, CreateLock, *:*, *, allow
      g, your-github-org:your-github-team, role:Developer
    scopes: "openid, groups, email, profile, federated:id"
dex:
  config:
    connectors:
    - config:
        clientID: GITHUB_OAUTH_CLIENT_ID
        clientSecret: GITHUB_OAUTH_CLIENT_SECRET
        orgs:
        - name: your-github-org
        redirectURI: https://kuberpult.example.com/dex/callback
      id: github
      name: GitHub
      type: github
    issuer: https://kuberpult.example.com/dex
    staticClients:
    - id: sample-id-kuberpult-dex
      name: kuberpult
      redirectURIs:
      - https://kuberpult.example.com/callback
      secret: sample-secret-kuberpult-dex
    storage:
      type: memory
```
Remark:
- The scopes have to be a string with comma seperated values
- The clientID in `dex.config.connectors[0].config.clientID` is used for authentication with e.g. GitHub
- The clientID in `auth.dexAuth.clientID` is another one which matches the staticClient at `dex.staticClients[0].id`
- The same goes for the secrets - I stumbled over this.

Now with this setup replacing:
- `kuberpult.example.com` with your hostname
- `GITHUB_OAUTH_CLIENT_ID` with your oauth client ID created in your GitHub Org
- `GITHUB_OAUTH_CLIENT_SECRET` with your oauth client secret created in your GitHub Org
- `your-github-org` with the name of your github-org
![image](https://github.com/freiheit-com/kuberpult/assets/133217951/0a560234-eb45-488f-a9fe-54c7871fc57a)

It should also work for you.

And of course you need to switch the image in `frontend-service` to the version of this PR.
Which was a little tricky for testing as `frontend.tag` option is not allowed the values anymore. I just patched the deployment in my cluster afterwards manually.

Afterwards access `kuberpult.example.com/environments` -> you will get redirected to GitHub login:
![image](https://github.com/freiheit-com/kuberpult/assets/133217951/80708f63-5e86-4b07-8f5a-d359f10b2f1e)

Then a cookie will be set:
![image](https://github.com/freiheit-com/kuberpult/assets/133217951/7dbc5dd8-1685-47ac-8d26-8929ac6fa1d5)

Which also contains the relevant information:
![image](https://github.com/freiheit-com/kuberpult/assets/133217951/a1b76d95-47ff-45f1-bec9-f60711e3fada)



