### PR TITLE
chore(ui): option to select timezone in events page

### DIFF
--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.scss
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.scss
@@ -68,4 +68,7 @@ Copyright freiheit.com*/
             width: 25%;
         }
     }
+    .select-timezone {
+        margin-bottom: 10px;
+    }
 }

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.test.tsx
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.test.tsx
@@ -152,26 +152,26 @@ test('CommitInfo component renders commit info when the response is valid', () =
             expectedEventsTable: {
                 head: ['Date:', 'Event Description:', 'Environments:'],
                 body: [
-                    ['2024-02-09T09:46:00', 'received data about this commit for the first time', 'dev, staging'],
-                    ['2024-02-10T09:46:00', 'Single deployment of application app to environment dev', 'dev'],
+                    ['2/9/2024, 09:46:00 AM', 'received data about this commit for the first time', 'dev, staging'],
+                    ['2/10/2024, 09:46:00 AM', 'Single deployment of application app to environment dev', 'dev'],
                     [
-                        '2024-02-11T09:46:00',
+                        '2/11/2024, 09:46:00 AM',
                         'Release train deployment of application app from environment dev to environment staging',
                         'staging',
                     ],
                     [
-                        '2024-02-12T09:46:00',
+                        '2/12/2024, 09:46:00 AM',
                         'Release train deployment of application app on environment group staging-group from environment dev to environment staging',
                         'staging',
                     ],
                     [
-                        '2024-02-13T09:46:00',
+                        '2/13/2024, 09:46:00 AM',
                         'Application app was blocked from deploying due to an environment lock with message "locked"',
                         'dev',
                     ],
-                    ['2024-02-13T09:46:00', 'This commit was replaced by 12345678 on dev.', 'dev'],
+                    ['2/13/2024, 09:46:00 AM', 'This commit was replaced by 12345678 on dev.', 'dev'],
                     [
-                        '2024-02-13T09:46:00',
+                        '2/13/2024, 09:46:00 AM',
                         'Application app was blocked from deploying due to a team lock with message "locked"',
                         'dev',
                     ],

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
@@ -111,30 +111,27 @@ export const CommitInfo: React.FC<CommitInfoProps> = (props) => {
 
 const CommitInfoEvents: React.FC<{ events: Event[] }> = (props) => {
     const [timezone, setTimezone] = useState<'UTC' | 'local'>('UTC');
-    const handleTimezoneToggle = (): void => {
-        setTimezone((preve) => (preve === 'local' ? 'UTC' : 'local'));
-    };
+    const handleChangeTimezone = React.useCallback(
+        (event: React.ChangeEvent<HTMLSelectElement>) => {
+            if (event.target.value === 'local' || event.target.value === 'UTC') {
+                setTimezone(event.target.value);
+            }
+        },
+        [setTimezone]
+    );
     const formatDate = (date: Date | undefined): string => {
         if (!date) return '';
         const selectedTimezone = timezone === 'local' ? Intl.DateTimeFormat().resolvedOptions().timeZone : 'UTC';
-        return date.toLocaleString('en-US', {
-            timeZone: selectedTimezone,
-            year: 'numeric',
-            month: 'numeric',
-            day: 'numeric',
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-        });
+        const localizedDate = new Date(
+            date.toLocaleString('en-US', {
+                timeZone: selectedTimezone,
+            })
+        );
+        return localizedDate.toISOString().split('.')[0];
     };
-    const handleToggleClick = handleTimezoneToggle;
     return (
         <div>
-            <select
-                className={'select-timezone'}
-                value={timezone}
-                onChange={handleToggleClick}
-                style={{ marginBottom: 10 }}>
+            <select className={'select-timezone'} value={timezone} onChange={handleChangeTimezone}>
                 <option value="local">Local Timezone</option>
                 <option value="UTC">UTC Timezone</option>
             </select>

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
@@ -111,6 +111,7 @@ export const CommitInfo: React.FC<CommitInfoProps> = (props) => {
 
 const CommitInfoEvents: React.FC<{ events: Event[] }> = (props) => {
     const [timezone, setTimezone] = useState<'UTC' | 'local'>('UTC');
+    const localTimezone = Intl.DateTimeFormat()?.resolvedOptions()?.timeZone ?? 'Europe/Berlin';
     const handleChangeTimezone = React.useCallback(
         (event: React.ChangeEvent<HTMLSelectElement>) => {
             if (event.target.value === 'local' || event.target.value === 'UTC') {
@@ -121,7 +122,7 @@ const CommitInfoEvents: React.FC<{ events: Event[] }> = (props) => {
     );
     const formatDate = (date: Date | undefined): string => {
         if (!date) return '';
-        const selectedTimezone = timezone === 'local' ? Intl.DateTimeFormat().resolvedOptions().timeZone : 'UTC';
+        const selectedTimezone = timezone === 'local' ? localTimezone : 'UTC';
         const localizedDate = new Date(
             date.toLocaleString('en-US', {
                 timeZone: selectedTimezone,
@@ -132,7 +133,7 @@ const CommitInfoEvents: React.FC<{ events: Event[] }> = (props) => {
     return (
         <div>
             <select className={'select-timezone'} value={timezone} onChange={handleChangeTimezone}>
-                <option value="local">Local Timezone</option>
+                <option value="local">{localTimezone} Timezone</option>
                 <option value="UTC">UTC Timezone</option>
             </select>
             <table className={'events'} border={1}>

--- a/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
+++ b/services/frontend-service/src/ui/components/CommitInfo/CommitInfo.tsx
@@ -13,7 +13,7 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright freiheit.com*/
-
+import React, { useState } from 'react';
 import { TopAppBar } from '../TopAppBar/TopAppBar';
 import { GetCommitInfoResponse, Event, LockPreventedDeploymentEvent_LockType } from '../../../api/api';
 
@@ -109,30 +109,60 @@ export const CommitInfo: React.FC<CommitInfoProps> = (props) => {
     );
 };
 
-const CommitInfoEvents: React.FC<{ events: Event[] }> = (props) => (
-    <table className={'events'} border={1}>
-        <thead>
-            <tr>
-                <th className={'date'}>Date:</th>
-                <th className={'description'}>Event Description:</th>
-                <th className={'environments'}>Environments:</th>
-            </tr>
-        </thead>
-        <tbody>
-            {props.events.map((event, _) => {
-                const createdAt = event.createdAt?.toISOString() || '';
-                const [description, environments] = eventDescription(event);
-                return (
-                    <tr key={event.uuid}>
-                        <td>{createdAt}</td>
-                        <td>{description}</td>
-                        <td>{environments}</td>
+const CommitInfoEvents: React.FC<{ events: Event[] }> = (props) => {
+    const [timezone, setTimezone] = useState<'UTC' | 'local'>('UTC');
+    const handleTimezoneToggle = (): void => {
+        setTimezone((preve) => (preve === 'local' ? 'UTC' : 'local'));
+    };
+    const formatDate = (date: Date | undefined): string => {
+        if (!date) return '';
+        const selectedTimezone = timezone === 'local' ? Intl.DateTimeFormat().resolvedOptions().timeZone : 'UTC';
+        return date.toLocaleString('en-US', {
+            timeZone: selectedTimezone,
+            year: 'numeric',
+            month: 'numeric',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+        });
+    };
+    const handleToggleClick = handleTimezoneToggle;
+    return (
+        <div>
+            <select
+                className={'select-timezone'}
+                value={timezone}
+                onChange={handleToggleClick}
+                style={{ marginBottom: 10 }}>
+                <option value="local">Local Timezone</option>
+                <option value="UTC">UTC Timezone</option>
+            </select>
+            <table className={'events'} border={1}>
+                <thead>
+                    <tr>
+                        <th className={'date'}>Date:</th>
+                        <th className={'description'}>Event Description:</th>
+                        <th className={'environments'}>Environments:</th>
                     </tr>
-                );
-            })}
-        </tbody>
-    </table>
-);
+                </thead>
+                <tbody>
+                    {props.events.map((event, _) => {
+                        const createdAt = formatDate(event.createdAt);
+                        const [description, environments] = eventDescription(event);
+                        return (
+                            <tr key={event.uuid}>
+                                <td>{createdAt}</td>
+                                <td>{description}</td>
+                                <td>{environments}</td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
+    );
+};
 
 const eventDescription = (event: Event): [JSX.Element, string] => {
     const tp = event.eventType;


### PR DESCRIPTION
Added a select option to select local or utc timezone in events page.
<img width="1126" alt="Screenshot 2024-07-03 at 17 06 41" src="https://github.com/freiheit-com/kuberpult/assets/22098895/54958160-8db8-4d1e-b2c9-aa51b643ee19">
<img width="1126" alt="Screenshot 2024-07-03 at 17 07 49" src="https://github.com/freiheit-com/kuberpult/assets/22098895/d91acb66-0832-4f11-8c12-0ee380cb7170">

