### PR TITLE
fix: Render long lock messages nicer

### DIFF
--- a/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.scss
+++ b/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.scss
@@ -38,8 +38,8 @@ Copyright freiheit.com*/
 }
 
 .lock-display-info-size-limit {
-    max-width: 300px;
-    max-height: 300px;
+    max-width: 15vw;
+    max-height: 5vw;
     overflow: auto;
     @extend .lock-display-info;
 }

--- a/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.scss
+++ b/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.scss
@@ -38,9 +38,9 @@ Copyright freiheit.com*/
 }
 
 .lock-display-info-size-limit {
-    max-width: 15vw;
-    max-height: 5vw;
+    flex-grow: 2;
     overflow: auto;
+    max-height: 30vh;
     @extend .lock-display-info;
 }
 

--- a/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.scss
+++ b/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.scss
@@ -20,7 +20,7 @@ Copyright freiheit.com*/
     margin: $locks-list-row-spacing;
     justify-content: center;
     align-items: center;
-    height: $locks-list-row-height;
+    height: fit-content;
 }
 
 .lock-display-table {
@@ -29,11 +29,19 @@ Copyright freiheit.com*/
     align-items: center;
     margin: $locks-list-row-margin;
     background-color: var(--mdc-theme-surface);
+    word-wrap: break-word;
 }
 
 .lock-display-info {
     flex: 1;
     text-align: center;
+}
+
+.lock-display-info-size-limit {
+    max-width: 300px;
+    max-height: 300px;
+    overflow: auto;
+    @extend .lock-display-info;
 }
 
 .lock-action {

--- a/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.tsx
+++ b/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.tsx
@@ -71,11 +71,11 @@ export const LockDisplay: React.FC<{ lock: DisplayLock }> = (props) => {
             <div className="lock-display__table">
                 <div className="lock-display-table">
                     {!!lock.date && <FormattedDate createdAt={lock.date} className={allClassNames} />}
-                    <div className="lock-display-info">{lock.environment}</div>
-                    {!!lock.application && <div className="lock-display-info">{lock.application}</div>}
-                    {!!lock.team && <div className="lock-display-info">{lock.team}</div>}
+                    <div className="lock-display-info-size-limit">{lock.environment}</div>
+                    {!!lock.application && <div className="lock-display-info-size-limit">{lock.application}</div>}
+                    {!!lock.team && <div className="lock-display-info-size-limit">{lock.team}</div>}
                     <div className="lock-display-info">{lock.lockId}</div>
-                    <div className="lock-display-info">{lock.message}</div>
+                    <div className="lock-display-info-size-limit">{lock.message}</div>
                     <div className="lock-display-info">{lock.authorName}</div>
                     <div className="lock-display-info">{lock.authorEmail}</div>
                     <Button

--- a/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.tsx
+++ b/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.tsx
@@ -71,9 +71,9 @@ export const LockDisplay: React.FC<{ lock: DisplayLock }> = (props) => {
             <div className="lock-display__table">
                 <div className="lock-display-table">
                     {!!lock.date && <FormattedDate createdAt={lock.date} className={allClassNames} />}
-                    <div className="lock-display-info-size-limit">{lock.environment}</div>
-                    {!!lock.application && <div className="lock-display-info-size-limit">{lock.application}</div>}
-                    {!!lock.team && <div className="lock-display-info-size-limit">{lock.team}</div>}
+                    <div className="lock-display-info">{lock.environment}</div>
+                    {!!lock.application && <div className="lock-display-info">{lock.application}</div>}
+                    {!!lock.team && <div className="lock-display-info">{lock.team}</div>}
                     <div className="lock-display-info">{lock.lockId}</div>
                     <div className="lock-display-info-size-limit">{lock.message}</div>
                     <div className="lock-display-info">{lock.authorName}</div>

--- a/services/frontend-service/src/ui/components/LocksTable/LocksTable.scss
+++ b/services/frontend-service/src/ui/components/LocksTable/LocksTable.scss
@@ -44,6 +44,11 @@ Copyright freiheit.com*/
         @extend .sub-headline1;
     }
 
+    .mdc-data-indicator-field-size-limit {
+        max-width: 300px;
+        @extend .mdc-data-indicator-field;
+    }
+
     .mdc-data-indicator-sort-button {
         padding-inline: 0;
     }

--- a/services/frontend-service/src/ui/components/LocksTable/LocksTable.scss
+++ b/services/frontend-service/src/ui/components/LocksTable/LocksTable.scss
@@ -44,11 +44,6 @@ Copyright freiheit.com*/
         @extend .sub-headline1;
     }
 
-    .mdc-data-indicator-field-size-limit {
-        max-width: 300px;
-        @extend .mdc-data-indicator-field;
-    }
-
     .mdc-data-indicator-sort-button {
         padding-inline: 0;
     }

--- a/services/frontend-service/src/ui/components/LocksTable/LocksTable.scss
+++ b/services/frontend-service/src/ui/components/LocksTable/LocksTable.scss
@@ -17,6 +17,7 @@ Copyright freiheit.com*/
 
 .mdc-data-table__table {
     width: 100%;
+    table-layout: fixed;
 }
 
 .mdc-data-table {

--- a/services/frontend-service/src/ui/components/LocksTable/LocksTable.tsx
+++ b/services/frontend-service/src/ui/components/LocksTable/LocksTable.tsx
@@ -29,8 +29,6 @@ export const LocksTable: React.FC<{
 
     const [sort, setSort] = React.useState<'newestToOldest' | 'oldestToNewest'>('newestToOldest');
 
-    const headersWithLimitSize = ['Environment', 'Message', 'Application', 'Team'];
-
     const sortOnClick = useCallback(() => {
         if (sort === 'oldestToNewest') {
             setSort('newestToOldest');
@@ -56,13 +54,7 @@ export const LocksTable: React.FC<{
                                 scope="col">
                                 <div className="mdc-data-indicator-header">
                                     {columnHeaders.map((columnHeader) => (
-                                        <div
-                                            key={columnHeader}
-                                            className={
-                                                headersWithLimitSize.includes(columnHeader)
-                                                    ? 'mdc-data-indicator-field-size-limit'
-                                                    : 'mdc-data-indicator-field'
-                                            }>
+                                        <div key={columnHeader} className="mdc-data-indicator-field">
                                             {columnHeader}
                                             {columnHeader === 'Date' && sort === 'oldestToNewest' && (
                                                 <Button

--- a/services/frontend-service/src/ui/components/LocksTable/LocksTable.tsx
+++ b/services/frontend-service/src/ui/components/LocksTable/LocksTable.tsx
@@ -54,7 +54,10 @@ export const LocksTable: React.FC<{
                                 scope="col">
                                 <div className="mdc-data-indicator-header">
                                     {columnHeaders.map((columnHeader) => (
-                                        <div key={columnHeader} className="mdc-data-indicator-field">
+                                        <div
+                                            key={columnHeader}
+                                            className="mdc-data-indicator-field"
+                                            style={columnHeader === 'Message' ? { flexGrow: 2 } : {}}>
                                             {columnHeader}
                                             {columnHeader === 'Date' && sort === 'oldestToNewest' && (
                                                 <Button

--- a/services/frontend-service/src/ui/components/LocksTable/LocksTable.tsx
+++ b/services/frontend-service/src/ui/components/LocksTable/LocksTable.tsx
@@ -29,6 +29,8 @@ export const LocksTable: React.FC<{
 
     const [sort, setSort] = React.useState<'newestToOldest' | 'oldestToNewest'>('newestToOldest');
 
+    const headersWithLimitSize = ['Environment', 'Message', 'Application', 'Team'];
+
     const sortOnClick = useCallback(() => {
         if (sort === 'oldestToNewest') {
             setSort('newestToOldest');
@@ -54,7 +56,13 @@ export const LocksTable: React.FC<{
                                 scope="col">
                                 <div className="mdc-data-indicator-header">
                                     {columnHeaders.map((columnHeader) => (
-                                        <div key={columnHeader} className="mdc-data-indicator-field">
+                                        <div
+                                            key={columnHeader}
+                                            className={
+                                                headersWithLimitSize.includes(columnHeader)
+                                                    ? 'mdc-data-indicator-field-size-limit'
+                                                    : 'mdc-data-indicator-field'
+                                            }>
                                             {columnHeader}
                                             {columnHeader === 'Date' && sort === 'oldestToNewest' && (
                                                 <Button


### PR DESCRIPTION
Now every column where there is the possibility to have a very long value (Environment, Lock Message, Team and Application)  is limited to a width and height of 15vw and 5vw in case of overflow a scroll will appear. This makes so the rest of the width is redistributed by the other flex box elements.  

BEFORE:
![Screenshot from 2024-08-09 11-53-06](https://github.com/user-attachments/assets/200716f0-289f-4900-8f3b-33700d5d36cd)

AFTER:
![Screenshot from 2024-08-12 09-22-51](https://github.com/user-attachments/assets/f1ff463c-fde6-4cad-9aeb-1e76527f6ea2)


Ref: SRX-7KZ8HP
