### PR TITLE
feat(ui): Display app locks more prominently

### DIFF
--- a/services/frontend-service/src/assets/_variables.scss
+++ b/services/frontend-service/src/assets/_variables.scss
@@ -146,6 +146,8 @@ $main-content-padding: ($top-app-bar-height + 0.5em) 1em 1em ($nav-bar-width + 1
 
 $warning-color: #e0d541;
 
+$warning-color-locked: #ff8c00;
+
 :root {
     // Colors
     --mdc-theme-primary: #2d70d6;

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.scss
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.scss
@@ -13,18 +13,27 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright freiheit.com*/
+
+@import '../../../assets/variables';
+
 .service-lane__header {
     background: var(--mdc-theme-primary);
     color: var(--mdc-theme-on-primary);
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: $service-lane-header-padding;
+    // the padding here has to be big enough, so that
+    // the border-radius of the whole lane does not break
+    padding: 0 4px 0 0;
     border-radius: $border-radius-medium;
     height: $service-lane-header-height;
 
     white-space: nowrap;
-    .service__name {
+    .service-lane-name {
+        margin-left: 5px;
+    }
+
+    .service-lane-wrapper {
         overflow: hidden;
         @extend .sub-headline1;
         display: flex;

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.test.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.test.tsx
@@ -529,7 +529,7 @@ type TestDataAppLockSummary = TestData & {
     expected: string | undefined;
 };
 const dataAppLockSummary: TestDataAppLockSummary[] = (() => {
-    const appWith1Lock: Environment_Application = {
+    const appWith1AppLock: Environment_Application = {
         name: 'test1',
         version: 123,
         queuedVersion: 0,
@@ -538,6 +538,30 @@ const dataAppLockSummary: TestDataAppLockSummary[] = (() => {
             l1: { message: 'test lock', lockId: '321' },
         },
         teamLocks: {},
+        team: 'test-team',
+    };
+    const appWith1TeamLock: Environment_Application = {
+        name: 'test1',
+        version: 123,
+        queuedVersion: 0,
+        undeployVersion: false,
+        locks: {},
+        teamLocks: {
+            l1: { message: 'test team lock', lockId: 't-1000' },
+        },
+        team: 'test-team',
+    };
+    const appWith1TeamLock1AppLock: Environment_Application = {
+        name: 'test1',
+        version: 123,
+        queuedVersion: 0,
+        undeployVersion: false,
+        locks: {
+            l1: { message: 'test app lock', lockId: 'a-1' },
+        },
+        teamLocks: {
+            l1: { message: 'test team lock', lockId: 't-1000' },
+        },
         team: 'test-team',
     };
     const appWith2Locks: Environment_Application = {
@@ -580,7 +604,7 @@ const dataAppLockSummary: TestDataAppLockSummary[] = (() => {
             expected: undefined,
         },
         {
-            name: 'test one lock',
+            name: 'test one app lock',
             renderedApp: {
                 name: 'test1',
                 releases: [],
@@ -593,7 +617,7 @@ const dataAppLockSummary: TestDataAppLockSummary[] = (() => {
                 {
                     name: 'foo2',
                     applications: {
-                        foo2: appWith1Lock,
+                        foo2: appWith1AppLock,
                     },
                     distanceToUpstream: 0,
                     priority: Priority.UPSTREAM,
@@ -603,7 +627,7 @@ const dataAppLockSummary: TestDataAppLockSummary[] = (() => {
             expected: '"test1" has 1 lock. Click on a tile to see details.',
         },
         {
-            name: 'test two locks',
+            name: 'test two app locks',
             renderedApp: {
                 name: 'test1',
                 releases: [],
@@ -617,6 +641,52 @@ const dataAppLockSummary: TestDataAppLockSummary[] = (() => {
                     name: 'foo2',
                     applications: {
                         foo2: appWith2Locks,
+                    },
+                    distanceToUpstream: 0,
+                    priority: Priority.UPSTREAM,
+                    locks: {},
+                },
+            ],
+            expected: '"test1" has 2 locks. Click on a tile to see details.',
+        },
+        {
+            name: 'test one team lock',
+            renderedApp: {
+                name: 'test1',
+                releases: [],
+                sourceRepoUrl: 'http://test2.com',
+                team: 'test-team',
+                undeploySummary: UndeploySummary.NORMAL,
+                warnings: [],
+            },
+            envs: [
+                {
+                    name: 'foo2',
+                    applications: {
+                        foo2: appWith1TeamLock,
+                    },
+                    distanceToUpstream: 0,
+                    priority: Priority.UPSTREAM,
+                    locks: {},
+                },
+            ],
+            expected: '"test1" has 1 lock. Click on a tile to see details.',
+        },
+        {
+            name: 'test one team + one app lock',
+            renderedApp: {
+                name: 'test1',
+                releases: [],
+                sourceRepoUrl: 'http://test2.com',
+                team: 'test-team',
+                undeploySummary: UndeploySummary.NORMAL,
+                warnings: [],
+            },
+            envs: [
+                {
+                    name: 'foo2',
+                    applications: {
+                        foo2: appWith1TeamLock1AppLock,
                     },
                     distanceToUpstream: 0,
                     priority: Priority.UPSTREAM,

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.test.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.test.tsx
@@ -600,7 +600,7 @@ const dataAppLockSummary: TestDataAppLockSummary[] = (() => {
                     locks: {},
                 },
             ],
-            expected: '"test1" has 1 application lock. Click on a tile to see details.',
+            expected: '"test1" has 1 lock. Click on a tile to see details.',
         },
         {
             name: 'test two locks',
@@ -623,7 +623,7 @@ const dataAppLockSummary: TestDataAppLockSummary[] = (() => {
                     locks: {},
                 },
             ],
-            expected: '"test1" has 2 application locks. Click on a tile to see details.',
+            expected: '"test1" has 2 locks. Click on a tile to see details.',
         },
     ];
     return result;

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -29,7 +29,7 @@ import { ReleaseCard } from '../ReleaseCard/ReleaseCard';
 import { DeleteWhite, HistoryWhite } from '../../../images';
 import { Application, Environment, UndeploySummary } from '../../../api/api';
 import * as React from 'react';
-import { AppLockSummary, TeamLockSummary } from '../chip/EnvironmentGroupChip';
+import { AppLockSummary } from '../chip/EnvironmentGroupChip';
 import { WarningBoxes } from './Warnings';
 import { DotsMenu, DotsMenuButton } from './DotsMenu';
 import { useCallback, useState } from 'react';
@@ -211,19 +211,16 @@ export const ServiceLane: React.FC<{ application: Application }> = (props) => {
         <div className="service-lane">
             {dialog}
             <div className="service-lane__header">
-                <div className="service__name">
-                    {application.team ? application.team : '<No Team> '}
-                    {teamLocks.length >= 1 && (
-                        <div className={'test-app-lock-summary'}>
-                            <TeamLockSummary team={application.team} numLocks={teamLocks.length} />
-                        </div>
-                    )}
-                    {' | ' + application.name}
+                <div className="service-lane-wrapper">
                     {appLocks.length >= 1 && (
                         <div className={'test-app-lock-summary'}>
-                            <AppLockSummary app={application.name} numLocks={appLocks.length} />
+                            <AppLockSummary app={application.name} numLocks={appLocks.length + teamLocks.length} />
                         </div>
                     )}
+                    <div className={'service-lane-name'}>
+                        <span title={'team name'}>{application.team ? application.team : '<No Team> '} </span>
+                        {' | '} <span title={'app name'}> {application.name}</span>
+                    </div>
                 </div>
                 <div className="service__actions__">{dotsMenu}</div>
             </div>

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -212,7 +212,7 @@ export const ServiceLane: React.FC<{ application: Application }> = (props) => {
             {dialog}
             <div className="service-lane__header">
                 <div className="service-lane-wrapper">
-                    {appLocks.length >= 1 && (
+                    {appLocks.length + teamLocks.length >= 1 && (
                         <div className={'test-app-lock-summary'}>
                             <AppLockSummary app={application.name} numLocks={appLocks.length + teamLocks.length} />
                         </div>

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
@@ -33,28 +33,14 @@ export const AppLockSummary: React.FC<{
     const plural = numLocks === 1 ? 'lock' : 'locks';
     return (
         <div
+            className={'app-lock-summary'}
             key={'app-lock-hint-' + app}
-            title={'"' + app + '" has ' + numLocks + ' application ' + plural + '. Click on a tile to see details.'}>
-            <div>
-                &nbsp;
-                <LocksWhite className="env-card-env-lock-icon" width="16px" height="16px" />
-            </div>
-        </div>
-    );
-};
-
-export const TeamLockSummary: React.FC<{
-    team: string;
-    numLocks: number;
-}> = ({ team, numLocks }) => {
-    const plural = numLocks === 1 ? 'lock' : 'locks';
-    return (
-        <div
-            key={'app-lock-hint-' + team}
-            title={'"' + team + '" has ' + numLocks + ' team ' + plural + '. Click on an icon to see details.'}>
-            <div>
-                &nbsp;
-                <LocksWhite className="env-card-env-lock-icon" width="16px" height="16px" />
+            title={'"' + app + '" has ' + numLocks + ' ' + plural + '. Click on a tile to see details.'}>
+            <div className={'app-lock-summary-wrapper'}>
+                <div className={'app-lock-summary-lock'}>
+                    <LocksWhite className="env-card-env-lock-icon" width="20px" height="20px" />
+                </div>
+                <div className={'app-lock-summary-text'}>Locked</div>
             </div>
         </div>
     );

--- a/services/frontend-service/src/ui/components/chip/chip.scss
+++ b/services/frontend-service/src/ui/components/chip/chip.scss
@@ -14,6 +14,7 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright freiheit.com*/
 @use '@material/chips/styles';
+@import '../../../assets/variables';
 
 .mdc-evolution-chip {
     height: $env-chip-height;
@@ -71,3 +72,26 @@ Copyright freiheit.com*/
 .environment-priority-unrecognized {
     background-color: $env-color-unrecognized;
 }
+
+
+.app-lock-summary {
+    min-width: 4.5em;
+    background-color: $warning-color-locked;
+    border-radius: 6px;
+
+    .app-lock-summary-wrapper {
+        display: flex;
+        margin-left: 6px;
+        margin-right: 6px;
+    }
+
+    .app-lock-summary-text {
+        font-size: small;
+        line-height: 40px;
+    }
+    .app-lock-summary-lock{
+        margin-top: 8px;
+    }
+
+}
+

--- a/services/frontend-service/src/ui/components/chip/chip.scss
+++ b/services/frontend-service/src/ui/components/chip/chip.scss
@@ -73,7 +73,6 @@ Copyright freiheit.com*/
     background-color: $env-color-unrecognized;
 }
 
-
 .app-lock-summary {
     min-width: 4.5em;
     background-color: $warning-color-locked;
@@ -89,9 +88,7 @@ Copyright freiheit.com*/
         font-size: small;
         line-height: 40px;
     }
-    .app-lock-summary-lock{
+    .app-lock-summary-lock {
         margin-top: 8px;
     }
-
 }
-


### PR DESCRIPTION
Ref: SRX-KNBOC7

This renders app locks on the main page with a orange-ish background color, as part of the service lane header (where the app name appears on the home page). This was done to make locks more obvious.

Also added tooltips to the app name and team name.

Before:
![Screenshot from 2024-08-14 16-53-03](https://github.com/user-attachments/assets/7d56f7c5-4330-49f1-a7b9-b0064bf09a6f)

Now:
![Screenshot from 2024-08-14 16-52-34](https://github.com/user-attachments/assets/4be21de2-c24d-42db-b9bf-df44f7d92e9c)
