### PR TITLE
chore(charts): consistent pod annotations

### DIFF
--- a/charts/kuberpult/templates/_helpers.tpl
+++ b/charts/kuberpult/templates/_helpers.tpl
@@ -1,5 +1,0 @@
-{{- define "rollout-podAnnotations" }}
-{{- if .Values.datadogTracing.enabled }}
-apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-rollout-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
-{{- end }}
-{{- end }}

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -61,7 +61,9 @@ spec:
 {{- if .Values.datadogTracing.enabled }}
         apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-cd-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
 {{- end }}
+{{- if .Values.cd.pod.annotations }}
 {{ .Values.cd.pod.annotations | toYaml | indent 8}}
+{{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -334,7 +336,9 @@ metadata:
 {{- if .Values.cd.backendConfig.create }}
     cloud.google.com/backend-config: '{"default": "kuberpult-cd-service"}'
 {{- end }}
+{{- if .Values.cd.service.annotations }}
 {{ .Values.cd.service.annotations | toYaml | indent 4}}
+{{- end }}
 spec:
   ports:
   - name: http

--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -56,9 +56,12 @@ spec:
         tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
         tags.datadoghq.com/service: kuberpult-cd-service
         tags.datadoghq.com/version: {{ $.Chart.AppVersion }}
+{{- end }}
       annotations:
+{{- if .Values.datadogTracing.enabled }}
         apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-cd-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
 {{- end }}
+{{ .Values.cd.pod.annotations | toYaml | indent 8}}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -327,10 +330,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kuberpult-cd-service
-  {{- if .Values.cd.backendConfig.create }}
   annotations:
+{{- if .Values.cd.backendConfig.create }}
     cloud.google.com/backend-config: '{"default": "kuberpult-cd-service"}'
-  {{- end }}
+{{- end }}
+{{ .Values.cd.service.annotations | toYaml | indent 4}}
 spec:
   ports:
   - name: http

--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -53,9 +53,12 @@ spec:
         tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
         tags.datadoghq.com/service: kuberpult-frontend-service
         tags.datadoghq.com/version: {{ $.Chart.AppVersion }}
+{{- end }}
       annotations:
+{{- if .Values.datadogTracing.enabled }}
         apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-frontend-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
 {{- end }}
+{{ .Values.frontend.pod.annotations | toYaml | indent 8}}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -223,9 +226,7 @@ metadata:
 {{- if .Values.ingress.iap.enabled }}
     cloud.google.com/backend-config: '{"default": "kuberpult"}'
 {{- end }}
-{{- range $key, $value := .Values.frontend.service.annotations }}
-    {{ $key | quote}}: {{ $value | quote}}
-{{- end }}
+{{ .Values.frontend.service.annotations | toYaml | indent 4}}
 spec:
   ports:
   - name: http

--- a/charts/kuberpult/templates/frontend-service.yaml
+++ b/charts/kuberpult/templates/frontend-service.yaml
@@ -58,7 +58,9 @@ spec:
 {{- if .Values.datadogTracing.enabled }}
         apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-frontend-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
 {{- end }}
+{{- if .Values.frontend.pod.annotations }}
 {{ .Values.frontend.pod.annotations | toYaml | indent 8}}
+{{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -226,7 +228,9 @@ metadata:
 {{- if .Values.ingress.iap.enabled }}
     cloud.google.com/backend-config: '{"default": "kuberpult"}'
 {{- end }}
+{{- if .Values.frontend.service.annotations }}
 {{ .Values.frontend.service.annotations | toYaml | indent 4}}
+{{- end }}
 spec:
   ports:
   - name: http

--- a/charts/kuberpult/templates/ingress.yaml
+++ b/charts/kuberpult/templates/ingress.yaml
@@ -25,7 +25,9 @@ metadata:
   annotations:
     cert-manager.io/acme-challenge-type: dns01
     cert-manager.io/cluster-issuer: letsencrypt
+{{- if .Values.ingress.annotations }}
 {{ .Values.ingress.annotations | toYaml | indent 4}}
+{{- end }}
   name: kuberpult
 spec:
 {{- if and (.Values.ingress.private) (eq .Values.kubernetesEngine "GKE") }}

--- a/charts/kuberpult/templates/ingress.yaml
+++ b/charts/kuberpult/templates/ingress.yaml
@@ -25,9 +25,7 @@ metadata:
   annotations:
     cert-manager.io/acme-challenge-type: dns01
     cert-manager.io/cluster-issuer: letsencrypt
-{{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key | quote}}: {{ $value | quote}}
-{{- end }}
+{{ .Values.ingress.annotations | toYaml | indent 4}}
   name: kuberpult
 spec:
 {{- if and (.Values.ingress.private) (eq .Values.kubernetesEngine "GKE") }}

--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -50,9 +50,12 @@ spec:
         tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
         tags.datadoghq.com/service: kuberpult-manifest-repo-export-service
         tags.datadoghq.com/version: {{ $.Chart.AppVersion }}
+{{- end }}
       annotations:
+{{- if .Values.datadogTracing.enabled }}
         apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-manifest-repo-export-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
 {{- end }}
+{{ .Values.manifestRepoExport.pod.annotations | toYaml | indent 8}}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -254,6 +257,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kuberpult-manifest-repo-export-service
+  annotations:
+{{ .Values.manifestRepoExport.service.annotations | toYaml | indent 4}}
 spec:
   ports:
   - name: grpc

--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -55,7 +55,9 @@ spec:
 {{- if .Values.datadogTracing.enabled }}
         apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-manifest-repo-export-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
 {{- end }}
+{{- if .Values.manifestRepoExport.pod.annotations }}
 {{ .Values.manifestRepoExport.pod.annotations | toYaml | indent 8}}
+{{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -257,8 +259,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kuberpult-manifest-repo-export-service
+{{- if .Values.manifestRepoExport.service.annotations }}
   annotations:
 {{ .Values.manifestRepoExport.service.annotations | toYaml | indent 4}}
+{{- end }}
 spec:
   ports:
   - name: grpc

--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -53,7 +53,7 @@ spec:
 {{- end }}
       annotations:
 {{- if .Values.datadogTracing.enabled }}
-apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-rollout-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
+ .      apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-rollout-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
 {{- end }}
 {{- if .Values.rollout.pod.annotations}}
 {{ .Values.rollout.pod.annotations | toYaml | indent 8}}

--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -55,7 +55,9 @@ spec:
 {{- if .Values.datadogTracing.enabled }}
 apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-rollout-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
 {{- end }}
+{{- if .Values.rollout.pod.annotations}}
 {{ .Values.rollout.pod.annotations | toYaml | indent 8}}
+{{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -186,8 +188,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kuberpult-rollout-service
+{{- if .Values.rollout.service.annotations }}
   annotations:
 {{ .Values.rollout.service.annotations | toYaml | indent 4}}
+{{- end }}
 spec:
   ports:
   - name: http

--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -25,7 +25,6 @@
 {{- if not (eq .Values.argocd.refreshEnabled nil) }}
 {{ fail "argocd.refreshEnabled is removed in favour of argocd.refresh.enabled"}}
 {{- end -}}
-{{- $podAnnotations := mustMergeOverwrite (dict) (include "rollout-podAnnotations" . | fromYaml ) .Values.rollout.podAnnotations -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -53,7 +52,10 @@ spec:
         tags.datadoghq.com/version: {{ $.Chart.AppVersion }}
 {{- end }}
       annotations:
-{{ $podAnnotations | toYaml | indent 8}}
+{{- if .Values.datadogTracing.enabled }}
+apm.datadoghq.com/env: '{"DD_SERVICE":"kuberpult-rollout-service","DD_ENV":"{{ .Values.datadogTracing.environment }}","DD_VERSION":"{{ $.Chart.AppVersion }}"}'
+{{- end }}
+{{ .Values.rollout.pod.annotations | toYaml | indent 8}}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -184,6 +186,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kuberpult-rollout-service
+  annotations:
+{{ .Values.rollout.service.annotations | toYaml | indent 4}}
 spec:
   ports:
   - name: http

--- a/charts/kuberpult/tests/charts_test.go
+++ b/charts/kuberpult/tests/charts_test.go
@@ -162,11 +162,11 @@ func getIngress(fileName string) (*networking.Ingress, error) {
 
 func TestHelmChartsKuberpultCdEnvVariables(t *testing.T) {
 	tcs := []struct {
-		Name            string
-		Values          string
-		ExpectedEnvs    []core.EnvVar
-		ExpectedMissing []core.EnvVar
-		ExpectedPodAnnotations	map[string]string
+		Name                   string
+		Values                 string
+		ExpectedEnvs           []core.EnvVar
+		ExpectedMissing        []core.EnvVar
+		ExpectedPodAnnotations map[string]string
 	}{
 		{
 			Name: "Minimal values.yaml leads to proper default values",
@@ -358,7 +358,7 @@ datadogTracing:
 				},
 			},
 			ExpectedMissing: []core.EnvVar{},
-			ExpectedPodAnnotations: map[string]string {
+			ExpectedPodAnnotations: map[string]string{
 				"apm.datadoghq.com/env": `{"DD_SERVICE":"kuberpult-cd-service","DD_ENV":"shared","DD_VERSION":"v8.14.1-1-gf4383c93"}`,
 			},
 		},
@@ -660,7 +660,7 @@ db:
 			},
 			ExpectedMissing: []core.EnvVar{},
 			ExpectedPodAnnotations: map[string]string{
-				"test-key": "test-value",
+				"test-key":  "test-value",
 				"secondKey": "secondValue",
 			},
 		},
@@ -1359,12 +1359,12 @@ frontend:
 func TestIngress(t *testing.T) {
 	ingressClassGcePrivate := "gce-private"
 	tcs := []struct {
-		Name      string
-		Values    string
-		UseDex    bool
-		UseUi     bool
-		UseOldApi bool
-		UseNewApi bool
+		Name                     string
+		Values                   string
+		UseDex                   bool
+		UseUi                    bool
+		UseOldApi                bool
+		UseNewApi                bool
 		ExpectedExtraAnnotations map[string]string
 	}{
 		{
@@ -1454,14 +1454,14 @@ ingress:
 			UseNewApi: true,
 			ExpectedExtraAnnotations: map[string]string{
 				"test-annotation-key": "test-value",
-				"secondKey": "secondValue",
+				"secondKey":           "secondValue",
 			},
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
-			ExpectedAnnotations := map[string]string {
+			ExpectedAnnotations := map[string]string{
 				"cert-manager.io/acme-challenge-type":            "dns01",
 				"cert-manager.io/cluster-issuer":                 "letsencrypt",
 				"kubernetes.io/ingress.allow-http":               "false",
@@ -1476,7 +1476,7 @@ ingress:
 					APIVersion: "networking.k8s.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "kuberpult",
+					Name:        "kuberpult",
 					Annotations: ExpectedAnnotations,
 				},
 				Spec: networking.IngressSpec{
@@ -1538,14 +1538,14 @@ func filterDDVersion(dict map[string]string) {
 
 func TestAnnotations(t *testing.T) {
 	tcs := []struct {
-		Name            string
-		Values          string
-		ExpectedCdPodAnnotations	map[string]string
-		ExpectedCdServiceAnnotations map[string]string
-		ExpectedManifestRepoExportPodAnnotations map[string]string
+		Name                                         string
+		Values                                       string
+		ExpectedCdPodAnnotations                     map[string]string
+		ExpectedCdServiceAnnotations                 map[string]string
+		ExpectedManifestRepoExportPodAnnotations     map[string]string
 		ExpectedManifestRepoExportServiceAnnotations map[string]string
-		ExpectedFrontendPodAnnotations map[string]string
-		ExpectedFrontendServiceAnnotations map[string]string
+		ExpectedFrontendPodAnnotations               map[string]string
+		ExpectedFrontendServiceAnnotations           map[string]string
 	}{
 		{
 			Name: "Test no annotations",
@@ -1568,13 +1568,13 @@ db:
 datadogTracing:
   enabled: true
 `,
-			ExpectedCdPodAnnotations: map[string]string {
+			ExpectedCdPodAnnotations: map[string]string{
 				"apm.datadoghq.com/env": `{"DD_SERVICE":"kuberpult-cd-service","DD_ENV":"shared"`,
 			},
-			ExpectedManifestRepoExportPodAnnotations: map[string]string {
+			ExpectedManifestRepoExportPodAnnotations: map[string]string{
 				"apm.datadoghq.com/env": `{"DD_SERVICE":"kuberpult-manifest-repo-export-service","DD_ENV":"shared"`,
 			},
-			ExpectedFrontendPodAnnotations: map[string]string {
+			ExpectedFrontendPodAnnotations: map[string]string{
 				"apm.datadoghq.com/env": `{"DD_SERVICE":"kuberpult-frontend-service","DD_ENV":"shared"`,
 			},
 		},
@@ -1603,15 +1603,15 @@ db:
   dbOption: postgreSQL
 `,
 			ExpectedCdPodAnnotations: map[string]string{
-				"test-key": "test-value",
+				"test-key":  "test-value",
 				"secondKey": "secondValue",
 			},
 			ExpectedManifestRepoExportPodAnnotations: map[string]string{
-				"test-key": "test-value2",
+				"test-key":  "test-value2",
 				"secondKey": "secondValue2",
 			},
 			ExpectedFrontendPodAnnotations: map[string]string{
-				"test-key": "test-value3",
+				"test-key":  "test-value3",
 				"secondKey": "secondValue3",
 			},
 		},
@@ -1642,18 +1642,18 @@ db:
   dbOption: postgreSQL
 `,
 			ExpectedCdPodAnnotations: map[string]string{
-				"test-key": "test-value",
-				"secondKey": "secondValue",
+				"test-key":              "test-value",
+				"secondKey":             "secondValue",
 				"apm.datadoghq.com/env": `{"DD_SERVICE":"kuberpult-cd-service","DD_ENV":"shared"`,
 			},
 			ExpectedManifestRepoExportPodAnnotations: map[string]string{
-				"test-key": "test-value2",
-				"secondKey": "secondValue2",
+				"test-key":              "test-value2",
+				"secondKey":             "secondValue2",
 				"apm.datadoghq.com/env": `{"DD_SERVICE":"kuberpult-manifest-repo-export-service","DD_ENV":"shared"`,
 			},
 			ExpectedFrontendPodAnnotations: map[string]string{
-				"test-key": "test-value3",
-				"secondKey": "secondValue3",
+				"test-key":              "test-value3",
+				"secondKey":             "secondValue3",
 				"apm.datadoghq.com/env": `{"DD_SERVICE":"kuberpult-frontend-service","DD_ENV":"shared"`,
 			},
 		},
@@ -1685,16 +1685,16 @@ db:
   dbOption: postgreSQL
 `,
 			ExpectedCdServiceAnnotations: map[string]string{
-				"test-key": "test-value",
+				"test-key":  "test-value",
 				"secondKey": "secondValue",
 			},
 			ExpectedManifestRepoExportServiceAnnotations: map[string]string{
-				"test-key": "test-value2",
+				"test-key":  "test-value2",
 				"secondKey": "secondValue2",
 			},
 			ExpectedFrontendServiceAnnotations: map[string]string{
-				"test-key": "test-value3",
-				"secondKey": "secondValue3",
+				"test-key":                        "test-value3",
+				"secondKey":                       "secondValue3",
 				"cloud.google.com/backend-config": `{"default": "kuberpult"}`,
 			},
 		},

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -85,6 +85,10 @@ cd:
   allowLongAppNames: false
 # List of allowed domains that the links provided in releases, release trains and locks must match
   allowedDomains: ""
+  service:
+    annotations: {}
+  pod:
+    annotations: {}
   backendConfig:
     create: false   # Add backend config for health checks on GKE only
     timeoutSec: 300  # 30sec is the default on gcp loadbalancers, however kuberpult needs more with parallel requests. It is the time how long the loadbalancer waits for kuberpult to finish calls to the rest endpoint "release"
@@ -139,6 +143,10 @@ db:
     memory: "200Mi"
 manifestRepoExport:
   image: kuberpult-manifest-repo-export-service
+  service:
+    annotations: {}
+  pod:
+    annotations: {}
   resources:
     limits:
       cpu: 2
@@ -172,6 +180,8 @@ frontend:
 # See frontend-service.yaml for automatically added annotations.
   service:
     annotations: {}
+  pod:
+    annotations: {}
   resources:
     limits:
       cpu: 500m
@@ -189,6 +199,10 @@ frontend:
   grpcMaxRecvMsgSize: 4
 rollout:
   enabled: false
+  service:
+    annotations: {}
+  pod:
+    annotations: {}
   image: kuberpult-rollout-service
   resources:
     limits:
@@ -199,8 +213,6 @@ rollout:
       memory: 250Mi
   # The maximum message size in mega bytes the client can receive.
   grpcMaxRecvMsgSize: 4
-  # annotations given here will take precedence over the defaults defined in _helpers.tpl
-  podAnnotations: {}
 
 ingress:
   # The simplest setup involves an ingress, to make kuberpult available outside the cluster.


### PR DESCRIPTION
Ref: SRX-BUFHA5

BREAKING CHANGE: `rollout.podAnnotations` in helm charts is moved to `rollout.pod.annotations`. Now we have these parameters:
[frontend|cd|rollout|manifestRepoExport].pod.annotations
[frontend|cd|rollout|manifestRepoExport].service.annotations
ingress.annotations
