### PR TITLE
fix(dex): do not format the serviceUrl twice

### DIFF
--- a/pkg/auth/dex.go
+++ b/pkg/auth/dex.go
@@ -296,7 +296,7 @@ func (a *DexAppClient) oauth2Config(scopes []string) (c *oauth2.Config, err erro
 }
 
 // Verifies if the user is authenticated.
-func VerifyToken(ctx context.Context, r *http.Request, clientID, baseURL, dexFullNameOverride string, useClusterInternalCommunication bool) (jwt.MapClaims, error) {
+func VerifyToken(ctx context.Context, r *http.Request, clientID, baseURL, dexServiceURL string, useClusterInternalCommunication bool) (jwt.MapClaims, error) {
 	// Get the token cookie from the request
 	cookie, err := r.Cookie(dexOAUTHTokenName)
 
@@ -315,9 +315,6 @@ func VerifyToken(ctx context.Context, r *http.Request, clientID, baseURL, dexFul
 	} else {
 		tokenString = cookie.Value
 	}
-
-	// Get the dex service name
-	dexServiceURL := fmt.Sprintf(dexServiceURLPattern, dexFullNameOverride)
 
 	// Validates token audience and expiring date.
 	idToken, err := ValidateOIDCToken(ctx, baseURL+issuerPATH, tokenString, clientID, dexServiceURL, useClusterInternalCommunication)

--- a/services/frontend-service/pkg/interceptors/interceptors.go
+++ b/services/frontend-service/pkg/interceptors/interceptors.go
@@ -181,8 +181,8 @@ func DexAPIInterceptor(
 	httpHandler(w, req)
 }
 
-func GetContextFromDex(w http.ResponseWriter, req *http.Request, clientID, baseURL, dexFullNameOverride string, DexRbacPolicy *auth.RBACPolicies, useClusterInternalCommunication bool) (context.Context, error) {
-	claims, err := auth.VerifyToken(req.Context(), req, clientID, baseURL, dexFullNameOverride, useClusterInternalCommunication)
+func GetContextFromDex(w http.ResponseWriter, req *http.Request, clientID, baseURL, dexServiceURL string, DexRbacPolicy *auth.RBACPolicies, useClusterInternalCommunication bool) (context.Context, error) {
+	claims, err := auth.VerifyToken(req.Context(), req, clientID, baseURL, dexServiceURL, useClusterInternalCommunication)
 	if err != nil {
 		logger.FromContext(req.Context()).Info(fmt.Sprintf("Error verifying token for Dex: %s", err))
 		return req.Context(), err


### PR DESCRIPTION
The formatting for the dex service url was applied twice, thus returning an invalid url.