### PR TITLE
fix: allow configuring the grpc recv message size for grpc clients

### DIFF
--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -153,6 +153,8 @@ spec:
               key: KUBERPULT_REVOLUTION_DORA_TOKEN
         - name: KUBERPULT_REVOLUTION_DORA_MAX_EVENT_AGE
           value: "2h"
+        - name: KUBERPULT_GRPC_MAX_RECV_MSG_SIZE
+          value: "{{ .Values.rollout.grpcMaxRecvMsgSize }}"
         volumeMounts:
         # We need to mount a writeable tmp directory for argocd connections to work correctly. https://github.com/argoproj/argo-cd/issues/14115
         - name: tmp

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -167,6 +167,8 @@ rollout:
     requests:
       cpu: 500m
       memory: 250Mi
+  # The maximum message size in mega bytes the client can receive.
+  grpcMaxRecvMsgSize: 4
   # annotations given here will take precedence over the defaults defined in _helpers.tpl
   podAnnotations: {}
 

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -187,7 +187,7 @@ func runServer(ctx context.Context) error {
 
 	grpcClientOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(cred),
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(c.GrpcMaxRecvMsgSize*megaBytes)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(c.GrpcMaxRecvMsgSize * megaBytes)),
 	}
 
 	if c.EnableTracing {

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -187,6 +187,7 @@ func runServer(ctx context.Context) error {
 
 	grpcClientOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(cred),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(c.GrpcMaxRecvMsgSize*megaBytes)),
 	}
 
 	if c.EnableTracing {

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -136,7 +136,7 @@ func getGrpcClients(ctx context.Context, config Config) (api.OverviewServiceClie
 
 	grpcClientOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(cred),
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(config.GrpcMaxRecvMsgSize*megaBytes)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(config.GrpcMaxRecvMsgSize * megaBytes)),
 	}
 	if config.EnableTracing {
 		grpcClientOpts = append(grpcClientOpts,

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -54,6 +54,8 @@ type Config struct {
 	CdServerSecure bool   `default:"false" split_words:"true"`
 	EnableTracing  bool   `default:"false" split_words:"true"`
 
+	GrpcMaxRecvMsgSize int `default:"4" split_words:"true"`
+
 	ArgocdServer             string `split_words:"true"`
 	ArgocdInsecure           bool   `default:"false" split_words:"true"`
 	ArgocdToken              string `split_words:"true"`
@@ -118,6 +120,7 @@ func RunServer() {
 }
 
 func getGrpcClients(ctx context.Context, config Config) (api.OverviewServiceClient, api.VersionServiceClient, error) {
+	const megaBytes int = 1024 * 1024
 	var cred credentials.TransportCredentials = insecure.NewCredentials()
 	if config.CdServerSecure {
 		systemRoots, err := x509.SystemCertPool()
@@ -133,6 +136,7 @@ func getGrpcClients(ctx context.Context, config Config) (api.OverviewServiceClie
 
 	grpcClientOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(cred),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(config.GrpcMaxRecvMsgSize*megaBytes)),
 	}
 	if config.EnableTracing {
 		grpcClientOpts = append(grpcClientOpts,


### PR DESCRIPTION
The fix in https://github.com/freiheit-com/kuberpult/pull/1628 was only fixing the server side part but not the client-side problem.