### PR TITLE
chore(manifest-export-service): expose a metric for esl processing delays

### DIFF
--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -167,7 +167,6 @@ func Run(ctx context.Context) error {
 		if err != nil {
 			logger.FromContext(ctx).Fatal("datadog.metrics.error", zap.Error(err))
 		}
-		ctx = context.WithValue(ctx, repository.DdMetricsKey, ddMetrics)
 	}
 
 	cfg := repository.RepositoryConfig{

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -104,12 +104,12 @@ func Run(ctx context.Context) error {
 	}
 	enableMetricsString, err := readEnvVar("KUBERPULT_ENABLE_METRICS")
 	if err != nil {
-		enableMetricsString = "false"
+		return err
 	}
 	enableMetrics := enableMetricsString == "true"
 	DatatDogStatsAddr, err := readEnvVar("KUBERPULT_DOGSTATSD_ADDR")
 	if err != nil {
-		DatatDogStatsAddr = "127.0.0.1:8125"
+		return err
 	}
 
 	var eslProcessingBackoff uint64
@@ -218,10 +218,10 @@ func Run(ctx context.Context) error {
 			if ddMetrics != nil {
 				processDelay, err := calculateProcessDelay(ctx, esl, time.Now())
 				if err != nil {
-					log.Warn("error in calculateProcessDelay %v", err)
+					log.Error("Error in calculateProcessDelay %v", err)
 				}
 				if err := ddMetrics.Gauge("process_delay_seconds", processDelay, []string{}, 1); err != nil {
-					log.Warn("error in ddMetrics.Gauge %v", err)
+					log.Error("Error in ddMetrics.Gauge %v", err)
 				}
 			}
 			if esl == nil {

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -242,9 +242,6 @@ func Run(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("error in DBWriteCutoff %v", err)
 			}
-			if err != nil {
-				log.Warn("error in DBReadCutoff %v", err)
-			}
 			return nil
 		})
 		if err != nil {

--- a/services/manifest-repo-export-service/pkg/cmd/server_test.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/freiheit-com/kuberpult/pkg/db"
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
+)
+
+func TestCalculateProcessDelay(t *testing.T) {
+	exampleTime, err := time.Parse("2006-01-02 15:04:05", "2024-06-18 16:14:07")
+	if err != nil {
+		t.Fatal(err)
+	}
+	exampleTime10SecondsBefore := exampleTime.Add(-10 * time.Second)
+	tcs := []struct {
+		Name          string
+		eslEvent      *db.EslEventRow
+		currentTime   time.Time
+		ExpectedDelay float64
+	}{
+		{
+			Name:          "Should return 0 if there are no events",
+			eslEvent:      nil,
+			currentTime:   time.Now(),
+			ExpectedDelay: 0,
+		},
+		{
+			Name:          "Should return 0 if time created is not set",
+			eslEvent:      &db.EslEventRow{},
+			currentTime:   time.Now(),
+			ExpectedDelay: 0,
+		},
+		{
+			Name: "With one Event",
+			eslEvent: &db.EslEventRow{
+				EslId:     1,
+				Created:   exampleTime10SecondsBefore,
+				EventType: "CreateApplicationVersion",
+				EventJson: "{}",
+			},
+			currentTime:   exampleTime,
+			ExpectedDelay: 10,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := testutil.MakeTestContext()
+			delay, err := calculateProcessDelay(ctx, tc.eslEvent, tc.currentTime)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if delay != tc.ExpectedDelay {
+				t.Errorf("expected %f, got %f", tc.ExpectedDelay, delay)
+			}
+		})
+	}
+}

--- a/services/manifest-repo-export-service/pkg/cmd/server_test.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server_test.go
@@ -1,3 +1,19 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
 package cmd
 
 import (

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -37,7 +37,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/freiheit-com/kuberpult/pkg/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -58,10 +57,6 @@ import (
 type contextKey string
 
 const DdMetricsKey contextKey = "ddMetrics"
-
-var (
-	ddMetrics statsd.ClientInterface
-)
 
 // A Repository provides a multiple reader / single writer access to a git repository.
 type Repository interface {
@@ -209,13 +204,6 @@ func openOrCreate(path string, storageBackend StorageBackend) (*git.Repository, 
 
 func New(ctx context.Context, cfg RepositoryConfig) (Repository, error) {
 	logger := logger.FromContext(ctx)
-
-	ddMetricsFromCtx := ctx.Value(DdMetricsKey)
-	if ddMetricsFromCtx != nil {
-		ddMetrics = ddMetricsFromCtx.(statsd.ClientInterface)
-	} else {
-		logger.Sugar().Warnf("could not load ddmetrics from context - running without datadog metrics")
-	}
 
 	if cfg.Branch == "" {
 		cfg.Branch = "master"

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -54,10 +54,6 @@ import (
 	git "github.com/libgit2/git2go/v34"
 )
 
-type contextKey string
-
-const DdMetricsKey contextKey = "ddMetrics"
-
 // A Repository provides a multiple reader / single writer access to a git repository.
 type Repository interface {
 	Apply(ctx context.Context, tx *sql.Tx, transformers ...Transformer) error

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -37,9 +37,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/freiheit-com/kuberpult/pkg/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"github.com/DataDog/datadog-go/v5/statsd"
 
 	backoff "github.com/cenkalti/backoff/v4"
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
@@ -56,6 +56,7 @@ import (
 )
 
 type contextKey string
+
 const DdMetricsKey contextKey = "ddMetrics"
 
 var (


### PR DESCRIPTION
manifest-repo-export-service creates a metric that outputs the delay between "last processed event" and "last event that should be processed". Its measured in seconds and is exposed on datadog