### PR TITLE
chore(dex): upgrade dex version so it supports machine-machine auth

### DIFF
--- a/charts/kuberpult/Chart.yaml.tpl
+++ b/charts/kuberpult/Chart.yaml.tpl
@@ -45,7 +45,7 @@ appVersion: "${VERSION}"
 dependencies:
 - name: dex
   condition: auth.dexAuth.installDex
-  version: "0.14.2"
+  version: "0.17.1"
   repository: https://charts.dexidp.io
 
 maintainers:


### PR DESCRIPTION
Dex only supports machine to machine auth from `v2.38.0` see:
https://github.com/dexidp/dex/releases/tag/v2.38.0

In my eyes it makes sense to directly upgrade to latest (as of now `v2.39.1`), as it will probably be used more and more once #1554  is merged.

The aligning version of the chart would be `0.17.1` : https://github.com/dexidp/helm-charts/releases

For testing:
```shell
#!/usr/bin/env bash
KUBERPULT_URL="https://kuberpult.com"
TOKEN="$(gcloud auth print-access-token)"
ACCESS_TOKEN_JSON=$(curl -X POST "${KUBERPULT_URL}/dex/token" -H "Content-Type: application/x-www-form-urlencoded" --user kuberpult-dex:kuberpult-dex-secret --data-urlencode "connector_id=google-oidc" --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" --data-urlencode "scope=openid email profile" --data-urlencode "requested_token_type=urn:ietf:params:oauth:token-type:access_token" --data-urlencode "subject_token=${TOKEN}" --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:access_token")
ACCESS_TOKEN=$(echo -n "${ACCESS_TOKEN_JSON}" | jq -r .access_token)

url="${KUBERPULT_URL}/environments/staging/locks/staging-lock"

curl -X PUT "$url" -d '{"message": "test app lock"}' -H 'Content-Type: application/json' --cookie "kuberpult.oauth=${ACCESS_TOKEN}"
```

with config.yaml
```yaml
kuberpult:
  auth:
    dexAuth:
      baseURL: https://kuberpult.com
      clientId: kuberpult-dex
      clientSecret: kuberpult-dex-really-secret
      enabled: true
      installDex: true
      policy_csv: |
        p, role:Developer, CreateLock, *:*, *, allow
        p, role:Developer, DeleteLock, *:*, *, allow
        p, role:Developer, CreateRelease, *:*, *, allow
        p, role:Developer, DeployRelease, *:*, *, allow
        p, role:Developer, CreateUndeploy, *:*, *, allow
        p, role:Developer, DeployUndeploy, *:*, *, allow
        p, role:Developer, CreateEnvironment, *:*, *, allow
        p, role:Developer, DeleteEnvironmentApplication, *:*, *, allow
        p, role:Developer, DeployReleaseTrain, *:*, *, allow
        g, testorg:testgroup, role:Developer
      scopes: openid, groups, email, profile, federated:id
  cd:
    db:
      dbOption: "NO_DB"
  dex:
    config:
      connectors:
      - config:
          clientID: id
          clientSecret: secret
          redirectURI: https://kuberpult.com/dex/callback
        id: google
        name: Google
        type: google
      - config:
          issuer: https://accounts.google.com
          userNameKey: sub
          getUserInfo: true
          scopes:
          - openid
          - email
          - profile
          - audience:server:client_id:kuberpult-dex
        id: google-oidc
        name: Google OIDC only for machine login - do not use
        type: oidc
      issuer: https://kuberpult.com/dex
      staticClients:
      - id: kuberpult-dex-public
        secret: public-really-secret
        name: kuberpult-public
        public: true
      - id: kuberpult-dex
        name: kuberpult
        public: true
        redirectURIs:
        - https://kuberpult.com/callback
        - https://kuberpult.com/dex/callback
        secret: kuberpult-dex-really-secret
        trustedPeers:
        - kuberpult-dex-public
      storage:
        type: memory


```

However the better way would be to use a public client which is allowed to be accessed by the private one:

```
ACCESS_TOKEN_JSON=$(curl -X POST "${KUBERPULT_URL}/dex/token" -H "Content-Type: application/x-www-form-urlencoded" --user kuberpult-dex-public:public-secret --data-urlencode "connector_id=google-oidc" --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" --data-urlencode "scope=openid email profile audience:server:client_id:kuberpult-dex" --data-urlencode "requested_token_type=urn:ietf:params:oauth:token-type:access_token" --data-urlencode "subject_token=${TOKEN}" --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:access_token")
```
However, this adds e.g.
```
  "aud": [
    "kuberpult-dex",
    "kuberpult-dex-public"
  ],
```
to the claim which would've to be supportend in the verify method.
Then you can remove the `public: true` in the `kuberpult-dex` client.

