### PR TITLE
chore(ci): Only create pre-releases by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           changelog-generator-opt: "emojis=true"
+          # By default, every release is a "pre-release" from now on.
+          # Setting this flag to true will happen manually (after testing).
+          prerelease: true
       - name: Append helm chart to release
         run: |
           echo $VERSION


### PR DESCRIPTION
Up until now, kuberpult only had "full" releases on GitHub: https://github.com/freiheit-com/kuberpult/releases
This PR changes that to make the distinction between "pre-release" (the new default) and "full release", which will only be set manually.