### PR TITLE
feat(db): handle group locks

### DIFF
--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -507,7 +507,7 @@ func getTransformer(ctx context.Context, eslEventType db.EventType) (repository.
 		return &repository.CreateUndeployApplicationVersion{}, nil
 	case db.EvtCreateEnvironmentGroupLock:
 		//exhaustruct:ignore
-		return &repository.EvtCreateEnvironmentGroupLock{}, nil
+		return &repository.CreateEnvironmentGroupLock{}, nil
 	case db.EvtDeleteEnvironmentGroupLock:
 		//exhaustruct:ignore
 		return &repository.EvtDeleteEnvironmentGroupLock{}, nil

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -510,7 +510,7 @@ func getTransformer(ctx context.Context, eslEventType db.EventType) (repository.
 		return &repository.CreateEnvironmentGroupLock{}, nil
 	case db.EvtDeleteEnvironmentGroupLock:
 		//exhaustruct:ignore
-		return &repository.EvtDeleteEnvironmentGroupLock{}, nil
+		return &repository.DeleteEnvironmentGroupLock{}, nil
 	case db.EvtUndeployApplication:
 		//exhaustruct:ignore
 		return &repository.UndeployApplication{}, nil

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -505,6 +505,12 @@ func getTransformer(ctx context.Context, eslEventType db.EventType) (repository.
 	case db.EvtCreateUndeployApplicationVersion:
 		//exhaustruct:ignore
 		return &repository.CreateUndeployApplicationVersion{}, nil
+	case db.EvtCreateEnvironmentGroupLock:
+		//exhaustruct:ignore
+		return &repository.EvtCreateEnvironmentGroupLock{}, nil
+	case db.EvtDeleteEnvironmentGroupLock:
+		//exhaustruct:ignore
+		return &repository.EvtDeleteEnvironmentGroupLock{}, nil
 	case db.EvtUndeployApplication:
 		//exhaustruct:ignore
 		return &repository.UndeployApplication{}, nil

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -1837,3 +1837,59 @@ func (u *UndeployApplication) Transform(
 	}
 	return fmt.Sprintf("application '%v' was deleted successfully", u.Application), nil
 }
+
+type EvtCreateEnvironmentGroupLock struct {
+	Authentication        `json:"-"`
+	TransformerMetadata   `json:"metadata"`
+	TransformerEslVersion db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslVersion
+}
+
+func (c *EvtCreateEnvironmentGroupLock) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
+func (c *EvtCreateEnvironmentGroupLock) SetEslVersion(eslVersion db.TransformerID) {
+	c.TransformerEslVersion = eslVersion
+}
+
+func (c *EvtCreateEnvironmentGroupLock) GetDBEventType() db.EventType {
+	return db.EvtCreateUndeployApplicationVersion
+}
+
+func (c *EvtCreateEnvironmentGroupLock) Transform(
+	_ context.Context,
+	_ *State,
+	_ TransformerContext,
+	_ *sql.Tx,
+) (string, error) {
+	// group locks are handled on the cd-service, and split into environment locks
+	return fmt.Sprintf("empty commit for group lock creation"), nil
+}
+
+type EvtDeleteEnvironmentGroupLock struct {
+	Authentication        `json:"-"`
+	TransformerMetadata   `json:"metadata"`
+	TransformerEslVersion db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslVersion
+}
+
+func (c *EvtDeleteEnvironmentGroupLock) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
+func (c *EvtDeleteEnvironmentGroupLock) SetEslVersion(eslVersion db.TransformerID) {
+	c.TransformerEslVersion = eslVersion
+}
+
+func (c *EvtDeleteEnvironmentGroupLock) GetDBEventType() db.EventType {
+	return db.EvtCreateUndeployApplicationVersion
+}
+
+func (c *EvtDeleteEnvironmentGroupLock) Transform(
+	_ context.Context,
+	_ *State,
+	_ TransformerContext,
+	_ *sql.Tx,
+) (string, error) {
+	// group locks are handled on the cd-service, and split into environment locks
+	return fmt.Sprintf("empty commit for group lock deletion"), nil
+}

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -1838,25 +1838,25 @@ func (u *UndeployApplication) Transform(
 	return fmt.Sprintf("application '%v' was deleted successfully", u.Application), nil
 }
 
-type EvtCreateEnvironmentGroupLock struct {
+type CreateEnvironmentGroupLock struct {
 	Authentication        `json:"-"`
 	TransformerMetadata   `json:"metadata"`
 	TransformerEslVersion db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslVersion
 }
 
-func (c *EvtCreateEnvironmentGroupLock) GetEslVersion() db.TransformerID {
+func (c *CreateEnvironmentGroupLock) GetEslVersion() db.TransformerID {
 	return c.TransformerEslVersion
 }
 
-func (c *EvtCreateEnvironmentGroupLock) SetEslVersion(eslVersion db.TransformerID) {
+func (c *CreateEnvironmentGroupLock) SetEslVersion(eslVersion db.TransformerID) {
 	c.TransformerEslVersion = eslVersion
 }
 
-func (c *EvtCreateEnvironmentGroupLock) GetDBEventType() db.EventType {
-	return db.EvtCreateUndeployApplicationVersion
+func (c *CreateEnvironmentGroupLock) GetDBEventType() db.EventType {
+	return db.EvtCreateEnvironmentGroupLock
 }
 
-func (c *EvtCreateEnvironmentGroupLock) Transform(
+func (c *CreateEnvironmentGroupLock) Transform(
 	_ context.Context,
 	_ *State,
 	_ TransformerContext,
@@ -1881,7 +1881,7 @@ func (c *EvtDeleteEnvironmentGroupLock) SetEslVersion(eslVersion db.TransformerI
 }
 
 func (c *EvtDeleteEnvironmentGroupLock) GetDBEventType() db.EventType {
-	return db.EvtCreateUndeployApplicationVersion
+	return db.EvtDeleteEnvironmentGroupLock
 }
 
 func (c *EvtDeleteEnvironmentGroupLock) Transform(

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -1863,7 +1863,7 @@ func (c *CreateEnvironmentGroupLock) Transform(
 	_ *sql.Tx,
 ) (string, error) {
 	// group locks are handled on the cd-service, and split into environment locks
-	return fmt.Sprintf("empty commit for group lock creation"), nil
+	return "empty commit for group lock creation", nil
 }
 
 type DeleteEnvironmentGroupLock struct {
@@ -1891,5 +1891,5 @@ func (c *DeleteEnvironmentGroupLock) Transform(
 	_ *sql.Tx,
 ) (string, error) {
 	// group locks are handled on the cd-service, and split into environment locks
-	return fmt.Sprintf("empty commit for group lock deletion"), nil
+	return "empty commit for group lock deletion", nil
 }

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -1866,25 +1866,25 @@ func (c *CreateEnvironmentGroupLock) Transform(
 	return fmt.Sprintf("empty commit for group lock creation"), nil
 }
 
-type EvtDeleteEnvironmentGroupLock struct {
+type DeleteEnvironmentGroupLock struct {
 	Authentication        `json:"-"`
 	TransformerMetadata   `json:"metadata"`
 	TransformerEslVersion db.TransformerID `json:"-"` // Tags the transformer with EventSourcingLight eslVersion
 }
 
-func (c *EvtDeleteEnvironmentGroupLock) GetEslVersion() db.TransformerID {
+func (c *DeleteEnvironmentGroupLock) GetEslVersion() db.TransformerID {
 	return c.TransformerEslVersion
 }
 
-func (c *EvtDeleteEnvironmentGroupLock) SetEslVersion(eslVersion db.TransformerID) {
+func (c *DeleteEnvironmentGroupLock) SetEslVersion(eslVersion db.TransformerID) {
 	c.TransformerEslVersion = eslVersion
 }
 
-func (c *EvtDeleteEnvironmentGroupLock) GetDBEventType() db.EventType {
+func (c *DeleteEnvironmentGroupLock) GetDBEventType() db.EventType {
 	return db.EvtDeleteEnvironmentGroupLock
 }
 
-func (c *EvtDeleteEnvironmentGroupLock) Transform(
+func (c *DeleteEnvironmentGroupLock) Transform(
 	_ context.Context,
 	_ *State,
 	_ TransformerContext,


### PR DESCRIPTION
Group locks do not really need to be handled in the manifest-export, because a group lock is just a list of locks for multiple envs, meaning the cd-service creates separate events for each one.

Ref: SRX-KNBOC7