### PR TITLE
feat(cd-service): store Failed Esl Events

### DIFF
--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -306,7 +306,7 @@ auth:
     enabled: false
     # Indicates if dex is to be installed. If you want to use your own Dex instance do not enable this flag.
     installDex: false
-    # Overrides the name of the dex resources. Allows creating multiple Dex instances on the same cluster. 
+    # Overrides the name of the dex resources. Allows creating multiple Dex instances on the same cluster.
     fullNameOverride: "kuberpult-dex"
     # If kuberpult cannot find a role in the dex response, it will use the role "default".
     # This is only recommended for when you want the simplest possible setup, or for testing purposes.

--- a/database/migrations/postgres/1720611031124325_event_sourcing_light_failed.up.sql
+++ b/database/migrations/postgres/1720611031124325_event_sourcing_light_failed.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS event_sourcing_light_failed
+(
+    eslId SERIAL PRIMARY KEY,
+    created TIMESTAMP,
+    event_type VARCHAR(255),
+    json VARCHAR
+);

--- a/database/migrations/sqlite/1720611031124325_event_sourcing_light_failed.up.sql
+++ b/database/migrations/sqlite/1720611031124325_event_sourcing_light_failed.up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS event_sourcing_light_failed
 (
-    eslId INTEGER PRIMARY KEY autincrement,
+    eslId INTEGER PRIMARY KEY autoincrement,
     created TIMESTAMP,
     event_type VARCHAR(255),
     json VARCHAR

--- a/database/migrations/sqlite/1720611031124325_event_sourcing_light_failed.up.sql
+++ b/database/migrations/sqlite/1720611031124325_event_sourcing_light_failed.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS event_sourcing_light_failed
+(
+    eslId INTEGER PRIMARY KEY autincrement,
+    created TIMESTAMP,
+    event_type VARCHAR(255),
+    json VARCHAR
+);

--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -688,7 +688,7 @@ service EslService {
 message GetFailedEslsRequest {}
 
 message EslItem {
-  int64 EslId = 1;
+  int64 esl_id = 1;
   google.protobuf.Timestamp created_at = 2;
   string event_type = 3;
   string json = 4;

--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -680,3 +680,20 @@ message ServiceDeployRequest {
 }
 
 message ServiceDeployResponse {}
+
+service EslService {
+  rpc GetFailedEsls (GetFailedEslsRequest) returns (GetFailedEslsResponse) {}
+}
+
+message GetFailedEslsRequest {}
+
+message EslItem {
+  int64 EslId = 1;
+  google.protobuf.Timestamp created_at = 2;
+  string event_type = 3;
+  string json = 4;
+}
+
+message GetFailedEslsResponse {
+  repeated EslItem failed_esls = 1;
+}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -4453,7 +4453,6 @@ func (h *DBHandler) DBWriteFailedEslEvent(ctx context.Context,  tx *sql.Tx, eslE
 	span, _ := tracer.StartSpanFromContext(ctx, "DBWriteEslEventInternal")
 	defer span.Finish()
 
-
 	insertQuery := h.AdaptQuery("INSERT INTO event_sourcing_light_failed (created, event_type , json)  VALUES (?, ?, ?);")
 
 	span.SetTag("query", insertQuery)
@@ -4479,7 +4478,7 @@ func (h *DBHandler) DBReadLastFailedEslEvents(ctx context.Context, tx *sql.Tx, l
 		return nil, fmt.Errorf("DBReadlastFailedEslEvents: no transaction provided")
 	}
 
-	query := h.AdaptQuery("SELECT created, event_type, json FROM event_sourcing_light_failed ORDER BY created DESC LIMIT ?;")
+	query := h.AdaptQuery("SELECT eslId, created, event_type, json FROM event_sourcing_light_failed ORDER BY created DESC LIMIT ?;")
 	span.SetTag("query", query)
 	rows, err := tx.QueryContext(ctx, query, limit)
 	if err != nil {
@@ -4497,7 +4496,7 @@ func (h *DBHandler) DBReadLastFailedEslEvents(ctx context.Context, tx *sql.Tx, l
 
 	for rows.Next() {
 		row := &EslEventRow{}
-		err := rows.Scan(&row.Created, &row.EventType, &row.EventJson)
+		err := rows.Scan(&row.EslId, &row.Created, &row.EventType, &row.EventJson)
 		if err != nil {
 			return nil, fmt.Errorf("could not read failed events from DB. Error: %w\n", err)
 		}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -4495,7 +4495,12 @@ func (h *DBHandler) DBReadLastFailedEslEvents(ctx context.Context, tx *sql.Tx, l
 	failedEsls := make([]*EslEventRow, 0)
 
 	for rows.Next() {
-		row := &EslEventRow{}
+		row := &EslEventRow{
+			EslId:     0,
+			Created:   time.Unix(0, 0),
+			EventType: "",
+			EventJson: "",
+		}
 		err := rows.Scan(&row.EslId, &row.Created, &row.EventType, &row.EventJson)
 		if err != nil {
 			return nil, fmt.Errorf("could not read failed events from DB. Error: %w\n", err)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -4443,15 +4443,15 @@ func (h *DBHandler) WriteOverviewCache(ctx context.Context, transaction *sql.Tx,
 	}
 	return nil
 }
-func (h *DBHandler) DBWriteFailedEslEvent(ctx context.Context,  tx *sql.Tx, eslEvent *EslEventRow) error {
+func (h *DBHandler) DBWriteFailedEslEvent(ctx context.Context, tx *sql.Tx, eslEvent *EslEventRow) error {
+	span, _ := tracer.StartSpanFromContext(ctx, "DBWriteEslEventInternal")
+	defer span.Finish()
 	if h == nil {
 		return nil
 	}
 	if tx == nil {
 		return fmt.Errorf("DBWriteFailedEslEvent: no transaction provided")
 	}
-	span, _ := tracer.StartSpanFromContext(ctx, "DBWriteEslEventInternal")
-	defer span.Finish()
 
 	insertQuery := h.AdaptQuery("INSERT INTO event_sourcing_light_failed (created, event_type , json)  VALUES (?, ?, ?);")
 
@@ -4506,6 +4506,10 @@ func (h *DBHandler) DBReadLastFailedEslEvents(ctx context.Context, tx *sql.Tx, l
 			return nil, fmt.Errorf("could not read failed events from DB. Error: %w\n", err)
 		}
 		failedEsls = append(failedEsls, row)
+	}
+	err = closeRows(rows)
+	if err != nil {
+		return nil, fmt.Errorf("could not close rows. Error: %w\n", err)
 	}
 
 	return failedEsls, nil

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1717,13 +1717,14 @@ func TestReadWriteFailedEslEvent(t *testing.T) {
 				}
 
 				for i, actualEvent := range actualEvents {
-					if diff := cmp.Diff(tc.Events[len(tc.Events)-1-i].EslId, actualEvent.EslId); diff != "" {
+					reverse_index := len(tc.Events) - 1 - i // The order of the results should be descending
+					if diff := cmp.Diff(tc.Events[reverse_index].EslId, actualEvent.EslId); diff != "" {
 						t.Fatalf("event id mismatch (-want, +got):\n%s", diff)
 					}
-					if diff := cmp.Diff(tc.Events[len(tc.Events)-1-i].EventType, actualEvent.EventType); diff != "" {
+					if diff := cmp.Diff(tc.Events[reverse_index].EventType, actualEvent.EventType); diff != "" {
 						t.Fatalf("event type mismatch (-want, +got):\n%s", diff)
 					}
-					if diff := cmp.Diff(tc.Events[len(tc.Events)-1-i].EventJson, actualEvent.EventJson); diff != "" {
+					if diff := cmp.Diff(tc.Events[reverse_index].EventJson, actualEvent.EventJson); diff != "" {
 						t.Fatalf("event json mismatch (-want, +got):\n%s", diff)
 					}
 				}

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -392,6 +392,7 @@ func RunServer() {
 							Policy:     dexRbacPolicy,
 						},
 					})
+					api.RegisterEslServiceServer(srv, &service.EslServiceServer{Repository: repo})
 					reflection.Register(srv)
 					reposerver.Register(srv, repo, cfg)
 

--- a/services/cd-service/pkg/service/esl.go
+++ b/services/cd-service/pkg/service/esl.go
@@ -1,5 +1,4 @@
-/*
-This file is part of kuberpult.
+/*This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -13,8 +12,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright freiheit.com
-*/
+Copyright freiheit.com*/
+
 package service
 
 import (

--- a/services/cd-service/pkg/service/esl.go
+++ b/services/cd-service/pkg/service/esl.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type EslServiceServer struct {
+	Repository repository.Repository
+}
+
+func (s *EslServiceServer) GetFailedEsls(ctx context.Context, req *api.GetFailedEslsRequest) (*api.GetFailedEslsResponse, error) {
+	state := s.Repository.State()
+	var response *api.GetFailedEslsResponse = &api.GetFailedEslsResponse{}
+	if state.DBHandler.ShouldUseOtherTables() {
+		err :=  state.DBHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+			failedEslRows, err := s.Repository.State().DBHandler.DBReadLastFailedEslEvents(ctx, transaction, 20)
+			if err != nil {
+				return err
+			}
+			failedEslItems := make([]*api.EslItem, len(failedEslRows))
+			for i, failedEslRow := range failedEslRows {
+				failedEslItems[i] = &api.EslItem{
+					EslId: int64(failedEslRow.EslId),
+					CreatedAt: timestamppb.New(failedEslRow.Created),
+					EventType: string(failedEslRow.EventType),
+					Json: failedEslRow.EventJson,
+				}
+			}
+			response = &api.GetFailedEslsResponse{
+				FailedEsls: failedEslItems,
+			}
+
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return response, nil
+}

--- a/services/cd-service/pkg/service/esl.go
+++ b/services/cd-service/pkg/service/esl.go
@@ -1,4 +1,5 @@
-/*This file is part of kuberpult.
+/*
+This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -12,7 +13,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright freiheit.com*/
+Copyright freiheit.com
+*/
 package service
 
 import (

--- a/services/cd-service/pkg/service/esl.go
+++ b/services/cd-service/pkg/service/esl.go
@@ -19,6 +19,8 @@ package service
 import (
 	"context"
 	"database/sql"
+	"fmt"
+
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
 	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -57,6 +59,8 @@ func (s *EslServiceServer) GetFailedEsls(ctx context.Context, req *api.GetFailed
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		return nil, fmt.Errorf("GetFailedEsls is only implemented for the database")
 	}
 	return response, nil
 }

--- a/services/cd-service/pkg/service/esl_test.go
+++ b/services/cd-service/pkg/service/esl_test.go
@@ -41,7 +41,7 @@ func TestGetFailedEslsService(t *testing.T) {
 			FailedEsls: []*db.EslEventRow{
 				{
 					EslId:     1,
-					EventJson: string(`{"env":"dev","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`),
+					EventJson: `{"env":"dev","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`,
 					EventType: db.EvtCreateApplicationVersion,
 					Created:   time.Now(),
 				},
@@ -52,7 +52,7 @@ func TestGetFailedEslsService(t *testing.T) {
 						EslId:     1,
 						CreatedAt: timestamppb.New(time.Now()),
 						EventType: string(db.EvtCreateApplicationVersion),
-						Json:      string(`{"env":"dev","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`),
+						Json:      `{"env":"dev","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`,
 					},
 				},
 			},
@@ -62,13 +62,13 @@ func TestGetFailedEslsService(t *testing.T) {
 			FailedEsls: []*db.EslEventRow{
 				{
 					EslId:     1,
-					EventJson: string(`{"env":"dev","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`),
+					EventJson: `{"env":"dev","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`,
 					EventType: db.EvtCreateApplicationVersion,
 					Created:   time.Now(),
 				},
 				{
 					EslId:     2,
-					EventJson: string(`{"env":"dev2","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`),
+					EventJson: `{"env":"dev2","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`,
 					EventType: db.EvtCreateEnvironment,
 					Created:   time.Now(),
 				},
@@ -79,13 +79,13 @@ func TestGetFailedEslsService(t *testing.T) {
 						EslId:     2,
 						CreatedAt: timestamppb.New(time.Now()),
 						EventType: string(db.EvtCreateEnvironment),
-						Json:      string(`{"env":"dev2","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`),
+						Json:      `{"env":"dev2","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`,
 					},
 					{
 						EslId:     1,
 						CreatedAt: timestamppb.New(time.Now()),
 						EventType: string(db.EvtCreateApplicationVersion),
-						Json:      string(`{"env":"dev","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`),
+						Json:      `{"env":"dev","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`,
 					},
 				},
 			},

--- a/services/cd-service/pkg/service/esl_test.go
+++ b/services/cd-service/pkg/service/esl_test.go
@@ -1,5 +1,4 @@
-/*
-This file is part of kuberpult.
+/*This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -13,8 +12,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright freiheit.com
-*/
+Copyright freiheit.com*/
+
 package service
 
 import (

--- a/services/cd-service/pkg/service/esl_test.go
+++ b/services/cd-service/pkg/service/esl_test.go
@@ -1,0 +1,143 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+package service
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
+	"github.com/freiheit-com/kuberpult/pkg/db"
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestGetFailedEslsService(t *testing.T) {
+	tcs := []struct {
+		Name             string
+		FailedEsls       []*db.EslEventRow
+		ExpectedResponse *api.GetFailedEslsResponse
+	}{
+		{
+			Name: "One failed Esl",
+			FailedEsls: []*db.EslEventRow{
+				{
+					EslId:     1,
+					EventJson: string(`{"env":"dev","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`),
+					EventType: db.EvtCreateApplicationVersion,
+					Created:   time.Now(),
+				},
+			},
+			ExpectedResponse: &api.GetFailedEslsResponse{
+				FailedEsls: []*api.EslItem{
+					{
+						EslId:     1,
+						CreatedAt: timestamppb.New(time.Now()),
+						EventType: string(db.EvtCreateApplicationVersion),
+						Json:      string(`{"env":"dev","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`),
+					},
+				},
+			},
+		},
+		{
+			Name: "Multiple failed Esls",
+			FailedEsls: []*db.EslEventRow{
+				{
+					EslId:     1,
+					EventJson: string(`{"env":"dev","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`),
+					EventType: db.EvtCreateApplicationVersion,
+					Created:   time.Now(),
+				},
+				{
+					EslId:     2,
+					EventJson: string(`{"env":"dev2","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`),
+					EventType: db.EvtCreateEnvironment,
+					Created:   time.Now(),
+				},
+			},
+			ExpectedResponse: &api.GetFailedEslsResponse{
+				FailedEsls: []*api.EslItem{
+					{
+						EslId:     2,
+						CreatedAt: timestamppb.New(time.Now()),
+						EventType: string(db.EvtCreateEnvironment),
+						Json:      string(`{"env":"dev2","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`),
+					},
+					{
+						EslId:     1,
+						CreatedAt: timestamppb.New(time.Now()),
+						EventType: string(db.EvtCreateApplicationVersion),
+						Json:      string(`{"env":"dev","app":"my-app","lockId":"ui-v2-ke1up","message":"test","metadata":{"authorEmail":"testemail@example.com","authorName":"testauthor"}}`),
+					},
+				},
+			},
+		},
+		{
+			Name:       "No failed Esls",
+			FailedEsls: []*db.EslEventRow{},
+			ExpectedResponse: &api.GetFailedEslsResponse{
+				FailedEsls: []*api.EslItem{},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			migrationsPath, err := testutil.CreateMigrationsPath(4)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dbConfig := &db.DBConfig{
+				DriverName:     "sqlite3",
+				MigrationsPath: migrationsPath,
+				WriteEslOnly:   false,
+			}
+			repo, err := setupRepositoryTestWithDB(t, dbConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+			svc := &EslServiceServer{
+				Repository: repo,
+			}
+			err = repo.State().DBHandler.WithTransaction(testutil.MakeTestContext(), false, func(ctx context.Context, transaction *sql.Tx) error {
+				for _, failedEsl := range tc.FailedEsls {
+					err := repo.State().DBHandler.DBWriteFailedEslEvent(ctx, transaction, failedEsl)
+					if err != nil {
+						return err
+					}
+				}
+				return err
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			response, err := svc.GetFailedEsls(context.Background(), &api.GetFailedEslsRequest{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			opts := cmp.Options{cmpopts.IgnoreFields(api.EslItem{}, "CreatedAt"), cmpopts.IgnoreUnexported(api.GetFailedEslsResponse{}, api.EslItem{}, timestamppb.Timestamp{})}
+			if diff := cmp.Diff(tc.ExpectedResponse, response, opts); diff != "" {
+				t.Logf("response: %+v", response)
+				t.Logf("expected: %+v", tc.ExpectedResponse)
+				t.Fatal("Output mismatch (-want +got):\n", diff)
+			}
+		})
+	}
+}

--- a/services/cd-service/pkg/service/esl_test.go
+++ b/services/cd-service/pkg/service/esl_test.go
@@ -1,4 +1,5 @@
-/*This file is part of kuberpult.
+/*
+This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -12,7 +13,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright freiheit.com*/
+Copyright freiheit.com
+*/
 package service
 
 import (

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -294,6 +294,7 @@ func runServer(ctx context.Context) error {
 		GitClient:                   api.NewGitServiceClient(cdCon),
 		EnvironmentServiceClient:    api.NewEnvironmentServiceClient(cdCon),
 		ReleaseTrainPrognosisClient: releaseTrainPrognosisClient,
+		EslServiceClient:            api.NewEslServiceClient(cdCon),
 	}
 	api.RegisterOverviewServiceServer(gsrv, gproxy)
 	api.RegisterBatchServiceServer(gsrv, gproxy)
@@ -301,6 +302,7 @@ func runServer(ctx context.Context) error {
 	api.RegisterGitServiceServer(gsrv, gproxy)
 	api.RegisterEnvironmentServiceServer(gsrv, gproxy)
 	api.RegisterReleaseTrainPrognosisServiceServer(gsrv, gproxy)
+	api.RegisterEslServiceServer(gsrv, gproxy)
 
 	frontendConfigService := &service.FrontendConfigServiceServer{
 		Config: config.FrontendConfig{
@@ -624,6 +626,7 @@ type GrpcProxy struct {
 	GitClient                   api.GitServiceClient
 	EnvironmentServiceClient    api.EnvironmentServiceClient
 	ReleaseTrainPrognosisClient api.ReleaseTrainPrognosisServiceClient
+	EslServiceClient            api.EslServiceClient
 }
 
 func (p *GrpcProxy) ProcessBatch(
@@ -638,6 +641,12 @@ func (p *GrpcProxy) ProcessBatch(
 	}
 
 	return p.BatchClient.ProcessBatch(ctx, in)
+}
+
+func (p *GrpcProxy) GetFailedEsls(
+	ctx context.Context,
+	in *api.GetFailedEslsRequest) (*api.GetFailedEslsResponse, error) {
+	return p.EslServiceClient.GetFailedEsls(ctx, in)
 }
 
 func (p *GrpcProxy) GetOverview(

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -264,7 +264,11 @@ func Run(ctx context.Context) error {
 			}
 			transformer, err := processEslEvent(ctx, repo, esl, transaction)
 			if err != nil {
-				return fmt.Errorf("error in processEslEvent %v", err)
+				err2 := dbHandler.DBWriteFailedEslEvent(ctx, transaction, esl)
+				if err2 != nil {
+					return fmt.Errorf("error in DBWriteFailedEslEvent %v", err2)
+				}
+				transformer = nil
 			}
 			if transformer == nil {
 				log.Warn("event processing skipped")


### PR DESCRIPTION
Whenever the manifest-export service fails to process and esl, it will save it in the failed esls table and skip it.
There's a new Endpoint in cd-service/frontend-service which Gives the list of last 20 failed esls.