### PR TITLE
feat: Add full name override for DEX resources

### DIFF
--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -145,6 +145,8 @@ spec:
         - name: KUBERPULT_DEX_ENABLED
           value: "{{ .Values.auth.dexAuth.enabled }}"
 {{- if .Values.auth.dexAuth.enabled }}
+        - name: KUBERPULT_DEX_FULL_NAME_OVERRIDE
+          value: "{{ .Values.auth.dexAuth.fullNameOverride }}"
         - name: KUBERPULT_DEX_CLIENT_ID
           value: "{{ .Values.auth.dexAuth.clientId }}"
         - name: KUBERPULT_DEX_CLIENT_SECRET

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -306,6 +306,8 @@ auth:
     enabled: false
     # Indicates if dex is to be installed. If you want to use your own Dex instance do not enable this flag.
     installDex: false
+    # Overrides the name of the dex resources. Allows creating multiple Dex instances on the same cluster. 
+    fullNameOverride: ""
     # If kuberpult cannot find a role in the dex response, it will use the role "default".
     # This is only recommended for when you want the simplest possible setup, or for testing purposes.
     defaultRoleEnabled: false

--- a/pkg/auth/dex.go
+++ b/pkg/auth/dex.go
@@ -296,7 +296,7 @@ func (a *DexAppClient) oauth2Config(scopes []string) (c *oauth2.Config, err erro
 }
 
 // Verifies if the user is authenticated.
