### PR TITLE
feat(charts): Add an option to enable cloudSqlProxy in helm charts

### DIFF
--- a/charts/kuberpult/install-kuberpult-helm.sh
+++ b/charts/kuberpult/install-kuberpult-helm.sh
@@ -25,10 +25,8 @@ cd:
     requests:
       memory: 200Mi
       cpu: 0.05
-  db:
-    dbOption: sqlite
-    location: /sqlite
-    writeEslTableOnly: false
+db:
+  dbOption: NO_DB
 frontend:
   resources:
     limits:

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -35,6 +35,9 @@
 {{- if not (or (eq .Values.cd.db.dbOption "cloudsql") (eq .Values.cd.db.dbOption "sqlite") (eq .Values.cd.db.dbOption "NO_DB")) }}
 {{ fail ".Values.cd.db.dbOption does not contain a valid value (NO_DB, sqlite, cloudsql)."}}
 {{ end -}}
+{{- if (and (.Values.cd.db.dbOption.cloudSqlProxyEnabled) (eq .Values.cd.db.dbOption "NO_DB") }}
+{{ fail "Cloudsql proxy cannot be used with NO_DB option"}}
+{{ end -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -79,7 +82,7 @@ spec:
       serviceAccountName: {{ .Values.cd.db.k8sName }}  
 {{- end }} 
       containers:
-{{- if eq .Values.cd.db.dbOption "cloudsql" }}
+{{- if .Values.cd.db.dbOption.cloudSqlProxyEnabled }}
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL Auth Proxy
         # Make sure to update on a regular schedule!

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -32,8 +32,8 @@
 {{- if .Values.cd.tag }}
 {{ fail "Values.cd.tag cannot be used anymore. We only support the same appVersion for all services at this point."}}
 {{ end -}}
-{{- if not (or (eq .Values.cd.db.dbOption "cloudsql") (eq .Values.cd.db.dbOption "NO_DB")) }}
-{{ fail ".Values.cd.db.dbOption does not contain a valid value (NO_DB, cloudsql)."}}
+{{- if not (or (eq .Values.cd.db.dbOption "postgreSQL") (eq .Values.cd.db.dbOption "NO_DB")) }}
+{{ fail ".Values.cd.db.dbOption does not contain a valid value (NO_DB, postgreSQL)."}}
 {{ end -}}
 {{- if (and (.Values.cd.db.dbOption.cloudSqlProxyEnabled) (eq .Values.cd.db.dbOption "NO_DB") }}
 {{ fail "Cloudsql proxy cannot be used with NO_DB option"}}
@@ -78,7 +78,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- if eq .Values.cd.db.dbOption "cloudsql" }}
+{{- if eq .Values.cd.db.dbOption "postgreSQL" }}
       serviceAccountName: {{ .Values.cd.db.k8sName }}  
 {{- end }} 
       containers:
@@ -241,17 +241,17 @@ spec:
           value: "{{ .Values.datadogProfiling.enabled }}"
         - name: KUBERPULT_MAXIMUM_QUEUE_SIZE
           value: "{{ .Values.cd.backendConfig.queueSize }}"
-        - name: KUBERPULT_DB_OPTION # { NO_DB, cloudsql}
+        - name: KUBERPULT_DB_OPTION # { NO_DB, postgreSQL}
           value: {{ .Values.cd.db.dbOption }}
         - name: KUBERPULT_DB_WRITE_ESL_TABLE_ONLY
           value: "{{ .Values.cd.db.writeEslTableOnly }}"
-{{- if (eq .Values.cd.db.dbOption "cloudsql") }}
+{{- if (eq .Values.cd.db.dbOption "postgreSQL") }}
         - name: KUBERPULT_DB_LOCATION
           value: {{ .Values.cd.db.location }}
         - name: KUBERPULT_DB_MIGRATIONS_LOCATION
           value: {{ .Values.cd.db.migrations }}
 {{- end }}
-{{- if eq .Values.cd.db.dbOption "cloudsql" }}
+{{- if eq .Values.cd.db.dbOption "postgreSQL" }}
         - name: KUBERPULT_DB_NAME
           value: "{{ .Values.cd.db.dbName }}"
         - name: KUBERPULT_DB_USER_NAME
@@ -266,7 +266,7 @@ spec:
         - name: KUBERPULT_GARBAGE_COLLECTION_FREQUENCY
           value: "{{ .Values.git.garbageCollectionFrequency }}"
         volumeMounts:
-{{- if (eq .Values.cd.db.dbOption "cloudsql") }}
+{{- if (eq .Values.cd.db.dbOption "postgreSQL") }}
         - name: migrations
           mountPath: {{ .Values.cd.db.migrations }}
           readOnly: false
@@ -317,7 +317,7 @@ spec:
         configMap:
           name: kuberpult-keyring
 {{- end }}
-{{- if eq .Values.cd.db.dbOption "cloudsql" }}
+{{- if eq .Values.cd.db.dbOption "postgreSQL" }}
       - name: migrations
         configMap:
           name: kuberpult-migrations-cloudsql

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -32,10 +32,10 @@
 {{- if .Values.cd.tag }}
 {{ fail "Values.cd.tag cannot be used anymore. We only support the same appVersion for all services at this point."}}
 {{ end -}}
-{{- if not (or (eq .Values.cd.db.dbOption "postgreSQL") (eq .Values.cd.db.dbOption "NO_DB")) }}
-{{ fail ".Values.cd.db.dbOption does not contain a valid value (NO_DB, postgreSQL)."}}
+{{- if not (or (eq .Values.db.dbOption "postgreSQL") (eq .Values.db.dbOption "NO_DB")) }}
+{{ fail ".Values.db.dbOption does not contain a valid value (NO_DB, postgreSQL)."}}
 {{ end -}}
-{{- if (and (.Values.cd.db.dbOption.cloudSqlProxyEnabled) (eq .Values.cd.db.dbOption "NO_DB") }}
+{{- if (and (.Values.db.dbOption.cloudSqlProxyEnabled) (eq .Values.db.dbOption "NO_DB") }}
 {{ fail "Cloudsql proxy cannot be used with NO_DB option"}}
 {{ end -}}
 ---
@@ -78,11 +78,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- if eq .Values.cd.db.dbOption "postgreSQL" }}
-      serviceAccountName: {{ .Values.cd.db.k8sName }}  
+{{- if eq .Values.db.dbOption "postgreSQL" }}
+      serviceAccountName: {{ .Values.db.k8sName }}  
 {{- end }} 
       containers:
-{{- if .Values.cd.db.dbOption.cloudSqlProxyEnabled }}
+{{- if .Values.db.dbOption.cloudSqlProxyEnabled }}
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL Auth Proxy
         # Make sure to update on a regular schedule!
@@ -97,9 +97,9 @@ spec:
 
           # Replace DB_PORT with the port the proxy should listen on
 
-          - "--port={{ .Values.cd.db.authProxyPort }}"
+          - "--port={{ .Values.db.authProxyPort }}"
 
-          - {{ .Values.cd.db.dbConnectionName | quote }}
+          - {{ .Values.db.dbConnectionName | quote }}
         securityContext:
           # The default Cloud SQL Auth Proxy image runs as the
           # "nonroot" user and group (uid: 65532) by default.
@@ -114,11 +114,11 @@ spec:
             # The proxy's memory use scales linearly with the number of active
             # connections. Fewer open connections will use less memory. Adjust
             # this value based on your application's requirements.
-            memory: {{ .Values.cd.db.requests.memory }}
+            memory: {{ .Values.db.requests.memory }}
             # The proxy's CPU use scales linearly with the amount of IO between
             # the database and the application. Adjust this value based on your
             # application's requirements.
-            cpu:  {{ .Values.cd.db.requests.cpu }}
+            cpu:  {{ .Values.db.requests.cpu }}
 {{- end }}
       - name: service
         image: "{{ .Values.hub }}/{{ .Values.cd.image }}:{{ $.Chart.AppVersion }}"
@@ -242,22 +242,22 @@ spec:
         - name: KUBERPULT_MAXIMUM_QUEUE_SIZE
           value: "{{ .Values.cd.backendConfig.queueSize }}"
         - name: KUBERPULT_DB_OPTION # { NO_DB, postgreSQL}
-          value: {{ .Values.cd.db.dbOption }}
+          value: {{ .Values.db.dbOption }}
         - name: KUBERPULT_DB_WRITE_ESL_TABLE_ONLY
-          value: "{{ .Values.cd.db.writeEslTableOnly }}"
-{{- if (eq .Values.cd.db.dbOption "postgreSQL") }}
+          value: "{{ .Values.db.writeEslTableOnly }}"
+{{- if (eq .Values.db.dbOption "postgreSQL") }}
         - name: KUBERPULT_DB_LOCATION
-          value: {{ .Values.cd.db.location }}
+          value: {{ .Values.db.location }}
         - name: KUBERPULT_DB_MIGRATIONS_LOCATION
-          value: {{ .Values.cd.db.migrations }}
+          value: {{ .Values.db.migrations }}
 {{- end }}
-{{- if eq .Values.cd.db.dbOption "postgreSQL" }}
+{{- if eq .Values.db.dbOption "postgreSQL" }}
         - name: KUBERPULT_DB_NAME
-          value: "{{ .Values.cd.db.dbName }}"
+          value: "{{ .Values.db.dbName }}"
         - name: KUBERPULT_DB_USER_NAME
-          value: "{{ .Values.cd.db.dbUser }}"
+          value: "{{ .Values.db.dbUser }}"
         - name: KUBERPULT_DB_USER_PASSWORD
-          value: "{{ .Values.cd.db.dbPassword }}"
+          value: "{{ .Values.db.dbPassword }}"
 {{- end }}
         - name: KUBERPULT_ALLOW_LONG_APP_NAMES
           value: "{{ .Values.cd.allowLongAppNames }}"
@@ -266,9 +266,9 @@ spec:
         - name: KUBERPULT_GARBAGE_COLLECTION_FREQUENCY
           value: "{{ .Values.git.garbageCollectionFrequency }}"
         volumeMounts:
-{{- if (eq .Values.cd.db.dbOption "postgreSQL") }}
+{{- if (eq .Values.db.dbOption "postgreSQL") }}
         - name: migrations
-          mountPath: {{ .Values.cd.db.migrations }}
+          mountPath: {{ .Values.db.migrations }}
           readOnly: false
 {{- end }}
         - name: repository
@@ -317,7 +317,7 @@ spec:
         configMap:
           name: kuberpult-keyring
 {{- end }}
-{{- if eq .Values.cd.db.dbOption "postgreSQL" }}
+{{- if eq .Values.db.dbOption "postgreSQL" }}
       - name: migrations
         configMap:
           name: kuberpult-migrations-cloudsql

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -78,8 +78,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- if eq .Values.db.dbOption "postgreSQL" }}
-      serviceAccountName: {{ .Values.db.k8sName }}  
+{{- if (and (eq .Values.db.dbOption "postgreSQL") (.Values.db.k8sServiceAccountName)) }}
+      serviceAccountName: {{ .Values.db.k8sServiceAccountName }}  
 {{- end }} 
       containers:
 {{- if .Values.db.cloudSqlProxyEnabled }}

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -35,7 +35,7 @@
 {{- if not (or (eq .Values.db.dbOption "postgreSQL") (eq .Values.db.dbOption "NO_DB")) }}
 {{ fail ".Values.db.dbOption does not contain a valid value (NO_DB, postgreSQL)."}}
 {{ end -}}
