### PR TITLE
fix: check if index does not already exist

### DIFF
--- a/database/migrations/sqlite/1714726277027648_events.up.sql
+++ b/database/migrations/sqlite/1714726277027648_events.up.sql
@@ -8,4 +8,4 @@ CREATE TABLE IF NOT EXISTS events
     PRIMARY KEY(uuid)
 );
 
-CREATE INDEX commitHashIdx on events (commitHash);
+CREATE INDEX IF NOT EXISTS commitHashIdx on events (commitHash);


### PR DESCRIPTION
Migrations fail if they have to be run again because this index already exists