### PR TITLE
fix: use prefix match instead of implementation specific path

### DIFF
--- a/charts/kuberpult/templates/ingress.yaml
+++ b/charts/kuberpult/templates/ingress.yaml
@@ -106,8 +106,8 @@ spec:
 {{- end }}
 {{- if .Values.ingress.allowedPaths.ui }}
 # UI bootstrapping:
-      - pathType: ImplementationSpecific
-        path: /ui/*
+      - pathType: Prefix
+        path: /ui/
         backend:
           service:
             name: kuberpult-frontend-service

--- a/charts/kuberpult/tests/charts_test.go
+++ b/charts/kuberpult/tests/charts_test.go
@@ -1526,7 +1526,7 @@ func makeAllIngressPaths(withDex, withUi, withOldApi, withNewApi bool) []network
 	}
 	if withUi {
 		result = append(result,
-			makeIngressImplementationSpecificPath("/ui/*"),
+			makeIngressPrefixPath("/ui/"),
 			makeIngressExactPath("/"),
 			makeIngressPrefixPath("/static/js/"),
 			makeIngressPrefixPath("/static/css/"),


### PR DESCRIPTION
The syntax used in the ingress does not work with nginx ingresses. As I understand the routing a simple Prefix routing should do the job here.

Ref: SRX-87V1VH