-func VerifyToken(ctx context.Context, r *http.Request, clientID, baseURL, dexServiceURL string, useClusterInternalCommunication bool) (jwt.MapClaims, error) {
+func VerifyToken(ctx context.Context, r *http.Request, clientID, baseURL, dexFullNameOverride string, useClusterInternalCommunication bool) (jwt.MapClaims, error) {
 	// Get the token cookie from the request
 	cookie, err := r.Cookie(dexOAUTHTokenName)
 
@@ -315,6 +315,9 @@ func VerifyToken(ctx context.Context, r *http.Request, clientID, baseURL, dexSer
 	} else {
 		tokenString = cookie.Value
 	}
+
+	// Get the dex service name
+	dexServiceURL := fmt.Sprintf(dexServiceURLPattern, dexFullNameOverride)
 
 	// Validates token audience and expiring date.
 	idToken, err := ValidateOIDCToken(ctx, baseURL+issuerPATH, tokenString, clientID, dexServiceURL, useClusterInternalCommunication)

--- a/pkg/auth/dex.go
+++ b/pkg/auth/dex.go
@@ -88,6 +88,7 @@ func NewDexAppClient(clientID, clientSecret, baseURL, nameOverride string, scope
 		RedirectURI:                     baseURL + callbackPATH,
 		IssuerURL:                       baseURL + issuerPATH,
 		UseClusterInternalCommunication: useClusterInternalCommunication,
+		DexServiceURL:                   fmt.Sprintf(dexServiceURLPattern, nameOverride),
 	}
 	//exhaustruct:ignore
 	transport := &http.Transport{
@@ -104,7 +105,6 @@ func NewDexAppClient(clientID, clientSecret, baseURL, nameOverride string, scope
 		DexURL: dexURL,
 		T:      a.Client.Transport,
 	}
-	a.DexServiceURL = fmt.Sprintf(dexServiceURLPattern, nameOverride)
 
 	// Register Dex handlers.
 	a.registerDexHandlers()

--- a/pkg/auth/dex.go
+++ b/pkg/auth/dex.go
@@ -42,6 +42,8 @@ type DexAuthContext struct {
 
 // Dex App Client.
 type DexAppClient struct {
+	// Dex service internal URL. Used to connect to dex internally in the cluster.
+	DexServiceURL string
 	// The Dex issuer URL. Needs to be match the dex issuer helm config.
 	IssuerURL string
 	// The host Kuberpult is running on.
@@ -62,7 +64,7 @@ type DexAppClient struct {
 
 const (
 	// Dex service internal URL. Used to connect to dex internally in the cluster.
-	dexServiceURL = "http://kuberpult-dex:5556"
+	dexServiceURLPattern = "http://%s:5556"
 	// Dex issuer path. Needs to be match the dex issuer helm config.
 	issuerPATH = "/dex"
 	// Dex callback path. Needs to be match the dex staticClients.redirectURIs helm config.
@@ -76,7 +78,7 @@ const (
 )
 
 // NewDexAppClient a Dex Client.
-func NewDexAppClient(clientID, clientSecret, baseURL string, scopes []string, useClusterInternalCommunication bool) (*DexAppClient, error) {
+func NewDexAppClient(clientID, clientSecret, baseURL, nameOverride string, scopes []string, useClusterInternalCommunication bool) (*DexAppClient, error) {
 	a := DexAppClient{
 		Client:                          nil,
 		ClientID:                        clientID,
@@ -97,11 +99,12 @@ func NewDexAppClient(clientID, clientSecret, baseURL string, scopes []string, us
 	}
 
 	// Creates a transport layer to map all requests to dex internally
-	dexURL, _ := url.Parse(dexServiceURL)
+	dexURL, _ := url.Parse(fmt.Sprintf(dexServiceURLPattern, nameOverride))
 	a.Client.Transport = DexRewriteURLRoundTripper{
 		DexURL: dexURL,
 		T:      a.Client.Transport,
 	}
+	a.DexServiceURL = fmt.Sprintf(dexServiceURLPattern, nameOverride)
 
 	// Register Dex handlers.
 	a.registerDexHandlers()
@@ -126,7 +129,7 @@ func (s DexRewriteURLRoundTripper) RoundTrip(r *http.Request) (*http.Response, e
 // Registers dex handlers for login
 func (a *DexAppClient) registerDexHandlers() {
 	// Handles calls to the Dex server. Calls are redirected internally using a reverse proxy.
-	http.HandleFunc(issuerPATH+"/", NewDexReverseProxy(dexServiceURL))
+	http.HandleFunc(issuerPATH+"/", NewDexReverseProxy(a.DexServiceURL))
 	// Handles the login callback to redirect to dex page.
 	http.HandleFunc(LoginPATH, a.handleDexLogin)
 	// Call back to the current app once the login is finished
@@ -212,7 +215,7 @@ func (a *DexAppClient) handleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	idToken, err := ValidateOIDCToken(ctx, a.IssuerURL, idTokenRAW, a.ClientID, a.UseClusterInternalCommunication)
+	idToken, err := ValidateOIDCToken(ctx, a.IssuerURL, idTokenRAW, a.ClientID, a.DexServiceURL, a.UseClusterInternalCommunication)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to verify the token: %v", err), http.StatusInternalServerError)
 		return
@@ -240,7 +243,7 @@ func (a *DexAppClient) handleCallback(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, a.BaseURL, http.StatusSeeOther)
 }
 
-func ValidateOIDCToken(ctx context.Context, issuerURL, rawToken string, allowedAudience string, useClusterInternalCommunication bool) (token *oidc.IDToken, err error) {
+func ValidateOIDCToken(ctx context.Context, issuerURL, rawToken, allowedAudience, dexServiceURL string, useClusterInternalCommunication bool) (token *oidc.IDToken, err error) {
 	var p *oidc.Provider
 	// Token must be verified against an allowed audience.
 	//exhaustruct:ignore
@@ -258,7 +261,7 @@ func ValidateOIDCToken(ctx context.Context, issuerURL, rawToken string, allowedA
 			Algorithms:    []string{"RS256"},
 		}
 		p = pc.NewProvider(ctx)
-		// As the issuer is e.g. https://kuberpult.com/dex and the providerBaseUrl is http://kuberpult-dex:5556/dex we need to SkipIssuerChecks
+		// As the issuer is e.g. https://kuberpult.com/dex and the providerBaseUrl is http://kuberpult-dex:5556/dex (default) we need to SkipIssuerChecks
 		config.SkipIssuerCheck = true
 	} else {
 		p, err = oidc.NewProvider(ctx, issuerURL)
@@ -293,7 +296,7 @@ func (a *DexAppClient) oauth2Config(scopes []string) (c *oauth2.Config, err erro
 }
 
 // Verifies if the user is authenticated.
-func VerifyToken(ctx context.Context, r *http.Request, clientID, baseURL string, useClusterInternalCommunication bool) (jwt.MapClaims, error) {
+func VerifyToken(ctx context.Context, r *http.Request, clientID, baseURL, dexServiceURL string, useClusterInternalCommunication bool) (jwt.MapClaims, error) {
 	// Get the token cookie from the request
 	cookie, err := r.Cookie(dexOAUTHTokenName)
 
@@ -314,7 +317,7 @@ func VerifyToken(ctx context.Context, r *http.Request, clientID, baseURL string,
 	}
 
 	// Validates token audience and expiring date.
-	idToken, err := ValidateOIDCToken(ctx, baseURL+issuerPATH, tokenString, clientID, useClusterInternalCommunication)
+	idToken, err := ValidateOIDCToken(ctx, baseURL+issuerPATH, tokenString, clientID, dexServiceURL, useClusterInternalCommunication)
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify token: %s", err)
 	}

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -242,7 +242,7 @@ func runServer(ctx context.Context) error {
 	var dexClient *auth.DexAppClient
 	if c.DexEnabled {
 		// Registers Dex handlers.
-		dexClient, err = auth.NewDexAppClient(c.DexClientId, c.DexClientSecret, c.DexBaseURL, auth.ReadScopes(c.DexScopes), c.DexUseClusterInternalCommunication)
+		dexClient, err = auth.NewDexAppClient(c.DexClientId, c.DexClientSecret, c.DexBaseURL, c.DexFullNameOverride, auth.ReadScopes(c.DexScopes), c.DexUseClusterInternalCommunication)
 		if err != nil {
 			logger.FromContext(ctx).Fatal("error registering dex handlers: ", zap.Error(err))
 		}

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -342,7 +342,7 @@ func runServer(ctx context.Context) error {
 	restHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer readAllAndClose(req.Body, 1024)
 		if c.DexEnabled {
-			interceptors.DexLoginInterceptor(w, req, httpHandler.Handle, c.DexClientId, c.DexBaseURL, policy, c.DexUseClusterInternalCommunication)
+			interceptors.DexLoginInterceptor(w, req, httpHandler.Handle, c.DexClientId, c.DexBaseURL, dexClient.DexServiceURL, policy, c.DexUseClusterInternalCommunication)
 			return
 		}
 		httpHandler.Handle(w, req)
@@ -366,7 +366,7 @@ func runServer(ctx context.Context) error {
 		}
 
 		if c.DexEnabled {
-			interceptors.DexAPIInterceptor(w, req, httpHandler.HandleAPI, c.DexClientId, c.DexBaseURL, policy, c.DexUseClusterInternalCommunication)
+			interceptors.DexAPIInterceptor(w, req, httpHandler.HandleAPI, c.DexClientId, c.DexBaseURL, dexClient.DexServiceURL, policy, c.DexUseClusterInternalCommunication)
 			return
 		}
 
@@ -563,7 +563,7 @@ func (p *Auth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		if c.DexEnabled {
 			source = "dex"
-			dexAuthContext := getUserFromDex(w, r, c.DexClientId, c.DexBaseURL, p.Policy, c.DexUseClusterInternalCommunication)
+			dexAuthContext := getUserFromDex(w, r, c.DexClientId, c.DexBaseURL, c.DexFullNameOverride, p.Policy, c.DexUseClusterInternalCommunication)
 			if dexAuthContext == nil {
 				logger.FromContext(ctx).Info(fmt.Sprintf("No role assigned from Dex user: %v", user))
 			} else {
@@ -597,8 +597,8 @@ func (p *Auth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getUserFromDex(w http.ResponseWriter, req *http.Request, clientID, baseURL string, policy *auth.RBACPolicies, useClusterInternalCommunication bool) *auth.DexAuthContext {
-	httpCtx, err := interceptors.GetContextFromDex(w, req, clientID, baseURL, policy, useClusterInternalCommunication)
+func getUserFromDex(w http.ResponseWriter, req *http.Request, clientID, baseURL, dexFullNameOverride string, policy *auth.RBACPolicies, useClusterInternalCommunication bool) *auth.DexAuthContext {
+	httpCtx, err := interceptors.GetContextFromDex(w, req, clientID, baseURL, dexFullNameOverride, policy, useClusterInternalCommunication)
 	if err != nil {
 		return nil
 	}

--- a/services/frontend-service/pkg/config/config.go
+++ b/services/frontend-service/pkg/config/config.go
@@ -40,6 +40,7 @@ type ServerConfig struct {
 	DexClientSecret                    string        `default:"" split_words:"true"`
 	DexRbacPolicyPath                  string        `split_words:"true"`
 	DexBaseURL                         string        `default:"" split_words:"true"`
+	DexFullNameOverride                string        `default:"kuberpult-dex" split_words:"true"`
 	DexScopes                          string        `default:"" split_words:"true"`
 	DexUseClusterInternalCommunication bool          `default:"false" split_words:"true"`
 	Version                            string        `default:""`

--- a/services/frontend-service/pkg/handler/handle.go
+++ b/services/frontend-service/pkg/handler/handle.go
@@ -20,11 +20,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/freiheit-com/kuberpult/pkg/auth"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/freiheit-com/kuberpult/pkg/auth"
 
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
 	xpath "github.com/freiheit-com/kuberpult/pkg/path"
@@ -114,7 +115,7 @@ func (s Server) HandleDex(w http.ResponseWriter, r *http.Request, client *auth.D
 	httpClient := &http.Client{}
 	dexContactUrl := ""
 	if client.UseClusterInternalCommunication {
-		dexContactUrl = "http://kuberpult-dex:5556"
+		dexContactUrl = client.DexServiceURL
 	} else {
 		dexContactUrl = client.BaseURL
 	}

--- a/services/frontend-service/pkg/interceptors/interceptors.go
+++ b/services/frontend-service/pkg/interceptors/interceptors.go
@@ -147,9 +147,9 @@ func DexLoginInterceptor(
 	w http.ResponseWriter,
 	req *http.Request,
 	httpHandler http.HandlerFunc,
-	clientID, baseURL string, DexRbacPolicy *auth.RBACPolicies, useClusterInternalCommunication bool,
+	clientID, baseURL, dexServiceURL string, DexRbacPolicy *auth.RBACPolicies, useClusterInternalCommunication bool,
 ) {
-	httpCtx, err := GetContextFromDex(w, req, clientID, baseURL, DexRbacPolicy, useClusterInternalCommunication)
+	httpCtx, err := GetContextFromDex(w, req, clientID, baseURL, dexServiceURL, DexRbacPolicy, useClusterInternalCommunication)
 	if err != nil {
 		logger.FromContext(req.Context()).Debug(fmt.Sprintf("Error verifying token for Dex: %s", err))
 		// If user is not authenticated redirect to the login page.
@@ -168,9 +168,9 @@ func DexAPIInterceptor(
 	w http.ResponseWriter,
 	req *http.Request,
 	httpHandler http.HandlerFunc,
-	clientID, baseURL string, DexRbacPolicy *auth.RBACPolicies, useClusterInternalCommunication bool,
+	clientID, baseURL, dexServiceURL string, DexRbacPolicy *auth.RBACPolicies, useClusterInternalCommunication bool,
 ) {
-	httpCtx, err := GetContextFromDex(w, req, clientID, baseURL, DexRbacPolicy, useClusterInternalCommunication)
+	httpCtx, err := GetContextFromDex(w, req, clientID, baseURL, dexServiceURL, DexRbacPolicy, useClusterInternalCommunication)
 	if err != nil {
 		logger.FromContext(req.Context()).Debug(fmt.Sprintf("Error verifying token for Dex: %s", err))
 		// If user is not authenticated respond with unauthorized
@@ -181,8 +181,8 @@ func DexAPIInterceptor(
 	httpHandler(w, req)
 }
 
-func GetContextFromDex(w http.ResponseWriter, req *http.Request, clientID, baseURL string, DexRbacPolicy *auth.RBACPolicies, useClusterInternalCommunication bool) (context.Context, error) {
-	claims, err := auth.VerifyToken(req.Context(), req, clientID, baseURL, useClusterInternalCommunication)
+func GetContextFromDex(w http.ResponseWriter, req *http.Request, clientID, baseURL, dexFullNameOverride string, DexRbacPolicy *auth.RBACPolicies, useClusterInternalCommunication bool) (context.Context, error) {
+	claims, err := auth.VerifyToken(req.Context(), req, clientID, baseURL, dexFullNameOverride, useClusterInternalCommunication)
 	if err != nil {
 		logger.FromContext(req.Context()).Info(fmt.Sprintf("Error verifying token for Dex: %s", err))
 		return req.Context(), err


### PR DESCRIPTION
When installing multiple instances of Kuberpult using Dex on the same cluster, there are namespace independent resources such as ClusterRoles that need to have a different naming. 

Dex allows this by setting the fullNameOverride that allows to provide a custom naming for all Dex resources.  Kuberpult needs to make the DexServiceURL configurable and do not use a constant value. 