### PR TITLE
fix: null db locks on migrations

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1043,6 +1043,10 @@ func (h *DBHandler) RunCustomMigrationEnvLocks(ctx context.Context, getAllEnvLoc
 						envName, err)
 				}
 			}
+
+			if len(activeLockIds) == 0 {
+				activeLockIds = []string{}
+			}
 			err = h.DBWriteAllEnvironmentLocks(ctx, transaction, 0, envName, activeLockIds)
 			if err != nil {
 				return fmt.Errorf("error writing environment locks ids to DB for environment %s: %v",


### PR DESCRIPTION
When running custom migrations, if no locks were found on some environment, the db would store this information as 'null'. Now stores an empty list