### PR TITLE
fix(db): add missing env vars for export-service

### DIFF
--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -135,6 +135,18 @@ spec:
             cpu: "{{ .Values.cd.resources.requests.cpu }}"
             memory: "{{ .Values.cd.resources.requests.memory }}"
         env:
+        - name: KUBERPULT_GIT_URL
+          value: {{ required ".Values.git.url is required" .Values.git.url | quote }}
+        - name: KUBERPULT_GIT_BRANCH
+          value: {{ .Values.git.branch | quote }}
+        - name: KUBERPULT_GIT_SSH_KEY
+          value: "/etc/ssh/identity"
+        - name: KUBERPULT_GIT_SSH_KNOWN_HOSTS
+          value: "/etc/ssh/ssh_known_hosts"
+        - name: KUBERPULT_ENABLE_SQLITE
+          value: "true"
+        - name: KUBERPULT_ARGO_CD_GENERATE_FILES
+          value: {{ .Values.argocd.generateFiles | quote }}
         - name: LOG_FORMAT
           value: {{ .Values.log.format | quote }}
         - name: LOG_LEVEL
@@ -192,6 +204,8 @@ spec:
         - name: KUBERPULT_ENABLE_PROFILING
           value: "{{ .Values.datadogProfiling.enabled }}"
         volumeMounts:
+        - name: ssh
+          mountPath: /etc/ssh
 {{- if .Values.datadogProfiling.enabled }}
         - name: datadog
           mountPath: /etc/datadog/

