### PR TITLE
feat(cd-service): accept prepublish releases

### DIFF
--- a/cli/pkg/release/http.go
+++ b/cli/pkg/release/http.go
@@ -98,6 +98,15 @@ func prepareHttpRequest(url string, authParams kutil.AuthenticationParameters, p
 		}
 	}
 
+	if parsedArgs.IsPrepublish {
+		if !parsedArgs.UseDexAuthentication {
+			return nil, fmt.Errorf("prepublish endpoint is only available for the new api endpoint which is only available through dex authentication")
+		}
+		if err := writer.WriteField("is_prepublish", fmt.Sprintf("%v", parsedArgs.IsPrepublish)); err != nil {
+			return nil, fmt.Errorf("error writing is_prepublish field, error: %w", err)
+		}
+	}
+
 	if err := writer.Close(); err != nil {
 		return nil, fmt.Errorf("error closing the writer, error: %w", err)
 	}

--- a/cli/pkg/release/parsing.go
+++ b/cli/pkg/release/parsing.go
@@ -45,6 +45,7 @@ type commandLineArguments struct {
 	skipSignatures       bool
 	signatures           cli_utils.RepeatedString
 	useDexAuthentication bool
+	isPrepublish		 bool
 }
 
 // checks whether every --environment arg is matched with a --manifest arg
@@ -194,6 +195,7 @@ func readArgs(args []string) (*commandLineArguments, error) {
 	fs.BoolVar(&cmdArgs.skipSignatures, "skip_signatures", false, "if set to true, then the command line does not accept the --signature args")
 	fs.Var(&cmdArgs.signatures, "signature", "the name of the file containing the signature of the manifest to be deployed (must be set immediately after --manifest)")
 	fs.BoolVar(&cmdArgs.useDexAuthentication, "use_dex_auth", false, "use /api/release endpoint, if set to true, dex must be enabled and dex token must be provided otherwise the request will be denied")
+	fs.BoolVar(&cmdArgs.isPrepublish, "is_prepublish", false, "if set to true, it will create a prepublish release")
 
 	if err := fs.Parse(args); err != nil {
 		return nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)
@@ -279,6 +281,7 @@ func convertToParams(cmdArgs commandLineArguments) (*ReleaseParameters, error) {
 		}
 	}
 	rp.UseDexAuthentication = cmdArgs.useDexAuthentication
+	rp.IsPrepublish = cmdArgs.isPrepublish
 	return &rp, nil
 }
 

--- a/cli/pkg/release/parsing.go
+++ b/cli/pkg/release/parsing.go
@@ -45,7 +45,7 @@ type commandLineArguments struct {
 	skipSignatures       bool
 	signatures           cli_utils.RepeatedString
 	useDexAuthentication bool
-	isPrepublish		 bool
+	isPrepublish         bool
 }
 
 // checks whether every --environment arg is matched with a --manifest arg
