### PR TITLE
fix(db): use UTC times in database

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -327,7 +327,7 @@ func (h *DBHandler) DBWriteEslEventInternal(ctx context.Context, eventType Event
 	span.SetTag("query", insertQuery)
 	_, err = tx.Exec(
 		insertQuery,
-		time.Now(),
+		time.Now().UTC(),
 		eventType,
 		jsonToInsert)
 
@@ -621,7 +621,7 @@ func (h *DBHandler) DBInsertRelease(ctx context.Context, transaction *sql.Tx, re
 	_, err = transaction.Exec(
 		insertQuery,
 		previousEslVersion+1,
-		time.Now(),
+		time.Now().UTC(),
 		release.ReleaseNumber,
 		release.App,
 		manifestJson,
@@ -661,7 +661,7 @@ func (h *DBHandler) DBInsertAllReleases(ctx context.Context, transaction *sql.Tx
 	_, err = transaction.Exec(
 		insertQuery,
 		previousEslVersion+1,
-		time.Now(),
+		time.Now().UTC(),
 		app,
 		metadataJson,
 	)
@@ -689,7 +689,7 @@ func (h *DBHandler) DBWriteAllApplications(ctx context.Context, transaction *sql
 	_, err = transaction.Exec(
 		insertQuery,
 		previousVersion+1,
-		time.Now(),
+		time.Now().UTC(),
 		jsonToInsert)
 
 	if err != nil {
@@ -1101,7 +1101,7 @@ func (h *DBHandler) DBInsertApplication(ctx context.Context, transaction *sql.Tx
 	_, err = transaction.Exec(
 		insertQuery,
 		previousEslVersion+1,
-		time.Now(),
+		time.Now().UTC(),
 		appName,
 		stateChange,
 		jsonToInsert,
@@ -1245,7 +1245,7 @@ func (h *DBHandler) DBWriteDeployment(ctx context.Context, tx *sql.Tx, deploymen
 	_, err = tx.Exec(
 		insertQuery,
 		previousEslVersion+1,
-		time.Now(),
+		time.Now().UTC(),
 		nullVersion,
 		deployment.App,
 		deployment.Env,
@@ -1288,7 +1288,7 @@ func (h *DBHandler) RunCustomMigrationReleases(ctx context.Context, getAllAppsFu
 				repoRelease := releases[r]
 				dbRelease := DBReleaseWithMetaData{
 					EslId:         InitialEslId,
-					Created:       time.Now(),
+					Created:       time.Now().UTC(),
 					ReleaseNumber: repoRelease.Version,
 					App:           app,
 					Manifests: DBReleaseManifests{
@@ -1777,7 +1777,7 @@ func (h *DBHandler) DBWriteEnvironmentLockInternal(ctx context.Context, tx *sql.
 	if useTimeInLock {
 		timetoInsert = envLock.Created
 	} else {
-		timetoInsert = time.Now()
+		timetoInsert = time.Now().UTC()
 	}
 	span.SetTag("query", insertQuery)
 	_, err = tx.Exec(
@@ -2028,7 +2028,7 @@ func (h *DBHandler) DBWriteAllEnvironmentLocks(ctx context.Context, transaction 
 	_, err = transaction.Exec(
 		insertQuery,
 		previousVersion+1,
-		time.Now(),
+		time.Now().UTC(),
 		environment,
 		jsonToInsert)
 	if err != nil {
@@ -2150,7 +2150,7 @@ func (h *DBHandler) DBWriteAllAppLocks(ctx context.Context, transaction *sql.Tx,
 	_, err = transaction.Exec(
 		insertQuery,
 		previousVersion+1,
-		time.Now(),
+		time.Now().UTC(),
 		environment,
 		appName,
 		jsonToInsert)
@@ -2446,7 +2446,7 @@ func (h *DBHandler) DBWriteApplicationLockInternal(ctx context.Context, tx *sql.
 	if useTimeInLock {
 		timetoInsert = appLock.Created
 	} else {
-		timetoInsert = time.Now()
+		timetoInsert = time.Now().UTC()
 	}
 	span.SetTag("query", insertQuery)
 	_, err = tx.Exec(
@@ -2740,7 +2740,7 @@ func (h *DBHandler) DBWriteTeamLockInternal(ctx context.Context, tx *sql.Tx, tea
 	if useTimeInLock {
 		timetoInsert = teamLock.Created
 	} else {
-		timetoInsert = time.Now()
+		timetoInsert = time.Now().UTC()
 	}
 	span.SetTag("query", insertQuery)
 	_, err = tx.Exec(
@@ -2774,7 +2774,7 @@ func (h *DBHandler) DBWriteAllTeamLocks(ctx context.Context, transaction *sql.Tx
 	_, err = transaction.Exec(
 		insertQuery,
 		previousVersion+1,
-		time.Now(),
+		time.Now().UTC(),
 		environment,
 		teamName,
 		jsonToInsert)
@@ -3288,7 +3288,7 @@ func (h *DBHandler) dbWriteDeploymentAttemptInternal(ctx context.Context, tx *sq
 	_, err = tx.Exec(
 		insertQuery,
 		previousEslVersion+1,
-		time.Now(),
+		time.Now().UTC(),
 		deployment.Env,
 		deployment.App,
 		nullVersion)

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -219,6 +219,9 @@ func Run(ctx context.Context) error {
 				if err != nil {
 					log.Error("Error in calculateProcessDelay %v", err)
 				}
+				if processDelay < 0 {
+					log.Warn("process delay is negative: esl-time: %v, now: %v, delay: %v", esl.Created, time.Now().UTC(), processDelay)
+				}
 				if err := ddMetrics.Gauge("process_delay_seconds", processDelay, []string{}, 1); err != nil {
 					log.Error("Error in ddMetrics.Gauge %v", err)
 				}

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -215,12 +215,13 @@ func Run(ctx context.Context) error {
 				return fmt.Errorf("error in readEslEvent %v", err)
 			}
 			if ddMetrics != nil {
-				processDelay, err := calculateProcessDelay(ctx, esl, time.Now().UTC())
+                                now :=time.Now().UTC()
+				processDelay, err := calculateProcessDelay(ctx, esl, now)
 				if err != nil {
 					log.Error("Error in calculateProcessDelay %v", err)
 				}
 				if processDelay < 0 {
-					log.Warn("process delay is negative: esl-time: %v, now: %v, delay: %v", esl.Created, time.Now().UTC(), processDelay)
+					log.Warn("process delay is negative: esl-time: %v, now: %v, delay: %v", esl.Created, now, processDelay)
 				}
 				if err := ddMetrics.Gauge("process_delay_seconds", processDelay, []string{}, 1); err != nil {
 					log.Error("Error in ddMetrics.Gauge %v", err)

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -215,7 +215,7 @@ func Run(ctx context.Context) error {
 				return fmt.Errorf("error in readEslEvent %v", err)
 			}
 			if ddMetrics != nil {
-                                now :=time.Now().UTC()
+				now := time.Now().UTC()
 				processDelay, err := calculateProcessDelay(ctx, esl, now)
 				if err != nil {
 					log.Error("Error in calculateProcessDelay %v", err)

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -215,7 +215,7 @@ func Run(ctx context.Context) error {
 				return fmt.Errorf("error in readEslEvent %v", err)
 			}
 			if ddMetrics != nil {
-				processDelay, err := calculateProcessDelay(ctx, esl, time.Now())
+				processDelay, err := calculateProcessDelay(ctx, esl, time.Now().UTC())
 				if err != nil {
 					log.Error("Error in calculateProcessDelay %v", err)
 				}

--- a/services/manifest-repo-export-service/pkg/db/cutoff.go
+++ b/services/manifest-repo-export-service/pkg/db/cutoff.go
@@ -75,7 +75,7 @@ func DBWriteCutoff(h *db.DBHandler, ctx context.Context, tx *sql.Tx, eslId db.Es
 	_, err := tx.Exec(
 		insertQuery,
 		eslId,
-		time.Now(),
+		time.Now().UTC(),
 	)
 	if err != nil {
 		return fmt.Errorf("could not query cutoff table from DB. Error: %w\n", err)


### PR DESCRIPTION
Use Utc time in all records in database. Also, log warning when processDelay metric is negative.