### PR TITLE
feat: allow writing to only the esl table

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -239,7 +239,7 @@ spec:
         - name: KUBERPULT_DB_OPTION # { NO_DB, cloudsql, sqlite }
           value: {{ .Values.cd.db.dbOption }}
         - name: KUBERPULT_WRITE_ESL_TABLE_ONLY
-          value: {{ .Values.cd.db.writeEslTableOnly }}
+          value: "{{ .Values.cd.db.writeEslTableOnly }}"
 {{- if or (eq .Values.cd.db.dbOption "cloudsql") (eq .Values.cd.db.dbOption "sqlite") }}
         - name: KUBERPULT_DB_LOCATION
           value: {{ .Values.cd.db.location }}

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -238,6 +238,8 @@ spec:
           value: "{{ .Values.cd.backendConfig.queueSize }}"
         - name: KUBERPULT_DB_OPTION # { NO_DB, cloudsql, sqlite }
           value: {{ .Values.cd.db.dbOption }}
+        - name: KUBERPULT_WRITE_ESL_TABLE_ONLY
+          value: {{ .Values.cd.db.writeEslTableOnly }}
 {{- if or (eq .Values.cd.db.dbOption "cloudsql") (eq .Values.cd.db.dbOption "sqlite") }}
         - name: KUBERPULT_DB_LOCATION
           value: {{ .Values.cd.db.location }}

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -102,6 +102,9 @@ cd:
     dbUser: "username"
     dbPassword: "password"
     migrations: /migrations
+    # If set to true, kuberpult will write only the ESL table.
+    # This is useful to already collect historical data in the database, while waiting for the full database implementation.
+    writeEslTableOnly: false
     requests:
       cpu: "100m"
       memory: "200Mi"

--- a/docker-compose-earthly.yml
+++ b/docker-compose-earthly.yml
@@ -8,6 +8,7 @@ services:
       - KUBERPULT_DB_LOCATION=/kp/database
       - KUBERPULT_DB_MIGRATIONS_LOCATION=/kp/database/migrations
       - KUBERPULT_DB_OPTION=sqlite
+      - KUBERPULT_DB_WRITE_ESL_TABLE_ONLY=false
       - KUBERPULT_GIT_BRANCH=master
       - KUBERPULT_GIT_NETWORK_TIMEOUT=3s
       - KUBERPULT_DEX_MOCK=false