@@ -195,7 +195,7 @@ func readArgs(args []string) (*commandLineArguments, error) {
 	fs.BoolVar(&cmdArgs.skipSignatures, "skip_signatures", false, "if set to true, then the command line does not accept the --signature args")
 	fs.Var(&cmdArgs.signatures, "signature", "the name of the file containing the signature of the manifest to be deployed (must be set immediately after --manifest)")
 	fs.BoolVar(&cmdArgs.useDexAuthentication, "use_dex_auth", false, "use /api/release endpoint, if set to true, dex must be enabled and dex token must be provided otherwise the request will be denied")
-	fs.BoolVar(&cmdArgs.isPrepublish, "is_prepublish", false, "if set to true, it will create a prepublish release")
+	fs.BoolVar(&cmdArgs.isPrepublish, "prepublish", false, "if set to true, it will create a prepublish release")
 
 	if err := fs.Parse(args); err != nil {
 		return nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)

--- a/cli/pkg/release/parsing_test.go
+++ b/cli/pkg/release/parsing_test.go
@@ -615,6 +615,23 @@ func TestReadArgs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "prepublish request",
+			args: []string{"--skip_signatures", "--application", "potato", "--environment", "production", "--manifest", "manifest-file.yaml", "--prepublish"},
+			expectedCmdArgs: &commandLineArguments{
+				skipSignatures: true,
+				isPrepublish:   true,
+				application: cli_utils.RepeatedString{
+					Values: []string{"potato"},
+				},
+				environments: cli_utils.RepeatedString{
+					Values: []string{"production"},
+				},
+				manifests: cli_utils.RepeatedString{
+					Values: []string{"manifest-file.yaml"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tcs {

--- a/cli/pkg/release/release.go
+++ b/cli/pkg/release/release.go
@@ -36,7 +36,7 @@ type ReleaseParameters struct {
 	Version              *uint64
 	DisplayVersion       *string
 	UseDexAuthentication bool
-	IsPrepublish		 bool
+	IsPrepublish         bool
 }
 
 // calls the Release endpoint with the specified parameters

--- a/cli/pkg/release/release.go
+++ b/cli/pkg/release/release.go
@@ -36,6 +36,7 @@ type ReleaseParameters struct {
 	Version              *uint64
 	DisplayVersion       *string
 	UseDexAuthentication bool
+	IsPrepublish		 bool
 }
 
 // calls the Release endpoint with the specified parameters

--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -212,6 +212,7 @@ message CreateReleaseRequest {
   string display_version = 10;
   string previous_commit_id = 11;
   string ci_link = 12;
+  bool is_prepublish = 13;
 }
 
 message CreateReleaseResponseSuccess {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -505,6 +505,7 @@ type DBReleaseMetaData struct {
 	UndeployVersion bool
 	IsMinor         bool
 	CiLink          string
+	IsPrepublish    bool
 }
 
 type DBReleaseManifests struct {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -702,6 +702,7 @@ func (h *DBHandler) processReleaseRows(ctx context.Context, err error, rows *sql
 			UndeployVersion: false,
 			IsMinor:         false,
 			CiLink:          "",
+			IsPrepublish:    false,
 		}
 		err = json.Unmarshal(([]byte)(metadataStr), &metaData)
 		if err != nil {

--- a/pkg/db/overview.go
+++ b/pkg/db/overview.go
@@ -269,14 +269,12 @@ func (h *DBHandler) UpdateOverviewRelease(ctx context.Context, transaction *sql.
 			if release.Deleted {
 				app.Releases = append(app.Releases[:relIndex], app.Releases[relIndex+1:]...)
 			} else {
-				if !release.Metadata.IsPrepublish {
-					app.Releases[relIndex] = apiRelease
-				}
+				app.Releases[relIndex] = apiRelease
 			}
 			foundRelease = true
 		}
 	}
-	if !foundRelease && !release.Deleted {
+	if !foundRelease && !release.Deleted && !release.Metadata.IsPrepublish {
 		app.Releases = append(app.Releases, apiRelease)
 	}
 

--- a/pkg/db/overview.go
+++ b/pkg/db/overview.go
@@ -269,7 +269,9 @@ func (h *DBHandler) UpdateOverviewRelease(ctx context.Context, transaction *sql.
 			if release.Deleted {
 				app.Releases = append(app.Releases[:relIndex], app.Releases[relIndex+1:]...)
 			} else {
-				app.Releases[relIndex] = apiRelease
+				if !release.Metadata.IsPrepublish {
+					app.Releases[relIndex] = apiRelease
+				}
 			}
 			foundRelease = true
 		}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -2516,7 +2516,11 @@ type Release struct {
 	CreatedAt       time.Time
 	DisplayVersion  string
 	IsMinor         bool
-	IsPrepublish    bool
+	/**
+	"IsPrepublish=true" is used at the start of the merge pipeline to create a pre-publish release which can't be deployed.
+	The goal is to get 100% of the commits even if the pipeline fails.
+	*/
+	IsPrepublish bool
 }
 
 func (rel *Release) ToProto() *api.Release {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -2515,6 +2515,7 @@ type Release struct {
 	CreatedAt       time.Time
 	DisplayVersion  string
 	IsMinor         bool
+	IsPrepublish    bool
 }
 
 func (rel *Release) ToProto() *api.Release {
@@ -2587,6 +2588,7 @@ func (s *State) GetApplicationRelease(ctx context.Context, transaction *sql.Tx, 
 			CreatedAt:       env.Created,
 			DisplayVersion:  env.Metadata.DisplayVersion,
 			IsMinor:         env.Metadata.IsMinor,
+			IsPrepublish:    env.Metadata.IsPrepublish,
 		}, nil
 	} else {
 		return s.GetApplicationReleaseFromManifest(application, version)

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -2379,6 +2379,7 @@ func (s *State) WriteAllReleases(ctx context.Context, transaction *sql.Tx, app s
 				SourceMessage:   repoRelease.SourceMessage,
 				DisplayVersion:  repoRelease.DisplayVersion,
 				IsMinor:         false,
+				IsPrepublish:    false,
 				CiLink:          "",
 			},
 			Deleted: false,
@@ -2610,6 +2611,7 @@ func (s *State) GetApplicationReleaseFromManifest(application string, version ui
 		CreatedAt:       time.Time{},
 		DisplayVersion:  "",
 		IsMinor:         false,
+		IsPrepublish:    false,
 	}
 	if cnt, err := readFile(s.Filesystem, s.Filesystem.Join(base, "source_commit_id")); err != nil {
 		if !os.IsNotExist(err) {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -383,6 +383,7 @@ type CreateApplicationVersion struct {
 	CiLink                string            `json:"ciLink"`
 	AllowedDomains        []string          `json:"-"`
 	TransformerEslVersion db.TransformerID  `json:"-"`
+	IsPrepublish          bool              `json:"isPrepublish"`
 }
 
 func (c *CreateApplicationVersion) GetDBEventType() db.EventType {
@@ -671,6 +672,7 @@ func (c *CreateApplicationVersion) Transform(
 				UndeployVersion: false,
 				IsMinor:         isMinor,
 				CiLink:          c.CiLink,
+				IsPrepublish:    c.IsPrepublish,
 			},
 			Created: time.Now(),
 			Deleted: false,

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1249,6 +1249,7 @@ func (c *CreateUndeployApplicationVersion) Transform(
 				DisplayVersion:  "",
 				UndeployVersion: true,
 				IsMinor:         false,
+				IsPrepublish:    false,
 				CiLink:          "",
 			},
 			Created: time.Now(),

--- a/services/cd-service/pkg/service/batch.go
+++ b/services/cd-service/pkg/service/batch.go
@@ -282,6 +282,7 @@ func (d *BatchServer) processAction(
 				CiLink:                in.CiLink,
 				AllowedDomains:        d.Config.AllowedCILinkDomains,
 				TransformerEslVersion: 0,
+				IsPrepublish:          in.IsPrepublish,
 			}, &api.BatchResult{
 				Result: &api.BatchResult_CreateReleaseResponse{
 					CreateReleaseResponse: &api.CreateReleaseResponse{

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -303,10 +303,12 @@ func (o *OverviewServiceServer) getOverview(
 						if rel == nil {
 							// ignore
 						} else {
-							release := rel.ToProto()
-							release.Version = id
-							release.UndeployVersion = rel.UndeployVersion
-							app.Releases = append(app.Releases, release)
+							if !rel.IsPrepublish {
+								release := rel.ToProto()
+								release.Version = id
+								release.UndeployVersion = rel.UndeployVersion
+								app.Releases = append(app.Releases, release)
+							}
 						}
 					}
 				}

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -607,7 +607,7 @@ func TestOverviewService(t *testing.T) {
 								Applications: map[string]*api.Environment_Application{
 									"test": {
 										Name:    "test",
-										Version: 1,
+										Version: 2,
 										DeploymentMetaData: &api.Environment_Application_DeploymentMetaData{
 											DeployAuthor: "testmail@example.com",
 											DeployTime:   "1",
@@ -665,6 +665,23 @@ func TestOverviewService(t *testing.T) {
 					Manifests: map[string]string{
 						"development": "v1",
 					},
+				},
+				&repository.CreateApplicationVersion{
+					Authentication:        repository.Authentication{},
+					Version:               2,
+					SourceCommitId:        "deadbeef",
+					SourceAuthor:          "example <example@example.com>",
+					SourceMessage:         "changed something (#678)",
+					Team:                  "team-123",
+					DisplayVersion:        "",
+					WriteCommitData:       false,
+					PreviousCommit:        "",
+					TransformerEslVersion: 1,
+					Application:           "test",
+					Manifests: map[string]string{
+						"development": "v1",
+					},
+					IsPrepublish: true,
 				},
 			},
 			Test: func(t *testing.T, svc *OverviewServiceServer) {

--- a/services/frontend-service/pkg/handler/commit_deployments_test.go
+++ b/services/frontend-service/pkg/handler/commit_deployments_test.go
@@ -82,7 +82,7 @@ func TestHandleCommitDeployments(t *testing.T) {
 			inputTail:          "123456/",
 			failGrpcCall:       false,
 			expectedStatusCode: http.StatusOK,
-			expectedResponse:   "{\"deploymentStatus\":{\"app1\":{\"deploymentStatus\":{\"dev\":\"DEPLOYED\",\"prod\":\"UNKNOWN\",\"stage\":\"PENDING\"}}}}\n",
+			expectedResponse:   "{\"deploymentStatus\":{\"app1\":{\"deploymentStatus\":{\"dev\":\"DEPLOYED\", \"prod\":\"UNKNOWN\", \"stage\":\"PENDING\"}}}}\n",
 		},
 	}
 	for _, tc := range tcs {

--- a/services/frontend-service/pkg/handler/release.go
+++ b/services/frontend-service/pkg/handler/release.go
@@ -300,6 +300,7 @@ func (s Server) handleApiRelease(w http.ResponseWriter, r *http.Request, tail st
 		DisplayVersion:   "",
 		Manifests:        map[string]string{},
 		CiLink:           "",
+		IsPrepublish:     false,
 	}
 	if err := r.ParseMultipartForm(MAXIMUM_MULTIPART_SIZE); err != nil {
 		w.WriteHeader(400)
@@ -413,6 +414,21 @@ func (s Server) handleApiRelease(w http.ResponseWriter, r *http.Request, tail st
 		}
 		tf.DisplayVersion = displayVersion[0]
 
+	}
+
+	if isPrepublish, ok := form.Value["is_prepublish"]; ok {
+		if len(isPrepublish) != 1 {
+			w.WriteHeader(400)
+			fmt.Fprintf(w, "Invalid is_prepublish value")
+			return
+		}
+		val, err := strconv.ParseBool(isPrepublish[0])
+		if err != nil {
+			w.WriteHeader(400)
+			fmt.Fprintf(w, "Invalid is_prepublish value: %s", err)
+			return
+		}
+		tf.IsPrepublish = val
 	}
 	if ciLink, ok := form.Value["ci_link"]; ok {
 		if len(ciLink) != 1 {

--- a/services/frontend-service/pkg/handler/release.go
+++ b/services/frontend-service/pkg/handler/release.go
@@ -95,6 +95,7 @@ func (s Server) HandleRelease(w http.ResponseWriter, r *http.Request, tail strin
 		DisplayVersion:   "",
 		Manifests:        map[string]string{},
 		CiLink:           "",
+		IsPrepublish:     false,
 	}
 	if err := r.ParseMultipartForm(MAXIMUM_MULTIPART_SIZE); err != nil {
 		w.WriteHeader(400)

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -1079,7 +1079,7 @@ func findOldApplicationVersions(ctx context.Context, transaction *sql.Tx, state 
 		if release == nil {
 			majorsCount += 1
 			logger.FromContext(ctx).Warn("Release not found in database")
-		} else if !release.Metadata.IsMinor {
+		} else if !release.Metadata.IsMinor && !release.Metadata.IsPrepublish {
 			majorsCount += 1
 		}
 		if majorsCount >= int(state.ReleaseVersionsLimit) {


### PR DESCRIPTION
Ref: SRX-LUOQKA

- Create Release endpoint now accepts is_prepublish flag.
- prepublish releases are not shown in the overview
- prepublish releases are skipped during cleanup process
- a new flag is added to the cli for creating prepublish releases