### PR TITLE
feat: Add Login Page when Dex enabled and validate token

### DIFF
--- a/services/frontend-service/package.json
+++ b/services/frontend-service/package.json
@@ -22,6 +22,7 @@
     "@peculiar/webcrypto": "1.4.5",
     "@types/react-beforeunload": "2.1.5",
     "classnames": "2.5.1",
+    "jwt-decode": "4.0.0", 
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.24.1",

--- a/services/frontend-service/src/setupTests.ts
+++ b/services/frontend-service/src/setupTests.ts
@@ -113,8 +113,9 @@ export const fakeLoadEverything = (load: boolean): void => {
 
 export const enableDexAuth = (setValidToken: boolean) => {
     if (setValidToken) {
-        // Dummy token with expiring date on year 56494 
-        document.cookie = 'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTc3Nzd9.p3ApN5elnhhRhrh7DCOF-9suPIXYC36Nycf0nHfxuf8';
+        // Dummy token with expiring date on year 56494
+        document.cookie =
+            'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTc3Nzd9.p3ApN5elnhhRhrh7DCOF-9suPIXYC36Nycf0nHfxuf8';
     }
     UpdateFrontendConfig.set({
         configs: {

--- a/services/frontend-service/src/setupTests.ts
+++ b/services/frontend-service/src/setupTests.ts
@@ -111,7 +111,7 @@ export const fakeLoadEverything = (load: boolean): void => {
     });
 };
 
-export const enableDexAuth = (setValidToken: boolean) => {
+export const enableDexAuth = (setValidToken: boolean): void => {
     if (setValidToken) {
         // Dummy token with expiring date on year 56494
         document.cookie =

--- a/services/frontend-service/src/setupTests.ts
+++ b/services/frontend-service/src/setupTests.ts
@@ -110,3 +110,24 @@ export const fakeLoadEverything = (load: boolean): void => {
         tagsReady: load,
     });
 };
+
+export const enableDexAuth = (setValidToken: boolean) => {
+    if (setValidToken) {
+        // Dummy token with expiring date on year 56494 
+        document.cookie = 'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTc3Nzd9.p3ApN5elnhhRhrh7DCOF-9suPIXYC36Nycf0nHfxuf8';
+    }
+    UpdateFrontendConfig.set({
+        configs: {
+            argoCd: undefined,
+            authConfig: {
+                dexAuth: {
+                    enabled: true,
+                },
+            },
+            kuberpultVersion: 'dontcare',
+            manifestRepoUrl: 'dontcare',
+            sourceRepoUrl: 'dontcare',
+            branch: 'dontcare',
+        },
+    });
+};

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -73,9 +73,6 @@ export const App: React.FC = () => {
             .then(
                 (result: GetFrontendConfigResponse) => {
                     UpdateFrontendConfig.set({ configs: result, configReady: true });
-                    if (result.authConfig?.dexAuth?.enabled) {
-                        // TODO(BB): set the redirect to /login here
-                    }
                 },
                 (error) => {
                     // eslint-disable-next-line no-console

--- a/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
@@ -169,7 +169,7 @@ Commit message body line 2`,
                 commitInfoReady: CommitInfoState.READY,
                 response: {
                     commitHash: 'potato',
-                    touchedApps: ['google', 'windows'],
+                    touchedApps: ['firstApp', 'secondApp'],
                     commitMessage: `Add google to windows
 Commit message body line 1
 Commit message body line 2`,
@@ -204,7 +204,7 @@ Commit message body line 2`,
             expect(container.getElementsByClassName('main-content commit-page')).toHaveLength(
                 tc.expectedMainContentCount
             );
-            expect(container.getElementsByClassName('release_train_button')).toHaveLength(tc.expectedNumLoginPage);
+            expect(container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')).toHaveLength(tc.expectedNumLoginPage);
             expect(container.textContent).toContain(tc.expectedText);
         });
     });

--- a/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
@@ -148,7 +148,7 @@ Commit message body line 2`,
             enableDexValidToken: false,
             commitHash: 'potato',
             expectedSpinnerCount: 0,
-            expectedMainContentCount: 1,
+            expectedMainContentCount: 0,
             expectedText: 'Log in to Dex',
             commitInfoStoreData: {
                 commitInfoReady: CommitInfoState.LOADING,

--- a/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
@@ -204,7 +204,9 @@ Commit message body line 2`,
             expect(container.getElementsByClassName('main-content commit-page')).toHaveLength(
                 tc.expectedMainContentCount
             );
-            expect(container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')).toHaveLength(tc.expectedNumLoginPage);
+            expect(
+                container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')
+            ).toHaveLength(tc.expectedNumLoginPage);
             expect(container.textContent).toContain(tc.expectedText);
         });
     });

--- a/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
@@ -185,7 +185,7 @@ Commit message body line 2`,
         test(tc.name, () => {
             fakeLoadEverything(tc.fakeLoadEverything);
             if (tc.commitInfoStoreData !== undefined) updateCommitInfo.set(tc.commitInfoStoreData);
-            if (tc.enableDex == true) {
+            if (tc.enableDex) {
                 enableDexAuth(tc.enableDexValidToken);
             }
 

--- a/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
@@ -186,7 +186,7 @@ Commit message body line 2`,
             fakeLoadEverything(tc.fakeLoadEverything);
             if (tc.commitInfoStoreData !== undefined) updateCommitInfo.set(tc.commitInfoStoreData);
             if (tc.enableDex == true) {
-                enableDexAuth(tc.enableDexValidToken)
+                enableDexAuth(tc.enableDexValidToken);
             }
 
             const { container } = render(

--- a/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
@@ -149,7 +149,7 @@ Commit message body line 2`,
             commitHash: 'potato',
             expectedSpinnerCount: 0,
             expectedMainContentCount: 1,
-            expectedText: 'Login Into Dex',
+            expectedText: 'Log in to Dex',
             commitInfoStoreData: {
                 commitInfoReady: CommitInfoState.LOADING,
                 response: undefined,
@@ -204,7 +204,7 @@ Commit message body line 2`,
             expect(container.getElementsByClassName('main-content commit-page')).toHaveLength(
                 tc.expectedMainContentCount
             );
-            expect(container.getElementsByClassName('login-page')).toHaveLength(tc.expectedNumLoginPage);
+            expect(container.getElementsByClassName('release_train_button')).toHaveLength(tc.expectedNumLoginPage);
             expect(container.textContent).toContain(tc.expectedText);
         });
     });

--- a/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.test.tsx
@@ -17,7 +17,7 @@ Copyright freiheit.com*/
 import { render } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { CommitInfoPage } from './CommitInfoPage';
-import { fakeLoadEverything } from '../../../setupTests';
+import { fakeLoadEverything, enableDexAuth } from '../../../setupTests';
 import { updateCommitInfo, CommitInfoState } from '../../utils/store';
 import { GetCommitInfoResponse } from '../../../api/api';
 
