### PR TITLE
fix(cd-service): do not write manifests for the prepublish releases

### DIFF
--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -290,7 +290,7 @@ func TestCustomMigrationReleases(t *testing.T) {
 				for i := range tc.expectedReleases {
 					expectedRelease := tc.expectedReleases[i]
 
-					release, err := dbHandler.DBSelectReleaseByVersion(ctx, transaction, expectedRelease.App, expectedRelease.ReleaseNumber)
+					release, err := dbHandler.DBSelectReleaseByVersion(ctx, transaction, expectedRelease.App, expectedRelease.ReleaseNumber, true)
 					if err != nil {
 						return err
 					}
@@ -1753,7 +1753,7 @@ func TestDeleteRelease(t *testing.T) {
 					t.Fatalf("number of team locks mismatch (-want, +got):\n%d", len(allReleases.Metadata.Releases))
 				}
 
-				latestRelease, err := dbHandler.DBSelectReleaseByVersion(ctx, transaction, tc.toInsert.App, tc.toInsert.ReleaseNumber)
+				latestRelease, err := dbHandler.DBSelectReleaseByVersion(ctx, transaction, tc.toInsert.App, tc.toInsert.ReleaseNumber, true)
 				if err != nil {
 					return err
 				}
@@ -2234,11 +2234,12 @@ func TestReadWriteAllEnvironments(t *testing.T) {
 func TestReadReleasesByApp(t *testing.T) {
 
 	tcs := []struct {
-		Name        string
-		Releases    []DBReleaseWithMetaData
-		AppName     string
-		Expected    []*DBReleaseWithMetaData
-		ExpectedErr error
+		Name                 string
+		Releases             []DBReleaseWithMetaData
+		RetrievePrepublishes bool
+		AppName              string
+		Expected             []*DBReleaseWithMetaData
+		ExpectedErr          error
 	}{
 		{
 			Name: "Retrieve one release",
@@ -2361,6 +2362,93 @@ func TestReadReleasesByApp(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "Prepublish Release should not be retrieved",
+			Releases: []DBReleaseWithMetaData{
+				{
+					EslVersion:    1,
+					ReleaseNumber: 1,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest1"}},
+				},
+				{
+					EslVersion:    2,
+					ReleaseNumber: 2,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest2"}},
+					Metadata:      DBReleaseMetaData{IsPrepublish: true},
+				},
+				{
+					EslVersion:    1,
+					ReleaseNumber: 3,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest3"}},
+				},
+			},
+			AppName:              "app1",
+			RetrievePrepublishes: false,
+			Expected: []*DBReleaseWithMetaData{
+				{
+					EslVersion:    1,
+					ReleaseNumber: 3,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest3"}},
+				},
+				{
+					EslVersion:    1,
+					ReleaseNumber: 1,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest1"}},
+				},
+			},
+		},
+		{
+			Name: "Prepublish Release should be retrieved",
+			Releases: []DBReleaseWithMetaData{
+				{
+					EslVersion:    1,
+					ReleaseNumber: 1,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest1"}},
+				},
+				{
+					EslVersion:    2,
+					ReleaseNumber: 2,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest2"}},
+					Metadata:      DBReleaseMetaData{IsPrepublish: true},
+				},
+				{
+					EslVersion:    1,
+					ReleaseNumber: 3,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest3"}},
+				},
+			},
+			AppName:              "app1",
+			RetrievePrepublishes: true,
+			Expected: []*DBReleaseWithMetaData{
+				{
+					EslVersion:    1,
+					ReleaseNumber: 3,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest3"}},
+				},
+				{
+					EslVersion:    2,
+					ReleaseNumber: 2,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest2"}},
+					Metadata:      DBReleaseMetaData{IsPrepublish: true},
+				},
+				{
+					EslVersion:    1,
+					ReleaseNumber: 1,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest1"}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -2377,7 +2465,7 @@ func TestReadReleasesByApp(t *testing.T) {
 						return fmt.Errorf("error while writing release, error: %w", err)
 					}
 				}
-				releases, err := dbHandler.DBSelectReleasesByApp(ctx, transaction, tc.AppName, false)
+				releases, err := dbHandler.DBSelectReleasesByApp(ctx, transaction, tc.AppName, false, !tc.RetrievePrepublishes)
 				if err != nil {
 					return fmt.Errorf("error while selecting release, error: %w", err)
 				}

--- a/pkg/db/overview.go
+++ b/pkg/db/overview.go
@@ -126,7 +126,7 @@ func (h *DBHandler) UpdateOverviewDeployment(ctx context.Context, transaction *s
 
 	if deployment.Version != nil { //Check if not trying to deploy an undeploy version
 		//Get the undeploy information from the release
-		release, err := h.DBSelectReleaseByVersion(ctx, transaction, appInEnv.Name, appInEnv.Version)
+		release, err := h.DBSelectReleaseByVersion(ctx, transaction, appInEnv.Name, appInEnv.Version, true)
 		if err != nil {
 			return fmt.Errorf("error getting release %d for app %s", appInEnv.Version, appInEnv.Name)
 		}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -2553,7 +2553,7 @@ func extractPrNumber(sourceMessage string) string {
 
 func (s *State) IsUndeployVersion(ctx context.Context, transaction *sql.Tx, application string, version uint64) (bool, error) {
 	if s.DBHandler.ShouldUseOtherTables() {
-		release, err := s.DBHandler.DBSelectReleaseByVersion(ctx, transaction, application, version)
+		release, err := s.DBHandler.DBSelectReleaseByVersion(ctx, transaction, application, version, true)
 		return release.Metadata.UndeployVersion, err
 	} else {
 		return s.IsUndeployVersionFromManifest(application, version)
@@ -2577,7 +2577,7 @@ func (s *State) IsUndeployVersionFromManifest(application string, version uint64
 
 func (s *State) GetApplicationRelease(ctx context.Context, transaction *sql.Tx, application string, version uint64) (*Release, error) {
 	if s.DBHandler.ShouldUseOtherTables() {
-		env, err := s.DBHandler.DBSelectReleaseByVersion(ctx, transaction, application, version)
+		env, err := s.DBHandler.DBSelectReleaseByVersion(ctx, transaction, application, version, true)
 		if err != nil {
 			return nil, fmt.Errorf("could not get release of app %s: %v", application, err)
 		}
@@ -2668,7 +2668,7 @@ func (s *State) GetApplicationReleaseFromManifest(application string, version ui
 func (s *State) GetApplicationReleaseManifests(ctx context.Context, transaction *sql.Tx, application string, version uint64) (map[string]*api.Manifest, error) {
 	manifests := map[string]*api.Manifest{}
 	if s.DBHandler.ShouldUseOtherTables() {
-		release, err := s.DBHandler.DBSelectReleaseByVersion(ctx, transaction, application, version)
+		release, err := s.DBHandler.DBSelectReleaseByVersion(ctx, transaction, application, version, true)
 		if err != nil {
 			return nil, fmt.Errorf("could not get release for app %s with version %v: %w", application, version, err)
 		}

--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -1142,7 +1142,7 @@ func TestMinorFlag(t *testing.T) {
 					return err
 				}
 				for _, minorVersion := range tc.ExpectedMinors {
-					release, err := state.DBHandler.DBSelectReleaseByVersion(ctxWithTime, transaction, appName, minorVersion)
+					release, err := state.DBHandler.DBSelectReleaseByVersion(ctxWithTime, transaction, appName, minorVersion, true)
 					if err != nil {
 						return err
 					}
@@ -1151,7 +1151,7 @@ func TestMinorFlag(t *testing.T) {
 					}
 				}
 				for _, majorVersion := range tc.ExpectedMajors {
-					release, err := state.DBHandler.DBSelectReleaseByVersion(ctxWithTime, transaction, appName, majorVersion)
+					release, err := state.DBHandler.DBSelectReleaseByVersion(ctxWithTime, transaction, appName, majorVersion, true)
 					if err != nil {
 						return err
 					}
@@ -1961,7 +1961,7 @@ func TestDeleteEnvFromAppWithDB(t *testing.T) {
 				if err != nil {
 					return fmt.Errorf("error: %v", err)
 				}
-				releases, err2 := state.DBHandler.DBSelectReleasesByApp(ctx, transaction, firstRelease.App, false)
+				releases, err2 := state.DBHandler.DBSelectReleasesByApp(ctx, transaction, firstRelease.App, false, true)
 				if err2 != nil {
 					return fmt.Errorf("error retrieving release: %v", err2)
 				}
@@ -2661,7 +2661,7 @@ func TestCreateUndeployDBState(t *testing.T) {
 				if diff := cmp.Diff(tc.expectedReleaseNumbers, allReleases.Metadata.Releases); diff != "" {
 					t.Fatalf("error mismatch on expected lock ids (-want, +got):\n%s", diff)
 				}
-				release, err2 := s.DBHandler.DBSelectReleaseByVersion(ctx, transaction, appName, uint64(allReleases.Metadata.Releases[len(allReleases.Metadata.Releases)-1]))
+				release, err2 := s.DBHandler.DBSelectReleaseByVersion(ctx, transaction, appName, uint64(allReleases.Metadata.Releases[len(allReleases.Metadata.Releases)-1]), true)
 				if err2 != nil {
 					t.Fatal(err)
 				}

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -332,7 +332,7 @@ func (c *DeployApplicationVersion) Transform(
 	var manifestContent []byte
 	releaseDir := releasesDirectoryWithVersion(fsys, c.Application, c.Version)
 	if state.DBHandler.ShouldUseOtherTables() {
-		version, err := state.DBHandler.DBSelectReleaseByVersion(ctx, transaction, c.Application, c.Version)
+		version, err := state.DBHandler.DBSelectReleaseByVersion(ctx, transaction, c.Application, c.Version, true)
 		if err != nil {
 			return "", err
 		}
@@ -1072,7 +1072,7 @@ func findOldApplicationVersions(ctx context.Context, transaction *sql.Tx, state 
 	indexToKeep := positionOfOldestVersion - 1
 	majorsCount := 0
 	for ; indexToKeep >= 0; indexToKeep-- {
-		release, err := state.DBHandler.DBSelectReleaseByVersion(ctx, transaction, name, versions[indexToKeep])
+		release, err := state.DBHandler.DBSelectReleaseByVersion(ctx, transaction, name, versions[indexToKeep], true)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/integration-tests/release_test.go
+++ b/tests/integration-tests/release_test.go
@@ -472,7 +472,7 @@ func callDBForLock(t *testing.T, dbHandler *db.DBHandler, ctx context.Context, e
 
 func callDBForReleases(t *testing.T, dbHandler *db.DBHandler, ctx context.Context, appName string) []*db.DBReleaseWithMetaData {
 	release, err := db.WithTransactionMultipleEntriesT(dbHandler, ctx, true, func(ctx context.Context, transaction *sql.Tx) ([]*db.DBReleaseWithMetaData, error) {
-		return dbHandler.DBSelectReleasesByApp(ctx, transaction, appName, false)
+		return dbHandler.DBSelectReleasesByApp(ctx, transaction, appName, false, true)
 	})
 	if err != nil {
 		t.Fatalf("DBSelectReleasesByApp failed %s", err)


### PR DESCRIPTION
Ref: SRX-LUOQKA

- Prepublish releases should not have any manifests
- You can have two releases with the same release version if one of them is a prepublish release.