### PR TITLE
chore(db): migrate releases table

### DIFF
--- a/database/migrations/postgres/1717749007994908_releases.up.sql
+++ b/database/migrations/postgres/1717749007994908_releases.up.sql
@@ -1,0 +1,1 @@
+../sqlite/1717749007994908_releases.up.sql

--- a/database/migrations/sqlite/1717749007994908_releases.up.sql
+++ b/database/migrations/sqlite/1717749007994908_releases.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS releases
+(
+    eslVersion INTEGER, -- internal ID for ESL
+    releaseVersion INTEGER, -- release ID given by the client that calls CreateApplicationVersion
+    created TIMESTAMP,
+    appName VARCHAR,
+    envName VARCHAR,
+    manifest VARCHAR,
+    metadata VARCHAR,
+    PRIMARY KEY(eslVersion, releaseVersion, appName, envName)
+);

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -775,7 +775,7 @@ type AllReleases map[uint64]ReleaseWithManifest
 // During the "CustomMigrations" we read from the manifest repo, and write to the database.
 // The functions here are there to retrieve data, so they should not need to access the DB.
 // Therefore, they should not need a "transaction" parameter.
-// There are currently some exceptions, like GetAllDeploymentsFun. This will be changed in
+// There are currently some exceptions, like GetAllDeploymentsFun. This will be changed in SRX-PA568W.
 
 type GetAllDeploymentsFun = func(ctx context.Context, transaction *sql.Tx) (AllDeployments, error)
 type GetAllEnvLocksFun = func(ctx context.Context, transaction *sql.Tx) (AllEnvLocks, error)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -772,6 +772,11 @@ type AllDeployments []Deployment
 type AllEnvLocks map[string][]EnvironmentLock
 type AllReleases map[uint64]ReleaseWithManifest
 
+// During the "CustomMigrations" we read from the manifest repo, and write to the database.
+// The functions here are there to retrieve data, so they should not need to access the DB.
+// Therefore, they should not need a "transaction" parameter.
+// There are currently some exceptions, like GetAllDeploymentsFun. This will be changed in
+
 type GetAllDeploymentsFun = func(ctx context.Context, transaction *sql.Tx) (AllDeployments, error)
 type GetAllEnvLocksFun = func(ctx context.Context, transaction *sql.Tx) (AllEnvLocks, error)
 type GetAllReleasesFun = func(ctx context.Context, app string) (AllReleases, error)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -304,6 +304,8 @@ const (
 	EvtReleaseTrain                     EventType = "ReleaseTrain"
 )
 
