### PR TITLE
fix(dex): restore default value for fullNameOverride

### DIFF
--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -307,7 +307,7 @@ auth:
     # Indicates if dex is to be installed. If you want to use your own Dex instance do not enable this flag.
     installDex: false
     # Overrides the name of the dex resources. Allows creating multiple Dex instances on the same cluster. 
-    fullNameOverride: ""
+    fullNameOverride: "kuberpult-dex"
     # If kuberpult cannot find a role in the dex response, it will use the role "default".
     # This is only recommended for when you want the simplest possible setup, or for testing purposes.
     defaultRoleEnabled: false


### PR DESCRIPTION
This change restores the original behavior of "fullNameOverride", so that there is no breaking change in the helm chart values.

The field was introduced in #1734 where the default value was changed accidentally.