### PR TITLE
fix(ui): Disable deploy button if it is a no-op

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -517,8 +517,6 @@ describe('Release Dialog', () => {
     };
 
     describe(`Test automatic cart opening`, () => {
-        // it('Test using direct call to open function', () => {});
-
         describe.each(dataLocks)('click handling', (testcase) => {
             it('Test using deploy button click simulation ' + testcase.name, () => {
                 UpdateAction.set({ actions: [] });

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.test.tsx
@@ -517,7 +517,7 @@ describe('Release Dialog', () => {
     };
 
     describe(`Test automatic cart opening`, () => {
-        it('Test using direct call to open function', () => {});
+        // it('Test using direct call to open function', () => {});
 
         describe.each(dataLocks)('click handling', (testcase) => {
             it('Test using deploy button click simulation ' + testcase.name, () => {

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -240,13 +240,14 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
         .flat();
 
     const allowDeployment: boolean = ((): boolean => {
+        //!release.isPrepublish)();
         if (release.isPrepublish) {
             return false;
         }
         if (!otherRelease) {
-            return false;
+            return true;
         }
-        return otherRelease.version === release.version;
+        return otherRelease.version !== release.version;
     })();
 
     return (
@@ -317,7 +318,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                             <ExpandButton
                                 onClickSubmit={deployAndLockClick}
                                 defaultButtonLabel={'Deploy & Lock'}
-                                disabled={allowDeployment}
+                                disabled={!allowDeployment}
                             />
                         </div>
                     </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -239,6 +239,16 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
         )
         .flat();
 
+    const allowDeployment: boolean = ((): boolean => {
+        if (release.isPrepublish) {
+            return false;
+        }
+        if (!otherRelease) {
+            return false;
+        }
+        return otherRelease.version === release.version;
+    })();
+
     return (
         <li key={env.name} className={classNames('env-card', className)}>
             <div className="env-card-header">
@@ -307,7 +317,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                             <ExpandButton
                                 onClickSubmit={deployAndLockClick}
                                 defaultButtonLabel={'Deploy & Lock'}
-                                disabled={release.isPrepublish}
+                                disabled={allowDeployment}
                             />
                         </div>
                     </div>
@@ -320,10 +330,9 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
 export const EnvironmentList: React.FC<{
     release: Release;
     app: string;
-    version: number;
     team: string;
     className?: string;
-}> = ({ release, app, version, className, team }) => {
+}> = ({ release, app, className, team }) => {
     const allEnvGroups: EnvironmentGroup[] = useEnvironmentGroups();
     return (
         <div className="release-env-group-list">
@@ -410,7 +419,7 @@ export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
                         highlightEffect={false}
                     />
                 </div>
-                <EnvironmentList app={app} team={team} className={className} release={release} version={version} />
+                <EnvironmentList app={app} team={team} className={className} release={release} />
             </>
         </PlainDialog>
     );

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -240,7 +240,6 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
         .flat();
 
     const allowDeployment: boolean = ((): boolean => {
-        //!release.isPrepublish)();
         if (release.isPrepublish) {
             return false;
         }

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -232,6 +232,7 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                             <button
                               aria-label="Deploy & Lock"
                               class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated"
+                              disabled=""
                             >
                               <div
                                 class="mdc-button__ripple"
@@ -245,6 +246,7 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                             <button
                               aria-label=""
                               class="mdc-button button-expand"
+                              disabled=""
                             >
                               <div
                                 class="mdc-button__ripple"
@@ -506,6 +508,7 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                             <button
                               aria-label="Deploy & Lock"
                               class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated"
+                              disabled=""
                             >
                               <div
                                 class="mdc-button__ripple"
@@ -519,6 +522,7 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                             <button
                               aria-label=""
                               class="mdc-button button-expand"
+                              disabled=""
                             >
                               <div
                                 class="mdc-button__ripple"
@@ -780,6 +784,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                             <button
                               aria-label="Deploy & Lock"
                               class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated"
+                              disabled=""
                             >
                               <div
                                 class="mdc-button__ripple"
@@ -793,6 +798,7 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                             <button
                               aria-label=""
                               class="mdc-button button-expand"
+                              disabled=""
                             >
                               <div
                                 class="mdc-button__ripple"


### PR DESCRIPTION
This enables the deploy button in the release dialog only if the same version is not already deployed on the given environment.

Ref: SRX-78FWXB

![image](https://github.com/user-attachments/assets/11b34477-0432-471e-bd0f-660bda6e2680)