-{{- if (and (.Values.db.dbOption.cloudSqlProxyEnabled) (eq .Values.db.dbOption "NO_DB") }}
+{{- if (and (.Values.db.cloudSqlProxyEnabled) (eq .Values.db.dbOption "NO_DB")) }}
 {{ fail "Cloudsql proxy cannot be used with NO_DB option"}}
 {{ end -}}
 ---
@@ -82,7 +82,7 @@ spec:
       serviceAccountName: {{ .Values.db.k8sName }}  
 {{- end }} 
       containers:
-{{- if .Values.db.dbOption.cloudSqlProxyEnabled }}
+{{- if .Values.db.cloudSqlProxyEnabled }}
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL Auth Proxy
         # Make sure to update on a regular schedule!

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -32,8 +32,8 @@
 {{- if .Values.cd.tag }}
 {{ fail "Values.cd.tag cannot be used anymore. We only support the same appVersion for all services at this point."}}
 {{ end -}}
-{{- if not (or (eq .Values.cd.db.dbOption "cloudsql") (eq .Values.cd.db.dbOption "sqlite") (eq .Values.cd.db.dbOption "NO_DB")) }}
-{{ fail ".Values.cd.db.dbOption does not contain a valid value (NO_DB, sqlite, cloudsql)."}}
+{{- if not (or (eq .Values.cd.db.dbOption "cloudsql") (eq .Values.cd.db.dbOption "NO_DB")) }}
+{{ fail ".Values.cd.db.dbOption does not contain a valid value (NO_DB, cloudsql)."}}
 {{ end -}}
 {{- if (and (.Values.cd.db.dbOption.cloudSqlProxyEnabled) (eq .Values.cd.db.dbOption "NO_DB") }}
 {{ fail "Cloudsql proxy cannot be used with NO_DB option"}}
@@ -241,11 +241,11 @@ spec:
           value: "{{ .Values.datadogProfiling.enabled }}"
         - name: KUBERPULT_MAXIMUM_QUEUE_SIZE
           value: "{{ .Values.cd.backendConfig.queueSize }}"
-        - name: KUBERPULT_DB_OPTION # { NO_DB, cloudsql, sqlite }
+        - name: KUBERPULT_DB_OPTION # { NO_DB, cloudsql}
           value: {{ .Values.cd.db.dbOption }}
         - name: KUBERPULT_DB_WRITE_ESL_TABLE_ONLY
           value: "{{ .Values.cd.db.writeEslTableOnly }}"
-{{- if or (eq .Values.cd.db.dbOption "cloudsql") (eq .Values.cd.db.dbOption "sqlite") }}
+{{- if (eq .Values.cd.db.dbOption "cloudsql") }}
         - name: KUBERPULT_DB_LOCATION
           value: {{ .Values.cd.db.location }}
         - name: KUBERPULT_DB_MIGRATIONS_LOCATION
@@ -266,14 +266,9 @@ spec:
         - name: KUBERPULT_GARBAGE_COLLECTION_FREQUENCY
           value: "{{ .Values.git.garbageCollectionFrequency }}"
         volumeMounts:
-{{- if or (eq .Values.cd.db.dbOption "cloudsql") (eq .Values.cd.db.dbOption "sqlite") }}
+{{- if (eq .Values.cd.db.dbOption "cloudsql") }}
         - name: migrations
           mountPath: {{ .Values.cd.db.migrations }}
-          readOnly: false
-{{- end }}
-{{- if eq .Values.cd.db.dbOption "sqlite" }}
-        - name: sqlite
-          mountPath: /sqlite
           readOnly: false
 {{- end }}
         - name: repository
@@ -326,16 +321,6 @@ spec:
       - name: migrations
         configMap:
           name: kuberpult-migrations-cloudsql
-{{- end }}
-{{- if eq .Values.cd.db.dbOption "sqlite" }}
-      - name: migrations
-        configMap:
-          name: kuberpult-migrations-sqlite
-{{- end }}
-{{- if eq .Values.cd.db.dbOption "sqlite" }}
-      - name: sqlite
-        emptyDir:
-          sizeLimit: 1Gi
 {{- end }}
 {{- if .Values.environment_configs.bootstrap_mode }}
       - name: environment-configs

--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -62,7 +62,7 @@ spec:
       serviceAccountName: {{ .Values.db.k8sName }}
 {{- end }}
       containers:
-{{- if eq .Values.db.cloudSqlProxyEnabled }}
+{{- if .Values.db.cloudSqlProxyEnabled }}
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL Auth Proxy
         # Make sure to update on a regular schedule!

--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -14,14 +14,14 @@
 
 # Copyright freiheit.com
 
-{{- if not (or (eq .Values.cd.db.dbOption "postgreSQL") (eq .Values.cd.db.dbOption "NO_DB")) }}
-{{ fail ".Values.cd.db.dbOption does not contain a valid value (NO_DB, postgreSQL)."}}
+{{- if not (or (eq .Values.db.dbOption "postgreSQL") (eq .Values.db.dbOption "NO_DB")) }}
+{{ fail ".Values.db.dbOption does not contain a valid value (NO_DB, postgreSQL)."}}
 {{ end -}}
 
 # the export service is only enabled, if the DB is enabled
-{{- if (eq .Values.cd.db.dbOption "postgreSQL") }}
+{{- if (eq .Values.db.dbOption "postgreSQL") }}
 
-{{- if eq .Values.cd.db.writeEslTableOnly false }}
+{{- if eq .Values.db.writeEslTableOnly false }}
 
 
 ---
@@ -58,11 +58,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- if eq .Values.cd.db.dbOption "postgreSQL" }}
-      serviceAccountName: {{ .Values.cd.db.k8sName }}
+{{- if eq .Values.db.dbOption "postgreSQL" }}
+      serviceAccountName: {{ .Values.db.k8sName }}
 {{- end }}
       containers:
