### PR TITLE
chore: renaming pnpm scripts to be consistent

### DIFF
--- a/services/frontend-service/Earthfile
+++ b/services/frontend-service/Earthfile
@@ -67,8 +67,8 @@ node-modules:
 
 lint-ui:
     FROM +deps-ui
-    RUN pnpm eslint
-    RUN pnpm lint-scss
+    RUN pnpm eslint-check
+    RUN pnpm scss-check
 
 unit-test-ui:
     FROM +deps-ui

--- a/services/frontend-service/Makefile
+++ b/services/frontend-service/Makefile
@@ -95,12 +95,12 @@ test-go: $(ALL_GO_FILES) | proto
 	$(GO) test $(GO_TEST_ARGS) ./...
 
 test-ts: src/api/api.ts
-	pnpm eslint
+	pnpm eslint-check
 	# The extra '--' was added because of pnpm, Usage: pnpm test [-- <args>...]
 	pnpm test -- --watchAll=false
 
-lint-scss: deps
-	pnpm lint-scss
+scss-check: deps
+	pnpm scss-check
 
 docker:
 	$(EARTHLY) +docker --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)

--- a/services/frontend-service/package.json
+++ b/services/frontend-service/package.json
@@ -37,11 +37,11 @@
     "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "test": "TC=Europe/Berlin react-scripts test --color",
     "start": "WATCHPACK_POLLING=true CHOKIDAR_USEPOLLING=true react-scripts start",
-    "eslint": "eslint --cache --cache-location 'misc/.eslintcache' --ext .ts,.tsx src/",
+    "eslint-check": "eslint --cache --cache-location 'misc/.eslintcache' --ext .ts,.tsx src/",
     "eslint-fix": "eslint --fix --cache --cache-location 'misc/.eslintcache' --ext .ts,.tsx src/",
     "circular-check": "madge -c --extensions ts,tsx --ts-config tsconfig.json --no-spinner src/",
-    "lint-scss": "prettier -c --parser scss 'src/**/*.scss'",
-    "format-scss": "prettier --write --parser scss 'src/**/*.scss'"
+    "scss-check": "prettier -c --parser scss 'src/**/*.scss'",
+    "scss-fix": "prettier --write --parser scss 'src/**/*.scss'"
   },
   "devDependencies": {
     "@babel/core": "7.25.2",


### PR DESCRIPTION
now we have eslint-check/eslint-fix and scss-check/scss-lintlint

Ref: SRX-KNBOC7