### PR TITLE
chore: upgrade go to 1.21 consistently

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/freiheit-com/kuberpult
 
-go 1.19
+go 1.21
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.5.0


### PR DESCRIPTION
It was already using docker images versioned 1.21.