-{{- if eq .Values.cd.db.cloudSqlProxyEnabled }}
+{{- if eq .Values.db.cloudSqlProxyEnabled }}
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL Auth Proxy
         # Make sure to update on a regular schedule!
@@ -77,9 +77,9 @@ spec:
 
           # Replace DB_PORT with the port the proxy should listen on
 
-          - "--port={{ .Values.cd.db.authProxyPort }}"
+          - "--port={{ .Values.db.authProxyPort }}"
 
-          - {{ .Values.cd.db.dbConnectionName | quote }}
+          - {{ .Values.db.dbConnectionName | quote }}
         securityContext:
           # The default Cloud SQL Auth Proxy image runs as the
           # "nonroot" user and group (uid: 65532) by default.
@@ -94,11 +94,11 @@ spec:
             # The proxy's memory use scales linearly with the number of active
             # connections. Fewer open connections will use less memory. Adjust
             # this value based on your application's requirements.
-            memory: {{ .Values.cd.db.requests.memory }}
+            memory: {{ .Values.db.requests.memory }}
             # The proxy's CPU use scales linearly with the amount of IO between
             # the database and the application. Adjust this value based on your
             # application's requirements.
-            cpu:  {{ .Values.cd.db.requests.cpu }}
+            cpu:  {{ .Values.db.requests.cpu }}
 {{- end }}
       - name: service
         image: "{{ .Values.hub }}/{{ .Values.manifestRepoExport.image }}:{{ $.Chart.AppVersion }}"
