### PR TITLE
fix(db): replace sequence prediction

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -73,7 +73,7 @@ type DBHandler struct {
 }
 
 type EslId int64
-type TransformerID uint
+type TransformerID EslId
 type AppStateChange string
 
 const (

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -1042,7 +1042,7 @@ func (r *repository) ApplyTransformersInternal(ctx context.Context, transaction 
 			}
 			if internal == nil {
 				return nil, nil, nil, &TransformerBatchApplyError{
-					TransformerError: fmt.Errorf("could not find esl even that was just inserted with event type %v", t.GetDBEventType()),
+					TransformerError: fmt.Errorf("could not find esl event that was just inserted with event type %v", t.GetDBEventType()),
 					Index:            i,
 				}
 			}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -377,7 +377,7 @@ type CreateApplicationVersion struct {
 	DisplayVersion   string            `json:"displayVersion"`
 	WriteCommitData  bool              `json:"writeCommitData"`
 	PreviousCommit   string            `json:"previousCommit"`
-	TransformerEslID db.TransformerID  `json:"eslid"`
+	TransformerEslID db.TransformerID  `json:"-"`
 }
 
 func (c *CreateApplicationVersion) GetDBEventType() db.EventType {
@@ -1050,7 +1050,7 @@ type CreateUndeployApplicationVersion struct {
 	Authentication   `json:"-"`
 	Application      string           `json:"app"`
 	WriteCommitData  bool             `json:"writeCommitData"`
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -1208,7 +1208,7 @@ func removeCommit(fs billy.Filesystem, commitID, application string) error {
 type UndeployApplication struct {
 	Authentication   `json:"-"`
 	Application      string           `json:"app"`
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -1357,7 +1357,7 @@ type DeleteEnvFromApp struct {
 	Authentication   `json:"-"`
 	Application      string           `json:"app"`
 	Environment      string           `json:"env"`
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -1445,7 +1445,7 @@ func (u *DeleteEnvFromApp) Transform(
 
 type CleanupOldApplicationVersions struct {
 	Application      string
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 }
 
 func (c *CleanupOldApplicationVersions) GetDBEventType() db.EventType {
@@ -1568,7 +1568,7 @@ type CreateEnvironmentLock struct {
 	Environment      string           `json:"env"`
 	LockId           string           `json:"lockId"`
 	Message          string           `json:"message"`
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -1731,7 +1731,7 @@ type DeleteEnvironmentLock struct {
 	Authentication   `json:"-"`
 	Environment      string           `json:"env"`
 	LockId           string           `json:"lockId"`
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -1822,7 +1822,7 @@ type CreateEnvironmentGroupLock struct {
 	EnvironmentGroup string           `json:"env"`
 	LockId           string           `json:"lockId"`
 	Message          string           `json:"message"`
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -1869,7 +1869,7 @@ type DeleteEnvironmentGroupLock struct {
 	Authentication   `json:"-"`
 	EnvironmentGroup string           `json:"envGroup"`
 	LockId           string           `json:"lockId"`
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -1915,7 +1915,7 @@ type CreateEnvironmentApplicationLock struct {
 	Application      string           `json:"app"`
 	LockId           string           `json:"lockId"`
 	Message          string           `json:"message"`
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -2004,7 +2004,7 @@ type DeleteEnvironmentApplicationLock struct {
 	Environment      string           `json:"env"`
 	Application      string           `json:"app"`
 	LockId           string           `json:"lockId"`
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -2080,7 +2080,7 @@ type CreateEnvironmentTeamLock struct {
 	Team             string           `json:"team"`
 	LockId           string           `json:"lockId"`
 	Message          string           `json:"message"`
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -2199,7 +2199,7 @@ type DeleteEnvironmentTeamLock struct {
 	Environment      string           `json:"env"`
 	Team             string           `json:"team"`
 	LockId           string           `json:"lockId"`
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 }
 
 func (c *DeleteEnvironmentTeamLock) GetDBEventType() db.EventType {
@@ -2276,7 +2276,7 @@ type CreateEnvironment struct {
 	Authentication   `json:"-"`
 	Environment      string                   `json:"env"`
 	Config           config.EnvironmentConfig `json:"config"`
-	TransformerEslID db.TransformerID         `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID         `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -2403,7 +2403,7 @@ type DeployApplicationVersion struct {
 	WriteCommitData  bool                            `json:"writeCommitData"`
 	SourceTrain      *DeployApplicationVersionSource `json:"sourceTrain"`
 	Author           string                          `json:"author"`
-	TransformerEslID db.TransformerID                `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID                `json:"-"` // Tags the transformer with EventSourcingLight eslid
 }
 
 func (c *DeployApplicationVersion) GetDBEventType() db.EventType {
@@ -2837,7 +2837,7 @@ type ReleaseTrain struct {
 	CommitHash       string           `json:"commitHash"`
 	WriteCommitData  bool             `json:"writeCommitData"`
 	Repo             Repository       `json:"-"`
-	TransformerEslID db.TransformerID `json:"eslid"`
+	TransformerEslID db.TransformerID `json:"-"`
 }
 
 func (c *ReleaseTrain) GetDBEventType() db.EventType {
@@ -3592,7 +3592,7 @@ func (c *envReleaseTrain) Transform(
 // services" commit log.
 type skippedServices struct {
 	Messages         []string
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -3623,7 +3623,7 @@ func (c *skippedServices) Transform(
 
 type skippedService struct {
 	Message          string
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -3634,6 +3634,7 @@ func (c *skippedService) GetDBEventType() db.EventType {
 func (c *skippedService) SetEslID(id db.TransformerID) {
 	c.TransformerEslID = id
 }
+
 func (c *skippedService) Transform(_ context.Context, _ *State, _ TransformerContext, _ *sql.Tx) (string, error) {
 	return c.Message, nil
 }

--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -320,7 +320,7 @@ func TestTransformerWritesEslDataRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("marshal error: %v\njson: \n%s\n", err, row.EventJson)
 			}
-
+			tc.Transformer.SetEslID(0) // the eslId is not part of the json blob anymore
 			if diff := cmp.Diff(tc.Transformer, jsonInterface, protocmp.Transform()); diff != "" {
 				t.Fatalf("error mismatch (-want, +got):\n%s", diff)
 			}

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -331,6 +331,7 @@ func processEslEvent(ctx context.Context, repo repository.Repository, esl *db.Es
 	if err != nil {
 		return nil, err
 	}
+	t.SetEslID(db.TransformerID(esl.EslId))
 	logger.FromContext(ctx).Sugar().Infof("read esl event of type (%s) event=%v", t.GetDBEventType(), t)
 
 	err = repo.Apply(ctx, tx, t)

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -114,6 +114,7 @@ type Transformer interface {
 	GetDBEventType() db.EventType
 	GetMetadata() *TransformerMetadata
 	GetEslID() db.TransformerID
+	SetEslID(id db.TransformerID)
 }
 
 type TransformerContext interface {
@@ -252,11 +253,15 @@ type QueueApplicationVersion struct {
 	Environment      string
 	Application      string
 	Version          uint64
-	TransformerEslID db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 }
 
 func (c *QueueApplicationVersion) GetEslID() db.TransformerID {
 	return c.TransformerEslID
+}
+
+func (c *QueueApplicationVersion) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
 }
 
 func (c *QueueApplicationVersion) Transform(
@@ -293,7 +298,7 @@ type DeployApplicationVersion struct {
 	WriteCommitData     bool                            `json:"writeCommitData"`
 	SourceTrain         *DeployApplicationVersionSource `json:"sourceTrain"`
 	Author              string                          `json:"author"`
-	TransformerEslID    db.TransformerID                `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID    db.TransformerID                `json:"-"` // Tags the transformer with EventSourcingLight eslid
 }
 
 func (c *DeployApplicationVersion) GetDBEventType() db.EventType {
@@ -302,6 +307,10 @@ func (c *DeployApplicationVersion) GetDBEventType() db.EventType {
 
 func (c *DeployApplicationVersion) GetEslID() db.TransformerID {
 	return c.TransformerEslID
+}
+
+func (c *DeployApplicationVersion) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
 }
 
 type DeployApplicationVersionSource struct {
@@ -491,12 +500,16 @@ type CreateEnvironmentLock struct {
 	Environment         string           `json:"env"`
 	LockId              string           `json:"lockId"`
 	Message             string           `json:"message"`
-	TransformerEslID    db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID    db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
 func (c *CreateEnvironmentLock) GetEslID() db.TransformerID {
 	return c.TransformerEslID
+}
+
+func (c *CreateEnvironmentLock) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
 }
 
 func (c *CreateEnvironmentLock) GetDBEventType() db.EventType {
@@ -573,13 +586,18 @@ type DeleteEnvironmentLock struct {
 	TransformerMetadata `json:"metadata"`
 	Environment         string           `json:"env"`
 	LockId              string           `json:"lockId"`
-	TransformerEslID    db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID    db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
 func (c *DeleteEnvironmentLock) GetEslID() db.TransformerID {
 	return c.TransformerEslID
 }
+
+func (c *DeleteEnvironmentLock) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
+}
+
 func (c *DeleteEnvironmentLock) GetDBEventType() db.EventType {
 	return db.EvtDeleteEnvironmentLock
 }
@@ -623,12 +641,16 @@ type CreateEnvironmentApplicationLock struct {
 	Application         string           `json:"app"`
 	LockId              string           `json:"lockId"`
 	Message             string           `json:"message"`
-	TransformerEslID    db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID    db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
 func (c *CreateEnvironmentApplicationLock) GetEslID() db.TransformerID {
 	return c.TransformerEslID
+}
+
+func (c *CreateEnvironmentApplicationLock) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
 }
 
 func (c *CreateEnvironmentApplicationLock) GetDBEventType() db.EventType {
@@ -681,7 +703,7 @@ type DeleteEnvironmentApplicationLock struct {
 	Environment         string           `json:"env"`
 	Application         string           `json:"app"`
 	LockId              string           `json:"lockId"`
-	TransformerEslID    db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID    db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
@@ -691,6 +713,10 @@ func (c *DeleteEnvironmentApplicationLock) GetDBEventType() db.EventType {
 
 func (c *DeleteEnvironmentApplicationLock) GetEslID() db.TransformerID {
 	return c.TransformerEslID
+}
+
+func (c *DeleteEnvironmentApplicationLock) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
 }
 
 func (c *DeleteEnvironmentApplicationLock) Transform(
@@ -735,11 +761,15 @@ type CreateApplicationVersion struct {
 	DisplayVersion      string            `json:"displayVersion"`
 	WriteCommitData     bool              `json:"writeCommitData"`
 	PreviousCommit      string            `json:"previousCommit"`
-	TransformerEslID    db.TransformerID  `json:"eslID"`
+	TransformerEslID    db.TransformerID  `json:"-"`
 }
 
 func (c *CreateApplicationVersion) GetEslID() db.TransformerID {
 	return c.TransformerEslID
+}
+
+func (c *CreateApplicationVersion) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
 }
 
 func (c *CreateApplicationVersion) GetDBEventType() db.EventType {
@@ -1073,13 +1103,18 @@ type CreateEnvironmentTeamLock struct {
 	Team                string           `json:"team"`
 	LockId              string           `json:"lockId"`
 	Message             string           `json:"message"`
-	TransformerEslID    db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID    db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
 func (c *CreateEnvironmentTeamLock) GetEslID() db.TransformerID {
 	return c.TransformerEslID
 }
+
+func (c *CreateEnvironmentTeamLock) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
+}
+
 func (c *CreateEnvironmentTeamLock) GetDBEventType() db.EventType {
 	return db.EvtCreateEnvironmentTeamLock
 }
@@ -1158,12 +1193,16 @@ type DeleteEnvironmentTeamLock struct {
 	Environment         string           `json:"env"`
 	Team                string           `json:"team"`
 	LockId              string           `json:"lockId"`
-	TransformerEslID    db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID    db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
 func (c *DeleteEnvironmentTeamLock) GetEslID() db.TransformerID {
 	return c.TransformerEslID
+}
+
+func (c *DeleteEnvironmentTeamLock) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
 }
 
 func (c *DeleteEnvironmentTeamLock) GetDBEventType() db.EventType {
@@ -1210,12 +1249,16 @@ type CreateEnvironment struct {
 	TransformerMetadata `json:"metadata"`
 	Environment         string                   `json:"env"`
 	Config              config.EnvironmentConfig `json:"config"`
-	TransformerEslID    db.TransformerID         `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID    db.TransformerID         `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
 func (c *CreateEnvironment) GetEslID() db.TransformerID {
 	return c.TransformerEslID
+}
+
+func (c *CreateEnvironment) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
 }
 
 func (c *CreateEnvironment) GetDBEventType() db.EventType {
@@ -1319,12 +1362,16 @@ func removeCommit(fs billy.Filesystem, commitID, application string) error {
 type CleanupOldApplicationVersions struct {
 	Application         string
 	TransformerMetadata `json:"metadata"`
-	TransformerEslID    db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID    db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
 func (c *CleanupOldApplicationVersions) GetEslID() db.TransformerID {
 	return c.TransformerEslID
+}
+
+func (c *CleanupOldApplicationVersions) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
 }
 
 func (c *CleanupOldApplicationVersions) GetDBEventType() db.EventType {
@@ -1385,12 +1432,16 @@ type ReleaseTrain struct {
 	CommitHash          string           `json:"commitHash"`
 	WriteCommitData     bool             `json:"writeCommitData"`
 	Repo                Repository       `json:"-"`
-	TransformerEslID    db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID    db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 
 }
 
 func (c *ReleaseTrain) GetEslID() db.TransformerID {
 	return c.TransformerEslID
+}
+
+func (c *ReleaseTrain) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
 }
 
 func (c *ReleaseTrain) GetDBEventType() db.EventType {
@@ -1463,7 +1514,7 @@ func (u *ReleaseTrain) Transform(
 
 type MigrationTransformer struct {
 	TransformerMetadata `json:"metadata"`
-	TransformerEslID    db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID    db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 }
 
 func (c *MigrationTransformer) GetDBEventType() db.EventType {
@@ -1477,16 +1528,24 @@ func (c *MigrationTransformer) GetEslID() db.TransformerID {
 	return c.TransformerEslID
 }
 
+func (c *MigrationTransformer) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
+}
+
 type DeleteEnvFromApp struct {
 	Authentication      `json:"-"`
 	TransformerMetadata `json:"metadata"`
 	Environment         string           `json:"environment"`
 	Application         string           `json:"application"`
-	TransformerEslID    db.TransformerID `json:"eslid"` // Tags the transformer with EventSourcingLight eslid
+	TransformerEslID    db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslid
 }
 
 func (u *DeleteEnvFromApp) GetEslID() db.TransformerID {
 	return u.TransformerEslID
+}
+
+func (c *DeleteEnvFromApp) SetEslID(eslId db.TransformerID) {
+	c.TransformerEslID = eslId
 }
 
 func (u *DeleteEnvFromApp) GetDBEventType() db.EventType {


### PR DESCRIPTION
The original attempt was to read "last_value" of a squence to determine the *next* Primary Key and also write it into the json blob.
    
This was error prone, and especially failed on the first startup (with an "empty" sequence).
    
This PR changes this approach. It was necessary to add an interface function to set the transformer ID.
    
Background: The transformer ID is required for the commit events, so that we can easily find all commit events of one transformer.