### PR TITLE
feat(ESL): Esl for DeleteEnvFromApp to Database

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -560,6 +560,7 @@ func (h *DBHandler) processReleaseRows(ctx context.Context, err error, rows *sql
 	var result []*DBReleaseWithMetaData
 	var maxEslId EslId = -1
 	for rows.Next() {
+		//exhaustruct:ignore
 		var row = &DBReleaseWithMetaData{}
 		var metadataStr string
 		var manifestStr string

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -478,16 +478,17 @@ func (h *DBHandler) DBSelectReleaseByVersion(ctx context.Context, tx *sql.Tx, ap
 	return processedRows[0], nil
 }
 
-func (h *DBHandler) DBSelectReleasesByApp(ctx context.Context, tx *sql.Tx, app string) ([]*DBReleaseWithMetaData, error) {
+func (h *DBHandler) DBSelectReleasesByApp(ctx context.Context, tx *sql.Tx, app string, deleted bool) ([]*DBReleaseWithMetaData, error) {
 	selectQuery := h.AdaptQuery(fmt.Sprintf(
 		"SELECT eslVersion, created, appName, metadata, manifests, releaseVersion, deleted " +
 			" FROM releases " +
-			" WHERE appName=?" +
+			" WHERE appName=? AND deleted=?" +
 			" ORDER BY eslVersion, created DESC;"))
 	rows, err := tx.QueryContext(
 		ctx,
 		selectQuery,
 		app,
+		deleted,
 	)
 
 	return h.processReleaseRows(ctx, err, rows)

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1707,7 +1707,7 @@ func TestReadReleasesByApp(t *testing.T) {
 						return fmt.Errorf("error while writing release, error: %w", err)
 					}
 				}
-				releases, err := dbHandler.DBSelectReleasesByApp(ctx, transaction, tc.AppName)
+				releases, err := dbHandler.DBSelectReleasesByApp(ctx, transaction, tc.AppName, false)
 				if err != nil {
 					return fmt.Errorf("error while selecting release, error: %w", err)
 				}

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1691,6 +1691,50 @@ func TestReadReleasesByApp(t *testing.T) {
 			AppName:  "app1`",
 			Expected: nil,
 		},
+		{
+			Name: "Different Releases with different eslIDs",
+			Releases: []DBReleaseWithMetaData{
+				{
+					EslId:         1,
+					ReleaseNumber: 1,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest1"}},
+				},
+				{
+					EslId:         2,
+					ReleaseNumber: 2,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest2"}},
+				},
+				{
+					EslId:         1,
+					ReleaseNumber: 3,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest3"}},
+				},
+			},
+			AppName: "app1",
+			Expected: []*DBReleaseWithMetaData{
+				{
+					EslId:         1,
+					ReleaseNumber: 3,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest3"}},
+				},
+				{
+					EslId:         2,
+					ReleaseNumber: 2,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest2"}},
+				},
+				{
+					EslId:         1,
+					ReleaseNumber: 1,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest1"}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tcs {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1344,7 +1344,7 @@ func (u *DeleteEnvFromApp) Transform(
 	}
 
 	if state.DBHandler.ShouldUseOtherTables() {
-		releases, err := state.DBHandler.DBSelectReleasesByApp(ctx, transaction, u.Application)
+		releases, err := state.DBHandler.DBSelectReleasesByApp(ctx, transaction, u.Application, false)
 		if err != nil {
 			return "", err
 		}
@@ -1356,7 +1356,7 @@ func (u *DeleteEnvFromApp) Transform(
 					newManifests[envName] = manifest
 				}
 			}
-			newRelese := db.DBReleaseWithMetaData{
+			newRelease := db.DBReleaseWithMetaData{
 				EslId:         dbReleaseWithMetadata.EslId + 1,
 				ReleaseNumber: dbReleaseWithMetadata.ReleaseNumber,
 				App:           dbReleaseWithMetadata.App,
@@ -1365,7 +1365,7 @@ func (u *DeleteEnvFromApp) Transform(
 				Metadata:      dbReleaseWithMetadata.Metadata,
 				Deleted:       dbReleaseWithMetadata.Deleted,
 			}
-			err = state.DBHandler.DBInsertRelease(ctx, transaction, newRelese, dbReleaseWithMetadata.EslId)
+			err = state.DBHandler.DBInsertRelease(ctx, transaction, newRelease, dbReleaseWithMetadata.EslId)
 			if err != nil {
 				return "", err
 			}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1357,8 +1357,10 @@ func (u *DeleteEnvFromApp) Transform(
 				}
 			}
 			newRelese := db.DBReleaseWithMetaData{
+				EslId:         dbReleaseWithMetadata.EslId + 1,
 				ReleaseNumber: dbReleaseWithMetadata.ReleaseNumber,
 				App:           dbReleaseWithMetadata.App,
+				Created:       time.Now().UTC(),
 				Manifests:     db.DBReleaseManifests{Manifests: newManifests},
 				Metadata:      dbReleaseWithMetadata.Metadata,
 				Deleted:       dbReleaseWithMetadata.Deleted,

--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -1131,6 +1131,122 @@ func TestCreateEnvironmentTransformer(t *testing.T) {
 	}
 }
 
+func TestDeleteEnvFromAppWithDB(t *testing.T) {
+	firstRelease := db.DBReleaseWithMetaData{
+		EslId:         1,
+		ReleaseNumber: 10,
+		App:           "app",
+		Manifests: db.DBReleaseManifests{
+			Manifests: map[string]string{
+				"env":  "testenvmanifest",
+				"env2": "testenvmanifest2",
+			},
+		},
+		Metadata: db.DBReleaseMetaData{
+			SourceAuthor:   "test",
+			SourceMessage:  "test",
+			SourceCommitId: "test",
+			DisplayVersion: "test",
+		},
+	}
+	secondRelease := db.DBReleaseWithMetaData{
+		EslId:         1,
+		ReleaseNumber: 11,
+		App:           "app",
+		Manifests: db.DBReleaseManifests{
+			Manifests: map[string]string{
+				"env1": "testenvmanifest",
+				"env2": "testenvmanifest2",
+			},
+		},
+		Metadata: db.DBReleaseMetaData{
+			SourceAuthor:   "test",
+			SourceMessage:  "test",
+			SourceCommitId: "test",
+			DisplayVersion: "test",
+		},
+	}
+	tcs := []struct {
+		Name              string
+		PrevReleases      []db.DBReleaseWithMetaData
+		Transforms        []Transformer
+		ExpectedManifests map[string]string
+	}{
+		{
+			Name:         "Simple Delete Env From App",
+			PrevReleases: []db.DBReleaseWithMetaData{firstRelease},
+			Transforms: []Transformer{
+				&DeleteEnvFromApp{
+					Application: firstRelease.App,
+					Environment: "env",
+				},
+			},
+			ExpectedManifests: map[string]string{
+				"env2": "testenvmanifest2",
+			},
+		},
+		{
+			Name:         "Delete Env that doesn't exist",
+			PrevReleases: []db.DBReleaseWithMetaData{firstRelease},
+			Transforms: []Transformer{
+				&DeleteEnvFromApp{
+					Application: firstRelease.App,
+					Environment: "env3",
+				},
+			},
+			ExpectedManifests: firstRelease.Manifests.Manifests,
+		},
+		{
+			Name:         "Multiple Manifests",
+			PrevReleases: []db.DBReleaseWithMetaData{firstRelease, secondRelease},
+			Transforms: []Transformer{
+				&DeleteEnvFromApp{
+					Application: firstRelease.App,
+					Environment: "env",
+				},
+			},
+			ExpectedManifests: map[string]string{
+				"env2": "testenvmanifest2",
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctxWithTime := time.WithTimeNow(testutil.MakeTestContext(), timeNowOld)
+			repo := SetupRepositoryTestWithDB(t)
+			err := repo.State().DBHandler.WithTransaction(ctxWithTime, func(ctx context.Context, transaction *sql.Tx) error {
+				for _, release := range tc.PrevReleases {
+					repo.State().DBHandler.DBInsertRelease(ctx, transaction, release, 0)
+				}
+				_, state, _, err := repo.ApplyTransformersInternal(ctx, transaction, tc.Transforms...)
+				if err != nil {
+					return fmt.Errorf("error: %v", err)
+				}
+				releases, err2 := state.DBHandler.DBSelectReleasesByApp(ctx, transaction, firstRelease.App)
+				if err2 != nil {
+					return fmt.Errorf("error retrieving release: %v", err2)
+				}
+				for _, release := range releases {
+					if diff := cmp.Diff(firstRelease.EslId+1, release.EslId); diff != "" {
+						return fmt.Errorf("error mismatch ReleaseNumber - want, +got:\n%s", diff)
+					}
+					for env, manifest := range tc.ExpectedManifests {
+						if diff := cmp.Diff(manifest, release.Manifests.Manifests[env]); diff != "" {
+							return fmt.Errorf("error mismatch Manifests - want, +got:\n%s", diff)
+						}
+					}
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
 func version(v int) *int64 {
 	var result = int64(v)
 	return &result

--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -1224,7 +1224,7 @@ func TestDeleteEnvFromAppWithDB(t *testing.T) {
 				if err != nil {
 					return fmt.Errorf("error: %v", err)
 				}
-				releases, err2 := state.DBHandler.DBSelectReleasesByApp(ctx, transaction, firstRelease.App)
+				releases, err2 := state.DBHandler.DBSelectReleasesByApp(ctx, transaction, firstRelease.App, false)
 				if err2 != nil {
 					return fmt.Errorf("error retrieving release: %v", err2)
 				}

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -375,6 +375,9 @@ func getTransformer(ctx context.Context, eslEventType db.EventType) (repository.
 	case db.EvtCreateEnvironment:
 		//exhaustruct:ignore
 		return &repository.CreateEnvironment{}, nil
+	case db.EvtDeleteEnvFromApp:
+		//exhaustruct:ignore
+		return &repository.DeleteEnvFromApp{}, nil
 	default:
 		logger.FromContext(ctx).Sugar().Warnf("Found an unknown event %s. No further events will be processed.", eslEventType)
 		return nil, nil

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -76,10 +76,6 @@ func applicationDirectory(fs billy.Filesystem, application string) string {
 	return fs.Join("applications", application)
 }
 
-func environmentDirectory(fs billy.Filesystem, environment string) string {
-	return fs.Join("environments", environment)
-}
-
 func environmentApplicationDirectory(fs billy.Filesystem, environment, application string) string {
 	return fs.Join("environments", environment, "applications", application)
 }


### PR DESCRIPTION
This Esl is created in the database. Also, in each release in the database the environment will be deleted from the manifest(actually, a new release with new eslID will be created).
Also, The manifest-export-service will read this esl, and delete environment directory in the git repo.