### PR TITLE
fix(ci): Restore rollout tests

### DIFF
--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -791,7 +791,7 @@ func (c *CreateApplicationVersion) Transform(
 	releaseDir := releasesDirectoryWithVersion(fs, c.Application, version)
 	appDir := applicationDirectory(fs, c.Application)
 	if err := fs.MkdirAll(releaseDir, 0777); err != nil {
-		return "", GetCreateReleaseGeneralFailure(err)
+		return "", GetCreateReleaseGeneralFailure(fmt.Errorf("mkdir %s error:%v", releaseDir, err))
 	}
 
 	var checkForInvalidCommitId = func(commitId, helperText string) {
@@ -808,27 +808,27 @@ func (c *CreateApplicationVersion) Transform(
 	if c.SourceCommitId != "" {
 		c.SourceCommitId = strings.ToLower(c.SourceCommitId)
 		if err := util.WriteFile(fs, fs.Join(releaseDir, fieldSourceCommitId), []byte(c.SourceCommitId), 0666); err != nil {
-			return "", GetCreateReleaseGeneralFailure(err)
+			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", fieldSourceCommitId, err))
 		}
 	}
 
 	if c.SourceAuthor != "" {
 		if err := util.WriteFile(fs, fs.Join(releaseDir, fieldSourceAuthor), []byte(c.SourceAuthor), 0666); err != nil {
-			return "", GetCreateReleaseGeneralFailure(err)
+			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", fieldSourceAuthor, err))
 		}
 	}
 	if c.SourceMessage != "" {
 		if err := util.WriteFile(fs, fs.Join(releaseDir, fieldSourceMessage), []byte(c.SourceMessage), 0666); err != nil {
-			return "", GetCreateReleaseGeneralFailure(err)
+			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", fieldSourceMessage, err))
 		}
 	}
 	if c.DisplayVersion != "" {
 		if err := util.WriteFile(fs, fs.Join(releaseDir, fieldDisplayVersion), []byte(c.DisplayVersion), 0666); err != nil {
-			return "", GetCreateReleaseGeneralFailure(err)
+			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", fieldDisplayVersion, err))
 		}
 	}
 	if err := util.WriteFile(fs, fs.Join(releaseDir, fieldCreatedAt), []byte(time2.GetTimeNow(ctx).Format(time.RFC3339)), 0666); err != nil {
-		return "", GetCreateReleaseGeneralFailure(err)
+		return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", fieldCreatedAt, err))
 	}
 
 	if c.Team != "" {
@@ -839,22 +839,22 @@ func (c *CreateApplicationVersion) Transform(
 		if _, err := fs.Stat(teamFileLoc); err == nil { //If path to file exists
 			err := fs.Remove(teamFileLoc)
 			if err != nil {
-				return "", GetCreateReleaseGeneralFailure(err)
+				return "", GetCreateReleaseGeneralFailure(fmt.Errorf("remove %s error:%v", teamFileLoc, err))
 			}
 		}
 		if err := util.WriteFile(fs, teamFileLoc, []byte(c.Team), 0666); err != nil {
-			return "", GetCreateReleaseGeneralFailure(err)
+			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", teamFileLoc, err))
 		}
 	}
 	isLatest, err := isLatestVersion(state, c.Application, version)
 	if err != nil {
-		return "", GetCreateReleaseGeneralFailure(err)
+		return "", GetCreateReleaseGeneralFailure(fmt.Errorf("islatest version error:%v", err))
 	}
 	if !isLatest {
 		// check that we can actually backfill this version
 		oldVersions, err := findOldApplicationVersions(ctx, transaction, state, c.Application)
 		if err != nil {
-			return "", GetCreateReleaseGeneralFailure(err)
+			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("findOldApplicationVersions error:%v", err))
 		}
 		for _, oldVersion := range oldVersions {
 			if version == oldVersion {
@@ -906,10 +906,10 @@ func (c *CreateApplicationVersion) Transform(
 		}
 
 		if err = fs.MkdirAll(envDir, 0777); err != nil {
-			return "", GetCreateReleaseGeneralFailure(err)
+			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("mkdir %s error:%v", envDir, err))
 		}
 		if err := util.WriteFile(fs, fs.Join(envDir, "manifests.yaml"), []byte(man), 0666); err != nil {
-			return "", GetCreateReleaseGeneralFailure(err)
+			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", envDir, err))
 		}
 
 		teamOwner, err := state.GetApplicationTeamOwner(ctx, transaction, c.Application)
@@ -939,7 +939,7 @@ func (c *CreateApplicationVersion) Transform(
 				if ok {
 					continue // LockedErrors are expected
 				} else {
-					return "", GetCreateReleaseGeneralFailure(err)
+					return "", GetCreateReleaseGeneralFailure(fmt.Errorf("execute error:%v", err))
 				}
 			}
 		}

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -791,7 +791,7 @@ func (c *CreateApplicationVersion) Transform(
 	releaseDir := releasesDirectoryWithVersion(fs, c.Application, version)
 	appDir := applicationDirectory(fs, c.Application)
 	if err := fs.MkdirAll(releaseDir, 0777); err != nil {
-		return "", GetCreateReleaseGeneralFailure(fmt.Errorf("mkdir %s error:%v", releaseDir, err))
+		return "", GetCreateReleaseGeneralFailure(err)
 	}
 
 	var checkForInvalidCommitId = func(commitId, helperText string) {
@@ -808,27 +808,27 @@ func (c *CreateApplicationVersion) Transform(
 	if c.SourceCommitId != "" {
 		c.SourceCommitId = strings.ToLower(c.SourceCommitId)
 		if err := util.WriteFile(fs, fs.Join(releaseDir, fieldSourceCommitId), []byte(c.SourceCommitId), 0666); err != nil {
-			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", fieldSourceCommitId, err))
+			return "", GetCreateReleaseGeneralFailure(err)
 		}
 	}
 
 	if c.SourceAuthor != "" {
 		if err := util.WriteFile(fs, fs.Join(releaseDir, fieldSourceAuthor), []byte(c.SourceAuthor), 0666); err != nil {
-			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", fieldSourceAuthor, err))
+			return "", GetCreateReleaseGeneralFailure(err)
 		}
 	}
 	if c.SourceMessage != "" {
 		if err := util.WriteFile(fs, fs.Join(releaseDir, fieldSourceMessage), []byte(c.SourceMessage), 0666); err != nil {
-			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", fieldSourceMessage, err))
+			return "", GetCreateReleaseGeneralFailure(err)
 		}
 	}
 	if c.DisplayVersion != "" {
 		if err := util.WriteFile(fs, fs.Join(releaseDir, fieldDisplayVersion), []byte(c.DisplayVersion), 0666); err != nil {
-			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", fieldDisplayVersion, err))
+			return "", GetCreateReleaseGeneralFailure(err)
 		}
 	}
 	if err := util.WriteFile(fs, fs.Join(releaseDir, fieldCreatedAt), []byte(time2.GetTimeNow(ctx).Format(time.RFC3339)), 0666); err != nil {
-		return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", fieldCreatedAt, err))
+		return "", GetCreateReleaseGeneralFailure(err)
 	}
 
 	if c.Team != "" {
@@ -839,22 +839,22 @@ func (c *CreateApplicationVersion) Transform(
 		if _, err := fs.Stat(teamFileLoc); err == nil { //If path to file exists
 			err := fs.Remove(teamFileLoc)
 			if err != nil {
-				return "", GetCreateReleaseGeneralFailure(fmt.Errorf("remove %s error:%v", teamFileLoc, err))
+				return "", GetCreateReleaseGeneralFailure(err)
 			}
 		}
 		if err := util.WriteFile(fs, teamFileLoc, []byte(c.Team), 0666); err != nil {
-			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", teamFileLoc, err))
+			return "", GetCreateReleaseGeneralFailure(err)
 		}
 	}
 	isLatest, err := isLatestVersion(state, c.Application, version)
 	if err != nil {
-		return "", GetCreateReleaseGeneralFailure(fmt.Errorf("islatest version error:%v", err))
+		return "", GetCreateReleaseGeneralFailure(err)
 	}
 	if !isLatest {
 		// check that we can actually backfill this version
 		oldVersions, err := findOldApplicationVersions(ctx, transaction, state, c.Application)
 		if err != nil {
-			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("findOldApplicationVersions error:%v", err))
+			return "", GetCreateReleaseGeneralFailure(err)
 		}
 		for _, oldVersion := range oldVersions {
 			if version == oldVersion {
@@ -906,10 +906,10 @@ func (c *CreateApplicationVersion) Transform(
 		}
 
 		if err = fs.MkdirAll(envDir, 0777); err != nil {
-			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("mkdir %s error:%v", envDir, err))
+			return "", GetCreateReleaseGeneralFailure(err)
 		}
 		if err := util.WriteFile(fs, fs.Join(envDir, "manifests.yaml"), []byte(man), 0666); err != nil {
-			return "", GetCreateReleaseGeneralFailure(fmt.Errorf("writefile %s error:%v", envDir, err))
+			return "", GetCreateReleaseGeneralFailure(err)
 		}
 
 		teamOwner, err := state.GetApplicationTeamOwner(ctx, transaction, c.Application)
@@ -939,7 +939,7 @@ func (c *CreateApplicationVersion) Transform(
 				if ok {
 					continue // LockedErrors are expected
 				} else {
-					return "", GetCreateReleaseGeneralFailure(fmt.Errorf("execute error:%v", err))
+					return "", GetCreateReleaseGeneralFailure(err)
 				}
 			}
 		}

--- a/tests/integration-tests/cluster-setup/argocd-kuberpult.sh
+++ b/tests/integration-tests/cluster-setup/argocd-kuberpult.sh
@@ -224,6 +224,8 @@ print "connection to frontend service successful"
 waitForDeployment "default" "app=kuberpult-rollout-service"
 waitForDeployment "default" "app=kuberpult-manifest-repo-export-service"
 
+portForwardAndWait "default" deploy/postgres "5432" "5432"
+
 kubectl get deployment
 kubectl get pods
 

--- a/tests/integration-tests/cluster-setup/argocd-kuberpult.sh
+++ b/tests/integration-tests/cluster-setup/argocd-kuberpult.sh
@@ -67,10 +67,6 @@ $(sed -e "s/^/        /" </kp/known_hosts)
   cm:
     accounts.kuberpult: apiKey
     timeout.reconciliation: 0s
-  params:
-    controller.repo.server.plaintext: "true"
-    server.repo.server.plaintext: "true"
-    repo.server: kuberpult-cd-service:8443
   rbac:
     policy.csv: |
       p, role:kuberpult, applications, refresh, */*, allow
@@ -168,21 +164,21 @@ rollout:
   resources:
     limits:
       memory: 200Mi
-      cpu: 0.05
+      cpu: 0.2
     requests:
       memory: 200Mi
-      cpu: 0.05
+      cpu: 0.2
 manifestRepoExport:
-  eslProcessingIdleTimeSeconds: 15
+  eslProcessingIdleTimeSeconds: 1
   resources:
     limits:
       memory: 200Mi
-      cpu: 0.05
+      cpu: 0.2
     requests:
       memory: 200Mi
-      cpu: 0.05
+      cpu: 0.2
 manageArgoApplications:
-  enabled: true
+  enabled: false
 ingress:
   domainName: kuberpult.example.com
 log:

--- a/tests/integration-tests/cluster-setup/setup-cluster-ssh.sh
+++ b/tests/integration-tests/cluster-setup/setup-cluster-ssh.sh
@@ -26,11 +26,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: my-private-ssh-repo
-  namespace: default
   labels:
     argocd.argoproj.io/secret-type: repository
   namespace: ${ARGO_NAMESPACE}
 stringData:
+  project: test-env
+  insecure: "true"
   url: ssh://git@server.${GIT_NAMESPACE}.svc.cluster.local/git/repos/manifests
   sshPrivateKey: |
 $(sed -e "s/^/    /" <"$scratch"/client)

--- a/tests/integration-tests/cluster-setup/setup-postgres.sh
+++ b/tests/integration-tests/cluster-setup/setup-postgres.sh
@@ -22,21 +22,6 @@ function waitForDeployment() {
   done
 }
 
-function portForwardAndWait() {
-  ns="$1"
-  deployment="$2"
-  portHere="$3"
-  portThere="$4"
-  ports="$portHere:$portThere"
-  print "portForwardAndWait for $ns/$deployment $ports"
-  kubectl -n "$ns" port-forward "$deployment" "$ports" &
-  print "portForwardAndWait: waiting until the port forward works..."
-  until nc -vz localhost "$portHere"
-  do
-    sleep 1s
-  done
-}
-
 kubectl apply -f - <<EOF
 ---
 apiVersion: v1
@@ -87,5 +72,4 @@ spec:
 EOF
 
 waitForDeployment default "app=postgres"
-portForwardAndWait "default" deploy/postgres "5432" "5432"
 echo "done setting up postgres"

--- a/tests/integration-tests/rollout_test.go
+++ b/tests/integration-tests/rollout_test.go
@@ -84,12 +84,12 @@ func TestArgoRolloutWork(t *testing.T) {
 			releaseApp(t, tc.app, map[string]string{
 				"development2": string(data),
 			})
-			time.Sleep(5 * time.Second)
+			time.Sleep(10 * time.Second)
 			// We have to sync the root app once because we have created a new app
 			runArgo(t, "app", "sync", "root")
 			// The sync may already be in progress, therefore we wait here for pending operations to finish
-			// runArgo(t, "app", "wait", appName, "--operation")
-			// runArgo(t, "app", "sync", appName)
+			runArgo(t, "app", "wait", appName, "--operation")
+			runArgo(t, "app", "sync", appName)
 			_, appData := runArgo(t, "app", "get", appName, "-o", "yaml")
 			var app simplifiedArgoApp
 			err = yaml.Unmarshal(appData, &app)


### PR DESCRIPTION
* Restore rollout-tests that were disabled until the migration to the export-service.
* Improve stability of the integration tests

Ref: SRX-QVB8S7