### PR TITLE
fix(db): remove probes

### DIFF
--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -109,24 +109,6 @@ spec:
           - name: grpc
             containerPort: 8443
             protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-          initialDelaySeconds: {{ .Values.cd.probes.readiness.initialDelaySeconds }}
-          periodSeconds: {{ .Values.cd.probes.readiness.periodSeconds }}
-          successThreshold: {{ .Values.cd.probes.readiness.successThreshold }}
-          timeoutSeconds: {{ .Values.cd.probes.readiness.timeoutSeconds }}
-          failureThreshold: {{ .Values.cd.probes.readiness.failureThreshold }}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-          initialDelaySeconds: {{ .Values.cd.probes.liveness.initialDelaySeconds }}
-          periodSeconds: {{ .Values.cd.probes.liveness.periodSeconds }}
-          successThreshold: {{ .Values.cd.probes.liveness.successThreshold }}
-          timeoutSeconds: {{ .Values.cd.probes.liveness.timeoutSeconds }}
-          failureThreshold: {{ .Values.cd.probes.liveness.failureThreshold }}
         resources:
           limits:
             cpu: "{{ .Values.cd.resources.limits.cpu }}"


### PR DESCRIPTION
The manifest-repo-export-service has no endpoints at all, so it also does not need probes.
The probes were essentially broken in kubernetes.
