### PR TITLE
fix(chore): clean up buildfiles

### DIFF
--- a/services/cd-service/Buildfile.yaml
+++ b/services/cd-service/Buildfile.yaml
@@ -1,10 +1,3 @@
----
-apiVersion: v1beta1
-kind: Service
-metadata:
-  name: cd-service
-  tier: backend
-  version: v1
 spec:
   buildWith: infrastructure/docker/builder
   dependsOn:

--- a/services/cloudrun-service/Buildfile.yaml
+++ b/services/cloudrun-service/Buildfile.yaml
@@ -1,6 +1,3 @@
----
-metadata:
-  builder: kuberpult-builder
 spec:
   buildWith: infrastructure/docker/builder
   dependsOn:

--- a/services/frontend-service/Buildfile.yaml
+++ b/services/frontend-service/Buildfile.yaml
@@ -1,5 +1,3 @@
-metadata:
-  name: frontend-service
 spec:
   buildWith: infrastructure/docker/builder
   dependsOn:

--- a/services/rollout-service/Buildfile.yaml
+++ b/services/rollout-service/Buildfile.yaml
@@ -1,6 +1,3 @@
----
-metadata:
-  builder: kuberpult-builder
 spec:
   buildWith: infrastructure/docker/builder
   dependsOn:


### PR DESCRIPTION
- remove apiVersion, as it is only in one Buildfile and thus seems used
- remove kind, as it is only in one Buildfile and thus seems used
- remove metadata.name, as it is not in all Buildfiles and thus seems used
- remove metadata.tier, as it is not in all Buildfiles and thus seems used
- remove metadata.version, as it is not in all Buildfiles and thus seems used
- remove metadata.builder, as it is not in all Buildfiles and thus seems used
