### PR TITLE
feat(cli): allow CLI to talk to arbitrary Kuberpult instances

### DIFF
--- a/cli/cmd/kuberpult-client/main.go
+++ b/cli/cmd/kuberpult-client/main.go
@@ -1,4 +1,5 @@
-/*This file is part of kuberpult.
+/*
+This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -12,7 +13,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright freiheit.com*/
+Copyright freiheit.com
+*/
 package main
 
 import "github.com/freiheit-com/kuberpult/cli/pkg/cmd"

--- a/cli/cmd/kuberpult-client/main.go
+++ b/cli/cmd/kuberpult-client/main.go
@@ -1,5 +1,4 @@
-/*
-This file is part of kuberpult.
+/*This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -13,8 +12,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright freiheit.com
-*/
+Copyright freiheit.com*/
+
 package main
 
 import "github.com/freiheit-com/kuberpult/cli/pkg/cmd"

--- a/cli/pkg/cli_utils/repeated_types_test.go
+++ b/cli/pkg/cli_utils/repeated_types_test.go
@@ -40,11 +40,11 @@ func (e errMatcher) Is(err error) bool {
 
 func TestParseCommandLineArgsString(t *testing.T) {
 	type testCase struct {
-		name             string
-		argNames   []string
-		cmdArgs          []string
-		expectedValues   map[string]string
-		expectedErrorMsg string
+		name           string
+		argNames       []string
+		cmdArgs        []string
+		expectedValues map[string]string
+		expectedError  error
 	}
 
 	tcs := []testCase{
@@ -73,9 +73,11 @@ func TestParseCommandLineArgsString(t *testing.T) {
 			argNames: []string{
 				"arg",
 			},
-			cmdArgs:          []string{"--arg"},
-			expectedValues:   map[string]string{},
-			expectedErrorMsg: "flag needs an argument: -arg",
+			cmdArgs:        []string{"--arg"},
+			expectedValues: map[string]string{},
+			expectedError: errMatcher{
+				msg: "flag needs an argument: -arg",
+			},
 		},
 	}
 
@@ -93,7 +95,7 @@ func TestParseCommandLineArgsString(t *testing.T) {
 
 			err := fs.Parse(tc.cmdArgs)
 			// check errors
-			if diff := cmp.Diff(errMatcher{tc.expectedErrorMsg}, err, cmpopts.EquateErrors()); !(err == nil && tc.expectedErrorMsg == "") && diff != "" {
+			if diff := cmp.Diff(tc.expectedError, err, cmpopts.EquateErrors()); diff != "" {
 				t.Fatalf("error mismatch (-want, +got):\n%s", diff)
 			}
 
@@ -109,11 +111,11 @@ func TestParseCommandLineArgsString(t *testing.T) {
 
 func TestParseCommandLineArgsInt(t *testing.T) {
 	type testCase struct {
-		name             string
-		argNames   []string
-		cmdArgs          []string
-		expectedValues   map[string]string
-		expectedErrorMsg string
+		name           string
+		argNames       []string
+		cmdArgs        []string
+		expectedValues map[string]string
+		expectedError  error
 	}
 
 	tcs := []testCase{
@@ -142,16 +144,20 @@ func TestParseCommandLineArgsInt(t *testing.T) {
 			argNames: []string{
 				"arg",
 			},
-			cmdArgs:          []string{"--arg"},
-			expectedErrorMsg: "flag needs an argument: -arg",
+			cmdArgs: []string{"--arg"},
+			expectedError: errMatcher{
+				msg: "flag needs an argument: -arg",
+			},
 		},
 		{
 			name: "arg specified but with invalid value",
 			argNames: []string{
 				"arg",
 			},
-			cmdArgs:          []string{"--arg", "potato"},
-			expectedErrorMsg: "invalid value \"potato\" for flag -arg: the provided value \"potato\" is not an integer",
+			cmdArgs: []string{"--arg", "potato"},
+			expectedError: errMatcher{
+				msg: "invalid value \"potato\" for flag -arg: the provided value \"potato\" is not an integer",
+			},
 		},
 	}
 
@@ -169,7 +175,7 @@ func TestParseCommandLineArgsInt(t *testing.T) {
 
 			err := fs.Parse(tc.cmdArgs)
 			// check errors
-			if diff := cmp.Diff(errMatcher{tc.expectedErrorMsg}, err, cmpopts.EquateErrors()); !(err == nil && tc.expectedErrorMsg == "") && diff != "" {
+			if diff := cmp.Diff(tc.expectedError, err, cmpopts.EquateErrors()); diff != "" {
 				t.Fatalf("error mismatch (-want, +got):\n%s", diff)
 			}
 

--- a/cli/pkg/cmd/cli.go
+++ b/cli/pkg/cmd/cli.go
@@ -22,8 +22,15 @@ import (
 	"os"
 )
 
+type kuberpultClientParameters struct {
+	url         string
+	authorName  *string
+	authorEmail *string
+	iapToken    *string
+}
+
 func RunCLI() {
-	params, other, err := parseArgs(os.Args[1:])
+	kpClientParams, other, err := parseArgs(os.Args[1:])
 	if err != nil {
 		log.Fatalf("error while parsing command line arguments, error: %v", err)
 	}
@@ -32,19 +39,18 @@ func RunCLI() {
 		log.Fatalf("a subcommand must be specified")
 	}
 
-	var iapToken *string
-	if envVar, envVarExists := os.LookupEnv("KUBERPULT_IAP_TOKEN"); envVarExists {
-		iapToken = &envVar
-	}
-	
 	subcommand := other[0]
 	subflags := other[1:]
+
+	if envVar, envVarExists := os.LookupEnv("KUBERPULT_IAP_TOKEN"); envVarExists {
+		kpClientParams.iapToken = &envVar
+	}
 
 	switch subcommand {
 	case "help":
 		fmt.Println(helpMessage)
 	case "release":
-		handleRelease(params.url, iapToken, subflags)
+		handleRelease(*kpClientParams, subflags)
 	default:
 		log.Fatalf("unknown subcommand %s", subcommand)
 	}

--- a/cli/pkg/cmd/handlers.go
+++ b/cli/pkg/cmd/handlers.go
@@ -31,13 +31,12 @@ func handleRelease(kpClientParams kuberpultClientParameters, args []string) {
 	}
 
 	authParams := kutil.AuthenticationParameters{
-		Url:         kpClientParams.url,
 		IapToken:    kpClientParams.iapToken,
 		AuthorName:  kpClientParams.authorName,
 		AuthorEmail: kpClientParams.authorEmail,
 	}
 
-	if err = rl.Release(authParams, *parsedArgs); err != nil {
+	if err = rl.Release(kpClientParams.url, authParams, *parsedArgs); err != nil {
 		log.Fatalf("error on release, error: %v", err)
 	}
 }

--- a/cli/pkg/cmd/handlers.go
+++ b/cli/pkg/cmd/handlers.go
@@ -19,17 +19,25 @@ package cmd
 import (
 	"log"
 
+	kutil "github.com/freiheit-com/kuberpult/cli/pkg/kuberpult_utils"
 	rl "github.com/freiheit-com/kuberpult/cli/pkg/release"
 )
 
-func handleRelease(url string, iapToken *string, args []string) {
+func handleRelease(kpClientParams kuberpultClientParameters, args []string) {
 	parsedArgs, err := rl.ParseArgs(args)
 
 	if err != nil {
 		log.Fatalf("error while parsing command line args, error: %v", err)
 	}
 
-	if err = rl.Release(url, iapToken, parsedArgs); err != nil {
+	authParams := kutil.AuthenticationParameters{
+		Url:         kpClientParams.url,
+		IapToken:    kpClientParams.iapToken,
+		AuthorName:  kpClientParams.authorName,
+		AuthorEmail: kpClientParams.authorEmail,
+	}
+
+	if err = rl.Release(authParams, *parsedArgs); err != nil {
 		log.Fatalf("error on release, error: %v", err)
 	}
 }

--- a/cli/pkg/cmd/handlers.go
+++ b/cli/pkg/cmd/handlers.go
@@ -17,35 +17,19 @@ Copyright freiheit.com*/
 package cmd
 
 import (
-	"fmt"
 	"log"
-	"os"
+
+	rl "github.com/freiheit-com/kuberpult/cli/pkg/release"
 )
 
-func RunCLI() {
-	params, other, err := parseArgs(os.Args[1:])
+func handleRelease(url string, iapToken *string, args []string) {
+	parsedArgs, err := rl.ParseArgs(args)
+
 	if err != nil {
-		log.Fatalf("error while parsing command line arguments, error: %v", err)
+		log.Fatalf("error while parsing command line args, error: %v", err)
 	}
 
-	if len(other) == 0 {
-		log.Fatalf("a subcommand must be specified")
-	}
-
-	var iapToken *string
-	if envVar, envVarExists := os.LookupEnv("KUBERPULT_IAP_TOKEN"); envVarExists {
-		iapToken = &envVar
-	}
-	
-	subcommand := other[0]
-	subflags := other[1:]
-
-	switch subcommand {
-	case "help":
-		fmt.Println(helpMessage)
-	case "release":
-		handleRelease(params.url, iapToken, subflags)
-	default:
-		log.Fatalf("unknown subcommand %s", subcommand)
+	if err = rl.Release(url, iapToken, parsedArgs); err != nil {
+		log.Fatalf("error on release, error: %v", err)
 	}
 }

--- a/cli/pkg/cmd/parsing.go
+++ b/cli/pkg/cmd/parsing.go
@@ -1,0 +1,80 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
+)
+
+type commandLineArguments struct {
+	url cli_utils.RepeatedString
+}
+
+type kuberpultClientParameters struct {
+	url string
+}
+
+func readArgs(args []string) (*commandLineArguments, []string, error) {
+	cmdArgs := commandLineArguments{}
+	
+	fs := flag.NewFlagSet("top level", flag.ContinueOnError)
+
+	fs.Var(&cmdArgs.url, "url", "the URL of the Kuberpult instance (must be set exactly once)")
+
+	if err := fs.Parse(args); err != nil {
+		return nil, nil, fmt.Errorf("error while reading command line arguments, error: %w", err)
+	}
+
+	other := fs.Args()
+
+	return &cmdArgs, other, nil
+}
+
+func argsValid(cmdArgs *commandLineArguments) (bool, string) {
+	if len(cmdArgs.url.Values) != 1 {
+		return false, "the --url arg must be set exactly once"
+	}
+	return true, ""
+}
+
+func convertToParams(cmdArgs *commandLineArguments) (*kuberpultClientParameters, error) {
+	if ok, msg := argsValid(cmdArgs); !ok {
+		return nil, fmt.Errorf(msg)
+	}
+
+	params := kuberpultClientParameters{}
+	
+	params.url = cmdArgs.url.Values[0]
+	
+	return &params, nil
+}
+
+func parseArgs(args []string) (*kuberpultClientParameters, []string, error) {
+	cmdArgs, other, err := readArgs(args)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)
+	}
+
+	params, err := convertToParams(cmdArgs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error while creating kuberpult client parameters, error: %w", err)
+	}
+
+	return params, other, nil
+}

--- a/cli/pkg/cmd/parsing_test.go
+++ b/cli/pkg/cmd/parsing_test.go
@@ -128,12 +128,12 @@ func TestParseArgs(t *testing.T) {
 				t.Fatalf("error mismatch (-want, +got):\n%s", diff)
 			}
 
-			if !cmp.Equal(params, tc.expectedParams, cmp.AllowUnexported(kuberpultClientParameters{})) {
-				t.Fatalf("expected args %v, got %v", tc.expectedParams, params)
+			if diff := cmp.Diff(params, tc.expectedParams, cmp.AllowUnexported(kuberpultClientParameters{})); diff != "" {
+				t.Fatalf("expected args:\n  %v\ngot:\n  %v\ndiff:\n  %s\n", tc.expectedParams, params, diff)
 			}
 
-			if !cmp.Equal(other, tc.expectedOther, cmpopts.EquateEmpty()) {
-				t.Fatalf("expected other args %v, got %v", tc.expectedOther, other)
+			if diff := cmp.Diff(other, tc.expectedOther, cmpopts.EquateEmpty()); diff != "" {
+				t.Fatalf("expected other args:\n  %v\ngot:\n  %v\ndiff:\n  %s\n", tc.expectedOther, other, diff)
 			}
 		})
 	}

--- a/cli/pkg/cmd/parsing_test.go
+++ b/cli/pkg/cmd/parsing_test.go
@@ -1,0 +1,102 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+// Used to compare two error message strings, needed because errors.Is(fmt.Errorf(text),fmt.Errorf(text)) == false
+type errMatcher struct {
+	msg string
+}
+
+func (e errMatcher) Error() string {
+	return e.msg
+}
+
+func (e errMatcher) Is(err error) bool {
+	return e.Error() == err.Error()
+}
+
+func TestParseArgs(t *testing.T) {
+	type TestCase struct {
+		name             string
+		cmdArgs          string
+		expectedParams   *kuberpultClientParameters
+		expectedOther    []string
+		expectedErrorMsg string
+	}
+
+	tcs := []TestCase{
+		{
+			name:             "nothing provided",
+			cmdArgs:          "",
+			expectedErrorMsg: "error while creating kuberpult client parameters, error: the --url arg must be set exactly once",
+		},
+		{
+			name:             "something other than --url is provided",
+			cmdArgs:          "--potato tomato",
+			expectedErrorMsg: "error while parsing command line arguments, error: error while reading command line arguments, error: flag provided but not defined: -potato",
+		},
+		{
+			name:    "only --url is provided",
+			cmdArgs: "--url something.somewhere",
+			expectedParams: &kuberpultClientParameters{
+				url: "something.somewhere",
+			},
+		},
+		{
+			name: "--url is provided along with some other stuff",
+			cmdArgs: "--url something.somewhere --potato tomato",
+			expectedErrorMsg: "error while parsing command line arguments, error: error while reading command line arguments, error: flag provided but not defined: -potato",
+		},
+		{
+			name: "--url is provided with some tail",
+			cmdArgs: "--url something.somewhere potato --tomato",
+			expectedParams: &kuberpultClientParameters{
+				url: "something.somewhere",
+			},
+			expectedOther: []string{"potato", "--tomato"},
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			params, other, err := parseArgs(strings.Split(tc.cmdArgs, " "))
+			// check errors
+			if diff := cmp.Diff(errMatcher{tc.expectedErrorMsg}, err, cmpopts.EquateErrors()); !(err == nil && tc.expectedErrorMsg == "") && diff != "" {
+				t.Fatalf("error mismatch (-want, +got):\n%s", diff)
+			}
+
+			if !cmp.Equal(params, tc.expectedParams, cmp.AllowUnexported(kuberpultClientParameters{})) {
+				t.Fatalf("expected args %v, got %v", tc.expectedParams, params)
+			}
+
+			if !cmp.Equal(other, tc.expectedOther, cmpopts.EquateEmpty()) {
+				t.Fatalf("expected other args %v, got %v", tc.expectedOther, other)
+			}
+		})
+	}
+}

--- a/cli/pkg/kuberpult_utils/auth_params.go
+++ b/cli/pkg/kuberpult_utils/auth_params.go
@@ -17,7 +17,6 @@ Copyright freiheit.com*/
 package kuberpult_utils
 
 type AuthenticationParameters struct {
-	Url         string
 	IapToken    *string
 	AuthorName  *string
 	AuthorEmail *string

--- a/cli/pkg/kuberpult_utils/auth_params.go
+++ b/cli/pkg/kuberpult_utils/auth_params.go
@@ -1,0 +1,24 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package kuberpult_utils
+
+type AuthenticationParameters struct {
+	Url         string
+	IapToken    *string
+	AuthorName  *string
+	AuthorEmail *string
+}

--- a/cli/pkg/release/http.go
+++ b/cli/pkg/release/http.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 )
 
-func prepareHttpRequest(url string, parsedArgs *ReleaseParameters) (*http.Request, error) {
+func prepareHttpRequest(url string, iapToken *string, parsedArgs *ReleaseParameters) (*http.Request, error) {
 	form := bytes.NewBuffer(nil)
 	writer := multipart.NewWriter(form)
 
@@ -105,7 +105,9 @@ func prepareHttpRequest(url string, parsedArgs *ReleaseParameters) (*http.Reques
 		return nil, fmt.Errorf("error creating the HTTP request, error: %w", err)
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-
+	if iapToken != nil {
+		req.Header.Add("Authorization", "Bearer "+*iapToken)
+	}
 	return req, nil
 }
 

--- a/cli/pkg/release/http.go
+++ b/cli/pkg/release/http.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"encoding/base64"
 )
 
 func prepareHttpRequest(authParams kutil.AuthenticationParameters, parsedArgs ReleaseParameters) (*http.Request, error) {
@@ -107,17 +108,20 @@ func prepareHttpRequest(authParams kutil.AuthenticationParameters, parsedArgs Re
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	
-	if authParams.AuthorName != nil {
-		req.Header.Add("author-name", *authParams.AuthorName)
-	}
 	
 	if authParams.IapToken != nil {
 		req.Header.Add("Authorization", "Bearer "+*authParams.IapToken)
 	}
+	
+	if authParams.AuthorName != nil {
+		req.Header.Add("author-name", base64.StdEncoding.EncodeToString([]byte(*authParams.AuthorName)))
+	}
 
 	if authParams.AuthorEmail != nil {
-		req.Header.Add("author-email", *authParams.AuthorEmail)
+		req.Header.Add("author-email", base64.StdEncoding.EncodeToString([]byte(*authParams.AuthorEmail)))
 	}
+
+	fmt.Println(req.Header)
 	
 	return req, nil
 }

--- a/cli/pkg/release/http.go
+++ b/cli/pkg/release/http.go
@@ -26,7 +26,7 @@ import (
 	"encoding/base64"
 )
 
-func prepareHttpRequest(authParams kutil.AuthenticationParameters, parsedArgs ReleaseParameters) (*http.Request, error) {
+func prepareHttpRequest(url string, authParams kutil.AuthenticationParameters, parsedArgs ReleaseParameters) (*http.Request, error) {
 	form := bytes.NewBuffer(nil)
 	writer := multipart.NewWriter(form)
 
@@ -102,7 +102,7 @@ func prepareHttpRequest(authParams kutil.AuthenticationParameters, parsedArgs Re
 		return nil, fmt.Errorf("error closing the writer, error: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, authParams.Url, form)
+	req, err := http.NewRequest(http.MethodPost, url, form)
 	if err != nil {
 		return nil, fmt.Errorf("error creating the HTTP request, error: %w", err)
 	}

--- a/cli/pkg/release/http.go
+++ b/cli/pkg/release/http.go
@@ -18,12 +18,12 @@ package release
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	kutil "github.com/freiheit-com/kuberpult/cli/pkg/kuberpult_utils"
 	"io"
 	"mime/multipart"
 	"net/http"
-	"encoding/base64"
 )
 
 func prepareHttpRequest(url string, authParams kutil.AuthenticationParameters, parsedArgs ReleaseParameters) (*http.Request, error) {
@@ -107,12 +107,11 @@ func prepareHttpRequest(url string, authParams kutil.AuthenticationParameters, p
 		return nil, fmt.Errorf("error creating the HTTP request, error: %w", err)
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	
-	
+
 	if authParams.IapToken != nil {
 		req.Header.Add("Authorization", "Bearer "+*authParams.IapToken)
 	}
-	
+
 	if authParams.AuthorName != nil {
 		req.Header.Add("author-name", base64.StdEncoding.EncodeToString([]byte(*authParams.AuthorName)))
 	}
@@ -122,7 +121,7 @@ func prepareHttpRequest(url string, authParams kutil.AuthenticationParameters, p
 	}
 
 	fmt.Println(req.Header)
-	
+
 	return req, nil
 }
 

--- a/cli/pkg/release/http_test.go
+++ b/cli/pkg/release/http_test.go
@@ -545,8 +545,8 @@ func TestRequestCreation(t *testing.T) {
 			}
 
 			// check multipart form values
-			if !cmp.Equal(mockServer.multipartForm.Value, tc.expectedMultipartFormValue) {
-				t.Fatalf("request multipart forms are different, expected %v, received %v", tc.expectedMultipartFormValue, mockServer.multipartForm)
+			if diff := cmp.Diff(mockServer.multipartForm.Value, tc.expectedMultipartFormValue); diff != "" {
+				t.Fatalf("request multipart forms are different\nexpected:\n  %v\nreceived:\n  %v\ndiff:\n  %s", tc.expectedMultipartFormValue, mockServer.multipartForm, diff)
 			}
 
 			// check multipart form files
@@ -577,8 +577,8 @@ func TestRequestCreation(t *testing.T) {
 				}
 				fileHeaders[key] = simpleHeaders
 			}
-			if !cmp.Equal(fileHeaders, tc.expectedMultipartFormFile, cmp.AllowUnexported(simpleMultipartFormFileHeader{})) {
-				t.Fatalf("request multipart forms are different, expected %v, received %v", tc.expectedMultipartFormFile, fileHeaders)
+			if diff := cmp.Diff(fileHeaders, tc.expectedMultipartFormFile, cmp.AllowUnexported(simpleMultipartFormFileHeader{})); diff != "" {
+				t.Fatalf("request multipart forms are different\nexpected:\n  %v\nreceived:\n  %v\ndiff:\n  %s\n", tc.expectedMultipartFormFile, fileHeaders, diff)
 			}
 		})
 	}

--- a/cli/pkg/release/http_test.go
+++ b/cli/pkg/release/http_test.go
@@ -537,7 +537,7 @@ func TestRequestCreation(t *testing.T) {
 			server := httptest.NewServer(mockServer)
 
 			// check errors
-			err := Release(server.URL, tc.params)
+			err := Release(server.URL, nil, tc.params)
 			// check errors
 			if diff := cmp.Diff(errMatcher{tc.expectedErrorMsg}, err, cmpopts.EquateErrors()); !(err == nil && tc.expectedErrorMsg == "") && diff != "" {
 				t.Fatalf("error mismatch (-want, +got):\n%s", diff)

--- a/cli/pkg/release/http_test.go
+++ b/cli/pkg/release/http_test.go
@@ -65,7 +65,7 @@ func TestRequestCreation(t *testing.T) {
 		params                     ReleaseParameters
 		expectedMultipartFormValue map[string][]string
 		expectedMultipartFormFile  map[string][]simpleMultipartFormFileHeader
-		expectedErrorMsg           string
+		expectedErrorMsg           error
 		responseCode               int
 	}
 
@@ -127,7 +127,7 @@ func TestRequestCreation(t *testing.T) {
 				"signatures[development]": {
 					{
 						filename: "development-signature",
-						content: "some development signature",
+						content:  "some development signature",
 					},
 				},
 			},
@@ -139,7 +139,7 @@ func TestRequestCreation(t *testing.T) {
 				Application: "potato",
 				Manifests: map[string][]byte{
 					"development": []byte("some development manifest"),
-					"production": []byte("some production manifest"),
+					"production":  []byte("some production manifest"),
 				},
 			},
 			expectedMultipartFormValue: map[string][]string{
@@ -167,11 +167,11 @@ func TestRequestCreation(t *testing.T) {
 				Application: "potato",
 				Manifests: map[string][]byte{
 					"development": []byte("some development manifest"),
-					"production": []byte("some production manifest"),
+					"production":  []byte("some production manifest"),
 				},
 				Signatures: map[string][]byte{
 					"development": []byte("some development signature"),
-					"production": []byte("some production signature"),
+					"production":  []byte("some production signature"),
 				},
 			},
 			expectedMultipartFormValue: map[string][]string{
@@ -193,16 +193,15 @@ func TestRequestCreation(t *testing.T) {
 				"signatures[development]": {
 					{
 						filename: "development-signature",
-						content: "some development signature",
+						content:  "some development signature",
 					},
 				},
 				"signatures[production]": {
 					{
 						filename: "production-signature",
-						content: "some production signature",
+						content:  "some production signature",
 					},
 				},
-				
 			},
 			responseCode: http.StatusOK,
 		},
@@ -212,7 +211,7 @@ func TestRequestCreation(t *testing.T) {
 				Application: "potato",
 				Manifests: map[string][]byte{
 					"development": []byte("some development manifest"),
-					"production": []byte("some production manifest"),
+					"production":  []byte("some production manifest"),
 				},
 			},
 			expectedMultipartFormValue: map[string][]string{
@@ -232,8 +231,10 @@ func TestRequestCreation(t *testing.T) {
 					},
 				},
 			},
-			expectedErrorMsg: "error while issuing HTTP request, error: response was not OK or Accepted\nresponse code: 400\nresponse body:\n   ",
-			responseCode:     http.StatusBadRequest,
+			expectedErrorMsg: errMatcher{
+				msg: "error while issuing HTTP request, error: response was not OK or Accepted\nresponse code: 400\nresponse body:\n   ",
+			},
+			responseCode: http.StatusBadRequest,
 		},
 		{
 			name: "multiple environment manifests with teams set",
@@ -241,7 +242,7 @@ func TestRequestCreation(t *testing.T) {
 				Application: "potato",
 				Manifests: map[string][]byte{
 					"development": []byte("some development manifest"),
-					"production": []byte("some production manifest"),
+					"production":  []byte("some production manifest"),
 				},
 				Team: strPtr("potato-team"),
 			},
@@ -271,7 +272,7 @@ func TestRequestCreation(t *testing.T) {
 				Application: "potato",
 				Manifests: map[string][]byte{
 					"development": []byte("some development manifest"),
-					"production": []byte("some production manifest"),
+					"production":  []byte("some production manifest"),
 				},
 				Team:           strPtr("potato-team"),
 				SourceCommitId: strPtr("0123abcdef0123abcdef0123abcdef0123abcdef"),
@@ -303,7 +304,7 @@ func TestRequestCreation(t *testing.T) {
 				Application: "potato",
 				Manifests: map[string][]byte{
 					"development": []byte("some development manifest"),
-					"production": []byte("some production manifest"),
+					"production":  []byte("some production manifest"),
 				},
 				Team:             strPtr("potato-team"),
 				SourceCommitId:   strPtr("0123abcdef0123abcdef0123abcdef0123abcdef"),
@@ -337,7 +338,7 @@ func TestRequestCreation(t *testing.T) {
 				Application: "potato",
 				Manifests: map[string][]byte{
 					"development": []byte("some development manifest"),
-					"production": []byte("some production manifest"),
+					"production":  []byte("some production manifest"),
 				},
 				Team:             strPtr("potato-team"),
 				SourceCommitId:   strPtr("0123abcdef0123abcdef0123abcdef0123abcdef"),
@@ -373,7 +374,7 @@ func TestRequestCreation(t *testing.T) {
 				Application: "potato",
 				Manifests: map[string][]byte{
 					"development": []byte("some development manifest"),
-					"production": []byte("some production manifest"),
+					"production":  []byte("some production manifest"),
 				},
 				Team:             strPtr("potato-team"),
 				SourceCommitId:   strPtr("0123abcdef0123abcdef0123abcdef0123abcdef"),
@@ -411,7 +412,7 @@ func TestRequestCreation(t *testing.T) {
 				Application: "potato",
 				Manifests: map[string][]byte{
 					"development": []byte("some development manifest"),
-					"production": []byte("some production manifest"),
+					"production":  []byte("some production manifest"),
 				},
 				Team:             strPtr("potato-team"),
 				SourceCommitId:   strPtr("0123abcdef0123abcdef0123abcdef0123abcdef"),
@@ -449,7 +450,7 @@ func TestRequestCreation(t *testing.T) {
 				Application: "potato",
 				Manifests: map[string][]byte{
 					"development": []byte("some development manifest"),
-					"production": []byte("some production manifest"),
+					"production":  []byte("some production manifest"),
 				},
 				Team:             strPtr("potato-team"),
 				SourceCommitId:   strPtr("0123abcdef0123abcdef0123abcdef0123abcdef"),
@@ -489,7 +490,7 @@ func TestRequestCreation(t *testing.T) {
 				Application: "potato",
 				Manifests: map[string][]byte{
 					"development": []byte("some development manifest"),
-					"production": []byte("some production manifest"),
+					"production":  []byte("some production manifest"),
 				},
 				Team:             strPtr("potato-team"),
 				SourceCommitId:   strPtr("0123abcdef0123abcdef0123abcdef0123abcdef"),
@@ -536,11 +537,11 @@ func TestRequestCreation(t *testing.T) {
 				response: tc.responseCode,
 			}
 			server := httptest.NewServer(mockServer)
-			
-			authParams := kuberpult_utils.AuthenticationParameters {}
+
+			authParams := kuberpult_utils.AuthenticationParameters{}
 			err := Release(server.URL, authParams, tc.params)
 			// check errors
-			if diff := cmp.Diff(errMatcher{tc.expectedErrorMsg}, err, cmpopts.EquateErrors()); !(err == nil && tc.expectedErrorMsg == "") && diff != "" {
+			if diff := cmp.Diff(tc.expectedErrorMsg, err, cmpopts.EquateErrors()); diff != "" {
 				t.Fatalf("error mismatch (-want, +got):\n%s", diff)
 			}
 

--- a/cli/pkg/release/http_test.go
+++ b/cli/pkg/release/http_test.go
@@ -537,10 +537,8 @@ func TestRequestCreation(t *testing.T) {
 			}
 			server := httptest.NewServer(mockServer)
 			
-			authParams := kuberpult_utils.AuthenticationParameters {
-				Url: server.URL,
-			}
-			err := Release(authParams, tc.params)
+			authParams := kuberpult_utils.AuthenticationParameters {}
+			err := Release(server.URL, authParams, tc.params)
 			// check errors
 			if diff := cmp.Diff(errMatcher{tc.expectedErrorMsg}, err, cmpopts.EquateErrors()); !(err == nil && tc.expectedErrorMsg == "") && diff != "" {
 				t.Fatalf("error mismatch (-want, +got):\n%s", diff)

--- a/cli/pkg/release/parsing_test.go
+++ b/cli/pkg/release/parsing_test.go
@@ -567,8 +567,8 @@ func TestReadArgs(t *testing.T) {
 				t.Fatalf("error mismatch (-want, +got):\n%s", diff)
 			}
 
-			if !cmp.Equal(cmdArgs, tc.expectedCmdArgs, cmp.AllowUnexported(commandLineArguments{})) {
-				t.Fatalf("expected args %v, got %v", tc.expectedCmdArgs, cmdArgs)
+			if diff := cmp.Diff(cmdArgs, tc.expectedCmdArgs, cmp.AllowUnexported(commandLineArguments{})); diff != "" {
+				t.Fatalf("expected args:\n  %v\n, got:\n  %v, diff:\n  %s\n", tc.expectedCmdArgs, cmdArgs, diff)
 			}
 		})
 	}
@@ -736,8 +736,8 @@ func TestParseArgs(t *testing.T) {
 			}
 
 			// check result
-			if !cmp.Equal(params, tc.expectedParams, cmp.AllowUnexported(commandLineArguments{})) {
-				t.Fatalf("expected args %v, got %v", tc.expectedParams, params)
+			if diff := cmp.Diff(params, tc.expectedParams, cmp.AllowUnexported(commandLineArguments{})); diff != "" {
+				t.Fatalf("expected args:\n  %v\n, got:\n  %v\n, diff:\n  %s\n", tc.expectedParams, params, diff)
 			}
 		})
 	}

--- a/cli/pkg/release/release.go
+++ b/cli/pkg/release/release.go
@@ -38,8 +38,8 @@ type ReleaseParameters struct {
 
 // calls the Release endpoint with the specified parameters
 // this function might be used in the future for programmatic interaction with Kuberpult, hence its separation
-func Release(authParams kutil.AuthenticationParameters, params ReleaseParameters) error {
-	req, err := prepareHttpRequest(authParams, params)
+func Release(url string, authParams kutil.AuthenticationParameters, params ReleaseParameters) error {
+	req, err := prepareHttpRequest(url, authParams, params)
 	if err != nil {
 		return fmt.Errorf("error while preparing HTTP request, error: %w", err)
 	}

--- a/cli/pkg/release/release.go
+++ b/cli/pkg/release/release.go
@@ -18,6 +18,8 @@ package release
 
 import (
 	"fmt"
+
+	kutil "github.com/freiheit-com/kuberpult/cli/pkg/kuberpult_utils"
 )
 
 // a representation of the parameters of the /release endpoint
@@ -36,12 +38,12 @@ type ReleaseParameters struct {
 
 // calls the Release endpoint with the specified parameters
 // this function might be used in the future for programmatic interaction with Kuberpult, hence its separation
-func Release(url string, iapToken *string, params *ReleaseParameters) error {
-	req, err := prepareHttpRequest(url, iapToken, params)
+func Release(authParams kutil.AuthenticationParameters, params ReleaseParameters) error {
+	req, err := prepareHttpRequest(authParams, params)
 	if err != nil {
 		return fmt.Errorf("error while preparing HTTP request, error: %w", err)
 	}
-	if err := issueHttpRequest(req); err != nil {
+	if err := issueHttpRequest(*req); err != nil {
 		return fmt.Errorf("error while issuing HTTP request, error: %v", err)
 	}
 	return nil

--- a/cli/pkg/release/release.go
+++ b/cli/pkg/release/release.go
@@ -36,8 +36,8 @@ type ReleaseParameters struct {
 
 // calls the Release endpoint with the specified parameters
 // this function might be used in the future for programmatic interaction with Kuberpult, hence its separation
-func Release(url string, params *ReleaseParameters) error {
-	req, err := prepareHttpRequest(url, params)
+func Release(url string, iapToken *string, params *ReleaseParameters) error {
+	req, err := prepareHttpRequest(url, iapToken, params)
 	if err != nil {
 		return fmt.Errorf("error while preparing HTTP request, error: %w", err)
 	}


### PR DESCRIPTION
Here to add two functionalities for the Kuberpult CLI:
- ability to talk to an arbitrary Kuberpult URL (the `--url` flag)
- reading authentication information from the user (the `--author_name` and `--author_email` flags, the `KUBERPULT_IAP_TOKEN`)