### PR TITLE
fix: do not reset application sync policy on update

### DIFF
--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -176,7 +176,7 @@ func (a ArgoAppProcessor) CreateOrUpdateApp(ctx context.Context, overview *api.G
 
 			//exhaustruct:ignore
 			emptyAppSpec := v1alpha1.ApplicationSpec{}
-			diff := cmp.Diff(appUpdateRequest.Application.Spec, existingApp.Spec, cmp.AllowUnexported(emptyAppSpec.Destination))
+			diff := cmp.Diff(appUpdateRequest.Application.Spec, existingApp.Spec, cmp.AllowUnexported(emptyAppSpec.Destination), cmp.AllowUnexported(v1alpha1.SyncPolicy{}))
 			if diff != "" {
 				updateSpan, ctx := tracer.StartSpanFromContext(ctx, "UpdateApplications")
 				updateSpan.SetTag("application", app.Name)


### PR DESCRIPTION
When we do an update using the rollout-service, we always enable the auto-sync. If there is an application that has its auto-sync disabled manually for hotfix purposes, kuberpult will override this almost instantaneously on the next consume of the overview. For this purpose, we should make the diff between applications on the update call more granular, excluding the sync policy.