### PR TITLE
fix(productVersion): correct Annotated tag for running release trains

### DIFF
--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -333,11 +333,11 @@ func GetTags(cfg RepositoryConfig, repoName string, ctx context.Context) (tags [
 			}
 			tags = append(tags, &api.TagData{Tag: tagObject.Name(), CommitId: tagCommit.Id().String()})
 		} else {
-			commit, err := tagRef.Target().AsCommit()
+			tagCommit, err := repo.LookupCommit(tagRef.TargetId())
 			if err != nil {
 				return nil, fmt.Errorf("unable to lookup tag [%s]: %v", tagObject.Name(), err)
 			}
-			tags = append(tags, &api.TagData{Tag: tagObject.Name(), CommitId: commit.Id().String()})
+			tags = append(tags, &api.TagData{Tag: tagObject.Name(), CommitId: tagCommit.Id().String()})
 		}
 	}
 


### PR DESCRIPTION
- The commit for annotated tags was pointing at the commit hash of the tag object 
- Fixed to point at the commit object instead