### PR TITLE
fix(ci): Disable cache sharing between builds

### DIFF
--- a/infrastructure/earthly/go/Earthfile
+++ b/infrastructure/earthly/go/Earthfile
@@ -16,7 +16,7 @@ COMPILE:
     ARG USERARCH
     ARG main_path="cmd/server"
     ARG cgo_enabled=0
-    CACHE --sharing shared --id go-cache $(go env GOCACHE)
+    CACHE --sharing locked --id go-cache $(go env GOCACHE)
     RUN cd $main_path && \
         CGO_ENABLED=$cgo_enabled \
         GOARCH=$USERARCH \
@@ -36,14 +36,14 @@ COMPILE:
 UNIT_TEST:
     FUNCTION
     ARG GO_TEST_ARGS
-    CACHE --sharing shared --id go-cache $(go env GOCACHE)
+    CACHE --sharing locked --id go-cache $(go env GOCACHE)
     COPY pkg pkg
     RUN go test $GO_TEST_ARGS ./...
 
 LINT:
     FUNCTION
-    CACHE --sharing shared --id go-cache $(go env GOCACHE)
-    CACHE --sharing shared --id lint-cache /root/.cache/golangci-lint
+    CACHE --sharing locked --id go-cache $(go env GOCACHE)
+    CACHE --sharing locked --id lint-cache /root/.cache/golangci-lint
     ARG FILES_TO_FORMAT=$(gofmt -l ./)
     ARG skip_lint_errors="false"
     IF [ ! -z "$FILES_TO_FORMAT" ]

--- a/trivy/Earthfile
+++ b/trivy/Earthfile
@@ -35,7 +35,7 @@ scan-service:
     FROM +deps
     ARG --required service
     ARG --required version
-    CACHE --sharing shared --id trivy-cache /tmp/trivy_cache
+    CACHE --sharing locked --id trivy-cache /tmp/trivy_cache
 
     RUN trivy --cache-dir /tmp/trivy_cache image $IMAGE_REGISTRY/kuberpult-$service:$version -f template --template "@templates/html.tpl" -o kuberpult-$service.html
     SAVE ARTIFACT kuberpult-$service.html


### PR DESCRIPTION
* Using shared cache can consume a large amount of disk space because the buildkit creates a copy fof the cache mount for each concurrent build. If multiple builds are triggered at the same time then it consumes all the remaining disk space available and the buildkit will crash.