### PR TITLE
fix: Fix random hash generation for create-release.sh on MacOS

### DIFF
--- a/infrastructure/scripts/create-testdata/create-release.sh
+++ b/infrastructure/scripts/create-testdata/create-release.sh
@@ -11,7 +11,7 @@ applicationOwnerTeam=${2:-sreteam}
 prev=${3:-""}
 
 # 40 is the length of a full git commit hash.
-commit_id=$(LC_CTYPE=C tr -dc a-f0-9 </dev/urandom | head -c 40 ; echo '')
+commit_id=$(head -c 20 /dev/urandom | sha1sum | awk '{print $1}') # SHA-1 produces 40-character hashes 
 authors[0]="urbansky"
 authors[1]="Medo"
 authors[2]="Hannes"
@@ -67,7 +67,7 @@ for env in development development2 staging fakeprod-de fakeprod-ca
 do
   file=$(mktemp "${TMPDIR:-/tmp}/$env.XXXXXX")
   signatureFile=$(mktemp "${TMPDIR:-/tmp}/$env.XXXXXX")
-  randomValue=$(LC_CTYPE=C tr -dc a-f0-9 </dev/urandom | head -c 12 ; echo '')
+  randomValue=$(head -c 20 /dev/urandom | sha1sum | awk '{print $1}' | head -c 12)
 cat <<EOF > "${file}"
 ---
 apiVersion: v1


### PR DESCRIPTION
Use `sha1sum` to generate the hashes instead of relying on the output of `/dev/urandom`