### PR TITLE
chore: add vendor to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ services/cd-service/host
 services/cd-service/known_hosts
 services/cd-service/repository_checked_out/
 CHANGELOG.tmp.md
+vendor/


### PR DESCRIPTION
Background: Some IDEs run into errors when processing the go modules. The workaround is to run "go mod vendor", which creates this directory.

Ref: SRX-L070MM