### PR TITLE
feat(frontend): Remove plaintext logging of dexClientSecret

### DIFF
--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -132,7 +132,6 @@ func runServer(ctx context.Context) error {
 		logger.FromContext(ctx).Error("config.parse", zap.Error(err))
 		return err
 	}
-	logger.FromContext(ctx).Warn(fmt.Sprintf("config: \n%v", c))
 	if c.GitAuthorEmail == "" {
 		msg := "DefaultGitAuthorEmail must not be empty"
 		logger.FromContext(ctx).Error(msg)


### PR DESCRIPTION
Closes #1549 
This should now print e.g.:
```log
kuberpult-frontend-service  | {"level":"warn","ts":1714058149.364507,"caller":"cmd/server.go:142","msg":"config: \n{cd-service:8443 false  http://kuberpult-cd-service:80    false https://cd.dev.freiheit.systems/ tools  false https://login.microsoftonline.com/    false 1234 **********    https://github.com/freiheit-com/kuberpult/commit/{commit} https://github.com/freiheit-com/fdc-standard-setup-dev-env-manifest/tree/{branch}/{dir} main localhost:* user-local-dev-docker-compose user-local-dev@example.com 2m0s 10m0s false false}"}

```

I'm open to moving the stripSecrets function to another place - just give me a heads-up on where you want it :) The same holds if you'd like this done in another way.

Revolution ID: DSN-R3VBYG