+// ESL EVENTS
+
 // DBWriteEslEventInternal writes one event to the event-sourcing-light table, taking arbitrary data as input
 func (h *DBHandler) DBWriteEslEventInternal(ctx context.Context, eventType EventType, tx *sql.Tx, data interface{}) error {
 	if h == nil {
@@ -425,6 +427,130 @@ func (h *DBHandler) DBReadEslEventLaterThan(ctx context.Context, tx *sql.Tx, esl
 	}
 	return row, nil
 }
+
+// RELEASES
+
+type DBRelease struct {
+	EslId EslId
+	App   string
+	Env   string
+}
+
+type DBReleaseMetaData struct {
+	SourceAuthor   string
+	SourceCommitId string
+	SourceMessage  string
+	DisplayVersion string
+}
+
+type DBReleaseWithMetaData struct {
+	EslId         EslId
+	ReleaseNumber uint64
+	App           string
+	Env           string
+	Manifest      string
+	Metadata      DBReleaseMetaData
+}
+
+func (h *DBHandler) DBSelectAnyRelease(ctx context.Context, tx *sql.Tx) (*DBReleaseWithMetaData, error) {
+	selectQuery := h.AdaptQuery(fmt.Sprintf(
+		"SELECT eslVersion, appName, envName, metadata, manifest, releaseVersion " +
+			" FROM releases " +
+			" LIMIT 1;"))
+	rows, err := tx.QueryContext(
+		ctx,
+		selectQuery,
+	)
+	return h.processReleaseRow(ctx, err, rows)
+}
+
+func (h *DBHandler) DBSelectReleaseByVersion(ctx context.Context, tx *sql.Tx, app string, env string, releaseVersion uint64) (*DBReleaseWithMetaData, error) {
+	selectQuery := h.AdaptQuery(fmt.Sprintf(
+		"SELECT eslVersion, appName, envName, metadata, manifest, releaseVersion " +
+			" FROM releases " +
+			" WHERE appName=? AND envName=? AND releaseVersion=?" +
+			" ORDER BY eslVersion ASC " +
+			" LIMIT 1;"))
+	rows, err := tx.QueryContext(
+		ctx,
+		selectQuery,
+		app,
+		env,
+		releaseVersion,
+	)
+	return h.processReleaseRow(ctx, err, rows)
+}
+
+func (h *DBHandler) processReleaseRow(ctx context.Context, err error, rows *sql.Rows) (*DBReleaseWithMetaData, error) {
+	if err != nil {
+		return nil, fmt.Errorf("could not query releases table from DB. Error: %w\n", err)
+	}
+	defer func(rows *sql.Rows) {
+		err := rows.Close()
+		if err != nil {
+			logger.FromContext(ctx).Sugar().Warnf("releases: row could not be closed: %v", err)
+		}
+	}(rows)
+	//exhaustruct:ignore
+	var row = &DBReleaseWithMetaData{}
+	if rows.Next() {
+		var metadataStr string
+		err := rows.Scan(&row.EslId, &row.App, &row.Env, &metadataStr, &row.Manifest, &row.ReleaseNumber)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("Error scanning releases row from DB. Error: %w\n", err)
+		}
+		var metaData = DBReleaseMetaData{
+			SourceAuthor:   "",
+			SourceCommitId: "",
+			SourceMessage:  "",
+			DisplayVersion: "",
+		}
+		err = json.Unmarshal(([]byte)(metadataStr), &metaData)
+		if err != nil {
+			return nil, fmt.Errorf("Error during json unmarshal of releases. Error: %w. Data: %s\n", err, metadataStr)
+		}
+		row.Metadata = metaData
+	} else {
+		row = nil
+	}
+	err = closeRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	return row, nil
+}
+
+func (h *DBHandler) DBInsertRelease(ctx context.Context, transaction *sql.Tx, release DBReleaseWithMetaData, previousEslVersion EslId) error {
+	span, _ := tracer.StartSpanFromContext(ctx, "DBInsertRelease")
+	defer span.Finish()
+	jsonToInsert, err := json.Marshal(release.Metadata)
+	if err != nil {
+		return fmt.Errorf("insert release: could not marshal json data: %w", err)
+	}
+	insertQuery := h.AdaptQuery(
+		"INSERT INTO releases (eslVersion, created, releaseVersion, appName, envName, manifest, metadata)  VALUES (?, ?, ?, ?, ?, ?, ?);",
+	)
+	span.SetTag("query", insertQuery)
+	_, err = transaction.Exec(
+		insertQuery,
+		previousEslVersion+1,
+		time.Now(),
+		release.ReleaseNumber,
+		release.App,
+		release.Env,
+		release.Manifest,
+		jsonToInsert,
+	)
+	if err != nil {
+		return fmt.Errorf("could not insert release into DB. Error: %w\n", err)
+	}
+	return nil
+}
+
+// APPS
 
 func (h *DBHandler) DBWriteAllApplications(ctx context.Context, transaction *sql.Tx, previousVersion int64, applications []string) error {
 	span, _ := tracer.StartSpanFromContext(ctx, "DBWriteAllApplications")
@@ -625,11 +751,30 @@ type EnvironmentLockMetadata struct {
 	Message        string
 }
 
+type ReleaseWithManifest struct {
+	Version uint64
+	/**
+	"UndeployVersion=true" means that this version is empty, and has no manifest that could be deployed.
+	It is intended to help cleanup old services within the normal release cycle (e.g. dev->staging->production).
+	*/
+	UndeployVersion bool
+	SourceAuthor    string
+	SourceCommitId  string
+	SourceMessage   string
+	CreatedAt       time.Time
+	DisplayVersion  string
+
+	Manifest    string
+	Environment string
+}
+
 type AllDeployments []Deployment
 type AllEnvLocks map[string][]EnvironmentLock
+type AllReleases map[uint64]ReleaseWithManifest
 
 type GetAllDeploymentsFun = func(ctx context.Context, transaction *sql.Tx) (AllDeployments, error)
 type GetAllEnvLocksFun = func(ctx context.Context, transaction *sql.Tx) (AllEnvLocks, error)
+type GetAllReleasesFun = func(ctx context.Context, app string) (AllReleases, error)
 
 // GetAllAppsFun returns a map where the Key is an app name, and the value is a team name of that app
 type GetAllAppsFun = func() (map[string]string, error)
@@ -638,6 +783,7 @@ func (h *DBHandler) RunCustomMigrations(
 	ctx context.Context,
 	getAllAppsFun GetAllAppsFun,
 	getAllDeploymentsFun GetAllDeploymentsFun,
+	getAllReleasesFun GetAllReleasesFun,
 	getAllEnvLocksFun GetAllEnvLocksFun,
 ) error {
 	span, ctx := tracer.StartSpanFromContext(ctx, "RunCustomMigrations")
@@ -651,6 +797,10 @@ func (h *DBHandler) RunCustomMigrations(
 		return err
 	}
 	err = h.RunCustomMigrationDeployments(ctx, getAllDeploymentsFun)
+	if err != nil {
+		return err
+	}
+	err = h.RunCustomMigrationReleases(ctx, getAllAppsFun, getAllReleasesFun)
 	if err != nil {
 		return err
 	}
@@ -960,6 +1110,58 @@ func (h *DBHandler) DBWriteDeployment(ctx context.Context, tx *sql.Tx, deploymen
 	return nil
 }
 
+// CUSTOM MIGRATIONS
+
+func (h *DBHandler) RunCustomMigrationReleases(ctx context.Context, getAllAppsFun GetAllAppsFun, getAllReleasesFun GetAllReleasesFun) error {
+	return h.WithTransaction(ctx, func(ctx context.Context, transaction *sql.Tx) error {
+		l := logger.FromContext(ctx).Sugar()
+		allReleasesDb, err := h.DBSelectAnyRelease(ctx, transaction)
+		if err != nil {
+			l.Warnf("could not get releases from database - assuming the manifest repo is correct: %v", err)
+		}
+		if allReleasesDb != nil {
+			l.Warnf("There are already deployments in the DB - skipping migrations")
+			return nil
+		}
+
+		allAppsMap, err := getAllAppsFun()
+		if err != nil {
+			return err
+		}
+		for app := range allAppsMap {
+			l.Infof("processing app %s ...", app)
+
+			releases, err := getAllReleasesFun(ctx, app)
+			if err != nil {
+				return fmt.Errorf("geAllReleases failed %v", err)
+			}
+			for r := range releases {
+				repoRelease := releases[r]
+				dbRelease := DBReleaseWithMetaData{
+					EslId:         InitialEslId,
+					ReleaseNumber: repoRelease.Version,
+					App:           app,
+					Env:           repoRelease.Environment,
+					Manifest:      repoRelease.Manifest,
+					Metadata: DBReleaseMetaData{
+						SourceAuthor:   repoRelease.SourceAuthor,
+						SourceCommitId: repoRelease.SourceCommitId,
+						SourceMessage:  repoRelease.SourceMessage,
+						DisplayVersion: repoRelease.DisplayVersion,
+					},
+				}
+				err = h.DBInsertRelease(ctx, transaction, dbRelease, InitialEslId-1)
+				if err != nil {
+					return fmt.Errorf("error writing Release to DB for app %s in env %s: %v",
+						app, repoRelease.Environment, err)
+				}
+			}
+			l.Infof("done with app %s", app)
+		}
+		return nil
+	})
+}
+
 func (h *DBHandler) RunCustomMigrationDeployments(ctx context.Context, getAllDeploymentsFun GetAllDeploymentsFun) error {
 	return h.WithTransaction(ctx, func(ctx context.Context, transaction *sql.Tx) error {
 		l := logger.FromContext(ctx).Sugar()
@@ -1113,6 +1315,8 @@ func (h *DBHandler) RunCustomMigrationApps(ctx context.Context, getAllAppsFun Ge
 		return nil
 	})
 }
+
+// ENV LOCKS
 
 func (h *DBHandler) DBSelectAnyEnvLock(ctx context.Context, tx *sql.Tx) (*DBEnvironmentLock, error) {
 	selectQuery := h.AdaptQuery(fmt.Sprintf(

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -137,13 +137,6 @@ INSERT INTO all_apps (version , created , json)  VALUES (1, 	'1713218400', '{"ap
 			if err != nil {
 				t.Fatalf("Error querying dabatabse. Error: %v\n", err)
 			}
-			release, err := db.DBSelectAnyRelease(ctx, tx)
-			if err != nil {
-				t.Fatalf("Error querying dabatabse. Error: %v\n", err)
-			}
-			if release == nil {
-				t.Fatalf("Release should not be nil")
-			}
 			err = tx.Commit()
 			if err != nil {
 				t.Fatalf("Error commiting transaction. Error: %v\n", err)

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap"
 	"os"
+	"os/exec"
 	"path"
 	"strconv"
 	"testing"
@@ -136,6 +137,13 @@ INSERT INTO all_apps (version , created , json)  VALUES (1, 	'1713218400', '{"ap
 			if err != nil {
 				t.Fatalf("Error querying dabatabse. Error: %v\n", err)
 			}
+			release, err := db.DBSelectAnyRelease(ctx, tx)
+			if err != nil {
+				t.Fatalf("Error querying dabatabse. Error: %v\n", err)
+			}
+			if release == nil {
+				t.Fatalf("Release should not be nil")
+			}
 			err = tx.Commit()
 			if err != nil {
 				t.Fatalf("Error commiting transaction. Error: %v\n", err)
@@ -143,6 +151,108 @@ INSERT INTO all_apps (version , created , json)  VALUES (1, 	'1713218400', '{"ap
 
 			if diff := cmp.Diff(tc.expectedData, m); diff != "" {
 				t.Errorf("response mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCustomMigrationReleases(t *testing.T) {
+	var getAllApps = /*GetAllAppsFun*/ func() (map[string]string, error) {
+		result := map[string]string{
+			"app1": "team1",
+		}
+		return result, nil
+	}
+	var getAllReleases = /*GetAllReleasesFun*/ func(ctx context.Context, app string) (AllReleases, error) {
+		result := AllReleases{
+			1: ReleaseWithManifest{
+				Version:         666,
+				UndeployVersion: false,
+				SourceAuthor:    "auth1",
+				SourceCommitId:  "commit1",
+				SourceMessage:   "msg1",
+				CreatedAt:       time.Time{},
+				DisplayVersion:  "display1",
+				Manifest:        "manifest1",
+				Environment:     "dev",
+			},
+			2: ReleaseWithManifest{
+				Version:         777,
+				UndeployVersion: false,
+				SourceAuthor:    "auth2",
+				SourceCommitId:  "commit2",
+				SourceMessage:   "msg2",
+				CreatedAt:       time.Time{},
+				DisplayVersion:  "display2",
+				Manifest:        "manifest2",
+				Environment:     "dev",
+			},
+		}
+		return result, nil
+	}
+	tcs := []struct {
+		Name             string
+		expectedReleases []*DBReleaseWithMetaData
+	}{
+		{
+			Name: "Simple migration",
+			expectedReleases: []*DBReleaseWithMetaData{
+				{
+					EslId:         1,
+					ReleaseNumber: 666,
+					App:           "app1",
+					Env:           "dev",
+					Manifest:      "manifest1",
+					Metadata: DBReleaseMetaData{
+						SourceAuthor:   "auth1",
+						SourceCommitId: "commit1",
+						SourceMessage:  "msg1",
+						DisplayVersion: "display1",
+					},
+				},
+				{
+					EslId:         1,
+					ReleaseNumber: 777,
+					App:           "app1",
+					Env:           "dev",
+					Manifest:      "manifest2",
+					Metadata: DBReleaseMetaData{
+						SourceAuthor:   "auth2",
+						SourceCommitId: "commit2",
+						SourceMessage:  "msg2",
+						DisplayVersion: "display2",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			dbHandler := SetupRepositoryTestWithDB(t)
+			err3 := dbHandler.WithTransaction(ctx, func(ctx context.Context, transaction *sql.Tx) error {
+				err2 := dbHandler.RunCustomMigrationReleases(ctx, getAllApps, getAllReleases)
+				if err2 != nil {
+					return fmt.Errorf("error: %v", err2)
+				}
+				for i := range tc.expectedReleases {
+					expectedRelease := tc.expectedReleases[i]
+
+					release, err := dbHandler.DBSelectReleaseByVersion(ctx, transaction, expectedRelease.App, expectedRelease.Env, expectedRelease.ReleaseNumber)
+					if err != nil {
+						return err
+					}
+					if diff := cmp.Diff(expectedRelease, release); diff != "" {
+						t.Errorf("error mismatch (-want, +got):\n%s", diff)
+					}
+				}
+				return nil
+			})
+			if err3 != nil {
+				t.Fatalf("expected no error, got %v", err3)
 			}
 		})
 	}
@@ -590,5 +700,45 @@ func setupDB(t *testing.T) *DBHandler {
 		t.Fatal(err)
 	}
 
+	return dbHandler
+}
+
+func SetupRepositoryTestWithDB(t *testing.T) *DBHandler {
+	migrationsPath, err := testutil.CreateMigrationsPath(2)
+	if err != nil {
+		t.Fatalf("CreateMigrationsPath error: %v", err)
+	}
+	dbConfig := &DBConfig{
+		MigrationsPath: migrationsPath,
+		DriverName:     "sqlite3",
+	}
+
+	dir := t.TempDir()
+	remoteDir := path.Join(dir, "remote")
+	localDir := path.Join(dir, "local")
+	cmd := exec.Command("git", "init", "--bare", remoteDir)
+	err = cmd.Start()
+	if err != nil {
+		t.Fatalf("error starting %v", err)
+		return nil
+	}
+	err = cmd.Wait()
+	if err != nil {
+		t.Fatalf("error waiting %v", err)
+		return nil
+	}
+	t.Logf("test created dir: %s", localDir)
+
+	dbConfig.DbHost = dir
+
+	migErr := RunDBMigrations(*dbConfig)
+	if migErr != nil {
+		t.Fatal(migErr)
+	}
+
+	dbHandler, err := Connect(*dbConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
 	return dbHandler
 }

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -6291,8 +6291,16 @@ func SetupRepositoryTestWithDB(t *testing.T) Repository {
 	remoteDir := path.Join(dir, "remote")
 	localDir := path.Join(dir, "local")
 	cmd := exec.Command("git", "init", "--bare", remoteDir)
-	cmd.Start()
-	cmd.Wait()
+	err = cmd.Start()
+	if err != nil {
+		t.Fatalf("error starting %v", err)
+		return nil
+	}
+	err = cmd.Wait()
+	if err != nil {
+		t.Fatalf("error waiting %v", err)
+		return nil
+	}
 	t.Logf("test created dir: %s", localDir)
 
 	repoCfg := RepositoryConfig{
@@ -6310,11 +6318,11 @@ func SetupRepositoryTestWithDB(t *testing.T) Repository {
 		t.Fatal(migErr)
 	}
 
-	db, err := db.Connect(*dbConfig)
+	dbHandler, err := db.Connect(*dbConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
-	repoCfg.DBHandler = db
+	repoCfg.DBHandler = dbHandler
 
 	repo, err := New(
 		testutil.MakeTestContext(),


### PR DESCRIPTION
This only takes care of the custom migrations for the releases tables. It does not use the table yet, except during startup.