### PR TITLE
feat: allow disabling ingress paths

### DIFF
--- a/charts/kuberpult/templates/ingress.yaml
+++ b/charts/kuberpult/templates/ingress.yaml
@@ -39,6 +39,7 @@ spec:
   - host: {{ required ".ingress.domainName is required" .Values.ingress.domainName | quote }}
     http:
       paths:
+{{- if .Values.ingress.allowedPaths.oldRestApi }}
 # Old Rest API:
       - pathType: Prefix
         path: /release
@@ -61,6 +62,8 @@ spec:
             name: kuberpult-frontend-service
             port:
               name: http
+{{- end }}
+{{- if .Values.ingress.allowedPaths.restApi }}
 # New API:
       - pathType: Prefix
         path: /api/
@@ -69,6 +72,8 @@ spec:
             name: kuberpult-frontend-service
             port:
               name: http
+{{- end }}
+{{- if .Values.ingress.allowedPaths.dex }}
 # Dex (UI Authorization flow):
       - pathType: Prefix
         path: /dex
@@ -98,6 +103,8 @@ spec:
             name: kuberpult-frontend-service
             port:
               name: http
+{{- end }}
+{{- if .Values.ingress.allowedPaths.ui }}
 # UI bootstrapping:
       - pathType: ImplementationSpecific
         path: /ui/*
@@ -191,6 +198,7 @@ spec:
             name: kuberpult-frontend-service
             port:
               name: http
+{{- end }}
   tls:
   - hosts:
     - {{ default .Values.ingress.domainName .Values.ingress.tls.host | quote}}

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -202,12 +202,25 @@ rollout:
 
 ingress:
   # The simplest setup involves an ingress, to make kuberpult available outside the cluster.
-  # set to false, if you want use your own ingress:
+  # set to false, if you want to use your own ingress:
   create: false
   private: true
   annotations:
     nginx.ingress.kubernetes.io/proxy-read-timeout: 300
     kubernetes.io/ingress.allow-http: false
+  allowedPaths:
+    # Enables the ingress paths for the old REST API, starting with `/release`, `/environments/`, or `/environment-groups/`
+    # It is recommended to use the new api, but not all endpoints are available there yet.
+    oldRestApi: false
+
+    # Enables the ingress paths for the new REST API, starting with /api/
+    restApi: false
+
+    # Enables the ingress paths for using dex. Only required if `dex.dexAuth.enabled=true`
+    dex: false
+
+    # Enables the ingress paths for the UI (html, css, js and grpc over http paths)
+    ui: false
   domainName: null
   # note that IAP is a GCP specific feature. On GCP we recommend to enable it.
   iap:

--- a/docs/ingress.md
+++ b/docs/ingress.md
@@ -1,0 +1,17 @@
+# Ingress
+
+Kuberpult comes with an optional Ingress.
+The helm chart provides parameters to allow/deny individual paths.
+
+| helm option                       | Use Case                                                                                                |
+|-----------------------------------|---------------------------------------------------------------------------------------------------------|
+| `ingress.allowedPaths.ui`         | Required to use kuberpult's UI. Most setups will need this to be enabled.                               |
+| `ingress.allowedPaths.dex`        | Enable if you have dex enabled, see parameter `auth.dexAuth.enabled`                                    |
+| `ingress.allowedPaths.oldRestApi` | Enable if you are using endpoints starting with `/release`,  `/environments/` or `/environment-groups/` |
+| `ingress.allowedPaths.restApi`    | Enable if you are using endpoints starting with `/api/`                                                 |
+
+Note that by default all of them are **disabled**.
+
+This split can be used to improve security.
+Only allow what is really required.
+


### PR DESCRIPTION
Ref: SRX-XCZB2E

You can now select which parts of kuberpult
you want to expose in the ingress.

BREAKING CHANGE:
In order to get the same behavior as before, set
ingress.allowedPaths.oldRestApi: true
ingress.allowedPaths.restApi: true
ingress.allowedPaths.dex: true
ingress.allowedPaths.ui: true

Recommendation: Only allow paths that are required for your setup.