@@ -162,17 +162,17 @@ spec:
           value: "/etc/datadog/api-key"
 {{- end }}
         - name: KUBERPULT_DB_LOCATION
-          value: "{{ .Values.cd.db.location }}"
+          value: "{{ .Values.db.location }}"
         - name: KUBERPULT_DB_NAME
-          value: "{{ .Values.cd.db.dbName }}"
+          value: "{{ .Values.db.dbName }}"
         - name: KUBERPULT_DB_USER_NAME
-          value: "{{ .Values.cd.db.dbUser }}"
+          value: "{{ .Values.db.dbUser }}"
         - name: KUBERPULT_DB_USER_PASSWORD
-          value: "{{ .Values.cd.db.dbPassword }}"
+          value: "{{ .Values.db.dbPassword }}"
         - name: KUBERPULT_DB_OPTION # { NO_DB, postgreSQL}
-          value: {{ .Values.cd.db.dbOption }}
+          value: {{ .Values.db.dbOption }}
         - name: KUBERPULT_DB_AUTH_PROXY_PORT
-          value: "{{ .Values.cd.db.authProxyPort }}"
+          value: "{{ .Values.db.authProxyPort }}"
         - name: KUBERPULT_ARGO_CD_GENERATE_FILES
           value: {{ .Values.argocd.generateFiles | quote }}
 {{- if .Values.datadogTracing.enabled }}

