### PR TITLE
fix(productVersion): correct annotated tag usage when calling git tags

### DIFF
--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -25,8 +25,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/pkg/conversion"
-	time2 "github.com/freiheit-com/kuberpult/pkg/time"
 	"io"
 	"net/http"
 	"os"
@@ -38,6 +36,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/freiheit-com/kuberpult/pkg/conversion"
+	time2 "github.com/freiheit-com/kuberpult/pkg/time"
 
 	"github.com/freiheit-com/kuberpult/pkg/argocd"
 	"github.com/freiheit-com/kuberpult/pkg/argocd/v1alpha1"
@@ -332,7 +333,11 @@ func GetTags(cfg RepositoryConfig, repoName string, ctx context.Context) (tags [
 			}
 			tags = append(tags, &api.TagData{Tag: tagObject.Name(), CommitId: tagCommit.Id().String()})
 		} else {
-			tags = append(tags, &api.TagData{Tag: tagObject.Name(), CommitId: tagRef.Id().String()})
+			commit, err := tagRef.Target().AsCommit()
+			if err != nil {
+				return nil, fmt.Errorf("unable to lookup tag [%s]: %v", tagObject.Name(), err)
+			}
+			tags = append(tags, &api.TagData{Tag: tagObject.Name(), CommitId: commit.Id().String()})
 		}
 	}
 

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -22,9 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/pkg/config"
-	"github.com/freiheit-com/kuberpult/pkg/db"
-	"github.com/freiheit-com/kuberpult/pkg/testutil"
 	"io"
 	"io/fs"
 	"net/http"
@@ -36,6 +33,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/freiheit-com/kuberpult/pkg/config"
+	"github.com/freiheit-com/kuberpult/pkg/db"
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -429,8 +430,8 @@ func TestGetTags(t *testing.T) {
 			}
 			var expectedCommits []api.TagData
 			for addTag := range tc.tagsToAdd {
-				_, err := repo.Tags.Create(tc.tagsToAdd[addTag], commit, &git.Signature{Name: "SRE", Email: "testing@gmail"}, "testing")
-				expectedCommits = append(expectedCommits, api.TagData{Tag: tc.tagsToAdd[addTag], CommitId: commit.Id().String()})
+				commit, err := repo.Tags.Create(tc.tagsToAdd[addTag], commit, &git.Signature{Name: "SRE", Email: "testing@gmail"}, "testing")
+				expectedCommits = append(expectedCommits, api.TagData{Tag: tc.tagsToAdd[addTag], CommitId: commit.String()})
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
- Previously we were getting the commit of the tag which works for lightweight tags
- For annotated tags was previously only using the ID as a commit but need to reference the target of the tag