### PR TITLE
feat: Add  as an option for the self managed apps

### DIFF
--- a/services/rollout-service/pkg/argo/argo_test.go
+++ b/services/rollout-service/pkg/argo/argo_test.go
@@ -240,7 +240,6 @@ func (m *mockApplicationServiceClient) Create(ctx context.Context, req *applicat
 		LastEvent: "ADDED",
 	}
 	for _, existingArgoApp := range m.Apps {
-		fmt.Println(existingArgoApp.App.Name)
 		if existingArgoApp.App.Name == req.Application.Name {
 			// App alrady exists
 			return nil


### PR DESCRIPTION
Currently all of the teams need to be specified if we want to have the self managed applications in one project. However, this is not extendable at all. Instead, we should have an all option (marked as `*`).

Ref: SRX-SC9GBF