--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -58,8 +58,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- if eq .Values.db.dbOption "postgreSQL" }}
-      serviceAccountName: {{ .Values.db.k8sName }}
+{{- if (and (eq .Values.db.dbOption "postgreSQL") (.Values.db.k8sServiceAccountName)) }}
+      serviceAccountName: {{ .Values.db.k8sServiceAccountName }}
 {{- end }}
       containers:
 {{- if .Values.db.cloudSqlProxyEnabled }}

--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -62,7 +62,7 @@ spec:
       serviceAccountName: {{ .Values.cd.db.k8sName }}
 {{- end }}
       containers:
-{{- if eq .Values.cd.db.dbOption "cloudsql" }}
+{{- if eq .Values.cd.db.cloudSqlProxyEnabled }}
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL Auth Proxy
         # Make sure to update on a regular schedule!

--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -14,12 +14,12 @@
 
 # Copyright freiheit.com
 
-{{- if not (or (eq .Values.cd.db.dbOption "cloudsql") (eq .Values.cd.db.dbOption "NO_DB")) }}
-{{ fail ".Values.cd.db.dbOption does not contain a valid value (NO_DB, cloudsql)."}}
+{{- if not (or (eq .Values.cd.db.dbOption "postgreSQL") (eq .Values.cd.db.dbOption "NO_DB")) }}
+{{ fail ".Values.cd.db.dbOption does not contain a valid value (NO_DB, postgreSQL)."}}
 {{ end -}}
 
 # the export service is only enabled, if the DB is enabled
-{{- if (eq .Values.cd.db.dbOption "cloudsql") }}
+{{- if (eq .Values.cd.db.dbOption "postgreSQL") }}
 
 {{- if eq .Values.cd.db.writeEslTableOnly false }}
 
@@ -58,7 +58,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- if eq .Values.cd.db.dbOption "cloudsql" }}
+{{- if eq .Values.cd.db.dbOption "postgreSQL" }}
       serviceAccountName: {{ .Values.cd.db.k8sName }}
 {{- end }}
       containers:
@@ -169,7 +169,7 @@ spec:
           value: "{{ .Values.cd.db.dbUser }}"
         - name: KUBERPULT_DB_USER_PASSWORD
           value: "{{ .Values.cd.db.dbPassword }}"
-        - name: KUBERPULT_DB_OPTION # { NO_DB, cloudsql}
+        - name: KUBERPULT_DB_OPTION # { NO_DB, postgreSQL}
           value: {{ .Values.cd.db.dbOption }}
         - name: KUBERPULT_DB_AUTH_PROXY_PORT
           value: "{{ .Values.cd.db.authProxyPort }}"

--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -14,12 +14,12 @@
 
 # Copyright freiheit.com
 
-{{- if not (or (eq .Values.cd.db.dbOption "cloudsql") (eq .Values.cd.db.dbOption "sqlite") (eq .Values.cd.db.dbOption "NO_DB")) }}
-{{ fail ".Values.cd.db.dbOption does not contain a valid value (NO_DB, sqlite, cloudsql)."}}
+{{- if not (or (eq .Values.cd.db.dbOption "cloudsql") (eq .Values.cd.db.dbOption "NO_DB")) }}
+{{ fail ".Values.cd.db.dbOption does not contain a valid value (NO_DB, cloudsql)."}}
 {{ end -}}
 
 # the export service is only enabled, if the DB is enabled
-{{- if or (eq .Values.cd.db.dbOption "cloudsql") (eq .Values.cd.db.dbOption "sqlite") }}
+{{- if (eq .Values.cd.db.dbOption "cloudsql") }}
 
 {{- if eq .Values.cd.db.writeEslTableOnly false }}
 
@@ -169,7 +169,7 @@ spec:
           value: "{{ .Values.cd.db.dbUser }}"
         - name: KUBERPULT_DB_USER_PASSWORD
           value: "{{ .Values.cd.db.dbPassword }}"
-        - name: KUBERPULT_DB_OPTION # { NO_DB, cloudsql, sqlite }
+        - name: KUBERPULT_DB_OPTION # { NO_DB, cloudsql}
           value: {{ .Values.cd.db.dbOption }}
         - name: KUBERPULT_DB_AUTH_PROXY_PORT
           value: "{{ .Values.cd.db.authProxyPort }}"

