### PR TITLE
fix: Align the team filter buttons

### DIFF
--- a/services/frontend-service/src/ui/components/dropdown/dropdown.scss
+++ b/services/frontend-service/src/ui/components/dropdown/dropdown.scss
@@ -71,3 +71,10 @@ div.mdc-select {
     border: 1px solid blue;
     padding-left: 1em;
 }
+
+.confirmation-dialog-footer {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: space-evenly;
+    margin-bottom: 0.5em;
+}

--- a/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
+++ b/services/frontend-service/src/ui/components/dropdown/dropdown.tsx
@@ -101,7 +101,7 @@ export const DropdownSelect: React.FC<DropdownSelectProps> = (props) => {
                         </div>
                         <div className={'item'} key={'button-menu-all'} title={'ESC also closes the dialog'}>
                             <Button
-                                className="mdc-button--unelevated button-confirm"
+                                className="mdc-button__label"
                                 label={allTeamsLabel}
                                 onClick={onClear}
                                 highlightEffect={false}


### PR DESCRIPTION
Aligned the team filter buttons and also made the Clear button white for consistency purposes 
BEFORE:
![image](https://github.com/user-attachments/assets/45333982-4104-454f-8620-27793de88bce)
AFTER:
![Screenshot from 2024-08-12 10-55-48](https://github.com/user-attachments/assets/3991ed6c-a2e0-400c-b9ed-0dfa03472997)

Ref: SRX-7KZ8HP