### PR TITLE
fix: change allowUnexported for updating Argo apps

### DIFF
--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -176,7 +176,7 @@ func (a ArgoAppProcessor) CreateOrUpdateApp(ctx context.Context, overview *api.G
 			//exhaustruct:ignore
 			emptyAppSpec := v1alpha1.ApplicationSpec{}
 			//exhaustruct:ignore
-			emptyAppSyncPolicy := v1alpha1.SyncPolicyAutomated{}
+			emptyAppSyncPolicy := v1alpha1.ApplicationSpec{SyncPolicy: &v1alpha1.SyncPolicy{}}
 			//We have to exclude the unexported type destination and the syncPolicy
 			diff := cmp.Diff(appUpdateRequest.Application.Spec, existingApp.Spec,
 				cmp.AllowUnexported(emptyAppSpec.Destination),

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -175,12 +175,10 @@ func (a ArgoAppProcessor) CreateOrUpdateApp(ctx context.Context, overview *api.G
 
 			//exhaustruct:ignore
 			emptyAppSpec := v1alpha1.ApplicationSpec{}
-			//exhaustruct:ignore
-			emptyAppSyncPolicy := v1alpha1.ApplicationSpec{SyncPolicy: &v1alpha1.SyncPolicy{}}
 			//We have to exclude the unexported type destination and the syncPolicy
 			diff := cmp.Diff(appUpdateRequest.Application.Spec, existingApp.Spec,
 				cmp.AllowUnexported(emptyAppSpec.Destination),
-				cmp.AllowUnexported(emptyAppSyncPolicy))
+				cmp.AllowUnexported(emptyAppSpec.SyncPolicy))
 			if diff != "" {
 				updateSpan, ctx := tracer.StartSpanFromContext(ctx, "UpdateApplications")
 				updateSpan.SetTag("application", app.Name)


### PR DESCRIPTION
Before, we added a diff exclusion for the sync policy in the applications. Turns out the diff needs to be referenced from the app spec instead of from the object itself.