--- a/charts/kuberpult/tests/charts_test.go
+++ b/charts/kuberpult/tests/charts_test.go
@@ -358,9 +358,8 @@ git:
   url: "testURL"
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: NO_DB
+db:
+  dbOption: NO_DB
 `,
 			ExpectedEnvs: []core.EnvVar{},
 			ExpectedMissing: []core.EnvVar{
@@ -390,13 +389,12 @@ git:
   url: "testURL"
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: postgreSQL
-    location: "127.0.0.1"
-    dbName: dbName
-    dbUser: dbUser
-    dbPassword: dbPassword
+db:
+  dbOption: postgreSQL
+  location: "127.0.0.1"
+  dbName: dbName
+  dbUser: dbUser
+  dbPassword: dbPassword
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{
@@ -429,18 +427,17 @@ git:
   url: "testURL"
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: sqlite
-    location: /kp/database
-    dbName: does
-    dbUser: not
-    dbPassword: matter
+db:
+  dbOption: postgreSQL
+  location: /kp/database
+  dbName: does
+  dbUser: not
+  dbPassword: matter
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{
 					Name:  "KUBERPULT_DB_OPTION",
-					Value: "sqlite",
+					Value: "postgreSQL",
 				},
 				{
 					Name:  "KUBERPULT_DB_LOCATION",
@@ -469,19 +466,18 @@ git:
   url: "testURL"
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: sqlite
-    location: /kp/database
-    dbName: does
-    dbUser: not
-    dbPassword: matter
-    writeEslTableOnly: false
+db:
+  dbOption: postgreSQL
+  location: /kp/database
+  dbName: does
+  dbUser: not
+  dbPassword: matter
+  writeEslTableOnly: false
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{
 					Name:  "KUBERPULT_DB_OPTION",
-					Value: "sqlite",
+					Value: "postgreSQL",
 				},
 				{
 					Name:  "KUBERPULT_DB_LOCATION",
@@ -514,19 +510,18 @@ git:
   url: "testURL"
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: sqlite
-    location: /kp/database
-    dbName: does
-    dbUser: not
-    dbPassword: matter
-    writeEslTableOnly: true
+db:
+  dbOption: postgreSQL
+  location: /kp/database
+  dbName: does
+  dbUser: not
+  dbPassword: matter
+  writeEslTableOnly: true
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{
 					Name:  "KUBERPULT_DB_OPTION",
-					Value: "sqlite",
+					Value: "postgreSQL",
 				},
 				{
 					Name:  "KUBERPULT_DB_LOCATION",
@@ -659,10 +654,9 @@ git:
   url:  "checkThisValue"
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: "sqlite"
-    writeEslTableOnly: false
+db:
+  dbOption: "postgreSQL"
+  writeEslTableOnly: false
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{
@@ -681,10 +675,9 @@ ingress:
   domainName: "kuberpult-example.com"
 argocd:
   generateFiles: false
-cd:
-  db:
-    dbOption: "sqlite"
-    writeEslTableOnly: false
+db:
+  dbOption: "postgreSQL"
+  writeEslTableOnly: false
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{
@@ -707,10 +700,9 @@ ingress:
   domainName: "kuberpult-example.com"
 argocd:
   generateFiles: true
-cd:
-  db:
-    dbOption: "sqlite"
-    writeEslTableOnly: false
+db:
+  dbOption: "postgreSQL"
+  writeEslTableOnly: false
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{
@@ -733,10 +725,9 @@ ingress:
   domainName: "kuberpult-example.com"
 dataDogTracing:
   enabled: false
-cd:
-  db:
-    dbOption: "sqlite"
-    writeEslTableOnly: false
+db:
+  dbOption: "postgreSQL"
+  writeEslTableOnly: false
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{
@@ -780,10 +771,9 @@ ingress:
   domainName: "kuberpult-example.com"
 datadogTracing:
   enabled: true
-cd:
-  db:
-    dbOption: "sqlite"
-    writeEslTableOnly: false
+db:
+  dbOption: "postgreSQL"
+  writeEslTableOnly: false
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{
@@ -820,10 +810,9 @@ git:
   url: "testURL"
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: NO_DB
-    writeEslTableOnly: false
+db:
+  dbOption: NO_DB
+  writeEslTableOnly: false
 `,
 			ExpectedEnvs: []core.EnvVar{},
 			ExpectedMissing: []core.EnvVar{
@@ -853,14 +842,13 @@ git:
   url: "testURL"
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: postgreSQL
-    location: "127.0.0.1"
-    dbName: dbName
-    dbUser: dbUser
-    dbPassword: dbPassword
-    writeEslTableOnly: false
+db:
+  dbOption: postgreSQL
+  location: "127.0.0.1"
+  dbName: dbName
+  dbUser: dbUser
+  dbPassword: dbPassword
+  writeEslTableOnly: false
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{
@@ -893,19 +881,18 @@ git:
   url: "testURL"
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: sqlite
-    location: /kp/database
-    dbName: does
-    dbUser: not
-    dbPassword: matter
-    writeEslTableOnly: false
+db:
+  dbOption: postgreSQL
+  location: /kp/database
+  dbName: does
+  dbUser: not
+  dbPassword: matter
+  writeEslTableOnly: false
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{
 					Name:  "KUBERPULT_DB_OPTION",
-					Value: "sqlite",
+					Value: "postgreSQL",
 				},
 				{
 					Name:  "KUBERPULT_DB_LOCATION",
@@ -934,10 +921,9 @@ git:
   url: "testURL"
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: sqlite
-    writeEslTableOnly: false
+db:
+  dbOption: postgreSQL
+  writeEslTableOnly: false
 
 manifestRepoExport:
   eslProcessingBackoff: 5
@@ -956,10 +942,9 @@ git:
   url: "testURL"
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: sqlite
-    writeEslTableOnly: false
+db:
+  dbOption: postgreSQL
+  writeEslTableOnly: false
 `,
 			ExpectedMissing: []core.EnvVar{
 				{
@@ -976,10 +961,9 @@ git:
   releaseVersionsLimit: 15
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: sqlite
-    writeEslTableOnly: false
+db:
+  dbOption: postgreSQL
+  writeEslTableOnly: false
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{
@@ -995,10 +979,9 @@ git:
   url: "testURL"
 ingress:
   domainName: "kuberpult-example.com"
-cd:
-  db:
-    dbOption: sqlite
-    writeEslTableOnly: false
+db:
+  dbOption: postgreSQL
+  writeEslTableOnly: false
 `,
 			ExpectedEnvs: []core.EnvVar{
 				{

--- a/charts/kuberpult/tests/charts_test.go
+++ b/charts/kuberpult/tests/charts_test.go
@@ -384,7 +384,7 @@ cd:
 			},
 		},
 		{
-			Name: "Database cloudsql enabled 1",
+			Name: "Database postgreSQL enabled 1",
 			Values: `
 git:
   url: "testURL"
@@ -392,7 +392,7 @@ ingress:
   domainName: "kuberpult-example.com"
 cd:
   db:
-    dbOption: cloudsql
+    dbOption: postgreSQL
     location: "127.0.0.1"
     dbName: dbName
     dbUser: dbUser
@@ -401,7 +401,7 @@ cd:
 			ExpectedEnvs: []core.EnvVar{
 				{
 					Name:  "KUBERPULT_DB_OPTION",
-					Value: "cloudsql",
+					Value: "postgreSQL",
 				},
 				{
 					Name:  "KUBERPULT_DB_LOCATION",
@@ -423,7 +423,7 @@ cd:
 			ExpectedMissing: []core.EnvVar{},
 		},
 		{
-			Name: "Database cloudsql enabled 2",
+			Name: "Database postgreSQL enabled 2",
 			Values: `
 git:
   url: "testURL"
@@ -847,7 +847,7 @@ cd:
 			},
 		},
 		{
-			Name: "Database cloudsql enabled 1",
+			Name: "Database postgreSQL enabled 1",
 			Values: `
 git:
   url: "testURL"
@@ -855,7 +855,7 @@ ingress:
   domainName: "kuberpult-example.com"
 cd:
   db:
-    dbOption: cloudsql
+    dbOption: postgreSQL
     location: "127.0.0.1"
     dbName: dbName
     dbUser: dbUser
@@ -865,7 +865,7 @@ cd:
 			ExpectedEnvs: []core.EnvVar{
 				{
 					Name:  "KUBERPULT_DB_OPTION",
-					Value: "cloudsql",
+					Value: "postgreSQL",
 				},
 				{
 					Name:  "KUBERPULT_DB_LOCATION",
@@ -887,7 +887,7 @@ cd:
 			ExpectedMissing: []core.EnvVar{},
 		},
 		{
-			Name: "Database cloudsql enabled 2",
+			Name: "Database postgreSQL enabled 2",
 			Values: `
 git:
   url: "testURL"

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -108,6 +108,8 @@ cd:
 # k8sName is required if `dbOption = "cloudsql"`, otherwise it's ignored.
 # k8sName is the name of the kubernetes service account.
     k8sName: "k8sname"
+# cloudSqlProxyEnabled enables the cloudsql proxy. Not possible with `dbOption = "NO_DB"`.
+    cloudSqlProxyEnabled: false
     dbConnectionName: "connectioname"
     dbName: "databaseName"
     dbUser: "username"

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -118,9 +118,9 @@ db:
 # If you do want to try out the database, for now use
 # writeEslTableOnly: true
   dbOption: "NO_DB"
-# k8sName is required if `dbOption = "postgreSQL"`, otherwise it's ignored.
-# k8sName is the name of the kubernetes service account.
-  k8sName: "k8sname"
+# k8sServiceAccountName is required if `dbOption = "postgreSQL"`, otherwise it's ignored.
+# k8sServiceAccountName is the name of the kubernetes service account.
+  k8sServiceAccountName: "k8sServiceAccountName"
 # cloudSqlProxyEnabled enables the cloudsql proxy. Not possible with `dbOption = "NO_DB"`.
   cloudSqlProxyEnabled: false
   dbConnectionName: "connectioname"

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -101,7 +101,7 @@ cd:
     authProxyPort: 5432
 # As the Database feature is still work in progress, for now we recommend to set:
 # dbOption: "NO_DB"
-# Other valid values are "cloudsql" and "sqlite".
+# Other valid values are "cloudsql".
 # If you do want to try out the database, for now use
 # writeEslTableOnly: true
     dbOption: "NO_DB"

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -101,11 +101,11 @@ cd:
     authProxyPort: 5432
 # As the Database feature is still work in progress, for now we recommend to set:
 # dbOption: "NO_DB"
-# Other valid values are "cloudsql".
+# Other valid values are "postgreSQL".
 # If you do want to try out the database, for now use
 # writeEslTableOnly: true
     dbOption: "NO_DB"
-# k8sName is required if `dbOption = "cloudsql"`, otherwise it's ignored.
+# k8sName is required if `dbOption = "postgreSQL"`, otherwise it's ignored.
 # k8sName is the name of the kubernetes service account.
     k8sName: "k8sname"
 # cloudSqlProxyEnabled enables the cloudsql proxy. Not possible with `dbOption = "NO_DB"`.

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -95,32 +95,6 @@ cd:
     requests:
       cpu: 2
       memory: 3Gi
-# The Database is not ready for use on production and the helm options might change in the near future.
-  db:
-    location: "127.0.0.1"
-    authProxyPort: 5432
-# As the Database feature is still work in progress, for now we recommend to set:
-# dbOption: "NO_DB"
-# Other valid values are "postgreSQL".
-# If you do want to try out the database, for now use
-# writeEslTableOnly: true
-    dbOption: "NO_DB"
-# k8sName is required if `dbOption = "postgreSQL"`, otherwise it's ignored.
-# k8sName is the name of the kubernetes service account.
-    k8sName: "k8sname"
-# cloudSqlProxyEnabled enables the cloudsql proxy. Not possible with `dbOption = "NO_DB"`.
-    cloudSqlProxyEnabled: false
-    dbConnectionName: "connectioname"
-    dbName: "databaseName"
-    dbUser: "username"
-    dbPassword: "password"
-    migrations: /migrations
-    # If set to true, kuberpult will write only the ESL table.
-    # This is useful to already collect historical data in the database, while waiting for the full database implementation.
-    writeEslTableOnly: false
-    requests:
-      cpu: "100m"
-      memory: "200Mi"
   probes:
     liveness:
       periodSeconds: 10
@@ -134,6 +108,32 @@ cd:
       timeoutSeconds: 5
       failureThreshold: 10
       initialDelaySeconds: 5
+# The Database is not ready for use on production and the helm options might change in the near future.
+db:
+  location: "127.0.0.1"
+  authProxyPort: 5432
+# As the Database feature is still work in progress, for now we recommend to set:
+# dbOption: "NO_DB"
+# Other valid values are "postgreSQL".
+# If you do want to try out the database, for now use
+# writeEslTableOnly: true
+  dbOption: "NO_DB"
+# k8sName is required if `dbOption = "postgreSQL"`, otherwise it's ignored.
+# k8sName is the name of the kubernetes service account.
+  k8sName: "k8sname"
+# cloudSqlProxyEnabled enables the cloudsql proxy. Not possible with `dbOption = "NO_DB"`.
+  cloudSqlProxyEnabled: false
+  dbConnectionName: "connectioname"
+  dbName: "databaseName"
+  dbUser: "username"
+  dbPassword: "password"
+  migrations: /migrations
+  # If set to true, kuberpult will write only the ESL table.
+  # This is useful to already collect historical data in the database, while waiting for the full database implementation.
+  writeEslTableOnly: false
+  requests:
+    cpu: "100m"
+    memory: "200Mi"
 manifestRepoExport:
   image: kuberpult-manifest-repo-export-service
   resources:

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -231,7 +231,7 @@ func RunServer() {
 		var dbHandler *db.DBHandler = nil
 		if c.DbOption != "NO_DB" {
 			var dbCfg db.DBConfig
-			if c.DbOption == "cloudsql" {
+			if c.DbOption == "postgreSQL" {
 				dbCfg = db.DBConfig{
 					DbHost:         c.DbLocation,
 					DbPort:         c.DbAuthProxyPort,

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -151,7 +151,7 @@ func Run(ctx context.Context) error {
 	argoCdGenerateFiles := argoCdGenerateFilesString == "true"
 
 	var dbCfg db.DBConfig
-	if dbOption == "cloudsql" {
+	if dbOption == "postgreSQL" {
 		dbCfg = db.DBConfig{
 			DbHost:         dbLocation,
 			DbPort:         dbAuthProxyPort,

--- a/tests/integration-tests/cluster-setup/argocd-kuberpult.sh
+++ b/tests/integration-tests/cluster-setup/argocd-kuberpult.sh
@@ -129,10 +129,9 @@ kubectl create ns staging
 print 'installing kuberpult helm chart...'
 
 cat <<VALUES > vals.yaml
+db:
+  dbOption: NO_DB
 cd:
-  db:
-    dbOption: sqlite
-    location: /sqlite
   resources:
     limits:
       memory: 200Mi


### PR DESCRIPTION
Refactored helm charts.
All options under cd.db. are moved to db. in helm charts.
The dbOption cloudsql is renamed to "postgreSQL".
The sqlite db option is removed.
A helm parameter is added cloudSqlProxyEnabled: true that just adds the proxy

BREAKING CHANGE: helm chart values related to db change. dbOption cloudsql should be renamed to postgreSQL. Options under cd.db should move to db.