--- a/docs/database.md
+++ b/docs/database.md
@@ -44,3 +44,20 @@ write the following to the file `~/.sqliterc`:
 .mode column
 ```
 
+### Database Modes
+
+Kuberpult can run with 3 database modes:
+1) No Database at all, just use the manifest repo as before
+2) Use the Database only to write all incoming request in the "ESL" (event sourcing light) table.
+This just records the history.
+Note that the migrations are still running, so kuberpult will create some empty tables.
+3) Use the Database for all tables. Note that this is not fully implemented yet.
+With this mode, the cd-service writes to all database tables, and uses the manifest repo not at all.
+Another service will be introduced to export the database content to a manifest repo.
+
+
+#### Best Practice
+
+To implement the database modes correctly,
+we must use the functions `ShouldUseEslTable` before writing to the ESL table,
+and `ShouldUseOtherTables` before writing to any other table.

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -88,6 +88,7 @@ type Config struct {
 	DbUserPassword           string        `default:"" split_words:"true"`
 	DbAuthProxyPort          string        `default:"5432" split_words:"true"`
 	DbMigrationsLocation     string        `default:"" split_words:"true"`
+	DbWriteEslTableOnly      bool          `default:"false" split_words:"true"`
 }
 
 func (c *Config) storageBackend() repository.StorageBackend {
@@ -212,6 +213,7 @@ func RunServer() {
 					DbPassword:     c.DbUserPassword,
 					DbUser:         c.DbUserName,
 					MigrationsPath: c.DbMigrationsLocation,
+					WriteEslOnly:   c.DbWriteEslTableOnly,
 				}
 			} else if c.DbOption == "sqlite" {
 				dbCfg = repository.DBConfig{
@@ -222,6 +224,7 @@ func RunServer() {
 					DbPassword:     c.DbUserPassword,
 					DbUser:         c.DbUserName,
 					MigrationsPath: c.DbMigrationsLocation,
+					WriteEslOnly:   c.DbWriteEslTableOnly,
 				}
 			} else {
 				logger.FromContext(ctx).Fatal("Database was enabled but no valid DB option was provided.")
@@ -279,12 +282,14 @@ func RunServer() {
 		repositoryService := &service.Service{
 			Repository: repo,
 		}
-		if c.DbOption != "NO_DB" {
-			logger.FromContext(ctx).Warn("running custom migrations")
+		if dbHandler.ShouldUseOtherTables() {
+			logger.FromContext(ctx).Sugar().Warnf("running custom migrations, because KUBERPULT_DB_WRITE_ESL_TABLE_ONLY=true")
 			migErr := dbHandler.RunCustomMigrations(ctx, repo)
 			if migErr != nil {
 				logger.FromContext(ctx).Fatal("Error running custom database migrations", zap.Error(migErr))
 			}
+		} else {
+			logger.FromContext(ctx).Sugar().Warnf("Skipping custom migrations, because KUBERPULT_DB_WRITE_ESL_TABLE_ONLY=false")
 		}
 
 		span.Finish()

--- a/services/cd-service/pkg/repository/db.go
+++ b/services/cd-service/pkg/repository/db.go
@@ -49,6 +49,7 @@ type DBConfig struct {
 	DriverName     string
 	DbPassword     string
 	MigrationsPath string
+	WriteEslOnly   bool
 }
 
 type DBHandler struct {
@@ -57,6 +58,22 @@ type DBHandler struct {
 	MigrationsPath string
 	DB             *sql.DB
 	DBDriver       *database.Driver
+
+	/*
+		There are 3 modes:
+		1) DBHandler==nil: do not write anything to the DB
+		2) DBHandler!=nil && WriteEslOnly==true: write only the ESL table to the database. Stores all incoming data in the DB, but does not read the DB.
+		3) DBHandler!=nil && WriteEslOnly==false: write everything to the database.
+	*/
+	WriteEslOnly bool
+}
+
+func (h *DBHandler) ShouldUseEslTable() bool {
+	return h != nil
+}
+
+func (h *DBHandler) ShouldUseOtherTables() bool {
+	return h != nil && !h.WriteEslOnly
 }
 
 func Connect(cfg DBConfig) (*DBHandler, error) {
@@ -71,6 +88,7 @@ func Connect(cfg DBConfig) (*DBHandler, error) {
 		MigrationsPath: cfg.MigrationsPath,
 		DB:             db,
 		DBDriver:       &driver,
+		WriteEslOnly:   cfg.WriteEslOnly,
 	}, nil
 }
 

--- a/services/cd-service/pkg/repository/db_test.go
+++ b/services/cd-service/pkg/repository/db_test.go
@@ -265,3 +265,50 @@ func TestSqliteToPostgresQuery(t *testing.T) {
 		})
 	}
 }
+
+func TestHelperFunctions(t *testing.T) {
+	tcs := []struct {
+		Name                string
+		inputHandler        *DBHandler
+		expectedEslTable    bool
+		expectedOtherTables bool
+	}{
+		{
+			Name:                "nil handler",
+			inputHandler:        nil,
+			expectedEslTable:    false,
+			expectedOtherTables: false,
+		},
+		{
+			Name: "esl only",
+			inputHandler: &DBHandler{
+				WriteEslOnly: true,
+			},
+			expectedEslTable:    true,
+			expectedOtherTables: false,
+		},
+		{
+			Name: "other tables",
+			inputHandler: &DBHandler{
+				WriteEslOnly: false,
+			},
+			expectedEslTable:    true,
+			expectedOtherTables: true,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			actualEslTable := tc.inputHandler.ShouldUseEslTable()
+			if diff := cmp.Diff(tc.expectedEslTable, actualEslTable); diff != "" {
+				t.Errorf("response mismatch (-want, +got):\n%s", diff)
+			}
+			actualOtherTables := tc.inputHandler.ShouldUseOtherTables()
+			if diff := cmp.Diff(tc.expectedOtherTables, actualOtherTables); diff != "" {
+				t.Errorf("response mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -524,7 +524,7 @@ func (r *repository) applyTransformerBatches(transformerBatches []transformerBat
 				return r.applyTransformerBatches(transformerBatches, false, transaction)
 			} else {
 				e.finish(applyErr)
-				if r.DB != nil {
+				if r.DB.ShouldUseEslTable() {
 					// if we use the DB at all, then we only do one transformer per git push
 					// AND we need to handle the error in the caller to rollback in case of an error:
 					return nil, applyErr, nil
@@ -678,7 +678,7 @@ func (r *repository) ProcessQueueOnce(ctx context.Context, e transformerBatch, c
 
 	// Apply the items
 	var tx *sql.Tx = nil
-	if r.DB != nil {
+	if r.DB.ShouldUseEslTable() {
 		var txErr error
 		tx, txErr = r.DB.DB.BeginTx(ctx, nil)
 		if txErr != nil {
@@ -691,13 +691,13 @@ func (r *repository) ProcessQueueOnce(ctx context.Context, e transformerBatch, c
 	}
 	transformerBatches, err, changes := r.applyTransformerBatches(transformerBatches, true, tx)
 	if err != nil {
-		if r.DB != nil {
+		if r.DB.ShouldUseEslTable() {
 			logger.Sugar().Warnf("rolling back transaction because of %v", err)
 			_ = tx.Rollback()
 		}
 		return
 	}
-	if r.DB != nil {
+	if r.DB.ShouldUseEslTable() {
 		err = tx.Commit()
 		if err != nil {
 			return
@@ -1852,18 +1852,6 @@ func (s *State) GetEnvironmentConfigsForGroup(envGroup string) ([]string, error)
 func (s *State) GetEnvironmentApplications(environment string) ([]string, error) {
 	appDir := s.Filesystem.Join("environments", environment, "applications")
 	return names(s.Filesystem, appDir)
-}
-
-// GetApplications returns apps from either the db (if enabled), or otherwise the filesystem
-func (s *State) GetApplications(ctx context.Context, transaction *sql.Tx) ([]string, error) {
-	if s.DBHandler != nil {
-		result, err := s.DBHandler.DBSelectAllApplications(ctx, transaction)
-		if err != nil {
-			return nil, err
-		}
-		return result.Apps, nil
-	}
-	return s.GetApplicationsFromFile()
 }
 
 // GetApplicationsFromFile returns apps from the filesystem

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -408,7 +408,7 @@ func (c *CreateApplicationVersion) Transform(
 	if !valid.ApplicationName(c.Application) {
 		return "", GetCreateReleaseAppNameTooLong(c.Application, valid.AppNameRegExp, uint32(valid.MaxAppNameLen))
 	}
-	if state.DBHandler != nil {
+	if state.DBHandler.ShouldUseOtherTables() {
 		allApps, err := state.DBHandler.DBSelectAllApplications(ctx, transaction)
 		if err != nil {
 			return "", GetCreateReleaseGeneralFailure(err)
@@ -1095,7 +1095,7 @@ func (u *UndeployApplication) Transform(
 			return "", fmt.Errorf("UndeployApplication: unexpected error application '%v' environment '%v': '%w'", u.Application, env, err)
 		}
 	}
-	if state.DBHandler != nil {
+	if state.DBHandler.ShouldUseOtherTables() {
 		applications, err := state.DBHandler.DBSelectAllApplications(ctx, transaction)
 		if err != nil {
 			return "", fmt.Errorf("UndeployApplication: could not select all apps '%v': '%w'", u.Application, err)
@@ -2041,7 +2041,7 @@ func (c *DeployApplicationVersion) Transform(
 
 	if c.WriteCommitData { // write the corresponding event
 		deploymentEvent := createDeploymentEvent(c.Application, c.Environment, c.SourceTrain)
-		if s.DBHandler != nil {
+		if s.DBHandler.ShouldUseOtherTables() {
 			newReleaseCommitId, err := getCommitIDFromReleaseDir(ctx, fs, releaseDir)
 			if err != nil {
 				return "", GetCreateReleaseGeneralFailure(err)

--- a/services/cd-service/pkg/service/git.go
+++ b/services/cd-service/pkg/service/git.go
@@ -241,7 +241,7 @@ func (s *GitServer) GetEvents(ctx context.Context, fs billy.Filesystem, commitPa
 		}
 	}
 
-	if s.Config.DBHandler != nil {
+	if s.Config.DBHandler.ShouldUseOtherTables() {
 		events, err := s.Config.DBHandler.DBSelectAllEventsForCommit(ctx, commitID)
 		if err != nil {
 			return nil, fmt.Errorf("could not read events from DB: %v", err)


### PR DESCRIPTION
While we are still implementing the database, this feature toggle allows operators to already write the "ESL" (event sourcing light) table.

This is useful for storing the historical data already, and it can be used as a proof that the database setup works, without degrading performance by writing lots of data to lots of tables and also writing to the manifest repo at the same time.

Writing to the manifest repo will later be separated into its own service.