### PR TITLE
fix(docker-compose): add datadog env variables to docker compose file

### DIFF
--- a/docker-compose-earthly.yml
+++ b/docker-compose-earthly.yml
@@ -41,6 +41,8 @@ services:
       - KUBERPULT_GIT_SSH_KEY=/etc/ssh/identity
       - KUBERPULT_GIT_SSH_KNOWN_HOSTS=/etc/ssh/ssh_known_hosts
       - KUBERPULT_ENABLE_SQLITE=true
+      - KUBERPULT_ENABLE_METRICS=false
+      - KUBERPULT_DOGSTATSD_ADDR=127.0.0.1:8125
       - KUBERPULT_ARGO_CD_GENERATE_FILES=true
     volumes:
       - ./services/cd-service:/kp/kuberpult


### PR DESCRIPTION
Added KUBERPULT_ENABLE_METRICS and KUBERPULT_DOGSTATSD_ADDR environment variables to the docker compose file.