### PR TITLE
fix(cli): removed use dex auth flag from locks

### DIFF
--- a/cli/pkg/locks/app_lock_parsing.go
+++ b/cli/pkg/locks/app_lock_parsing.go
@@ -58,7 +58,6 @@ func readCreateAppLockArgs(args []string) (*CreateAppLockCommandLineArguments, e
 	fs.Var(&cmdArgs.environment, "environment", "the environment to lock")
 	fs.Var(&cmdArgs.message, "message", "lock message")
 	fs.Var(&cmdArgs.application, "application", "application to lock")
-	fs.BoolVar(&cmdArgs.useDexAuthentication, "use_dex_auth", false, "if set to true, the /api/* endpoint will be used. Dex must be enabled on the server side and a dex token must be provided, otherwise the request will be denied")
 
 	if err := fs.Parse(args); err != nil {
 		return nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)
@@ -85,7 +84,7 @@ func convertToCreateAppLockParams(cmdArgs CreateAppLockCommandLineArguments) (Lo
 		Environment:          cmdArgs.environment.Values[0],
 		Application:          cmdArgs.application.Values[0],
 		Message:              "",
-		UseDexAuthentication: cmdArgs.useDexAuthentication,
+		UseDexAuthentication: false, //For now there is no ambiguity as to which endpoint to use
 	}
 	if len(cmdArgs.message.Values) != 0 {
 		rp.Message = cmdArgs.message.Values[0]

--- a/cli/pkg/locks/app_lock_parsing.go
+++ b/cli/pkg/locks/app_lock_parsing.go
@@ -25,11 +25,10 @@ import (
 )
 
 type CreateAppLockCommandLineArguments struct {
-	environment          cli_utils.RepeatedString
-	lockId               cli_utils.RepeatedString
-	message              cli_utils.RepeatedString
-	application          cli_utils.RepeatedString
-	useDexAuthentication bool
+	environment cli_utils.RepeatedString
+	lockId      cli_utils.RepeatedString
+	message     cli_utils.RepeatedString
+	application cli_utils.RepeatedString
 }
 
 func argsValidCreateAppLock(cmdArgs *CreateAppLockCommandLineArguments) (result bool, errorMessage string) {

--- a/cli/pkg/locks/env_lock_parsing.go
+++ b/cli/pkg/locks/env_lock_parsing.go
@@ -53,7 +53,6 @@ func readCreateEnvLockArgs(args []string) (*CreateEnvLockCommandLineArguments, e
 	fs.Var(&cmdArgs.environment, "environment", "the environment to lock")
 	fs.Var(&cmdArgs.lockId, "lockID", "the ID of the lock you are trying to create")
 	fs.Var(&cmdArgs.message, "message", "lock message")
-	fs.BoolVar(&cmdArgs.useDexAuthentication, "use_dex_auth", false, "if set to true, the /api/* endpoint will be used. Dex must be enabled on the server side and a dex token must be provided, otherwise the request will be denied")
 
 	if err := fs.Parse(args); err != nil {
 		return nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)
@@ -80,7 +79,7 @@ func convertToCreateEnvironmentLockParams(cmdArgs CreateEnvLockCommandLineArgume
 	rp := EnvironmentLockParameters{
 		LockId:               cmdArgs.lockId.Values[0],
 		Environment:          cmdArgs.environment.Values[0],
-		UseDexAuthentication: cmdArgs.useDexAuthentication,
+		UseDexAuthentication: false, //For now there is no ambiguity as to which endpoint to use
 		Message:              "",
 	}
 	if len(cmdArgs.message.Values) != 0 {

--- a/cli/pkg/locks/env_lock_parsing.go
+++ b/cli/pkg/locks/env_lock_parsing.go
@@ -24,10 +24,9 @@ import (
 )
 
 type CreateEnvLockCommandLineArguments struct {
-	environment          cli_utils.RepeatedString
-	lockId               cli_utils.RepeatedString
-	message              cli_utils.RepeatedString
-	useDexAuthentication bool
+	environment cli_utils.RepeatedString
+	lockId      cli_utils.RepeatedString
+	message     cli_utils.RepeatedString
 }
 
 func argsValidCreateEnvLock(cmdArgs *CreateEnvLockCommandLineArguments) (result bool, errorMessage string) {

--- a/cli/pkg/locks/group_lock_parsing.go
+++ b/cli/pkg/locks/group_lock_parsing.go
@@ -24,10 +24,9 @@ import (
 )
 
 type CreateEnvGroupLockCommandLineArguments struct {
-	environmentGroup     cli_utils.RepeatedString
-	lockId               cli_utils.RepeatedString
-	message              cli_utils.RepeatedString
-	useDexAuthentication bool
+	environmentGroup cli_utils.RepeatedString
+	lockId           cli_utils.RepeatedString
+	message          cli_utils.RepeatedString
 }
 
 func argsValidCreateEnvGroupLock(cmdArgs *CreateEnvGroupLockCommandLineArguments) (result bool, errorMessage string) {

--- a/cli/pkg/locks/group_lock_parsing.go
+++ b/cli/pkg/locks/group_lock_parsing.go
@@ -53,7 +53,6 @@ func readCreateGroupLockArgs(args []string) (*CreateEnvGroupLockCommandLineArgum
 	fs.Var(&cmdArgs.environmentGroup, "environment-group", "the environment-group to lock")
 	fs.Var(&cmdArgs.lockId, "lockID", "the ID of the lock you are trying to create")
 	fs.Var(&cmdArgs.message, "message", "lock message")
-	fs.BoolVar(&cmdArgs.useDexAuthentication, "use_dex_auth", false, "if set to true, the /api/* endpoint will be used. Dex must be enabled on the server side and a dex token must be provided, otherwise the request will be denied")
 
 	if err := fs.Parse(args); err != nil {
 		return nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)
@@ -80,7 +79,7 @@ func convertToCreateGroupLockParams(cmdArgs CreateEnvGroupLockCommandLineArgumen
 	rp := EnvironmentGroupLockParameters{
 		LockId:               cmdArgs.lockId.Values[0],
 		EnvironmentGroup:     cmdArgs.environmentGroup.Values[0],
-		UseDexAuthentication: cmdArgs.useDexAuthentication,
+		UseDexAuthentication: false, //For now there is no ambiguity as to which endpoint to use
 		Message:              "",
 	}
 	if len(cmdArgs.message.Values) != 0 {

--- a/cli/pkg/locks/lock.go
+++ b/cli/pkg/locks/lock.go
@@ -90,6 +90,9 @@ func CreateLock(requestParams kutil.RequestParameters, authParams kutil.Authenti
 
 func (e *EnvironmentLockParameters) GetRestPath() string {
 	prefix := "environments"
+	if e.UseDexAuthentication {
+		prefix = "api/environments"
+	}
 	return fmt.Sprintf("%s/%s/locks/%s", prefix, e.Environment, e.LockId)
 }
 
@@ -109,6 +112,9 @@ func (e *EnvironmentLockParameters) FillForm() (*HttpFormDataInfo, error) {
 
 func (e *AppLockParameters) GetRestPath() string {
 	prefix := "environments"
+	if e.UseDexAuthentication {
+		prefix = "api/environments"
+	}
 	return fmt.Sprintf("%s/%s/applications/%s/locks/%s", prefix, e.Environment, e.Application, e.LockId)
 }
 
@@ -147,6 +153,9 @@ func (e *TeamLockParameters) FillForm() (*HttpFormDataInfo, error) {
 
 func (e *EnvironmentGroupLockParameters) GetRestPath() string {
 	prefix := "environment-groups"
+	if e.UseDexAuthentication {
+		prefix = "api/environment-groups"
+	}
 	return fmt.Sprintf("%s/%s/locks/%s", prefix, e.EnvironmentGroup, e.LockId)
 }
 

--- a/cli/pkg/locks/lock.go
+++ b/cli/pkg/locks/lock.go
@@ -90,10 +90,6 @@ func CreateLock(requestParams kutil.RequestParameters, authParams kutil.Authenti
 
 func (e *EnvironmentLockParameters) GetRestPath() string {
 	prefix := "environments"
-	if e.UseDexAuthentication {
-		prefix = "api/environments"
-	}
-
 	return fmt.Sprintf("%s/%s/locks/%s", prefix, e.Environment, e.LockId)
 }
 
@@ -113,10 +109,6 @@ func (e *EnvironmentLockParameters) FillForm() (*HttpFormDataInfo, error) {
 
 func (e *AppLockParameters) GetRestPath() string {
 	prefix := "environments"
-	if e.UseDexAuthentication {
-		prefix = "api/environments"
-	}
-
 	return fmt.Sprintf("%s/%s/applications/%s/locks/%s", prefix, e.Environment, e.Application, e.LockId)
 }
 
@@ -135,10 +127,7 @@ func (e *AppLockParameters) FillForm() (*HttpFormDataInfo, error) {
 }
 
 func (e *TeamLockParameters) GetRestPath() string {
-	prefix := "environments"
-	if e.UseDexAuthentication {
-		prefix = "api/environments"
-	}
+	prefix := "api/environments"
 	return fmt.Sprintf("%s/%s/lock/team/%s/%s", prefix, e.Environment, e.Team, e.LockId)
 }
 
@@ -158,9 +147,6 @@ func (e *TeamLockParameters) FillForm() (*HttpFormDataInfo, error) {
 
 func (e *EnvironmentGroupLockParameters) GetRestPath() string {
 	prefix := "environment-groups"
-	if e.UseDexAuthentication {
-		prefix = "api/environment-groups"
-	}
 	return fmt.Sprintf("%s/%s/locks/%s", prefix, e.EnvironmentGroup, e.LockId)
 }
 

--- a/cli/pkg/locks/lock.go
+++ b/cli/pkg/locks/lock.go
@@ -93,6 +93,7 @@ func (e *EnvironmentLockParameters) GetRestPath() string {
 	if e.UseDexAuthentication {
 		prefix = "api/environments"
 	}
+
 	return fmt.Sprintf("%s/%s/locks/%s", prefix, e.Environment, e.LockId)
 }
 
@@ -115,6 +116,7 @@ func (e *AppLockParameters) GetRestPath() string {
 	if e.UseDexAuthentication {
 		prefix = "api/environments"
 	}
+
 	return fmt.Sprintf("%s/%s/applications/%s/locks/%s", prefix, e.Environment, e.Application, e.LockId)
 }
 
@@ -156,6 +158,7 @@ func (e *EnvironmentGroupLockParameters) GetRestPath() string {
 	if e.UseDexAuthentication {
 		prefix = "api/environment-groups"
 	}
+
 	return fmt.Sprintf("%s/%s/locks/%s", prefix, e.EnvironmentGroup, e.LockId)
 }
 

--- a/cli/pkg/locks/team_lock_parsing.go
+++ b/cli/pkg/locks/team_lock_parsing.go
@@ -25,11 +25,10 @@ import (
 )
 
 type CreateTeamLockCommandLineArguments struct {
-	environment          cli_utils.RepeatedString
-	lockId               cli_utils.RepeatedString
-	message              cli_utils.RepeatedString
-	team                 cli_utils.RepeatedString
-	useDexAuthentication bool
+	environment cli_utils.RepeatedString
+	lockId      cli_utils.RepeatedString
+	message     cli_utils.RepeatedString
+	team        cli_utils.RepeatedString
 }
 
 func argsValidCreateTeamLock(cmdArgs *CreateTeamLockCommandLineArguments) (result bool, errorMessage string) {

--- a/cli/pkg/locks/team_lock_parsing.go
+++ b/cli/pkg/locks/team_lock_parsing.go
@@ -58,7 +58,6 @@ func readCreateTeamLockArgs(args []string) (*CreateTeamLockCommandLineArguments,
 	fs.Var(&cmdArgs.environment, "environment", "the environment to lock")
 	fs.Var(&cmdArgs.message, "message", "lock message")
 	fs.Var(&cmdArgs.team, "team", "application to lock")
-	fs.BoolVar(&cmdArgs.useDexAuthentication, "use_dex_auth", false, "if set to true, the /api/* endpoint will be used. Dex must be enabled on the server side and a dex token must be provided, otherwise the request will be denied")
 
 	if err := fs.Parse(args); err != nil {
 		return nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)
@@ -86,7 +85,7 @@ func convertToCreateTeamLockParams(cmdArgs CreateTeamLockCommandLineArguments) (
 		LockId:               cmdArgs.lockId.Values[0],
 		Environment:          cmdArgs.environment.Values[0],
 		Team:                 cmdArgs.team.Values[0],
-		UseDexAuthentication: cmdArgs.useDexAuthentication,
+		UseDexAuthentication: false, //For now there is no ambiguity as to which endpoint to use
 		Message:              "",
 	}
 	if len(cmdArgs.message.Values) != 0 {


### PR DESCRIPTION
Only the team locks are fully migrated to the new /api endpoint. Env, app and group locks are still on the old path, while the team locks are only on the /api. As such, there is no doubt on which endpoint to use on each case, so no flag is necessary.

Ref: SRX-QMIIYB