@@ -26,6 +26,8 @@ describe('Commit info page tests', () => {
         name: string;
         commitHash: string;
         fakeLoadEverything: boolean;
+        enableDex: boolean;
+        enableDexValidToken: boolean;
         commitInfoStoreData:
             | {
                   commitInfoReady: CommitInfoState;
@@ -35,12 +37,15 @@ describe('Commit info page tests', () => {
         expectedSpinnerCount: number;
         expectedMainContentCount: number;
         expectedText: string;
+        expectedNumLoginPage: number;
     };
 
     const testCases: TestCase[] = [
         {
             name: 'A loading spinner renders when the page is still loading',
             fakeLoadEverything: false,
+            enableDex: false,
+            enableDexValidToken: false,
             commitHash: 'potato',
             expectedSpinnerCount: 1,
             expectedMainContentCount: 0,
@@ -49,10 +54,13 @@ describe('Commit info page tests', () => {
                 commitInfoReady: CommitInfoState.LOADING,
                 response: undefined,
             },
+            expectedNumLoginPage: 0,
         },
         {
             name: 'An Error is shown when the commit ID is not provided in the URL',
             fakeLoadEverything: true,
+            enableDex: false,
+            enableDexValidToken: false,
             commitHash: '',
             expectedSpinnerCount: 0,
             expectedMainContentCount: 1,
@@ -61,10 +69,13 @@ describe('Commit info page tests', () => {
                 commitInfoReady: CommitInfoState.LOADING,
                 response: undefined,
             },
+            expectedNumLoginPage: 0,
         },
         {
             name: 'A spinner is shown when waiting for the server to respond',
             fakeLoadEverything: true,
+            enableDex: false,
+            enableDexValidToken: false,
             commitHash: 'potato',
             expectedSpinnerCount: 1,
             expectedMainContentCount: 0,
@@ -73,10 +84,13 @@ describe('Commit info page tests', () => {
                 commitInfoReady: CommitInfoState.LOADING,
                 response: undefined,
             },
+            expectedNumLoginPage: 0,
         },
         {
             name: 'An error message is shown when the backend returns an error',
             fakeLoadEverything: true,
+            enableDex: false,
+            enableDexValidToken: false,
             commitHash: 'potato',
             expectedSpinnerCount: 0,
             expectedMainContentCount: 1,
@@ -85,10 +99,13 @@ describe('Commit info page tests', () => {
                 response: undefined,
                 commitInfoReady: CommitInfoState.ERROR,
             },
+            expectedNumLoginPage: 0,
         },
         {
             name: 'An error message is shown when the backend returns a not found status',
             fakeLoadEverything: true,
+            enableDex: false,
+            enableDexValidToken: false,
             commitHash: 'potato',
             expectedSpinnerCount: 0,
             expectedMainContentCount: 1,
@@ -98,10 +115,13 @@ describe('Commit info page tests', () => {
                 response: undefined,
                 commitInfoReady: CommitInfoState.NOTFOUND,
             },
+            expectedNumLoginPage: 0,
         },
         {
             name: 'Some main content exists when the page is done loading',
             fakeLoadEverything: true,
+            enableDex: false,
+            enableDexValidToken: false,
             commitHash: 'potato',
             expectedSpinnerCount: 0,
             expectedMainContentCount: 1,
@@ -119,12 +139,55 @@ Commit message body line 2`,
                     nextCommitHash: '',
                 },
             },
+            expectedNumLoginPage: 0,
+        },
+        {
+            name: 'A login page renders when Dex is enabled',
+            fakeLoadEverything: true,
+            enableDex: true,
+            enableDexValidToken: false,
+            commitHash: 'potato',
+            expectedSpinnerCount: 0,
+            expectedMainContentCount: 1,
+            expectedText: 'Login Into Dex',
+            commitInfoStoreData: {
+                commitInfoReady: CommitInfoState.LOADING,
+                response: undefined,
+            },
+            expectedNumLoginPage: 1,
+        },
+        {
+            name: 'Some main content exists when Dex is enabled and the token is valid',
+            fakeLoadEverything: true,
+            enableDex: true,
+            enableDexValidToken: true,
+            commitHash: 'potato',
+            expectedSpinnerCount: 0,
+            expectedMainContentCount: 1,
+            expectedText: 'Add google to windows', // this "Commit + commit_message_first_line" string comes from the CommitInfo component logic (so we know that it actually rendered without having some mocking magic)
+            commitInfoStoreData: {
+                commitInfoReady: CommitInfoState.READY,
+                response: {
+                    commitHash: 'potato',
+                    touchedApps: ['google', 'windows'],
+                    commitMessage: `Add google to windows
+Commit message body line 1
+Commit message body line 2`,
+                    events: [],
+                    previousCommitHash: '',
+                    nextCommitHash: '',
+                },
+            },
+            expectedNumLoginPage: 0,
         },
     ];
     describe.each(testCases)('', (tc) => {
         test(tc.name, () => {
             fakeLoadEverything(tc.fakeLoadEverything);
             if (tc.commitInfoStoreData !== undefined) updateCommitInfo.set(tc.commitInfoStoreData);
+            if (tc.enableDex == true) {
+                enableDexAuth(tc.enableDexValidToken)
+            }
 
             const { container } = render(
                 <MemoryRouter initialEntries={['/ui/commits/' + tc.commitHash]}>
@@ -141,7 +204,7 @@ Commit message body line 2`,
             expect(container.getElementsByClassName('main-content commit-page')).toHaveLength(
                 tc.expectedMainContentCount
             );
-
+            expect(container.getElementsByClassName('login-page')).toHaveLength(tc.expectedNumLoginPage);
             expect(container.textContent).toContain(tc.expectedText);
         });
     });

--- a/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.tsx
+++ b/services/frontend-service/src/ui/Pages/CommitInfo/CommitInfoPage.tsx
@@ -15,7 +15,6 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright freiheit.com*/
 
 import { getCommitInfo, useCommitInfo, useGlobalLoadingState, CommitInfoState } from '../../utils/store';
-import { LoadingStateSpinner } from '../../utils/LoadingStateSpinner';
 import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
 import { Spinner } from '../../components/Spinner/Spinner';
 import { useParams } from 'react-router-dom';
@@ -24,7 +23,6 @@ import { CommitInfo } from '../../components/CommitInfo/CommitInfo';
 import { useAzureAuthSub } from '../../utils/AzureAuthProvider';
 
 export const CommitInfoPage: React.FC = () => {
-    const [everythingLoaded, loadingState] = useGlobalLoadingState();
     const { commit: commitHash } = useParams();
     const { authHeader } = useAzureAuthSub((auth) => auth);
 
@@ -36,8 +34,9 @@ export const CommitInfoPage: React.FC = () => {
 
     const commitInfo = useCommitInfo((res) => res);
 
-    if (!everythingLoaded) {
-        return <LoadingStateSpinner loadingState={loadingState} />;
+    const element = useGlobalLoadingState();
+    if (element) {
+        return element;
     }
 
     if (commitHash === undefined) {

--- a/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
@@ -255,7 +255,7 @@ describe('Environment Lane', () => {
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.spinnerExpected);
             expect(container.getElementsByClassName('environment-group-lane')).toHaveLength(testcase.expected);
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedMainContent);
-            expect(container.getElementsByClassName('login-page')).toHaveLength(testcase.expectedNumLoginPage);
+            expect(container.getElementsByClassName('release_train_button')).toHaveLength(testcase.expectedNumLoginPage);
             expect(container.getElementsByClassName('environment-lane__header')).toHaveLength(
                 testcase.expectedEnvHeaderWrapper
             );

--- a/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
@@ -255,7 +255,7 @@ describe('Environment Lane', () => {
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.spinnerExpected);
             expect(container.getElementsByClassName('environment-group-lane')).toHaveLength(testcase.expected);
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedMainContent);
-            expect(container.getElementsByClassName('release_train_button')).toHaveLength(
+            expect(container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')).toHaveLength(
                 testcase.expectedNumLoginPage
             );
             expect(container.getElementsByClassName('environment-lane__header')).toHaveLength(

--- a/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
@@ -18,7 +18,7 @@ import { UpdateOverview } from '../../utils/store';
 import { Environment, EnvironmentGroup, Priority } from '../../../api/api';
 import React from 'react';
 import { EnvironmentsPage } from './EnvironmentsPage';
-import { fakeLoadEverything } from '../../../setupTests';
+import { fakeLoadEverything, enableDexAuth } from '../../../setupTests';
 import { MemoryRouter } from 'react-router-dom';
 
 const sampleEnvsA: Environment[] = [
@@ -67,11 +67,14 @@ describe('Environment Lane', () => {
         name: string;
         environmentGroups: EnvironmentGroup[];
         loaded: boolean;
+        enableDex: boolean;
+        enableDexValidToken: boolean,
         expected: number;
         expectedEnvHeaderWrapper: number;
         expectedMainContent: number;
         spinnerExpected: number;
         expectedCardStyles: { className: string; count: number }[];
+        expectedNumLoginPage: number, 
     }
     const cases: dataT[] = [
         {
@@ -85,6 +88,8 @@ describe('Environment Lane', () => {
                 },
             ],
             loaded: true,
+            enableDex: false, 
+            enableDexValidToken: false, 
             expected: 1,
             expectedEnvHeaderWrapper: 1,
             expectedMainContent: 1,
@@ -95,6 +100,7 @@ describe('Environment Lane', () => {
                     count: 1,
                 },
             ],
+            expectedNumLoginPage: 0, 
         },
         {
             name: '2 group 1 env each',
@@ -113,6 +119,8 @@ describe('Environment Lane', () => {
                 },
             ],
             loaded: true,
+            enableDex: false, 
+            enableDexValidToken: false, 
             expected: 1,
             expectedEnvHeaderWrapper: 2,
             expectedMainContent: 1,
@@ -123,6 +131,7 @@ describe('Environment Lane', () => {
                     count: 2,
                 },
             ],
+            expectedNumLoginPage: 0, 
         },
         {
             name: '1 group 2 env',
@@ -135,6 +144,8 @@ describe('Environment Lane', () => {
                 },
             ],
             loaded: true,
+            enableDex: false, 
+            enableDexValidToken: false, 
             expected: 1,
             expectedEnvHeaderWrapper: 2,
             expectedMainContent: 1,
@@ -145,6 +156,7 @@ describe('Environment Lane', () => {
                     count: 3,
                 },
             ],
+            expectedNumLoginPage: 0, 
         },
         {
             name: 'card colors are decided by group priority not environment priority',
@@ -157,6 +169,8 @@ describe('Environment Lane', () => {
                 },
             ],
             loaded: true,
+            enableDex: false, 
+            enableDexValidToken: false, 
             expected: 1,
             expectedEnvHeaderWrapper: 2,
             expectedMainContent: 1,
@@ -171,16 +185,58 @@ describe('Environment Lane', () => {
                     count: 3,
                 },
             ],
+            expectedNumLoginPage: 0, 
         },
         {
             name: 'just the spinner',
             environmentGroups: [],
             loaded: false,
+            enableDex: false, 
+            enableDexValidToken: false, 
             expected: 0,
             expectedEnvHeaderWrapper: 0,
             expectedMainContent: 0,
             spinnerExpected: 1,
             expectedCardStyles: [],
+            expectedNumLoginPage: 0,
+        },
+        {
+            name: 'A login page renders when Dex is enabled',
+            environmentGroups: [],
+            loaded: true,
+            enableDex: true, 
+            enableDexValidToken: false, 
+            expected: 0,
+            expectedEnvHeaderWrapper: 0,
+            expectedMainContent: 1,
+            spinnerExpected: 0,
+            expectedCardStyles: [],
+            expectedNumLoginPage: 1,
+        },
+        {
+            name: '1 group 1 env with Dex enabled and a valid token',
+            environmentGroups: [
+                {
+                    environments: [sampleEnvsA[0]],
+                    distanceToUpstream: 0,
+                    environmentGroupName: 'g1',
+                    priority: Priority.YOLO,
+                },
+            ],
+            loaded: true,
+            enableDex: true, 
+            enableDexValidToken: true, 
+            expected: 1,
+            expectedEnvHeaderWrapper: 1,
+            expectedMainContent: 1,
+            spinnerExpected: 0,
+            expectedCardStyles: [
+                {
+                    className: 'environment-priority-yolo',
+                    count: 1,
+                },
+            ],
+            expectedNumLoginPage: 0, 
         },
     ];
     describe.each(cases)('Renders a row of environments', (testcase) => {
@@ -190,12 +246,16 @@ describe('Environment Lane', () => {
                 environmentGroups: testcase.environmentGroups,
             });
             fakeLoadEverything(testcase.loaded);
+            if (testcase.enableDex == true) {
+                enableDexAuth(testcase.enableDexValidToken)
+            }
             // when
             const { container } = getWrapper();
             // then
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.spinnerExpected);
             expect(container.getElementsByClassName('environment-group-lane')).toHaveLength(testcase.expected);
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedMainContent);
+            expect(container.getElementsByClassName('login-page')).toHaveLength(testcase.expectedNumLoginPage);
             expect(container.getElementsByClassName('environment-lane__header')).toHaveLength(
                 testcase.expectedEnvHeaderWrapper
             );

--- a/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
@@ -255,9 +255,9 @@ describe('Environment Lane', () => {
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.spinnerExpected);
             expect(container.getElementsByClassName('environment-group-lane')).toHaveLength(testcase.expected);
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedMainContent);
-            expect(container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')).toHaveLength(
-                testcase.expectedNumLoginPage
-            );
+            expect(
+                container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')
+            ).toHaveLength(testcase.expectedNumLoginPage);
             expect(container.getElementsByClassName('environment-lane__header')).toHaveLength(
                 testcase.expectedEnvHeaderWrapper
             );

--- a/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
@@ -68,13 +68,13 @@ describe('Environment Lane', () => {
         environmentGroups: EnvironmentGroup[];
         loaded: boolean;
         enableDex: boolean;
-        enableDexValidToken: boolean,
+        enableDexValidToken: boolean;
         expected: number;
         expectedEnvHeaderWrapper: number;
         expectedMainContent: number;
         spinnerExpected: number;
         expectedCardStyles: { className: string; count: number }[];
-        expectedNumLoginPage: number, 
+        expectedNumLoginPage: number;
     }
     const cases: dataT[] = [
         {
@@ -88,8 +88,8 @@ describe('Environment Lane', () => {
                 },
             ],
             loaded: true,
-            enableDex: false, 
-            enableDexValidToken: false, 
+            enableDex: false,
+            enableDexValidToken: false,
             expected: 1,
             expectedEnvHeaderWrapper: 1,
             expectedMainContent: 1,
@@ -100,7 +100,7 @@ describe('Environment Lane', () => {
                     count: 1,
                 },
             ],
-            expectedNumLoginPage: 0, 
+            expectedNumLoginPage: 0,
         },
         {
             name: '2 group 1 env each',
@@ -119,8 +119,8 @@ describe('Environment Lane', () => {
                 },
             ],
             loaded: true,
-            enableDex: false, 
-            enableDexValidToken: false, 
+            enableDex: false,
+            enableDexValidToken: false,
             expected: 1,
             expectedEnvHeaderWrapper: 2,
             expectedMainContent: 1,
@@ -131,7 +131,7 @@ describe('Environment Lane', () => {
                     count: 2,
                 },
             ],
-            expectedNumLoginPage: 0, 
+            expectedNumLoginPage: 0,
         },
         {
             name: '1 group 2 env',
@@ -144,8 +144,8 @@ describe('Environment Lane', () => {
                 },
             ],
             loaded: true,
-            enableDex: false, 
-            enableDexValidToken: false, 
+            enableDex: false,
+            enableDexValidToken: false,
             expected: 1,
             expectedEnvHeaderWrapper: 2,
             expectedMainContent: 1,
@@ -156,7 +156,7 @@ describe('Environment Lane', () => {
                     count: 3,
                 },
             ],
-            expectedNumLoginPage: 0, 
+            expectedNumLoginPage: 0,
         },
         {
             name: 'card colors are decided by group priority not environment priority',
@@ -169,8 +169,8 @@ describe('Environment Lane', () => {
                 },
             ],
             loaded: true,
-            enableDex: false, 
-            enableDexValidToken: false, 
+            enableDex: false,
+            enableDexValidToken: false,
             expected: 1,
             expectedEnvHeaderWrapper: 2,
             expectedMainContent: 1,
@@ -185,14 +185,14 @@ describe('Environment Lane', () => {
                     count: 3,
                 },
             ],
-            expectedNumLoginPage: 0, 
+            expectedNumLoginPage: 0,
         },
         {
             name: 'just the spinner',
             environmentGroups: [],
             loaded: false,
-            enableDex: false, 
-            enableDexValidToken: false, 
+            enableDex: false,
+            enableDexValidToken: false,
             expected: 0,
             expectedEnvHeaderWrapper: 0,
             expectedMainContent: 0,
@@ -204,8 +204,8 @@ describe('Environment Lane', () => {
             name: 'A login page renders when Dex is enabled',
             environmentGroups: [],
             loaded: true,
-            enableDex: true, 
-            enableDexValidToken: false, 
+            enableDex: true,
+            enableDexValidToken: false,
             expected: 0,
             expectedEnvHeaderWrapper: 0,
             expectedMainContent: 1,
@@ -224,8 +224,8 @@ describe('Environment Lane', () => {
                 },
             ],
             loaded: true,
-            enableDex: true, 
-            enableDexValidToken: true, 
+            enableDex: true,
+            enableDexValidToken: true,
             expected: 1,
             expectedEnvHeaderWrapper: 1,
             expectedMainContent: 1,
@@ -236,7 +236,7 @@ describe('Environment Lane', () => {
                     count: 1,
                 },
             ],
-            expectedNumLoginPage: 0, 
+            expectedNumLoginPage: 0,
         },
     ];
     describe.each(cases)('Renders a row of environments', (testcase) => {
@@ -247,7 +247,7 @@ describe('Environment Lane', () => {
             });
             fakeLoadEverything(testcase.loaded);
             if (testcase.enableDex == true) {
-                enableDexAuth(testcase.enableDexValidToken)
+                enableDexAuth(testcase.enableDexValidToken);
             }
             // when
             const { container } = getWrapper();
@@ -255,7 +255,9 @@ describe('Environment Lane', () => {
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.spinnerExpected);
             expect(container.getElementsByClassName('environment-group-lane')).toHaveLength(testcase.expected);
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedMainContent);
-            expect(container.getElementsByClassName('release_train_button')).toHaveLength(testcase.expectedNumLoginPage);
+            expect(container.getElementsByClassName('release_train_button')).toHaveLength(
+                testcase.expectedNumLoginPage
+            );
             expect(container.getElementsByClassName('environment-lane__header')).toHaveLength(
                 testcase.expectedEnvHeaderWrapper
             );

--- a/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.test.tsx
@@ -246,7 +246,7 @@ describe('Environment Lane', () => {
                 environmentGroups: testcase.environmentGroups,
             });
             fakeLoadEverything(testcase.loaded);
-            if (testcase.enableDex == true) {
+            if (testcase.enableDex) {
                 enableDexAuth(testcase.enableDexValidToken);
             }
             // when

--- a/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Environments/EnvironmentsPage.tsx
@@ -15,7 +15,6 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright freiheit.com*/
 import { useEnvironmentGroups, useEnvironments, useGlobalLoadingState } from '../../utils/store';
 import { EnvironmentCard, EnvironmentGroupCard } from '../../components/EnvironmentCard/EnvironmentCard';
-import { LoadingStateSpinner } from '../../utils/LoadingStateSpinner';
 import React from 'react';
 import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
 
@@ -26,9 +25,9 @@ export const EnvironmentsPage: React.FC = () => {
     // if they are equal (envsGroups.length === envs.length), then there are effectively no groups, but the cd-server still returns each env wrapped in a group
     const useGroups = envsGroups.length !== envs.length;
 
-    const [everythingLoaded, loadingState] = useGlobalLoadingState();
-    if (!everythingLoaded) {
-        return <LoadingStateSpinner loadingState={loadingState} />;
+    const element = useGlobalLoadingState();
+    if (element) {
+        return element;
     }
 
     const mainContent: JSX.Element = useGroups ? (

--- a/services/frontend-service/src/ui/Pages/Home/Home.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Home/Home.test.tsx
@@ -70,7 +70,7 @@ describe('App', () => {
         fakeLoadEverything(true);
         enableDexAuth(false);
         const { container } = getWrapper();
-        expect(container.getElementsByClassName('login-name')[0]).toHaveTextContent('Login Into Dex');
+        expect(container.getElementsByClassName('environment_name')[0]).toHaveTextContent('Log in to Dex');
     });
     it('Renders page if Dex enabled and valid token', () => {
         const buildTestApp = (suffix: string): Application => ({

--- a/services/frontend-service/src/ui/Pages/Home/Home.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Home/Home.test.tsx
@@ -19,7 +19,7 @@ import { searchCustomFilter, UpdateOverview, useApplicationsFilteredAndSorted, u
 import { Spy } from 'spy4js';
 import { MemoryRouter } from 'react-router-dom';
 import { Application, UndeploySummary } from '../../../api/api';
-import { fakeLoadEverything } from '../../../setupTests';
+import { fakeLoadEverything, enableDexAuth } from '../../../setupTests';
 
 const mock_ServiceLane = Spy.mockReactComponents('../../components/ServiceLane/ServiceLane', 'ServiceLane');
 
@@ -65,6 +65,39 @@ describe('App', () => {
         const { container } = getWrapper();
         // then
         expect(container.getElementsByClassName('spinner')).toHaveLength(1);
+    });
+    it('Renders login page if Dex enabled', () => {
+        fakeLoadEverything(true);
+        enableDexAuth(false);
+        const { container } = getWrapper();
+        expect(container.getElementsByClassName('login-name')[0]).toHaveTextContent('Login Into Dex');
+    });
+    it('Renders page if Dex enabled and valid token', () => {
+        const buildTestApp = (suffix: string): Application => ({
+            name: `test${suffix}`,
+            releases: [],
+            sourceRepoUrl: `http://test${suffix}.com`,
+            team: `team${suffix}`,
+            undeploySummary: UndeploySummary.NORMAL,
+            warnings: [],
+        });
+        // when
+        const sampleApps = {
+            app1: buildTestApp('1'),
+            app2: buildTestApp('2'),
+            app3: buildTestApp('3'),
+        };
+        UpdateOverview.set({
+            applications: sampleApps,
+        });
+        fakeLoadEverything(true);
+        enableDexAuth(true);
+        getWrapper();
+
+        // then apps are sorted and Service Lane is called
+        expect(mock_ServiceLane.ServiceLane.getCallArgument(0, 0)).toStrictEqual({ application: sampleApps.app1 });
+        expect(mock_ServiceLane.ServiceLane.getCallArgument(1, 0)).toStrictEqual({ application: sampleApps.app2 });
+        expect(mock_ServiceLane.ServiceLane.getCallArgument(2, 0)).toStrictEqual({ application: sampleApps.app3 });
     });
 });
 

--- a/services/frontend-service/src/ui/Pages/Home/Home.tsx
+++ b/services/frontend-service/src/ui/Pages/Home/Home.tsx
@@ -17,7 +17,6 @@ import { ServiceLane } from '../../components/ServiceLane/ServiceLane';
 import { useSearchParams } from 'react-router-dom';
 import { useApplicationsFilteredAndSorted, useGlobalLoadingState } from '../../utils/store';
 import React from 'react';
-import { LoadingStateSpinner } from '../../utils/LoadingStateSpinner';
 import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
 import { hideWithoutWarnings } from '../../utils/Links';
 
@@ -30,9 +29,9 @@ export const Home: React.FC = () => {
 
     const apps = Object.values(searchedApp);
 
-    const [everythingLoaded, loadingState] = useGlobalLoadingState();
-    if (!everythingLoaded) {
-        return <LoadingStateSpinner loadingState={loadingState} />;
+    const element = useGlobalLoadingState();
+    if (element) {
+        return element;
     }
 
     return (

--- a/services/frontend-service/src/ui/Pages/Locks/LocksPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Locks/LocksPage.test.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../utils/store';
 import { MemoryRouter } from 'react-router-dom';
 import { Environment, Priority } from '../../../api/api';
-import { fakeLoadEverything } from '../../../setupTests';
+import { fakeLoadEverything, enableDexAuth } from '../../../setupTests';
 
 describe('LocksPage', () => {
     const getNode = (): JSX.Element | any => (
@@ -36,6 +36,19 @@ describe('LocksPage', () => {
 
     it('Renders full app', () => {
         fakeLoadEverything(true);
+        const { container } = getWrapper();
+        expect(container.getElementsByClassName('mdc-data-table')[0]).toHaveTextContent('Environment Locks');
+        expect(container.getElementsByClassName('mdc-data-table')[1]).toHaveTextContent('Application Locks');
+    });
+    it('Renders login page if Dex enabled', () => {
+        fakeLoadEverything(true);
+        enableDexAuth(false);
+        const { container } = getWrapper();
+        expect(container.getElementsByClassName('login-name')[0]).toHaveTextContent('Login Into Dex');
+    });
+    it('Renders page page if Dex enabled and valid token', () => {
+        fakeLoadEverything(true);
+        enableDexAuth(true);
         const { container } = getWrapper();
         expect(container.getElementsByClassName('mdc-data-table')[0]).toHaveTextContent('Environment Locks');
         expect(container.getElementsByClassName('mdc-data-table')[1]).toHaveTextContent('Application Locks');

--- a/services/frontend-service/src/ui/Pages/Locks/LocksPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Locks/LocksPage.test.tsx
@@ -44,7 +44,7 @@ describe('LocksPage', () => {
         fakeLoadEverything(true);
         enableDexAuth(false);
         const { container } = getWrapper();
-        expect(container.getElementsByClassName('login-name')[0]).toHaveTextContent('Login Into Dex');
+        expect(container.getElementsByClassName('environment_name')[0]).toHaveTextContent('Log in to Dex');
     });
     it('Renders page page if Dex enabled and valid token', () => {
         fakeLoadEverything(true);

--- a/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
@@ -17,7 +17,6 @@ import React, { useMemo } from 'react';
 import { LocksTable } from '../../components/LocksTable/LocksTable';
 import { searchCustomFilter, sortLocks, useEnvironments, useGlobalLoadingState, useTeamLocks } from '../../utils/store';
 import { useSearchParams } from 'react-router-dom';
-import { LoadingStateSpinner } from '../../utils/LoadingStateSpinner';
 import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
 
 const applicationFieldHeaders = [
@@ -86,9 +85,9 @@ export const LocksPage: React.FC = () => {
             ),
         [appNameParam, envs]
     );
-    const [everythingLoaded, loadingState] = useGlobalLoadingState();
-    if (!everythingLoaded) {
-        return <LoadingStateSpinner loadingState={loadingState} />;
+    const element = useGlobalLoadingState();
+    if (element) {
+        return element;
     }
     return (
         <div>

--- a/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.test.tsx
@@ -30,26 +30,26 @@ describe('ProductVersionPage', () => {
         name: string;
         loaded: boolean;
         enableDex: boolean;
-        enableDexValidToken: boolean,
+        enableDexValidToken: boolean;
         expectedNumMainContent: number;
         expectedNumSpinner: number;
-        expectedNumLoginPage: number, 
+        expectedNumLoginPage: number;
     }
     const sampleEnvData: dataEnvT[] = [
         {
             name: 'renders main',
             loaded: true,
-            enableDex: false, 
-            enableDexValidToken: false, 
+            enableDex: false,
+            enableDexValidToken: false,
             expectedNumMainContent: 1,
             expectedNumSpinner: 0,
-            expectedNumLoginPage: 0, 
+            expectedNumLoginPage: 0,
         },
         {
             name: 'renders spinner',
             loaded: false,
-            enableDex: false, 
-            enableDexValidToken: false, 
+            enableDex: false,
+            enableDexValidToken: false,
             expectedNumMainContent: 0,
             expectedNumSpinner: 1,
             expectedNumLoginPage: 0,
@@ -57,8 +57,8 @@ describe('ProductVersionPage', () => {
         {
             name: 'renders Login Page with Dex enabled',
             loaded: true,
-            enableDex: true, 
-            enableDexValidToken: false, 
+            enableDex: true,
+            enableDexValidToken: false,
             expectedNumMainContent: 1,
             expectedNumSpinner: 0,
             expectedNumLoginPage: 1,
@@ -66,8 +66,8 @@ describe('ProductVersionPage', () => {
         {
             name: 'renders page with Dex enabled and valid token',
             loaded: true,
-            enableDex: true, 
-            enableDexValidToken: true, 
+            enableDex: true,
+            enableDexValidToken: true,
             expectedNumMainContent: 1,
             expectedNumSpinner: 0,
             expectedNumLoginPage: 0,
@@ -78,11 +78,13 @@ describe('ProductVersionPage', () => {
             fakeLoadEverything(testcase.loaded);
             const { container } = getWrapper();
             if (testcase.enableDex == true) {
-                enableDexAuth(testcase.enableDexValidToken)
+                enableDexAuth(testcase.enableDexValidToken);
             }
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedNumMainContent);
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.expectedNumSpinner);
-            expect(container.getElementsByClassName('release_train_button')).toHaveLength(testcase.expectedNumLoginPage);
+            expect(container.getElementsByClassName('release_train_button')).toHaveLength(
+                testcase.expectedNumLoginPage
+            );
         });
     });
 });

--- a/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.test.tsx
@@ -82,7 +82,7 @@ describe('ProductVersionPage', () => {
             }
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedNumMainContent);
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.expectedNumSpinner);
-            expect(container.getElementsByClassName('login-page')).toHaveLength(testcase.expectedNumLoginPage);
+            expect(container.getElementsByClassName('release_train_button')).toHaveLength(testcase.expectedNumLoginPage);
         });
     });
 });

--- a/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.test.tsx
@@ -82,7 +82,7 @@ describe('ProductVersionPage', () => {
             }
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedNumMainContent);
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.expectedNumSpinner);
-            expect(container.getElementsByClassName('release_train_button')).toHaveLength(
+            expect(container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')).toHaveLength(
                 testcase.expectedNumLoginPage
             );
         });

--- a/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.test.tsx
@@ -82,9 +82,9 @@ describe('ProductVersionPage', () => {
             }
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedNumMainContent);
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.expectedNumSpinner);
-            expect(container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')).toHaveLength(
-                testcase.expectedNumLoginPage
-            );
+            expect(
+                container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')
+            ).toHaveLength(testcase.expectedNumLoginPage);
         });
     });
 });

--- a/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.test.tsx
@@ -77,7 +77,7 @@ describe('ProductVersionPage', () => {
         it(testcase.name, () => {
             fakeLoadEverything(testcase.loaded);
             const { container } = getWrapper();
-            if (testcase.enableDex == true) {
+            if (testcase.enableDex) {
                 enableDexAuth(testcase.enableDexValidToken);
             }
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedNumMainContent);

--- a/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.test.tsx
@@ -16,7 +16,7 @@ Copyright freiheit.com*/
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { ProductVersionPage } from './ProductVersionPage';
-import { fakeLoadEverything } from '../../../setupTests';
+import { enableDexAuth, fakeLoadEverything } from '../../../setupTests';
 
 describe('ProductVersionPage', () => {
     const getNode = (): JSX.Element | any => (
@@ -29,29 +29,60 @@ describe('ProductVersionPage', () => {
     interface dataEnvT {
         name: string;
         loaded: boolean;
+        enableDex: boolean;
+        enableDexValidToken: boolean,
         expectedNumMainContent: number;
         expectedNumSpinner: number;
+        expectedNumLoginPage: number, 
     }
     const sampleEnvData: dataEnvT[] = [
         {
             name: 'renders main',
             loaded: true,
+            enableDex: false, 
+            enableDexValidToken: false, 
             expectedNumMainContent: 1,
             expectedNumSpinner: 0,
+            expectedNumLoginPage: 0, 
         },
         {
             name: 'renders spinner',
             loaded: false,
+            enableDex: false, 
+            enableDexValidToken: false, 
             expectedNumMainContent: 0,
             expectedNumSpinner: 1,
+            expectedNumLoginPage: 0,
+        },
+        {
+            name: 'renders Login Page with Dex enabled',
+            loaded: true,
+            enableDex: true, 
+            enableDexValidToken: false, 
+            expectedNumMainContent: 1,
+            expectedNumSpinner: 0,
+            expectedNumLoginPage: 1,
+        },
+        {
+            name: 'renders page with Dex enabled and valid token',
+            loaded: true,
+            enableDex: true, 
+            enableDexValidToken: true, 
+            expectedNumMainContent: 1,
+            expectedNumSpinner: 0,
+            expectedNumLoginPage: 0,
         },
     ];
     describe.each(sampleEnvData)(`Renders ProductVersionPage`, (testcase) => {
         it(testcase.name, () => {
             fakeLoadEverything(testcase.loaded);
             const { container } = getWrapper();
+            if (testcase.enableDex == true) {
+                enableDexAuth(testcase.enableDexValidToken)
+            }
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedNumMainContent);
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.expectedNumSpinner);
+            expect(container.getElementsByClassName('login-page')).toHaveLength(testcase.expectedNumLoginPage);
         });
     });
 });

--- a/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.tsx
+++ b/services/frontend-service/src/ui/Pages/ProductVersion/ProductVersionPage.tsx
@@ -15,14 +15,13 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright freiheit.com*/
 
 import { useGlobalLoadingState } from '../../utils/store';
-import { LoadingStateSpinner } from '../../utils/LoadingStateSpinner';
 import { ProductVersion } from '../../components/ProductVersion/ProductVersion';
 import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
 
 export const ProductVersionPage: React.FC = () => {
-    const [everythingLoaded, loadingState] = useGlobalLoadingState();
-    if (!everythingLoaded) {
-        return <LoadingStateSpinner loadingState={loadingState} />;
+    const element = useGlobalLoadingState();
+    if (element) {
+        return element;
     }
     return (
         <div>

--- a/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.test.tsx
@@ -203,7 +203,7 @@ describe('Commit info page tests', () => {
             expect(container.getElementsByClassName('main-content')).toHaveLength(tc.expectedMainContentCount);
 
             expect(container.textContent).toContain(tc.expectedText);
-            expect(container.getElementsByClassName('release_train_button')).toHaveLength(tc.expectedNumLoginPage);
+            expect(container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')).toHaveLength(tc.expectedNumLoginPage);
         });
     });
 });

--- a/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.test.tsx
@@ -203,7 +203,9 @@ describe('Commit info page tests', () => {
             expect(container.getElementsByClassName('main-content')).toHaveLength(tc.expectedMainContentCount);
 
             expect(container.textContent).toContain(tc.expectedText);
-            expect(container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')).toHaveLength(tc.expectedNumLoginPage);
+            expect(
+                container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')
+            ).toHaveLength(tc.expectedNumLoginPage);
         });
     });
 });

--- a/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.test.tsx
@@ -185,7 +185,7 @@ describe('Commit info page tests', () => {
             fakeLoadEverything(tc.fakeLoadEverything);
             if (tc.releaseTrainPrognosisStoreData !== undefined)
                 updateReleaseTrainPrognosis.set(tc.releaseTrainPrognosisStoreData);
-            if (tc.enableDex == true) {
+            if (tc.enableDex) {
                 enableDexAuth(tc.enableDexValidToken);
             }
 

--- a/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.test.tsx
@@ -16,7 +16,7 @@ Copyright freiheit.com*/
 
 import { render } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { fakeLoadEverything } from '../../../setupTests';
+import { fakeLoadEverything, enableDexAuth } from '../../../setupTests';
 import { ReleaseTrainPrognosisState, updateReleaseTrainPrognosis } from '../../utils/store';
 import { GetReleaseTrainPrognosisResponse, ReleaseTrainEnvSkipCause } from '../../../api/api';
 import { ReleaseTrainPage } from './ReleaseTrainPage';
@@ -26,6 +26,8 @@ describe('Commit info page tests', () => {
         name: string;
         envName: string;
         fakeLoadEverything: boolean;
+        enableDex: boolean;
+        enableDexValidToken: boolean;
         releaseTrainPrognosisStoreData:
             | {
                   releaseTrainPrognosisReady: ReleaseTrainPrognosisState;
@@ -35,12 +37,15 @@ describe('Commit info page tests', () => {
         expectedSpinnerCount: number;
         expectedMainContentCount: number;
         expectedText: string;
+        expectedNumLoginPage: number;
     };
 
     const testCases: TestCase[] = [
         {
             name: 'A loading spinner renders when the page is still loading',
             fakeLoadEverything: false,
+            enableDex: false,
+            enableDexValidToken: false,
             envName: 'development',
             expectedSpinnerCount: 1,
             expectedMainContentCount: 0,
@@ -49,10 +54,13 @@ describe('Commit info page tests', () => {
                 releaseTrainPrognosisReady: ReleaseTrainPrognosisState.LOADING,
                 response: undefined,
             },
+            expectedNumLoginPage: 0,
         },
         {
             name: 'An Error is shown when the environemnt name is not provided in the URL',
             fakeLoadEverything: true,
+            enableDex: false,
+            enableDexValidToken: false,
             envName: '',
             expectedSpinnerCount: 0,
             expectedMainContentCount: 1,
@@ -61,10 +69,13 @@ describe('Commit info page tests', () => {
                 releaseTrainPrognosisReady: ReleaseTrainPrognosisState.LOADING,
                 response: undefined,
             },
+            expectedNumLoginPage: 0,
         },
         {
             name: 'A spinner is shown when waiting for the server to respond',
             fakeLoadEverything: true,
+            enableDex: false,
+            enableDexValidToken: false,
             envName: 'development',
             expectedSpinnerCount: 1,
             expectedMainContentCount: 0,
@@ -73,10 +84,13 @@ describe('Commit info page tests', () => {
                 releaseTrainPrognosisReady: ReleaseTrainPrognosisState.LOADING,
                 response: undefined,
             },
+            expectedNumLoginPage: 0,
         },
         {
             name: 'An error message is shown when the backend returns an error',
             fakeLoadEverything: true,
+            enableDex: false,
+            enableDexValidToken: false,
             envName: 'development',
             expectedSpinnerCount: 0,
             expectedMainContentCount: 1,
@@ -85,10 +99,13 @@ describe('Commit info page tests', () => {
                 releaseTrainPrognosisReady: ReleaseTrainPrognosisState.ERROR,
                 response: undefined,
             },
+            expectedNumLoginPage: 0,
         },
         {
             name: 'An error message is shown when the backend returns a not found status',
             fakeLoadEverything: true,
+            enableDex: false,
+            enableDexValidToken: false,
             envName: 'development',
             expectedSpinnerCount: 0,
             expectedMainContentCount: 1,
@@ -97,10 +114,13 @@ describe('Commit info page tests', () => {
                 releaseTrainPrognosisReady: ReleaseTrainPrognosisState.NOTFOUND,
                 response: undefined,
             },
+            expectedNumLoginPage: 0,
         },
         {
             name: 'Some main content exists when the page is done loading',
             fakeLoadEverything: true,
+            enableDex: false,
+            enableDexValidToken: false,
             envName: 'development',
             expectedSpinnerCount: 0,
             expectedMainContentCount: 1,
@@ -118,6 +138,46 @@ describe('Commit info page tests', () => {
                     },
                 },
             },
+            expectedNumLoginPage: 0,
+        },
+        {
+            name: 'A login page renders when Dex is enabled',
+            fakeLoadEverything: true,
+            enableDex: true,
+            enableDexValidToken: false,
+            envName: 'development',
+            expectedSpinnerCount: 0,
+            expectedMainContentCount: 1,
+            expectedText: 'Login Into Dex',
+            releaseTrainPrognosisStoreData: {
+                releaseTrainPrognosisReady: ReleaseTrainPrognosisState.LOADING,
+                response: undefined,
+            },
+            expectedNumLoginPage: 1,
+        },
+        {
+            name: 'Some main content exists when Dex is enabled with a valid token',
+            fakeLoadEverything: true,
+            enableDex: true,
+            enableDexValidToken: true,
+            envName: 'development',
+            expectedSpinnerCount: 0,
+            expectedMainContentCount: 1,
+            expectedText: 'Prognosis for release train on environment development',
+            releaseTrainPrognosisStoreData: {
+                releaseTrainPrognosisReady: ReleaseTrainPrognosisState.READY,
+                response: {
+                    envsPrognoses: {
+                        development: {
+                            outcome: {
+                                $case: 'skipCause',
+                                skipCause: ReleaseTrainEnvSkipCause.ENV_HAS_BOTH_UPSTREAM_LATEST_AND_UPSTREAM_ENV,
+                            },
+                        },
+                    },
+                },
+            },
+            expectedNumLoginPage: 0,
         },
     ];
     describe.each(testCases)('', (tc) => {
@@ -125,6 +185,9 @@ describe('Commit info page tests', () => {
             fakeLoadEverything(tc.fakeLoadEverything);
             if (tc.releaseTrainPrognosisStoreData !== undefined)
                 updateReleaseTrainPrognosis.set(tc.releaseTrainPrognosisStoreData);
+            if (tc.enableDex == true) {
+                enableDexAuth(tc.enableDexValidToken)
+            }
 
             const { container } = render(
                 <MemoryRouter initialEntries={['/ui/environments/' + tc.envName + '/releaseTrain']}>
@@ -140,6 +203,7 @@ describe('Commit info page tests', () => {
             expect(container.getElementsByClassName('main-content')).toHaveLength(tc.expectedMainContentCount);
 
             expect(container.textContent).toContain(tc.expectedText);
+            expect(container.getElementsByClassName('login-page')).toHaveLength(tc.expectedNumLoginPage);
         });
     });
 });

--- a/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.test.tsx
@@ -148,7 +148,7 @@ describe('Commit info page tests', () => {
             envName: 'development',
             expectedSpinnerCount: 0,
             expectedMainContentCount: 1,
-            expectedText: 'Login Into Dex',
+            expectedText: 'Log in to Dex',
             releaseTrainPrognosisStoreData: {
                 releaseTrainPrognosisReady: ReleaseTrainPrognosisState.LOADING,
                 response: undefined,
@@ -203,7 +203,7 @@ describe('Commit info page tests', () => {
             expect(container.getElementsByClassName('main-content')).toHaveLength(tc.expectedMainContentCount);
 
             expect(container.textContent).toContain(tc.expectedText);
-            expect(container.getElementsByClassName('login-page')).toHaveLength(tc.expectedNumLoginPage);
+            expect(container.getElementsByClassName('release_train_button')).toHaveLength(tc.expectedNumLoginPage);
         });
     });
 });

--- a/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.test.tsx
@@ -186,7 +186,7 @@ describe('Commit info page tests', () => {
             if (tc.releaseTrainPrognosisStoreData !== undefined)
                 updateReleaseTrainPrognosis.set(tc.releaseTrainPrognosisStoreData);
             if (tc.enableDex == true) {
-                enableDexAuth(tc.enableDexValidToken)
+                enableDexAuth(tc.enableDexValidToken);
             }
 
             const { container } = render(

--- a/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.tsx
+++ b/services/frontend-service/src/ui/Pages/ReleaseTrain/ReleaseTrainPage.tsx
@@ -16,7 +16,6 @@ Copyright freiheit.com*/
 
 import { useParams } from 'react-router-dom';
 import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
-import { LoadingStateSpinner } from '../../utils/LoadingStateSpinner';
 import {
     ReleaseTrainPrognosisState,
     getReleaseTrainPrognosis,
@@ -29,7 +28,6 @@ import { Spinner } from '../../components/Spinner/Spinner';
 import { ReleaseTrainPrognosis } from '../../components/ReleaseTrainPrognosis/ReleaseTrainPrognosis';
 
 export const ReleaseTrainPage: React.FC = () => {
-    const [everythingLoaded, loadingState] = useGlobalLoadingState();
     const { targetEnv: envName } = useParams();
     const { authHeader } = useAzureAuthSub((auth) => auth);
 
@@ -41,8 +39,9 @@ export const ReleaseTrainPage: React.FC = () => {
 
     const releaseTrainPrognosis = useReleaseTrainPrognosis((res) => res);
 
-    if (!everythingLoaded) {
-        return <LoadingStateSpinner loadingState={loadingState} />;
+    const element = useGlobalLoadingState();
+    if (element) {
+        return element;
     }
 
     if (envName === undefined) {

--- a/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
@@ -30,36 +30,36 @@ describe('LocksPage', () => {
         name: string;
         loaded: boolean;
         enableDex: boolean;
-        enableDexValidToken: boolean,
+        enableDexValidToken: boolean;
         expectedNumMainContent: number;
         expectedNumSpinner: number;
-        expectedNumLoginPage: number, 
+        expectedNumLoginPage: number;
     }
 
     const sampleEnvData: dataEnvT[] = [
         {
             name: 'renders main',
             loaded: true,
-            enableDex: false, 
+            enableDex: false,
             enableDexValidToken: false,
             expectedNumMainContent: 1,
             expectedNumSpinner: 0,
-            expectedNumLoginPage: 0, 
+            expectedNumLoginPage: 0,
         },
         {
             name: 'renders spinner',
             loaded: false,
-            enableDex: false, 
+            enableDex: false,
             enableDexValidToken: false,
             expectedNumMainContent: 0,
             expectedNumSpinner: 1,
-            expectedNumLoginPage: 0, 
+            expectedNumLoginPage: 0,
         },
         {
             name: 'renders Login Page with Dex enabled',
             loaded: true,
-            enableDex: true, 
-            enableDexValidToken: false, 
+            enableDex: true,
+            enableDexValidToken: false,
             expectedNumMainContent: 1,
             expectedNumSpinner: 0,
             expectedNumLoginPage: 1,
@@ -67,8 +67,8 @@ describe('LocksPage', () => {
         {
             name: 'renders page with Dex enabled and valid token',
             loaded: true,
-            enableDex: true, 
-            enableDexValidToken: true, 
+            enableDex: true,
+            enableDexValidToken: true,
             expectedNumMainContent: 1,
             expectedNumSpinner: 0,
             expectedNumLoginPage: 0,
@@ -79,12 +79,14 @@ describe('LocksPage', () => {
         it(testcase.name, () => {
             fakeLoadEverything(testcase.loaded);
             if (testcase.enableDex == true) {
-                enableDexAuth(testcase.enableDexValidToken)
+                enableDexAuth(testcase.enableDexValidToken);
             }
             const { container } = getWrapper();
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedNumMainContent);
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.expectedNumSpinner);
-            expect(container.getElementsByClassName('release_train_button')).toHaveLength(testcase.expectedNumLoginPage);
+            expect(container.getElementsByClassName('release_train_button')).toHaveLength(
+                testcase.expectedNumLoginPage
+            );
         });
     });
 });

--- a/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
@@ -84,9 +84,9 @@ describe('LocksPage', () => {
             const { container } = getWrapper();
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedNumMainContent);
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.expectedNumSpinner);
-            expect(container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')).toHaveLength(
-                testcase.expectedNumLoginPage
-            );
+            expect(
+                container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')
+            ).toHaveLength(testcase.expectedNumLoginPage);
         });
     });
 });

--- a/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
@@ -78,7 +78,7 @@ describe('LocksPage', () => {
     describe.each(sampleEnvData)(`Renders ReleasesPage`, (testcase) => {
         it(testcase.name, () => {
             fakeLoadEverything(testcase.loaded);
-            if (testcase.enableDex == true) {
+            if (testcase.enableDex) {
                 enableDexAuth(testcase.enableDexValidToken);
             }
             const { container } = getWrapper();

--- a/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
@@ -84,7 +84,7 @@ describe('LocksPage', () => {
             const { container } = getWrapper();
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedNumMainContent);
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.expectedNumSpinner);
-            expect(container.getElementsByClassName('release_train_button')).toHaveLength(
+            expect(container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')).toHaveLength(
                 testcase.expectedNumLoginPage
             );
         });

--- a/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
@@ -16,7 +16,7 @@ Copyright freiheit.com*/
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { ReleasesPage } from './ReleasesPage';
-import { fakeLoadEverything } from '../../../setupTests';
+import { fakeLoadEverything, enableDexAuth } from '../../../setupTests';
 
 describe('LocksPage', () => {
     const getNode = (): JSX.Element | any => (
@@ -29,31 +29,62 @@ describe('LocksPage', () => {
     interface dataEnvT {
         name: string;
         loaded: boolean;
+        enableDex: boolean;
+        enableDexValidToken: boolean,
         expectedNumMainContent: number;
         expectedNumSpinner: number;
+        expectedNumLoginPage: number, 
     }
 
     const sampleEnvData: dataEnvT[] = [
         {
             name: 'renders main',
             loaded: true,
+            enableDex: false, 
+            enableDexValidToken: false,
             expectedNumMainContent: 1,
             expectedNumSpinner: 0,
+            expectedNumLoginPage: 0, 
         },
         {
             name: 'renders spinner',
             loaded: false,
+            enableDex: false, 
+            enableDexValidToken: false,
             expectedNumMainContent: 0,
             expectedNumSpinner: 1,
+            expectedNumLoginPage: 0, 
+        },
+        {
+            name: 'renders Login Page with Dex enabled',
+            loaded: true,
+            enableDex: true, 
+            enableDexValidToken: false, 
+            expectedNumMainContent: 1,
+            expectedNumSpinner: 0,
+            expectedNumLoginPage: 1,
+        },
+        {
+            name: 'renders page with Dex enabled and valid token',
+            loaded: true,
+            enableDex: true, 
+            enableDexValidToken: true, 
+            expectedNumMainContent: 1,
+            expectedNumSpinner: 0,
+            expectedNumLoginPage: 0,
         },
     ];
 
     describe.each(sampleEnvData)(`Renders ReleasesPage`, (testcase) => {
         it(testcase.name, () => {
             fakeLoadEverything(testcase.loaded);
+            if (testcase.enableDex == true) {
+                enableDexAuth(testcase.enableDexValidToken)
+            }
             const { container } = getWrapper();
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedNumMainContent);
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.expectedNumSpinner);
+            expect(container.getElementsByClassName('login-page')).toHaveLength(testcase.expectedNumLoginPage);
         });
     });
 });

--- a/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.test.tsx
@@ -84,7 +84,7 @@ describe('LocksPage', () => {
             const { container } = getWrapper();
             expect(container.getElementsByClassName('main-content')).toHaveLength(testcase.expectedNumMainContent);
             expect(container.getElementsByClassName('spinner')).toHaveLength(testcase.expectedNumSpinner);
-            expect(container.getElementsByClassName('login-page')).toHaveLength(testcase.expectedNumLoginPage);
+            expect(container.getElementsByClassName('release_train_button')).toHaveLength(testcase.expectedNumLoginPage);
         });
     });
 });

--- a/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Releases/ReleasesPage.tsx
@@ -15,7 +15,6 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright freiheit.com*/
 import { Releases } from '../../components/Releases/Releases';
 import { useGlobalLoadingState } from '../../utils/store';
-import { LoadingStateSpinner } from '../../utils/LoadingStateSpinner';
 import React from 'react';
 import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
 
@@ -23,9 +22,9 @@ export const ReleasesPage: React.FC = () => {
     const url = window.location.pathname.split('/');
     const app_name = url[url.length - 1];
 
-    const [everythingLoaded, loadingState] = useGlobalLoadingState();
-    if (!everythingLoaded) {
-        return <LoadingStateSpinner loadingState={loadingState} />;
+    const element = useGlobalLoadingState();
+    if (element) {
+        return element;
     }
 
     return (

--- a/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
+++ b/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
@@ -48,8 +48,8 @@ describe('LoginPage', () => {
     it('Renders full app', () => {
         fakeLoadEverything(true);
         const { container } = getWrapper();
-        expect(container.getElementsByClassName('login-name')[0]).toHaveTextContent('Login Into Dex');
-        expect(container.getElementsByClassName('login_button')[0]).toHaveTextContent('Login');
+        expect(container.getElementsByClassName('environment_name')[0]).toHaveTextContent('Log in to Dex');
+        expect(container.getElementsByClassName('release_train_button')[0]).toHaveTextContent('Login');
     });
 });
 

--- a/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
+++ b/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
@@ -17,39 +17,40 @@ import { LoginPage, isTokenValid } from './DexAuthProvider';
 import { MemoryRouter } from 'react-router-dom';
 import { render, renderHook } from '@testing-library/react';
 import { fakeLoadEverything } from '../../setupTests';
-import {
-    UpdateOverview,
-} from '../utils/store';
+import { UpdateOverview } from '../utils/store';
 
 // Mocking document.cookie
 Object.defineProperty(document, 'cookie', {
-  writable: true,
-  value: ''
+    writable: true,
+    value: '',
 });
 
 describe('isTokenValid', () => {
-  beforeEach(() => {
-    // Reset the cookie before each test
-    document.cookie = '';
-  });
+    beforeEach(() => {
+        // Reset the cookie before each test
+        document.cookie = '';
+    });
 
-  test('returns false with expired cookie', () => {
-    // Dummy token with expiring date on 10, July 2024
-    document.cookie = 'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTd9.6-QS6fw-tEdcmWJP2HNCPzRZaPQgZYwwi5HVoiIX3bo';
-    expect(isTokenValid()).toBe(false);
-  });
+    test('returns false with expired cookie', () => {
+        // Dummy token with expiring date on 10, July 2024
+        document.cookie =
+            'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTd9.6-QS6fw-tEdcmWJP2HNCPzRZaPQgZYwwi5HVoiIX3bo';
+        expect(isTokenValid()).toBe(false);
+    });
 
-  test('returns false with cookie with no expiring date', () => {
-    // Dummy token with no expiring date
-    document.cookie = 'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-    expect(isTokenValid()).toBe(false);
-  });
+    test('returns false with cookie with no expiring date', () => {
+        // Dummy token with no expiring date
+        document.cookie =
+            'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+        expect(isTokenValid()).toBe(false);
+    });
 
-  test('returns true with valid cookie', () => {
-    // Dummy token with expiring date on year 56494 
-    document.cookie = 'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTc3Nzd9.p3ApN5elnhhRhrh7DCOF-9suPIXYC36Nycf0nHfxuf8';
-    expect(isTokenValid()).toBe(true);
-  });
+    test('returns true with valid cookie', () => {
+        // Dummy token with expiring date on year 56494
+        document.cookie =
+            'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTc3Nzd9.p3ApN5elnhhRhrh7DCOF-9suPIXYC36Nycf0nHfxuf8';
+        expect(isTokenValid()).toBe(true);
+    });
 });
 
 describe('LoginPage', () => {

--- a/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
+++ b/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
@@ -65,6 +65,6 @@ describe('LoginPage', () => {
         fakeLoadEverything(true);
         const { container } = getWrapper();
         expect(container.getElementsByClassName('environment_name')[0]).toHaveTextContent('Log in to Dex');
-        expect(container.getElementsByClassName('release_train_button')[0]).toHaveTextContent('Login');
+        expect(container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')[0]).toHaveTextContent('Login');
     });
 });

--- a/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
+++ b/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
@@ -1,3 +1,18 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
 import { LoginPage, isTokenValid } from './DexAuthProvider';
 import { MemoryRouter } from 'react-router-dom';
 import { render, renderHook } from '@testing-library/react';
@@ -52,6 +67,3 @@ describe('LoginPage', () => {
         expect(container.getElementsByClassName('release_train_button')[0]).toHaveTextContent('Login');
     });
 });
-
-
-

--- a/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
+++ b/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
@@ -30,25 +30,35 @@ describe('isTokenValid', () => {
         document.cookie = '';
     });
 
-    test('returns false with expired cookie', () => {
-        // Dummy token with expiring date on 10, July 2024
-        document.cookie =
-            'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTd9.6-QS6fw-tEdcmWJP2HNCPzRZaPQgZYwwi5HVoiIX3bo';
-        expect(isTokenValid()).toBe(false);
-    });
+    interface dataEnvT {
+        name: string;
+        cookie: string;
+        expectedTokenValidation: boolean;
+    }
 
-    test('returns false with cookie with no expiring date', () => {
-        // Dummy token with no expiring date
-        document.cookie =
-            'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-        expect(isTokenValid()).toBe(false);
-    });
+    const sampleEnvData: dataEnvT[] = [
+        {
+            name: 'returns false with expired cookie',
+            cookie: 'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTd9.6-QS6fw-tEdcmWJP2HNCPzRZaPQgZYwwi5HVoiIX3bo',
+            expectedTokenValidation: false,
+        },
+        {
+            name: 'returns false with cookie with no expiring date',
+            cookie: 'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+            expectedTokenValidation: false,
+        },
+        {
+            name: 'returns true with valid cooki',
+            cookie: 'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTc3Nzd9.p3ApN5elnhhRhrh7DCOF-9suPIXYC36Nycf0nHfxuf8',
+            expectedTokenValidation: true,
+        },
+    ];
 
-    test('returns true with valid cookie', () => {
-        // Dummy token with expiring date on year 56494
-        document.cookie =
-            'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTc3Nzd9.p3ApN5elnhhRhrh7DCOF-9suPIXYC36Nycf0nHfxuf8';
-        expect(isTokenValid()).toBe(true);
+    describe.each(sampleEnvData)(`isTokenValid`, (tc) => {
+        it(tc.name, () => {
+            document.cookie = tc.cookie;
+            expect(isTokenValid()).toBe(tc.expectedTokenValidation);
+        });
     });
 });
 

--- a/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
+++ b/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
@@ -15,9 +15,8 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright freiheit.com*/
 import { LoginPage, isTokenValid } from './DexAuthProvider';
 import { MemoryRouter } from 'react-router-dom';
-import { render, renderHook } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { fakeLoadEverything } from '../../setupTests';
-import { UpdateOverview } from '../utils/store';
 
 // Mocking document.cookie
 Object.defineProperty(document, 'cookie', {
@@ -65,6 +64,8 @@ describe('LoginPage', () => {
         fakeLoadEverything(true);
         const { container } = getWrapper();
         expect(container.getElementsByClassName('environment_name')[0]).toHaveTextContent('Log in to Dex');
-        expect(container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')[0]).toHaveTextContent('Login');
+        expect(
+            container.getElementsByClassName('button-main env-card-deploy-btn mdc-button--unelevated')[0]
+        ).toHaveTextContent('Login');
     });
 });

--- a/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
+++ b/services/frontend-service/src/ui/utils/DexAuthProvider.test.tsx
@@ -1,0 +1,57 @@
+import { LoginPage, isTokenValid } from './DexAuthProvider';
+import { MemoryRouter } from 'react-router-dom';
+import { render, renderHook } from '@testing-library/react';
+import { fakeLoadEverything } from '../../setupTests';
+import {
+    UpdateOverview,
+} from '../utils/store';
+
+// Mocking document.cookie
+Object.defineProperty(document, 'cookie', {
+  writable: true,
+  value: ''
+});
+
+describe('isTokenValid', () => {
+  beforeEach(() => {
+    // Reset the cookie before each test
+    document.cookie = '';
+  });
+
+  test('returns false with expired cookie', () => {
+    // Dummy token with expiring date on 10, July 2024
+    document.cookie = 'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTd9.6-QS6fw-tEdcmWJP2HNCPzRZaPQgZYwwi5HVoiIX3bo';
+    expect(isTokenValid()).toBe(false);
+  });
+
+  test('returns false with cookie with no expiring date', () => {
+    // Dummy token with no expiring date
+    document.cookie = 'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+    expect(isTokenValid()).toBe(false);
+  });
+
+  test('returns true with valid cookie', () => {
+    // Dummy token with expiring date on year 56494 
+    document.cookie = 'kuberpult.oauth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MjA2MjE5OTc3Nzd9.p3ApN5elnhhRhrh7DCOF-9suPIXYC36Nycf0nHfxuf8';
+    expect(isTokenValid()).toBe(true);
+  });
+});
+
+describe('LoginPage', () => {
+    const getNode = (): JSX.Element | any => (
+        <MemoryRouter>
+            <LoginPage />
+        </MemoryRouter>
+    );
+    const getWrapper = () => render(getNode());
+
+    it('Renders full app', () => {
+        fakeLoadEverything(true);
+        const { container } = getWrapper();
+        expect(container.getElementsByClassName('login-name')[0]).toHaveTextContent('Login Into Dex');
+        expect(container.getElementsByClassName('login_button')[0]).toHaveTextContent('Login');
+    });
+});
+
+
+

--- a/services/frontend-service/src/ui/utils/DexAuthProvider.tsx
+++ b/services/frontend-service/src/ui/utils/DexAuthProvider.tsx
@@ -30,7 +30,7 @@ export const LoginPage: React.FC = () => {
             <main className="main-content">
                 <h1 className="environment_name">{'Log in to Dex'}</h1>
                 <h3 className="page_description">
-                    {'It seems that you are not logged in... Please login in to dex to get your user role!'}
+                    {'It looks like you are not logged in. Please log in to DEX to access your user role!'}
                 </h3>
                 <div className="space_apart_row">
                     <Button

--- a/services/frontend-service/src/ui/utils/DexAuthProvider.tsx
+++ b/services/frontend-service/src/ui/utils/DexAuthProvider.tsx
@@ -14,16 +14,13 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright freiheit.com*/
 import { jwtDecode } from 'jwt-decode';
-//import Cookies from 'js-cookie';
 import { TopAppBar } from '../components/TopAppBar/TopAppBar';
 import { Button } from '../components/button';
 import React from 'react';
 
 export const LoginPage: React.FC = () => {
-    // Define the navigation function using useCallback
+    // Redirect the user to the Dex Login
     const handleRedirect = React.useCallback(() => {
-        // Hard reload to invalidate cache and make the Dex call work.
-        window.location.reload();
         window.location.href = '/login';
     }, []);
 
@@ -32,10 +29,13 @@ export const LoginPage: React.FC = () => {
             <TopAppBar showAppFilter={false} showTeamFilter={false} showWarningFilter={false} />
             <main className="main-content">
                 <h1 className="environment_name">{'Log in to Dex'}</h1>
+                <h3 className="page_description">
+                    {'It seems that you are not loged in... Please login into dex to get your user role!'}
+                </h3>
                 <div className="space_apart_row">
                     <Button
                         label={'Login'}
-                        className="release_train_button"
+                        className={'button-main env-card-deploy-btn mdc-button--unelevated'}
                         onClick={handleRedirect}
                         highlightEffect={false}
                     />
@@ -47,7 +47,6 @@ export const LoginPage: React.FC = () => {
 
 // Validates the token expiring date
 export function isTokenValid(): boolean {
-    //const token = Cookies.get('kuberpult.oauth');
     const cookieValue = document.cookie
         .split('; ')
         .find((row) => row.startsWith('kuberpult.oauth='))

--- a/services/frontend-service/src/ui/utils/DexAuthProvider.tsx
+++ b/services/frontend-service/src/ui/utils/DexAuthProvider.tsx
@@ -30,7 +30,7 @@ export const LoginPage: React.FC = () => {
             <main className="main-content">
                 <h1 className="environment_name">{'Log in to Dex'}</h1>
                 <h3 className="page_description">
-                    {'It seems that you are not loged in... Please login into dex to get your user role!'}
+                    {'It seems that you are not logged in... Please login in to dex to get your user role!'}
                 </h3>
                 <div className="space_apart_row">
                     <Button

--- a/services/frontend-service/src/ui/utils/DexAuthProvider.tsx
+++ b/services/frontend-service/src/ui/utils/DexAuthProvider.tsx
@@ -31,16 +31,14 @@ export const LoginPage: React.FC = () => {
         <div>
             <TopAppBar showAppFilter={false} showTeamFilter={false} showWarningFilter={false} />
             <main className="main-content">
-                <div className="login-page">
-                    <h1 className="login-name">{'Login Into Dex'}</h1>
-                    <div className="space_apart_row">
-                        <Button
-                            label={'Login'}
-                            className="login_button"
-                            onClick={handleRedirect}
-                            highlightEffect={false}
-                        />
-                    </div>
+                <h1 className="environment_name">{'Log in to Dex'}</h1>
+                <div className="space_apart_row">
+                    <Button
+                        label={'Login'}
+                        className="release_train_button"
+                        onClick={handleRedirect}
+                        highlightEffect={false}
+                    />
                 </div>
             </main>
         </div>

--- a/services/frontend-service/src/ui/utils/DexAuthProvider.tsx
+++ b/services/frontend-service/src/ui/utils/DexAuthProvider.tsx
@@ -1,0 +1,68 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+import { jwtDecode } from 'jwt-decode';
+//import Cookies from 'js-cookie';
+import { TopAppBar } from '../components/TopAppBar/TopAppBar';
+import { Button } from '../components/button';
+import React from 'react';
+
+export const LoginPage: React.FC = () => {
+    // Define the navigation function using useCallback
+    const handleRedirect = React.useCallback(() => {
+        // Hard reload to invalidate cache and make the Dex call work.
+        window.location.reload();
+        window.location.href = '/login';
+    }, []);
+
+    return (
+        <div>
+            <TopAppBar showAppFilter={false} showTeamFilter={false} showWarningFilter={false} />
+            <main className="main-content">
+                <div className="login-page">
+                    <h1 className="login-name">{'Login Into Dex'}</h1>
+                    <div className="space_apart_row">
+                        <Button
+                            label={'Login'}
+                            className="login_button"
+                            onClick={handleRedirect}
+                            highlightEffect={false}
+                        />
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+};
+
+// Validates the token expiring date
+export function isTokenValid(): boolean {
+    //const token = Cookies.get('kuberpult.oauth');
+    const cookieValue = document.cookie
+        .split('; ')
+        .find((row) => row.startsWith('kuberpult.oauth='))
+        ?.split('=')[1];
+    if (!cookieValue) return false;
+
+    const decodedToken = jwtDecode(cookieValue);
+    if (!decodedToken) return false;
+
+    const currentTime = Date.now() / 1000;
+    if (!decodedToken.exp) return false;
+    if (decodedToken.exp < currentTime) {
+        return false;
+    }
+    return true;
+}

--- a/services/frontend-service/src/ui/utils/LoadingStateSpinner.test.tsx
+++ b/services/frontend-service/src/ui/utils/LoadingStateSpinner.test.tsx
@@ -25,6 +25,7 @@ const cases: { name: string; inputState: GlobalLoadingState; expectedMessage: st
         inputState: {
             configReady: true,
             azureAuthEnabled: true,
+            dexAuthEnabled: true,
             isAuthenticated: true,
             overviewLoaded: true,
         },
@@ -35,6 +36,7 @@ const cases: { name: string; inputState: GlobalLoadingState; expectedMessage: st
         inputState: {
             configReady: false,
             azureAuthEnabled: true,
+            dexAuthEnabled: true,
             isAuthenticated: true,
             overviewLoaded: true,
         },
@@ -45,6 +47,7 @@ const cases: { name: string; inputState: GlobalLoadingState; expectedMessage: st
         inputState: {
             configReady: true,
             azureAuthEnabled: true,
+            dexAuthEnabled: true,
             isAuthenticated: false,
             overviewLoaded: true,
         },
@@ -55,6 +58,7 @@ const cases: { name: string; inputState: GlobalLoadingState; expectedMessage: st
         inputState: {
             configReady: true,
             azureAuthEnabled: false,
+            dexAuthEnabled: true,
             isAuthenticated: false,
             overviewLoaded: true,
         },
@@ -65,6 +69,7 @@ const cases: { name: string; inputState: GlobalLoadingState; expectedMessage: st
         inputState: {
             configReady: true,
             azureAuthEnabled: true,
+            dexAuthEnabled: true,
             isAuthenticated: true,
             overviewLoaded: false,
         },

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -980,6 +980,11 @@ export const useGlobalLoadingState = (): React.ReactElement | undefined => {
     const dexAuthEnabled = configs.authConfig?.dexAuth?.enabled || false;
     const overviewLoaded = useOverviewLoaded();
     const everythingLoaded = overviewLoaded && configReady && (isAuthenticated || !azureAuthEnabled);
+    const validToken = isTokenValid();
+    if (dexAuthEnabled && !validToken) {
+        return <LoginPage />;
+    }
+
     if (!everythingLoaded) {
         return (
             <LoadingStateSpinner
@@ -992,11 +997,6 @@ export const useGlobalLoadingState = (): React.ReactElement | undefined => {
                 }}
             />
         );
-    }
-
-    const validToken = isTokenValid();
-    if (dexAuthEnabled && !validToken) {
-        return <LoginPage />;
     }
     return undefined;
 };

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -995,7 +995,7 @@ export const useGlobalLoadingState = (): React.ReactElement | undefined => {
     }
 
     const validToken = isTokenValid();
-    if (!dexAuthEnabled && !validToken) {
+    if (dexAuthEnabled && !validToken) {
         return <LoginPage />;
     }
     return undefined;

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -995,7 +995,7 @@ export const useGlobalLoadingState = (): React.ReactElement | undefined => {
     }
 
     const validToken = isTokenValid();
-    if (dexAuthEnabled && !validToken) {
+    if (!dexAuthEnabled && !validToken) {
         return <LoginPage />;
     }
     return undefined;

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -980,6 +980,20 @@ export const useGlobalLoadingState = (): React.ReactElement | undefined => {
     const dexAuthEnabled = configs.authConfig?.dexAuth?.enabled || false;
     const overviewLoaded = useOverviewLoaded();
     const everythingLoaded = overviewLoaded && configReady && (isAuthenticated || !azureAuthEnabled);
+    if (!configReady) {
+        return (
+            <LoadingStateSpinner
+                loadingState={{
+                    configReady,
+                    isAuthenticated,
+                    azureAuthEnabled,
+                    dexAuthEnabled,
+                    overviewLoaded,
+                }}
+            />
+        );
+    }
+
     const validToken = isTokenValid();
     if (dexAuthEnabled && !validToken) {
         return <LoginPage />;


### PR DESCRIPTION
When Dex is enabled the user is now redirected to a login page if it tries to access Kuberpult. 

![image](https://github.com/user-attachments/assets/74b53a70-1d35-4b2c-84bf-08f202156130)
