### PR TITLE
fix(db): retry all transactions by default

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1770,7 +1770,11 @@ func (h *DBHandler) RunCustomMigrationReleases(ctx context.Context, getAllAppsFu
 
 	return h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
 		l := logger.FromContext(ctx).Sugar()
-		if needsMigrating := h.needsReleasesMigrations(ctx, transaction); !needsMigrating {
+		needsMigrating, err := h.needsReleasesMigrations(ctx, transaction)
+		if err != nil {
+			return err
+		}
+		if !needsMigrating {
 			return nil
 		}
 		allAppsMap, err := getAllAppsFun()
@@ -1821,18 +1825,17 @@ func (h *DBHandler) RunCustomMigrationReleases(ctx context.Context, getAllAppsFu
 	})
 }
 
-func (h *DBHandler) needsReleasesMigrations(ctx context.Context, transaction *sql.Tx) bool {
+func (h *DBHandler) needsReleasesMigrations(ctx context.Context, transaction *sql.Tx) (bool, error) {
 	l := logger.FromContext(ctx).Sugar()
 	allReleasesDb, err := h.DBSelectAnyRelease(ctx, transaction)
 	if err != nil {
-		l.Warnf("could not get releases from database - assuming the manifest repo is correct: %v", err)
-		allReleasesDb = nil
+		return true, err
 	}
 	if allReleasesDb != nil {
 		l.Warnf("There are already deployments in the DB - skipping migrations")
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 
 }
 
@@ -1841,7 +1844,11 @@ func (h *DBHandler) RunCustomMigrationDeployments(ctx context.Context, getAllDep
 	defer span.Finish()
 
 	return h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-		if needsMigrating := h.needsDeploymentsMigrations(ctx, transaction); !needsMigrating {
+		needsMigrating, err := h.needsDeploymentsMigrations(ctx, transaction)
+		if err != nil {
+			return err
+		}
+		if !needsMigrating {
 			return nil
 		}
 		allDeploymentsInRepo, err := getAllDeploymentsFun(ctx, transaction)
@@ -1862,18 +1869,17 @@ func (h *DBHandler) RunCustomMigrationDeployments(ctx context.Context, getAllDep
 	})
 }
 
-func (h *DBHandler) needsDeploymentsMigrations(ctx context.Context, transaction *sql.Tx) bool {
+func (h *DBHandler) needsDeploymentsMigrations(ctx context.Context, transaction *sql.Tx) (bool, error) {
 	l := logger.FromContext(ctx).Sugar()
 	allAppsDb, err := h.DBSelectAnyDeployment(ctx, transaction)
 	if err != nil {
-		l.Warnf("could not get applications from database - assuming the manifest repo is correct: %v", err)
-		allAppsDb = nil
+		return true, err
 	}
 	if allAppsDb != nil {
 		l.Warnf("There are already deployments in the DB - skipping migrations")
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 type AllApplicationsJson struct {
@@ -1906,8 +1912,11 @@ func (h *DBHandler) RunCustomMigrationEnvLocks(ctx context.Context, getAllEnvLoc
 	defer span.Finish()
 
 	return h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-
-		if needsMigrating := h.needsEnvLocksMigrations(ctx, transaction); !needsMigrating {
+		needsMigrating, err := h.needsEnvLocksMigrations(ctx, transaction)
+		if err != nil {
+			return err
+		}
+		if !needsMigrating {
 			return nil
 		}
 
@@ -1942,18 +1951,17 @@ func (h *DBHandler) RunCustomMigrationEnvLocks(ctx context.Context, getAllEnvLoc
 	})
 }
 
-func (h *DBHandler) needsEnvLocksMigrations(ctx context.Context, transaction *sql.Tx) bool {
+func (h *DBHandler) needsEnvLocksMigrations(ctx context.Context, transaction *sql.Tx) (bool, error) {
 	l := logger.FromContext(ctx).Sugar()
 	allEnvLocksDb, err := h.DBSelectAnyActiveEnvLocks(ctx, transaction)
 	if err != nil {
-		l.Infof("could not get environment locks from database - assuming the manifest repo is correct: %v", err)
-		allEnvLocksDb = nil
+		return true, err
 	}
 	if allEnvLocksDb != nil {
 		l.Infof("There are already environment locks in the DB - skipping migrations")
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 func (h *DBHandler) RunCustomMigrationAppLocks(ctx context.Context, getAllAppLocksFun GetAllAppLocksFun) error {
@@ -1961,7 +1969,11 @@ func (h *DBHandler) RunCustomMigrationAppLocks(ctx context.Context, getAllAppLoc
 	defer span.Finish()
 
 	return h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-		if needsMigrating := h.needsAppLocksMigrations(ctx, transaction); !needsMigrating {
+		needsMigrating, err := h.needsAppLocksMigrations(ctx, transaction)
+		if err != nil {
+			return err
+		}
+		if !needsMigrating {
 			return nil
 		}
 		allAppLocksInRepo, err := getAllAppLocksFun(ctx)
@@ -1995,18 +2007,17 @@ func (h *DBHandler) RunCustomMigrationAppLocks(ctx context.Context, getAllAppLoc
 	})
 }
 
-func (h *DBHandler) needsAppLocksMigrations(ctx context.Context, transaction *sql.Tx) bool {
+func (h *DBHandler) needsAppLocksMigrations(ctx context.Context, transaction *sql.Tx) (bool, error) {
 	l := logger.FromContext(ctx).Sugar()
 	allAppLocksDb, err := h.DBSelectAnyActiveAppLock(ctx, transaction)
 	if err != nil {
-		l.Infof("could not get application locks from database - assuming the manifest repo is correct: %v", err)
-		allAppLocksDb = nil
+		return true, err
 	}
 	if allAppLocksDb != nil {
 		l.Infof("There are already application locks in the DB - skipping migrations")
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 func (h *DBHandler) RunCustomMigrationTeamLocks(ctx context.Context, getAllTeamLocksFun GetAllTeamLocksFun) error {
@@ -2014,7 +2025,11 @@ func (h *DBHandler) RunCustomMigrationTeamLocks(ctx context.Context, getAllTeamL
 	defer span.Finish()
 
 	return h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-		if needsMigrating := h.needsTeamLocksMigrations(ctx, transaction); !needsMigrating {
+		needsMigrating, err := h.needsTeamLocksMigrations(ctx, transaction)
+		if err != nil {
+			return err
+		}
+		if !needsMigrating {
 			return nil
 		}
 
@@ -2048,23 +2063,26 @@ func (h *DBHandler) RunCustomMigrationTeamLocks(ctx context.Context, getAllTeamL
 	})
 }
 
-func (h *DBHandler) needsTeamLocksMigrations(ctx context.Context, transaction *sql.Tx) bool {
+func (h *DBHandler) needsTeamLocksMigrations(ctx context.Context, transaction *sql.Tx) (bool, error) {
 	l := logger.FromContext(ctx).Sugar()
 	allTeamLocksDb, err := h.DBSelectAnyActiveTeamLock(ctx, transaction)
 	if err != nil {
-		l.Infof("could not get team locks from database - assuming the manifest repo is correct: %v", err)
-		allTeamLocksDb = nil
+		return true, err
 	}
 	if allTeamLocksDb != nil {
 		l.Infof("There are already team locks in the DB - skipping migrations")
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 func (h *DBHandler) RunCustomMigrationsCommitEvents(ctx context.Context, getAllEvents GetAllEventsFun) error {
 	return h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-		if needsMigrating := h.needsCommitEventsMigrations(ctx, transaction); !needsMigrating {
+		needsMigrating, err := h.needsCommitEventsMigrations(ctx, transaction)
+		if err != nil {
+			return err
+		}
+		if !needsMigrating {
 			return nil
 		}
 
@@ -2088,19 +2106,18 @@ func (h *DBHandler) RunCustomMigrationsCommitEvents(ctx context.Context, getAllE
 	})
 }
 
-func (h *DBHandler) needsCommitEventsMigrations(ctx context.Context, transaction *sql.Tx) bool {
+func (h *DBHandler) needsCommitEventsMigrations(ctx context.Context, transaction *sql.Tx) (bool, error) {
 	l := logger.FromContext(ctx).Sugar()
 
 	ev, err := h.DBSelectAnyEvent(ctx, transaction)
 	if err != nil {
-		l.Infof("could not get commit events from database - assuming the manifest repo is correct: %v", err)
-		ev = nil
+		return true, err
 	}
 	if ev != nil {
 		l.Infof("There are already commit events in the DB - skipping migrations")
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 func (h *DBHandler) RunCustomMigrationQueuedApplicationVersions(ctx context.Context, getAllQueuedVersionsFun GetAllQueuedVersionsFun) error {
@@ -2108,8 +2125,11 @@ func (h *DBHandler) RunCustomMigrationQueuedApplicationVersions(ctx context.Cont
 	defer span.Finish()
 
 	return h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-
-		if needsMigrating := h.needsQueuedDeploymentsMigrations(ctx, transaction); !needsMigrating {
+		needsMigrating, err := h.needsQueuedDeploymentsMigrations(ctx, transaction)
+		if err != nil {
+			return err
+		}
+		if !needsMigrating {
 			return nil
 		}
 
@@ -2131,38 +2151,49 @@ func (h *DBHandler) RunCustomMigrationQueuedApplicationVersions(ctx context.Cont
 	})
 }
 
-func (h *DBHandler) needsQueuedDeploymentsMigrations(ctx context.Context, transaction *sql.Tx) bool {
+func (h *DBHandler) needsQueuedDeploymentsMigrations(ctx context.Context, transaction *sql.Tx) (bool, error) {
 	l := logger.FromContext(ctx).Sugar()
-
 	allTeamLocksDb, err := h.DBSelectAnyDeploymentAttempt(ctx, transaction)
 	if err != nil {
-		l.Infof("could not get queued deployments from database - assuming the manifest repo is correct: %v", err)
-		allTeamLocksDb = nil
+		return true, err
 	}
 	if allTeamLocksDb != nil {
 		l.Infof("There are already queued deployments in the DB - skipping migrations")
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 // NeedsMigrations: Checks if we need migrations for any table.
 func (h *DBHandler) NeedsMigrations(ctx context.Context) (bool, error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "NeedsMigrations")
 	defer span.Finish()
-	var needsMigration bool
+	var needsMigration bool = false
 	txError := h.WithTransaction(ctx, true, func(ctx context.Context, transaction *sql.Tx) error {
-		needsMigration = h.NeedsEventSourcingLightMigrations(ctx, transaction) ||
-			h.needsAllAppsMigrations(ctx, transaction) ||
-			h.needsAppsMigrations(ctx, transaction) ||
-			h.needsDeploymentsMigrations(ctx, transaction) ||
-			h.needsReleasesMigrations(ctx, transaction) ||
-			h.needsEnvLocksMigrations(ctx, transaction) ||
-			h.needsAppLocksMigrations(ctx, transaction) ||
-			h.needsTeamLocksMigrations(ctx, transaction) ||
-			h.needsQueuedDeploymentsMigrations(ctx, transaction) ||
-			h.needsCommitEventsMigrations(ctx, transaction) ||
-			h.needsEnvironmentsMigrations(ctx, transaction)
+		var checkFunctions = []CheckFun{
+			(*DBHandler).NeedsEventSourcingLightMigrations,
+			(*DBHandler).needsAllAppsMigrations,
+			(*DBHandler).needsAppsMigrations,
+			(*DBHandler).needsDeploymentsMigrations,
+			(*DBHandler).needsReleasesMigrations,
+			(*DBHandler).needsEnvLocksMigrations,
+			(*DBHandler).needsAppLocksMigrations,
+			(*DBHandler).needsTeamLocksMigrations,
+			(*DBHandler).needsQueuedDeploymentsMigrations,
+			(*DBHandler).needsCommitEventsMigrations,
+			(*DBHandler).needsEnvironmentsMigrations,
+		}
+		for i := range checkFunctions {
+			f := checkFunctions[i]
+			needs, err := f(h, ctx, transaction)
+			if err != nil {
+				return err
+			}
+			if needs {
+				needsMigration = true
+				return nil
+			}
+		}
 		return nil
 	})
 	return needsMigration, txError
@@ -2174,26 +2205,31 @@ func (h *DBHandler) RunCustomMigrationsEventSourcingLight(ctx context.Context) e
 		span, _ := tracer.StartSpanFromContext(ctx, "RunCustomMigrationsEventSourcingLight")
 		defer span.Finish()
 
-		if needsMigrating := h.NeedsEventSourcingLightMigrations(ctx, transaction); !needsMigrating {
+		needsMigrating, err := h.NeedsEventSourcingLightMigrations(ctx, transaction)
+		if err != nil {
+			return err
+		}
+		if !needsMigrating {
 			return nil
-
 		}
 
 		return h.DBWriteMigrationsTransformer(ctx, transaction)
 	})
 }
 
-func (h *DBHandler) NeedsEventSourcingLightMigrations(ctx context.Context, transaction *sql.Tx) bool {
+type CheckFun = func(handler *DBHandler, ctx context.Context, transaction *sql.Tx) (bool, error)
+
+func (h *DBHandler) NeedsEventSourcingLightMigrations(ctx context.Context, transaction *sql.Tx) (bool, error) {
 	l := logger.FromContext(ctx).Sugar()
 	eslEvent, err := h.DBReadEslEventInternal(ctx, transaction, true) //true sorts by asc
 	if err != nil {
-		eslEvent = nil
+		return true, err
 	}
 	if eslEvent != nil && eslEvent.EslVersion == 0 { //Check if there is a 0th transformer already
 		l.Infof("Found Migrations transformer on database.")
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 func (h *DBHandler) DBWriteMigrationsTransformer(ctx context.Context, transaction *sql.Tx) error {
@@ -2241,7 +2277,11 @@ func (h *DBHandler) RunCustomMigrationAllAppsTable(ctx context.Context, getAllAp
 	defer span.Finish()
 
 	return h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-		if needMigrating := h.needsAllAppsMigrations(ctx, transaction); !needMigrating {
+		needMigrating, err := h.needsAllAppsMigrations(ctx, transaction)
+		if err != nil {
+			return err
+		}
+		if !needMigrating {
 			return nil
 		}
 
@@ -2258,14 +2298,14 @@ func (h *DBHandler) RunCustomMigrationAllAppsTable(ctx context.Context, getAllAp
 	})
 }
 
-func (h *DBHandler) needsAllAppsMigrations(ctx context.Context, transaction *sql.Tx) bool {
+func (h *DBHandler) needsAllAppsMigrations(ctx context.Context, transaction *sql.Tx) (bool, error) {
 	l := logger.FromContext(ctx).Sugar()
 	allAppsDb, err := h.DBSelectAllApplications(ctx, transaction)
 	if err != nil {
 		l.Warnf("could not get applications from database - assuming the manifest repo is correct: %v", err)
-		return false
+		return false, err
 	}
-	return allAppsDb == nil
+	return allAppsDb == nil, nil
 }
 
 func (h *DBHandler) RunCustomMigrationApps(ctx context.Context, getAllAppsFun GetAllAppsFun) error {
@@ -2273,7 +2313,11 @@ func (h *DBHandler) RunCustomMigrationApps(ctx context.Context, getAllAppsFun Ge
 	defer span.Finish()
 
 	return h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-		if needsMigrating := h.needsAppsMigrations(ctx, transaction); !needsMigrating {
+		needMigrating, err := h.needsAllAppsMigrations(ctx, transaction)
+		if err != nil {
+			return err
+		}
+		if !needMigrating {
 			return nil
 		}
 
@@ -2293,19 +2337,17 @@ func (h *DBHandler) RunCustomMigrationApps(ctx context.Context, getAllAppsFun Ge
 	})
 }
 
-func (h *DBHandler) needsAppsMigrations(ctx context.Context, transaction *sql.Tx) bool {
-	l := logger.FromContext(ctx).Sugar()
+func (h *DBHandler) needsAppsMigrations(ctx context.Context, transaction *sql.Tx) (bool, error) {
 	dbApp, err := h.DBSelectAnyApp(ctx, transaction)
 	if err != nil {
-		l.Warnf("could not get dbApp from database - assuming the manifest repo is correct: %v", err)
-		dbApp = nil
+		return true, err
 	}
 	if dbApp != nil {
 		// the migration was already done
 		logger.FromContext(ctx).Info("migration to apps was done already")
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 // ENV LOCKS
@@ -4481,7 +4523,11 @@ func (h *DBHandler) RunCustomMigrationEnvironments(ctx context.Context, getAllEn
 	defer span.Finish()
 
 	return h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-		if needsMigrating := h.needsEnvironmentsMigrations(ctx, transaction); !needsMigrating {
+		needsMigrating, err := h.needsEnvironmentsMigrations(ctx, transaction)
+		if err != nil {
+			return err
+		}
+		if !needsMigrating {
 			return nil
 		}
 		allEnvironments, err := getAllEnvironmentsFun(ctx)
@@ -4505,20 +4551,19 @@ func (h *DBHandler) RunCustomMigrationEnvironments(ctx context.Context, getAllEn
 	})
 }
 
-func (h *DBHandler) needsEnvironmentsMigrations(ctx context.Context, transaction *sql.Tx) bool {
+func (h *DBHandler) needsEnvironmentsMigrations(ctx context.Context, transaction *sql.Tx) (bool, error) {
 	log := logger.FromContext(ctx).Sugar()
 
 	arbitraryAllEnvsRow, err := h.DBSelectAnyEnvironment(ctx, transaction)
 
 	if err != nil {
-		log.Warnf("unable to check if custom migration for environments has already occured, error: %w", err)
-		arbitraryAllEnvsRow = nil
+		return true, err
 	}
 	if arbitraryAllEnvsRow != nil {
 		log.Infof("custom migration for environments already ran because row %v was found, skipping custom migration", arbitraryAllEnvsRow)
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 type OverviewCacheRow struct {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -2313,11 +2313,12 @@ func (h *DBHandler) RunCustomMigrationApps(ctx context.Context, getAllAppsFun Ge
 	defer span.Finish()
 
 	return h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-		needMigrating, err := h.needsAllAppsMigrations(ctx, transaction)
+		needMigrating, err := h.needsAppsMigrations(ctx, transaction)
 		if err != nil {
 			return err
 		}
 		if !needMigrating {
+			logger.FromContext(ctx).Sugar().Warnf("no need to migrate apps")
 			return nil
 		}
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1371,7 +1371,7 @@ func (h *DBHandler) DBSelectDeployment(ctx context.Context, tx *sql.Tx, appSelec
 		envSelector,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("could not query deployments table from DB. Error: %w\n", err)
+		return nil, fmt.Errorf("could not select deployment from DB. Error: %w\n", err)
 	}
 	defer func(rows *sql.Rows) {
 		err := rows.Close()
@@ -1446,7 +1446,7 @@ func (h *DBHandler) DBSelectDeploymentHistory(ctx context.Context, tx *sql.Tx, a
 		limit,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("could not query deployments table from DB. Error: %w\n", err)
+		return nil, fmt.Errorf("could not select deployment history from DB. Error: %w\n", err)
 	}
 	defer func(rows *sql.Rows) {
 		err := rows.Close()
@@ -1490,7 +1490,7 @@ func (h *DBHandler) DBSelectDeploymentsByTransformerID(ctx context.Context, tx *
 		limit,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("could not query deployments table from DB. Error: %w\n", err)
+		return nil, fmt.Errorf("could not select deployments by transformer id from DB. Error: %w\n", err)
 	}
 	defer func(rows *sql.Rows) {
 		err := rows.Close()
@@ -1527,7 +1527,7 @@ func (h *DBHandler) DBSelectAnyDeployment(ctx context.Context, tx *sql.Tx) (*DBD
 		selectQuery,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("could not query deployments table from DB. Error: %w\n", err)
+		return nil, fmt.Errorf("could not select any deployments from DB. Error: %w\n", err)
 	}
 	defer func(rows *sql.Rows) {
 		err := rows.Close()

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1488,7 +1488,7 @@ func TestReadWriteEnvironment(t *testing.T) {
 				}
 			}
 
-			envEntry, err := WithTransactionT(dbHandler, ctx, true, func(ctx context.Context, transaction *sql.Tx) (*DBEnvironment, error) {
+			envEntry, err := WithTransactionT(dbHandler, ctx, DefaultNumRetries, true, func(ctx context.Context, transaction *sql.Tx) (*DBEnvironment, error) {
 				envEntry, err := dbHandler.DBSelectEnvironment(ctx, transaction, tc.EnvToQuery)
 				if err != nil {
 					return nil, fmt.Errorf("error while selecting environment entry, error: %w", err)
@@ -1788,7 +1788,7 @@ func TestReadWriteAllEnvironments(t *testing.T) {
 				}
 			}
 
-			allEnvsEntry, err := WithTransactionT(dbHandler, ctx, true, func(ctx context.Context, transaction *sql.Tx) (*DBAllEnvironments, error) {
+			allEnvsEntry, err := WithTransactionT(dbHandler, ctx, DefaultNumRetries, true, func(ctx context.Context, transaction *sql.Tx) (*DBAllEnvironments, error) {
 				allEnvsEntry, err := dbHandler.DBSelectAllEnvironments(ctx, transaction)
 				if err != nil {
 					return nil, fmt.Errorf("error while selecting environment entry, error: %w", err)

--- a/pkg/db/transactions.go
+++ b/pkg/db/transactions.go
@@ -46,6 +46,7 @@ func (h *DBHandler) WithTransaction(ctx context.Context, readonly bool, f DBFunc
 	}
 	return nil
 }
+
 func (h *DBHandler) WithTransactionR(ctx context.Context, maxRetries uint, readonly bool, f DBFunction) error {
 	_, err := WithTransactionT(h, ctx, maxRetries, readonly, func(ctx context.Context, transaction *sql.Tx) (*interface{}, error) {
 		err2 := f(ctx, transaction)
@@ -80,7 +81,7 @@ func WithTransactionT[T any](h *DBHandler, ctx context.Context, maxRetries uint,
 
 // WithTransactionMultipleEntriesT is the same as WithTransaction, but you can also return and array of data, not just the error.
 func WithTransactionMultipleEntriesT[T any](h *DBHandler, ctx context.Context, readonly bool, f DBFunctionMultipleEntriesT[T]) ([]T, error) {
-	return WithTransactionMultipleEntriesRetryT(h, ctx, 1, readonly, f)
+	return WithTransactionMultipleEntriesRetryT(h, ctx, DefaultNumRetries, readonly, f)
 }
 
 // WithTransactionMultipleEntriesRetryT also supports retries

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -428,7 +428,7 @@ func New2(ctx context.Context, cfg RepositoryConfig) (Repository, setup.Backgrou
 
 			// Check configuration for errors and abort early if any:
 			if state.DBHandler.ShouldUseOtherTables() {
-				_, err = db.WithTransactionT(state.DBHandler, ctx, false, func(ctx context.Context, transaction *sql.Tx) (*map[string]config.EnvironmentConfig, error) {
+				_, err = db.WithTransactionT(state.DBHandler, ctx, db.DefaultNumRetries, false, func(ctx context.Context, transaction *sql.Tx) (*map[string]config.EnvironmentConfig, error) {
 					ret, err := state.GetEnvironmentConfigsAndValidate(ctx, transaction)
 					return &ret, err
 				})
@@ -537,6 +537,7 @@ func (r *repository) applyTransformerBatches(transformerBatches []transformerBat
 		var transaction *sql.Tx
 		var txErr error
 		e := transformerBatches[i]
+
 		if r.DB.ShouldUseEslTable() {
 			transaction, txErr = r.DB.BeginTransaction(e.ctx, false)
 			if txErr != nil {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -1098,6 +1098,11 @@ func (r *repository) afterTransform(ctx context.Context, state State, transactio
 	span, ctx := tracer.StartSpanFromContext(ctx, "afterTransform")
 	defer span.Finish()
 
+	if state.DBHandler.ShouldUseOtherTables() {
+		// if the DB is enabled fully, the manifest-export service takes care to update the argo apps
+		return nil
+	}
+
 	configs, err := state.GetAllEnvironmentConfigs(ctx, transaction)
 	if err != nil {
 		return err

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -113,6 +113,20 @@ func (err *TransformerBatchApplyError) Is(target error) bool {
 	return errors.Is(err.TransformerError, tgt.TransformerError)
 }
 
+func UnwrapUntilTransformerBatchApplyError(err error) *TransformerBatchApplyError {
+	for {
+		var applyErr *TransformerBatchApplyError
+		if errors.As(err, &applyErr) {
+			return applyErr
+		}
+		err2 := errors.Unwrap(err)
+		if err2 == nil {
+			// cannot unwrap any further
+			return nil
+		}
+	}
+}
+
 func defaultBackOffProvider() backoff.BackOff {
 	eb := backoff.NewExponentialBackOff()
 	eb.MaxElapsedTime = 7 * time.Second

--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -2002,7 +2002,8 @@ func TestUndeployApplicationDB(t *testing.T) {
 				t.Fatalf("Did no expect error but got):\n%+v", err)
 			}
 			if err != nil {
-				if diff := cmp.Diff(tc.expectedError, err.(*TransformerBatchApplyError), cmpopts.EquateErrors()); diff != "" {
+				applyErr := UnwrapUntilTransformerBatchApplyError(err)
+				if diff := cmp.Diff(tc.expectedError, applyErr, cmpopts.EquateErrors()); diff != "" {
 					t.Fatalf("error mismatch (-want, +got):\n%s", diff)
 				}
 			}

--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -449,7 +449,7 @@ func TestEnvLockTransformersWithDB(t *testing.T) {
 				}
 			}
 
-			locks, err := db.WithTransactionT(repo.State().DBHandler, ctx, false, func(ctx context.Context, transaction *sql.Tx) (*db.AllEnvLocksGo, error) {
+			locks, err := db.WithTransactionT(repo.State().DBHandler, ctx, db.DefaultNumRetries, false, func(ctx context.Context, transaction *sql.Tx) (*db.AllEnvLocksGo, error) {
 				return repo.State().DBHandler.DBSelectAllEnvironmentLocks(ctx, transaction, envProduction)
 			})
 
@@ -609,7 +609,7 @@ func TestTeamLockTransformersWithDB(t *testing.T) {
 				}
 			}
 
-			locks, err := db.WithTransactionT(repo.State().DBHandler, ctx, true, func(ctx context.Context, transaction *sql.Tx) (*db.AllTeamLocksGo, error) {
+			locks, err := db.WithTransactionT(repo.State().DBHandler, ctx, db.DefaultNumRetries, true, func(ctx context.Context, transaction *sql.Tx) (*db.AllTeamLocksGo, error) {
 				return repo.State().DBHandler.DBSelectAllTeamLocks(ctx, transaction, envAcceptance, team)
 			})
 

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
 
 	"github.com/freiheit-com/kuberpult/pkg/grpc"
 	"github.com/freiheit-com/kuberpult/pkg/valid"
@@ -363,6 +364,7 @@ func (d *BatchServer) ProcessBatch(
 	}
 	err = d.Repository.Apply(ctx, transformers...)
 	if err != nil {
+		logger.FromContext(ctx).Sugar().Warnf("error in repo apply: %v", err)
 		var applyErr *repository.TransformerBatchApplyError
 		if errors.Is(err, repository.ErrQueueFull) {
 			return nil, status.Error(codes.ResourceExhausted, fmt.Sprintf("Could not process ProcessBatch request. Err: %s", err.Error()))

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -1039,7 +1039,7 @@ func TestCreateEnvironmentTrain(t *testing.T) {
 			var envs map[string]config.EnvironmentConfig
 			if repo.State().DBHandler.ShouldUseOtherTables() {
 				var envsPtr *map[string]config.EnvironmentConfig
-				envsPtr, err = db.WithTransactionT(repo.State().DBHandler, ctx, true, func(ctx context.Context, transaction *sql.Tx) (*map[string]config.EnvironmentConfig, error) {
+				envsPtr, err = db.WithTransactionT(repo.State().DBHandler, ctx, db.DefaultNumRetries, true, func(ctx context.Context, transaction *sql.Tx) (*map[string]config.EnvironmentConfig, error) {
 					envs, err := repo.State().GetAllEnvironmentConfigs(ctx, transaction)
 					return &envs, err
 				})

--- a/services/cd-service/pkg/service/environment.go
+++ b/services/cd-service/pkg/service/environment.go
@@ -36,7 +36,7 @@ func (o *EnvironmentServiceServer) GetEnvironmentConfig(
 	in *api.GetEnvironmentConfigRequest) (*api.GetEnvironmentConfigResponse, error) {
 	state := o.Repository.State()
 
-	config, err := db.WithTransactionT(state.DBHandler, ctx, true, func(ctx context.Context, transaction *sql.Tx) (*config.EnvironmentConfig, error) {
+	config, err := db.WithTransactionT(state.DBHandler, ctx, db.DefaultNumRetries, true, func(ctx context.Context, transaction *sql.Tx) (*config.EnvironmentConfig, error) {
 		return state.GetEnvironmentConfig(ctx, transaction, in.Environment)
 	})
 

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -81,7 +81,7 @@ func (o *OverviewServiceServer) getOverviewDB(
 	s *repository.State) (*api.GetOverviewResponse, error) {
 
 	if s.DBHandler.ShouldUseOtherTables() {
-		response, err := db.WithTransactionT[api.GetOverviewResponse](s.DBHandler, ctx, false, func(ctx context.Context, transaction *sql.Tx) (*api.GetOverviewResponse, error) {
+		response, err := db.WithTransactionT[api.GetOverviewResponse](s.DBHandler, ctx, db.DefaultNumRetries, false, func(ctx context.Context, transaction *sql.Tx) (*api.GetOverviewResponse, error) {
 			var err2 error
 			cached_result, err2 := s.DBHandler.ReadLatestOverviewCache(ctx, transaction)
 			if err2 != nil {

--- a/services/cd-service/pkg/service/version.go
+++ b/services/cd-service/pkg/service/version.go
@@ -100,7 +100,7 @@ func (o *VersionServiceServer) GetManifests(ctx context.Context, req *api.GetMan
 	}
 
 	if state.DBHandler.ShouldUseOtherTables() {
-		result, err := db.WithTransactionT(state.DBHandler, ctx, false, func(ctx context.Context, transaction *sql.Tx) (*api.GetManifestsResponse, error) {
+		result, err := db.WithTransactionT(state.DBHandler, ctx, db.DefaultNumRetries, false, func(ctx context.Context, transaction *sql.Tx) (*api.GetManifestsResponse, error) {
 			var (
 				err     error
 				release uint64

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -730,6 +730,9 @@ func (r *repository) updateArgoCdApps(ctx context.Context, transaction *sql.Tx, 
 			if err != nil {
 				return fmt.Errorf("updateArgoCdApps: could not select app '%s' in db %v", appName, err)
 			}
+			if oneAppData == nil {
+				return fmt.Errorf("skipping app %s because it was not found in the database", appName)
+			}
 			version, err := state.GetEnvironmentApplicationVersion(ctx, transaction, env, appName)
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) {

--- a/services/manifest-repo-export-service/pkg/repository/transformer_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer_test.go
@@ -155,7 +155,7 @@ func TestTransformerWorksWithDb(t *testing.T) {
 					TransformerEslVersion: 1,
 				},
 			},
-			ExpectedError: errMatcher{"first apply failed, aborting: error at index 0 of transformer batch: " +
+			ExpectedError: errMatcher{"error within transaction: first apply failed, aborting: error at index 0 of transformer batch: " +
 				"release of app myapp with version 7 not found",
 			},
 			ExpectedApp:  nil,
@@ -228,7 +228,7 @@ func TestTransformerWorksWithDb(t *testing.T) {
 					PreviousCommit:  "",
 				},
 			},
-			ExpectedError: errMatcher{"first apply failed, aborting: error not specific to one transformer of this batch: " +
+			ExpectedError: errMatcher{"error within transaction: first apply failed, aborting: error not specific to one transformer of this batch: " +
 				"transformer metadata is empty",
 			},
 		},
@@ -247,7 +247,7 @@ func TestTransformerWorksWithDb(t *testing.T) {
 					TransformerEslVersion: 1,
 				},
 			},
-			ExpectedError: errMatcher{"first apply failed, aborting: error at index 0 of transformer batch: " +
+			ExpectedError: errMatcher{"error within transaction: first apply failed, aborting: error at index 0 of transformer batch: " +
 				"error accessing dir \"environments/acceptance\": file does not exist",
 			},
 		},
@@ -267,7 +267,7 @@ func TestTransformerWorksWithDb(t *testing.T) {
 					TransformerEslVersion: 1,
 				},
 			},
-			ExpectedError: errMatcher{"first apply failed, aborting: error at index 0 of transformer batch: " +
+			ExpectedError: errMatcher{"error within transaction: first apply failed, aborting: error at index 0 of transformer batch: " +
 				"error accessing dir \"environments/acceptance\": file does not exist",
 			},
 		},
@@ -283,7 +283,7 @@ func TestTransformerWorksWithDb(t *testing.T) {
 					TransformerEslVersion: 1,
 				},
 			},
-			ExpectedError: errMatcher{"first apply failed, aborting: error at index 0 of transformer batch: " +
+			ExpectedError: errMatcher{"error within transaction: first apply failed, aborting: error at index 0 of transformer batch: " +
 				"team 'my-team' does not exist",
 			},
 		},

--- a/tests/integration-tests/release_test.go
+++ b/tests/integration-tests/release_test.go
@@ -184,7 +184,7 @@ func TestReleaseCalls(t *testing.T) {
 		{
 			// Note that this test is not repeatable. Once the version exists, it cannot be overridden.
 			// To repeat the test, we would have to reset the manifest repo.
-			name:               "Simple invocation of /release endpoint with valid version",
+			name:               "Simple invocation of /release endpoint with valid version should be new",
 			inputApp:           "my-app-" + appSuffix,
 			inputManifest:      theManifest,
 			inputSignature:     CalcSignature(t, theManifest),
@@ -195,7 +195,7 @@ func TestReleaseCalls(t *testing.T) {
 		},
 		{
 			// this is the same test, but this time we expect 200, because the release already exists:
-			name:               "Simple invocation of /release endpoint with valid version",
+			name:               "Simple invocation of /release endpoint with valid version should already exist",
 			inputApp:           "my-app-" + appSuffix,
 			inputManifest:      theManifest,
 			inputSignature:     CalcSignature(t, theManifest),


### PR DESCRIPTION
By default, all transactions are now retried 3 times.

This also removes writing the argo apps from the cd-service (if the db is enabled), because the manifest-repo-export service already takes care of that.

Another change is to wrap all errors from the database, and unwrap TransformerErrors accordingly in ProcessBatch, so that we have both detailed error messages (wrap) and correct return codes (unwrap).

Ref: SRX-4CJW8O