### PR TITLE
fix: Pass context to OverviewServiceServer

### DIFF
--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -404,6 +404,7 @@ func RunServer() {
 						Repository:       repo,
 						RepositoryConfig: cfg,
 						Shutdown:         shutdownCh,
+						Context:          ctx,
 					}
 					api.RegisterOverviewServiceServer(srv, overviewSrv)
 					api.RegisterGitServiceServer(srv, &service.GitServer{Config: cfg, OverviewService: overviewSrv, PageSize: 10})

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -47,8 +47,8 @@ type OverviewServiceServer struct {
 	RepositoryConfig repository.RepositoryConfig
 	Shutdown         <-chan struct{}
 
-	notify notify.Notify
-
+	notify   notify.Notify
+	Context  context.Context
 	init     sync.Once
 	response atomic.Value
 }
@@ -492,9 +492,9 @@ func (o *OverviewServiceServer) subscribe() (<-chan struct{}, notify.Unsubscribe
 }
 
 func (o *OverviewServiceServer) update(s *repository.State) {
-	r, err := o.getOverviewDB(context.Background(), s)
+	r, err := o.getOverviewDB(o.Context, s)
 	if err != nil {
-		logger.FromContext(context.Background()).Error("error getting overview:", zap.Error(err))
+		logger.FromContext(o.Context).Error("error getting overview:", zap.Error(err))
 		return
 	}
 	o.response.Store(r)


### PR DESCRIPTION
* Pass the context to the OverviewServiceServer and use it in `update` function for correct logging.

Ref: SRX-GWLFAS