### PR TITLE
fix(ci): Optimize CI performance

### DIFF
--- a/.github/workflows/execution-plan-pr.yml
+++ b/.github/workflows/execution-plan-pr.yml
@@ -3,6 +3,9 @@ name: "Execution Plan on Pull Request"
   pull_request:
     branches:
       - main
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   execution-plan:
     uses: ./.github/workflows/execution-plan-snippet-earthly.yml

--- a/.github/workflows/execution-plan-snippet-earthly.yml
+++ b/.github/workflows/execution-plan-snippet-earthly.yml
@@ -144,6 +144,7 @@ jobs:
     if: |
         always() &&
         (needs.stageA_build.result != 'failed')  &&
+        (needs.stageA_build.result != 'cancelled')  &&
         (needs.execution_plan.outputs.stage_b != 'null')
     strategy:
       matrix:

--- a/Earthfile
+++ b/Earthfile
@@ -95,7 +95,7 @@ integration-test:
 # With alpine:3.18, we get occasional issues with gpg that says there's a process running already, even though there shouldn't be.
 # Ubuntu:22.04 seems to solve this issue.
     FROM ubuntu:22.04
-    RUN apt update && apt install -y curl gpg gpg-agent gettext bash git golang netcat-openbsd
+    RUN apt update && apt install --auto-remove -y curl gpg gpg-agent gettext bash git golang netcat-openbsd docker.io
     ARG GO_TEST_ARGS
     # K3S environment variables
     ENV KUBECONFIG=/kp/kubeconfig.yaml

--- a/infrastructure/docker/builder/Makefile
+++ b/infrastructure/docker/builder/Makefile
@@ -38,7 +38,7 @@ cleanup-main:
 
 release:
 	echo "Releasing $(IMAGENAME)"
-	earthly --push +publish --DOCKER_REGISTRY_URI=$(DOCKER_REGISTRY_URI) --IMAGE_TAG=$(IMAGE_TAG) --VERSION=$(VERSION)
+	earthly --no-output --push +publish --DOCKER_REGISTRY_URI=$(DOCKER_REGISTRY_URI) --IMAGE_TAG=$(IMAGE_TAG) --VERSION=$(VERSION)
 
 publish: release
 	echo $(IMAGE_TAG)

--- a/infrastructure/docker/git-ssh/Makefile
+++ b/infrastructure/docker/git-ssh/Makefile
@@ -37,7 +37,7 @@ cleanup-main:
 
 release:
 	echo "Releasing $(IMAGENAME)"
-	earthly --push +publish --DOCKER_REGISTRY_URI=$(DOCKER_REGISTRY_URI) --IMAGE_TAG=$(IMAGE_TAG)
+	earthly --no-output --push +publish --DOCKER_REGISTRY_URI=$(DOCKER_REGISTRY_URI) --IMAGE_TAG=$(IMAGE_TAG)
 
 publish: release
 	echo $(IMAGE_TAG)

--- a/infrastructure/earthly/go/Earthfile
+++ b/infrastructure/earthly/go/Earthfile
@@ -60,7 +60,6 @@ DOCKER:
     ARG entry_point="/main"
     ARG workdir=/kp
     ARG cgo_enabled=0
-    ARG --required image_tag
     ARG --required service
     ENV TZ=Europe/Berlin
     
@@ -79,7 +78,8 @@ DOCKER:
 
     USER kp
     WORKDIR $workdir
-
+    
+    ARG --required image_tag
     ARG use_datadog=false
     IF [ "$use_datadog" == "true" ]
         ARG dd_service=$service

--- a/services/cd-service/Makefile
+++ b/services/cd-service/Makefile
@@ -64,11 +64,11 @@ build: bin/main
 
 build-pr:
 	echo "build on pull request"
-	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --no-output --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 build-main:
 	echo "build on main"
-	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --no-output --push +build-main --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 .PHONY: cleanup-pr
 cleanup-pr:

--- a/services/frontend-service/Makefile
+++ b/services/frontend-service/Makefile
@@ -59,11 +59,11 @@ build: bin/main
 
 build-pr:
 	echo "build on pull request"
-	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --no-output --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 build-main:
 	echo "build on main"
-	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --no-output --push +build-main --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 .PHONY: cleanup-pr
 cleanup-pr:

--- a/services/rollout-service/Makefile
+++ b/services/rollout-service/Makefile
@@ -47,11 +47,11 @@ build: bin/main
 
 build-pr:
 	echo "build on pull request"
-	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --no-output --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 build-main:
 	echo "build on main"
-	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --no-output --push +build-main --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 .PHONY: cleanup-pr
 cleanup-pr:


### PR DESCRIPTION
This PR includes the following:
  * Do not save built images locally when running in the CI.
  * Cancel stale commits' runs when a new commit is pushed.
  * Install docker with apt in integration tests instead of earthly installing it every time. 