--- a/charts/kuberpult/tests/charts_test.go
+++ b/charts/kuberpult/tests/charts_test.go
@@ -362,12 +362,7 @@ cd:
   db:
     dbOption: NO_DB
 `,
-			ExpectedEnvs: []core.EnvVar{
-				{
-					Name:  "KUBERPULT_DB_OPTION",
-					Value: "NO_DB",
-				},
-			},
+			ExpectedEnvs: []core.EnvVar{},
 			ExpectedMissing: []core.EnvVar{
 
 				{
@@ -637,6 +632,319 @@ ingress:
 				for _, env := range tc.ExpectedEnvs {
 					if !CheckForEnvVariable(t, env, &targetDocument) {
 						t.Fatalf("Environment variable '%s' with value '%s' was expected, but not found.", env.Name, env.Value)
+					}
+				}
+				for _, env := range tc.ExpectedMissing {
+					if CheckForEnvVariable(t, env, &targetDocument) {
+						t.Fatalf("Found enviroment variable '%s' with value '%s', but was not expecting it.", env.Name, env.Value)
+					}
+				}
+
+			}
+		})
+	}
+}
+
+func TestHelmChartsKuberpultManifestExportEnvVariables(t *testing.T) {
+	tcs := []struct {
+		Name            string
+		Values          string
+		ExpectedEnvs    []core.EnvVar
+		ExpectedMissing []core.EnvVar
+	}{
+		{
+			Name: "Change Git URL",
+			Values: `
+git:
+  url:  "checkThisValue"
+ingress:
+  domainName: "kuberpult-example.com"
+cd:
+  db:
+    dbOption: "sqlite"
+    writeEslTableOnly: false
+`,
+			ExpectedEnvs: []core.EnvVar{
+				{
+					Name:  "KUBERPULT_GIT_URL",
+					Value: "checkThisValue",
+				},
+			},
+			ExpectedMissing: []core.EnvVar{},
+		},
+		{
+			Name: "Argo CD disabled",
+			Values: `
+git:
+  url: "testURL"
+ingress:
+  domainName: "kuberpult-example.com"
+argocd:
+  generateFiles: false
+cd:
+  db:
+    dbOption: "sqlite"
+    writeEslTableOnly: false
+`,
+			ExpectedEnvs: []core.EnvVar{
+				{
+					Name:  "KUBERPULT_ARGO_CD_GENERATE_FILES",
+					Value: "false",
+				},
+				{
+					Name:  "KUBERPULT_GIT_URL",
+					Value: "testURL",
+				},
+			},
+			ExpectedMissing: []core.EnvVar{},
+		},
+		{
+			Name: "Argo CD enabled simple test",
+			Values: `
+git:
+  url: "testURL"
+ingress:
+  domainName: "kuberpult-example.com"
+argocd:
+  generateFiles: true
+cd:
+  db:
+    dbOption: "sqlite"
+    writeEslTableOnly: false
+`,
+			ExpectedEnvs: []core.EnvVar{
+				{
+					Name:  "KUBERPULT_ARGO_CD_GENERATE_FILES",
+					Value: "true",
+				},
+				{
+					Name:  "KUBERPULT_GIT_URL",
+					Value: "testURL",
+				},
+			},
+			ExpectedMissing: []core.EnvVar{},
+		},
+		{
+			Name: "DD Metrics disabled",
+			Values: `
+git:
+  url: "testURL"
+ingress:
+  domainName: "kuberpult-example.com"
+dataDogTracing:
+  enabled: false
+cd:
+  db:
+    dbOption: "sqlite"
+    writeEslTableOnly: false
+`,
+			ExpectedEnvs: []core.EnvVar{
+				{
+					Name:  "KUBERPULT_GIT_URL",
+					Value: "testURL",
+				},
+			},
+			ExpectedMissing: []core.EnvVar{
+				{
+					Name:  "DD_AGENT_HOST",
+					Value: "",
+				},
+				{
+					Name:  "DD_ENV",
+					Value: "",
+				},
+				{
+					Name:  "DD_SERVICE",
+					Value: "",
+				},
+				{
+					Name:  "DD_VERSION",
+					Value: "",
+				},
+				{
+					Name:  "KUBERPULT_ENABLE_TRACING",
+					Value: "",
+				},
+				{
+					Name:  "DD_TRACE_DEBUG",
+					Value: "",
+				},
+			},
+		},
+		{
+			Name: "DD Tracing enabled",
+			Values: `
+git:
+  url: "testURL"
+ingress:
+  domainName: "kuberpult-example.com"
+datadogTracing:
+  enabled: true
+cd:
+  db:
+    dbOption: "sqlite"
+    writeEslTableOnly: false
+`,
+			ExpectedEnvs: []core.EnvVar{
+				{
+					Name:  "DD_AGENT_HOST",
+					Value: "",
+				},
+				{
+					Name:  "DD_ENV",
+					Value: "",
+				},
+				{
+					Name:  "DD_SERVICE",
+					Value: "",
+				},
+				{
+					Name:  "DD_VERSION",
+					Value: "",
+				},
+				{
+					Name:  "KUBERPULT_ENABLE_TRACING",
+					Value: "true",
+				},
+				{
+					Name:  "DD_TRACE_DEBUG",
+					Value: "false",
+				},
+			},
+			ExpectedMissing: []core.EnvVar{},
+		},
+		{
+			Name: "Database disabled",
+			Values: `
+git:
+  url: "testURL"
+ingress:
+  domainName: "kuberpult-example.com"
+cd:
+  db:
+    dbOption: NO_DB
+    writeEslTableOnly: false
+`,
+			ExpectedEnvs: []core.EnvVar{},
+			ExpectedMissing: []core.EnvVar{
+
+				{
+					Name:  "KUBERPULT_DB_LOCATION",
+					Value: "",
+				},
+				{
+					Name:  "KUBERPULT_DB_NAME",
+					Value: "",
+				},
+				{
+					Name:  "KUBERPULT_DB_USER_NAME",
+					Value: "",
+				},
+				{
+					Name:  "KUBERPULT_DB_USER_PASSWORD",
+					Value: "",
+				},
+			},
+		},
+		{
+			Name: "Database cloudsql enabled 1",
+			Values: `
+git:
+  url: "testURL"
+ingress:
+  domainName: "kuberpult-example.com"
+cd:
+  db:
+    dbOption: cloudsql
+    location: "127.0.0.1"
+    dbName: dbName
+    dbUser: dbUser
+    dbPassword: dbPassword
+    writeEslTableOnly: false
+`,
+			ExpectedEnvs: []core.EnvVar{
+				{
+					Name:  "KUBERPULT_DB_OPTION",
+					Value: "cloudsql",
+				},
+				{
+					Name:  "KUBERPULT_DB_LOCATION",
+					Value: "127.0.0.1",
+				},
+				{
+					Name:  "KUBERPULT_DB_NAME",
+					Value: "dbName",
+				},
+				{
+					Name:  "KUBERPULT_DB_USER_NAME",
+					Value: "dbUser",
+				},
+				{
+					Name:  "KUBERPULT_DB_USER_PASSWORD",
+					Value: "dbPassword",
+				},
+			},
+			ExpectedMissing: []core.EnvVar{},
+		},
+		{
+			Name: "Database cloudsql enabled 2",
+			Values: `
+git:
+  url: "testURL"
+ingress:
+  domainName: "kuberpult-example.com"
+cd:
+  db:
+    dbOption: sqlite
+    location: /kp/database
+    dbName: does
+    dbUser: not
+    dbPassword: matter
+    writeEslTableOnly: false
+`,
+			ExpectedEnvs: []core.EnvVar{
+				{
+					Name:  "KUBERPULT_DB_OPTION",
+					Value: "sqlite",
+				},
+				{
+					Name:  "KUBERPULT_DB_LOCATION",
+					Value: "/kp/database",
+				},
+			},
+			ExpectedMissing: []core.EnvVar{
+				{
+					Name:  "KUBERPULT_DB_NAME",
+					Value: "",
+				},
+				{
+					Name:  "KUBERPULT_DB_USER_NAME",
+					Value: "",
+				},
+				{
+					Name:  "KUBERPULT_DB_USER_PASSWORD",
+					Value: "",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			testDirName := t.TempDir()
+			outputFile := runHelm(t, []byte(tc.Values), testDirName)
+			if out, err := getDeployments(outputFile); err != nil {
+				t.Fatalf(fmt.Sprintf("%v", err))
+			} else {
+				for index := range out {
+					t.Logf("deployment found: %s", index)
+				}
+				targetDocument := out["kuberpult-manifest-repo-export-service"]
+				t.Logf("found document: %v", targetDocument)
+				for _, env := range tc.ExpectedEnvs {
+					if !CheckForEnvVariable(t, env, &targetDocument) {
+						t.Fatalf("%s Environment variable '%s' with value '%s' was expected, but not found.", tc.Name, env.Name, env.Value)
 					}
 				}
 				for _, env := range tc.ExpectedMissing {

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -41,6 +41,8 @@ func storageBackend(enableSqlite bool) repository.StorageBackend {
 
 func RunServer() {
 	err := logger.Wrap(context.Background(), func(ctx context.Context) error {
+		logger.FromContext(ctx).Warn("DEBUG: RunServer startup")
+
 		dbLocation, err := readEnvVar("KUBERPULT_DB_LOCATION")
 		if err != nil {
 			return err
@@ -49,6 +51,7 @@ func RunServer() {
 		if err != nil {
 			return err
 		}
+		logger.FromContext(ctx).Warn("DEBUG: RunServer startup env A")
 		dbOption, err := readEnvVar("KUBERPULT_DB_OPTION")
 		if err != nil {
 			return err
@@ -65,6 +68,7 @@ func RunServer() {
 		if err != nil {
 			return err
 		}
+		logger.FromContext(ctx).Warn("DEBUG: RunServer startup env B")
 		gitUrl, err := readEnvVar("KUBERPULT_GIT_URL")
 		if err != nil {
 			return err
@@ -77,6 +81,7 @@ func RunServer() {
 		if err != nil {
 			return err
 		}
+		logger.FromContext(ctx).Warn("DEBUG: RunServer startup env C")
 		gitSshKnownHosts, err := readEnvVar("KUBERPULT_GIT_SSH_KNOWN_HOSTS")
 		if err != nil {
 			return err
@@ -87,6 +92,7 @@ func RunServer() {
 			return err
 		}
 		enableSqliteStorageBackend := enableSqliteStorageBackendString == "true"
+		logger.FromContext(ctx).Warn("DEBUG: RunServer startup env D")
 
 		argoCdGenerateFilesString, err := readEnvVar("KUBERPULT_ARGO_CD_GENERATE_FILES")
 		if err != nil {
@@ -94,6 +100,7 @@ func RunServer() {
 		}
 		argoCdGenerateFiles := argoCdGenerateFilesString == "true"
 
+		logger.FromContext(ctx).Warn("DEBUG: RunServer startup 3")
 		var dbCfg db.DBConfig
 		if dbOption == "cloudsql" {
 			dbCfg = db.DBConfig{
@@ -124,8 +131,10 @@ func RunServer() {
 		if err != nil {
 			return err
 		}
+		logger.FromContext(ctx).Warn("DEBUG: RunServer startup 4")
 
 		err = dbHandler.WithTransaction(ctx, func(ctx context.Context, transaction *sql.Tx) error {
+			logger.FromContext(ctx).Warn("DEBUG: RunServer startup 5")
 			cfg := repository.RepositoryConfig{
 				URL:            gitUrl,
 				Path:           "./repository",
@@ -155,6 +164,7 @@ func RunServer() {
 
 			log := logger.FromContext(ctx).Sugar()
 			for {
+				logger.FromContext(ctx).Warn("DEBUG: RunServer startup - for A")
 				err = dbHandler.WithTransaction(ctx, func(ctx context.Context, transaction *sql.Tx) error {
 					eslId, err := cutoff.DBReadCutoff(dbHandler, ctx, transaction)
 					if err != nil {

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -40,178 +40,175 @@ func storageBackend(enableSqlite bool) repository.StorageBackend {
 }
 
 func RunServer() {
-	err := logger.Wrap(context.Background(), func(ctx context.Context) error {
-		logger.FromContext(ctx).Warn("DEBUG: RunServer startup")
-
-		dbLocation, err := readEnvVar("KUBERPULT_DB_LOCATION")
+	_ = logger.Wrap(context.Background(), func(ctx context.Context) error {
+		err := Run(ctx)
 		if err != nil {
-			return err
+			logger.FromContext(ctx).Sugar().Errorf("error in startup: %v %#v", err, err)
 		}
-		dbName, err := readEnvVar("KUBERPULT_DB_NAME")
-		if err != nil {
-			return err
-		}
-		logger.FromContext(ctx).Warn("DEBUG: RunServer startup env A")
-		dbOption, err := readEnvVar("KUBERPULT_DB_OPTION")
-		if err != nil {
-			return err
-		}
-		dbUserName, err := readEnvVar("KUBERPULT_DB_USER_NAME")
-		if err != nil {
-			return err
-		}
-		dbPassword, err := readEnvVar("KUBERPULT_DB_USER_PASSWORD")
-		if err != nil {
-			return err
-		}
-		dbAuthProxyPort, err := readEnvVar("KUBERPULT_DB_AUTH_PROXY_PORT")
-		if err != nil {
-			return err
-		}
-		logger.FromContext(ctx).Warn("DEBUG: RunServer startup env B")
-		gitUrl, err := readEnvVar("KUBERPULT_GIT_URL")
-		if err != nil {
-			return err
-		}
-		gitBranch, err := readEnvVar("KUBERPULT_GIT_BRANCH")
-		if err != nil {
-			return err
-		}
-		gitSshKey, err := readEnvVar("KUBERPULT_GIT_SSH_KEY")
-		if err != nil {
-			return err
-		}
-		logger.FromContext(ctx).Warn("DEBUG: RunServer startup env C")
-		gitSshKnownHosts, err := readEnvVar("KUBERPULT_GIT_SSH_KNOWN_HOSTS")
-		if err != nil {
-			return err
-		}
-		// not that this is for the git storage backand, not our database:
-		enableSqliteStorageBackendString, err := readEnvVar("KUBERPULT_ENABLE_SQLITE")
-		if err != nil {
-			return err
-		}
-		enableSqliteStorageBackend := enableSqliteStorageBackendString == "true"
-		logger.FromContext(ctx).Warn("DEBUG: RunServer startup env D")
-
-		argoCdGenerateFilesString, err := readEnvVar("KUBERPULT_ARGO_CD_GENERATE_FILES")
-		if err != nil {
-			return err
-		}
-		argoCdGenerateFiles := argoCdGenerateFilesString == "true"
-
-		logger.FromContext(ctx).Warn("DEBUG: RunServer startup 3")
-		var dbCfg db.DBConfig
-		if dbOption == "cloudsql" {
-			dbCfg = db.DBConfig{
-				DbHost:         dbLocation,
-				DbPort:         dbAuthProxyPort,
-				DriverName:     "postgres",
-				DbName:         dbName,
-				DbPassword:     dbPassword,
-				DbUser:         dbUserName,
-				MigrationsPath: "",
-				WriteEslOnly:   false,
-			}
-		} else if dbOption == "sqlite" {
-			dbCfg = db.DBConfig{
-				DbHost:         dbLocation,
-				DbPort:         dbAuthProxyPort,
-				DriverName:     "sqlite3",
-				DbName:         dbName,
-				DbPassword:     dbPassword,
-				DbUser:         dbUserName,
-				MigrationsPath: "",
-				WriteEslOnly:   false,
-			}
-		} else {
-			logger.FromContext(ctx).Fatal("Cannot start without DB configuration was provided.")
-		}
-		dbHandler, err := db.Connect(dbCfg)
-		if err != nil {
-			return err
-		}
-		logger.FromContext(ctx).Warn("DEBUG: RunServer startup 4")
-
-		err = dbHandler.WithTransaction(ctx, func(ctx context.Context, transaction *sql.Tx) error {
-			logger.FromContext(ctx).Warn("DEBUG: RunServer startup 5")
-			cfg := repository.RepositoryConfig{
-				URL:            gitUrl,
-				Path:           "./repository",
-				CommitterEmail: "noemail@example.com", // TODO will be handled in Ref SRX-PA568W
-				CommitterName:  "noname",
-				Credentials: repository.Credentials{
-					SshKey: gitSshKey,
-				},
-				Certificates: repository.Certificates{
-					KnownHostsFile: gitSshKnownHosts,
-				},
-				Branch:                 gitBranch,
-				NetworkTimeout:         120 * time.Second,
-				GcFrequency:            20,
-				BootstrapMode:          false,
-				EnvironmentConfigsPath: "./environment_configs.json",
-				StorageBackend:         storageBackend(enableSqliteStorageBackend),
-
-				ArgoCdGenerateFiles: argoCdGenerateFiles,
-				DBHandler:           dbHandler,
-			}
-
-			repo, err := repository.New(ctx, cfg)
-			if err != nil {
-				return fmt.Errorf("repository.new failed %v", err)
-			}
-
-			log := logger.FromContext(ctx).Sugar()
-			for {
-				logger.FromContext(ctx).Warn("DEBUG: RunServer startup - for A")
-				err = dbHandler.WithTransaction(ctx, func(ctx context.Context, transaction *sql.Tx) error {
-					eslId, err := cutoff.DBReadCutoff(dbHandler, ctx, transaction)
-					if err != nil {
-						return fmt.Errorf("error in DBReadCutoff %v", err)
-					}
-					if eslId == nil {
-						log.Infof("did not find cutoff")
-					} else {
-						log.Infof("found cutoff: %d", *eslId)
-					}
-					esl, err := readEslEvent(ctx, transaction, eslId, log, dbHandler)
-					if err != nil {
-						return fmt.Errorf("error in readEslEvent %v", err)
-					}
-					if esl == nil {
-						log.Warn("event processing skipped: no esl event found")
-						return nil
-					}
-					transformer, err := processEslEvent(ctx, repo, esl, transaction)
-					if err != nil {
-						return fmt.Errorf("error in processEslEvent %v", err)
-					}
-					if transformer == nil {
-						log.Warn("event processing skipped")
-						return nil
-					}
-					log.Infof("event processed successfully, now writing to cutoff...")
-					err = cutoff.DBWriteCutoff(dbHandler, ctx, transaction, esl.EslId)
-					if err != nil {
-						return fmt.Errorf("error in DBWriteCutoff %v", err)
-					}
-
-					return nil
-				})
-				if err != nil {
-					return fmt.Errorf("error in transaction %v", err)
-				}
-				d := 10 * time.Second
-				log.Infof("sleeping for %v before processing the next event", d)
-				time.Sleep(d)
-			}
-		})
-		return err
+		return nil
 	})
+}
+
+func Run(ctx context.Context) error {
+	logger.FromContext(ctx).Info("Startup")
+
+	dbLocation, err := readEnvVar("KUBERPULT_DB_LOCATION")
 	if err != nil {
-		fmt.Printf("error in startup: %v %#v", err, err)
+		return err
 	}
+	dbName, err := readEnvVar("KUBERPULT_DB_NAME")
+	if err != nil {
+		return err
+	}
+	dbOption, err := readEnvVar("KUBERPULT_DB_OPTION")
+	if err != nil {
+		return err
+	}
+	dbUserName, err := readEnvVar("KUBERPULT_DB_USER_NAME")
+	if err != nil {
+		return err
+	}
+	dbPassword, err := readEnvVar("KUBERPULT_DB_USER_PASSWORD")
+	if err != nil {
+		return err
+	}
+	dbAuthProxyPort, err := readEnvVar("KUBERPULT_DB_AUTH_PROXY_PORT")
+	if err != nil {
+		return err
+	}
+	gitUrl, err := readEnvVar("KUBERPULT_GIT_URL")
+	if err != nil {
+		return err
+	}
+	gitBranch, err := readEnvVar("KUBERPULT_GIT_BRANCH")
+	if err != nil {
+		return err
+	}
+	gitSshKey, err := readEnvVar("KUBERPULT_GIT_SSH_KEY")
+	if err != nil {
+		return err
+	}
+	gitSshKnownHosts, err := readEnvVar("KUBERPULT_GIT_SSH_KNOWN_HOSTS")
+	if err != nil {
+		return err
+	}
+	// not that this is for the git storage backand, not our database:
+	enableSqliteStorageBackendString, err := readEnvVar("KUBERPULT_ENABLE_SQLITE")
+	if err != nil {
+		return err
+	}
+	enableSqliteStorageBackend := enableSqliteStorageBackendString == "true"
+
+	argoCdGenerateFilesString, err := readEnvVar("KUBERPULT_ARGO_CD_GENERATE_FILES")
+	if err != nil {
+		return err
+	}
+	argoCdGenerateFiles := argoCdGenerateFilesString == "true"
+
+	var dbCfg db.DBConfig
+	if dbOption == "cloudsql" {
+		dbCfg = db.DBConfig{
+			DbHost:         dbLocation,
+			DbPort:         dbAuthProxyPort,
+			DriverName:     "postgres",
+			DbName:         dbName,
+			DbPassword:     dbPassword,
+			DbUser:         dbUserName,
+			MigrationsPath: "",
+			WriteEslOnly:   false,
+		}
+	} else if dbOption == "sqlite" {
+		dbCfg = db.DBConfig{
+			DbHost:         dbLocation,
+			DbPort:         dbAuthProxyPort,
+			DriverName:     "sqlite3",
+			DbName:         dbName,
+			DbPassword:     dbPassword,
+			DbUser:         dbUserName,
+			MigrationsPath: "",
+			WriteEslOnly:   false,
+		}
+	} else {
+		logger.FromContext(ctx).Fatal("Cannot start without DB configuration was provided.")
+	}
+	dbHandler, err := db.Connect(dbCfg)
+	if err != nil {
+		return err
+	}
+
+	err = dbHandler.WithTransaction(ctx, func(ctx context.Context, transaction *sql.Tx) error {
+		cfg := repository.RepositoryConfig{
+			URL:            gitUrl,
+			Path:           "./repository",
+			CommitterEmail: "noemail@example.com", // TODO will be handled in Ref SRX-PA568W
+			CommitterName:  "noname",
+			Credentials: repository.Credentials{
+				SshKey: gitSshKey,
+			},
+			Certificates: repository.Certificates{
+				KnownHostsFile: gitSshKnownHosts,
+			},
+			Branch:                 gitBranch,
+			NetworkTimeout:         120 * time.Second,
+			GcFrequency:            20,
+			BootstrapMode:          false,
+			EnvironmentConfigsPath: "./environment_configs.json",
+			StorageBackend:         storageBackend(enableSqliteStorageBackend),
+
+			ArgoCdGenerateFiles: argoCdGenerateFiles,
+			DBHandler:           dbHandler,
+		}
+
+		repo, err := repository.New(ctx, cfg)
+		if err != nil {
+			return fmt.Errorf("repository.new failed %v", err)
+		}
+
+		log := logger.FromContext(ctx).Sugar()
+		for {
+			err = dbHandler.WithTransaction(ctx, func(ctx context.Context, transaction *sql.Tx) error {
+				eslId, err := cutoff.DBReadCutoff(dbHandler, ctx, transaction)
+				if err != nil {
+					return fmt.Errorf("error in DBReadCutoff %v", err)
+				}
+				if eslId == nil {
+					log.Infof("did not find cutoff")
+				} else {
+					log.Infof("found cutoff: %d", *eslId)
+				}
+				esl, err := readEslEvent(ctx, transaction, eslId, log, dbHandler)
+				if err != nil {
+					return fmt.Errorf("error in readEslEvent %v", err)
+				}
+				if esl == nil {
+					log.Warn("event processing skipped: no esl event found")
+					return nil
+				}
+				transformer, err := processEslEvent(ctx, repo, esl, transaction)
+				if err != nil {
+					return fmt.Errorf("error in processEslEvent %v", err)
+				}
+				if transformer == nil {
+					log.Warn("event processing skipped")
+					return nil
+				}
+				log.Infof("event processed successfully, now writing to cutoff...")
+				err = cutoff.DBWriteCutoff(dbHandler, ctx, transaction, esl.EslId)
+				if err != nil {
+					return fmt.Errorf("error in DBWriteCutoff %v", err)
+				}
+
+				return nil
+			})
+			if err != nil {
+				return fmt.Errorf("error in transaction %v", err)
+			}
+			d := 10 * time.Second
+			log.Infof("sleeping for %v before processing the next event", d)
+			time.Sleep(d)
+		}
+	})
+	return err
 }
 
 func readEslEvent(ctx context.Context, transaction *sql.Tx, eslId *db.EslId, log *zap.SugaredLogger, dbHandler *db.DBHandler) (*db.EslEventRow, error) {


### PR DESCRIPTION
this fixes missing env vars,
adds chart tests
and handles the logging initialization better.
The logging with `fmt.Printf` did not work on kubernetes, so we now wrap the whole "Run" function into the logger.