### PR TITLE
feat: read DexEnabled variable frontend service

### DIFF
--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -327,7 +327,11 @@ message GetFrontendConfigResponse {
       string cloud_instance = 4;
       string redirect_url = 5;
     }
+    message DexAuthConfig {
+      bool enabled = 1;
+    }
     AzureAuthConfig azure_auth= 1;
+    DexAuthConfig dex_auth= 2;
   }
   ArgoCD argo_cd = 1;
   Auth auth_config = 2;

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -316,6 +316,9 @@ func runServer(ctx context.Context) error {
 					RedirectURL:   c.AzureRedirectUrl,
 					CloudInstance: c.AzureCloudInstance,
 				},
+				DexAuthConfig: &config.DexAuthConfig{
+					Enabled: c.DexEnabled,
+				},
 			},
 			ManifestRepoUrl:  c.ManifestRepoUrl,
 			SourceRepoUrl:    c.SourceRepoUrl,

--- a/services/frontend-service/pkg/config/config.go
+++ b/services/frontend-service/pkg/config/config.go
@@ -71,7 +71,8 @@ type ArgoCdConfig struct {
 }
 
 type AuthConfig struct {
-	AzureAuth *AzureAuthConfig `json:"azureAuth"`
+	AzureAuth     *AzureAuthConfig `json:"azureAuth"`
+	DexAuthConfig *DexAuthConfig   `json:"dexAuth"`
 }
 
 type AzureAuthConfig struct {
@@ -80,4 +81,8 @@ type AzureAuthConfig struct {
 	TenantId      string `json:"tenantId"`
 	CloudInstance string `json:"cloudInstance"`
 	RedirectURL   string `json:"redirectURL"`
+}
+
+type DexAuthConfig struct {
+	Enabled bool `json:"enabled"`
 }

--- a/services/frontend-service/pkg/service/config.go
+++ b/services/frontend-service/pkg/service/config.go
@@ -43,6 +43,9 @@ func (c *FrontendConfigServiceServer) GetConfig(
 				CloudInstance: c.Config.Auth.AzureAuth.CloudInstance,
 				RedirectUrl:   c.Config.Auth.AzureAuth.RedirectURL,
 			},
+			DexAuth: &api.GetFrontendConfigResponse_Auth_DexAuthConfig{
+				Enabled: c.Config.Auth.DexAuthConfig.Enabled,
+			},
 		},
 		SourceRepoUrl:    c.Config.SourceRepoUrl,
 		ManifestRepoUrl:  c.Config.ManifestRepoUrl,

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -74,8 +74,7 @@ export const App: React.FC = () => {
                 (result: GetFrontendConfigResponse) => {
                     UpdateFrontendConfig.set({ configs: result, configReady: true });
                     if (result.authConfig?.dexAuth?.enabled) {
-                        // eslint-disable-next-line no-console
-                        console.log('Dex is enabled lets redirect ');
+                        // TODO(BB): set the redirect to /login here. 
                     }
                 },
                 (error) => {

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -74,7 +74,7 @@ export const App: React.FC = () => {
                 (result: GetFrontendConfigResponse) => {
                     UpdateFrontendConfig.set({ configs: result, configReady: true });
                     if (result.authConfig?.dexAuth?.enabled) {
-                        // TODO(BB): set the redirect to /login here. 
+                        // TODO(BB): set the redirect to /login here
                     }
                 },
                 (error) => {

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -73,6 +73,10 @@ export const App: React.FC = () => {
             .then(
                 (result: GetFrontendConfigResponse) => {
                     UpdateFrontendConfig.set({ configs: result, configReady: true });
+                    if (result.authConfig?.dexAuth?.enabled) {
+                        // eslint-disable-next-line no-console
+                        console.log('Dex is enabled lets redirect ');
+                    }
                 },
                 (error) => {
                     // eslint-disable-next-line no-console


### PR DESCRIPTION
If the user is not logged in, it needs to be redirected to the `/login` page. 
This is only true if Dex is enabled, thus, we need to check this condition on the frontend service. 