### PR TITLE
chore: store relation between commit hash and transaction timestamp

### DIFF
--- a/database/migrations/postgres/1726064901745858_transaction_timestamps.up.sql
+++ b/database/migrations/postgres/1726064901745858_transaction_timestamps.up.sql
@@ -1,0 +1,7 @@
+-- Table that stores which timestamp
+CREATE TABLE IF NOT EXISTS commit_transaction_timestamps
+(
+    commitHash VARCHAR NOT NULL,
+    transactionTimestamp TIMESTAMP NOT NULL,
+    PRIMARY KEY(commitHash)
+);

--- a/database/migrations/postgres/1726064901745858_transaction_timestamps.up.sql
+++ b/database/migrations/postgres/1726064901745858_transaction_timestamps.up.sql
@@ -1,4 +1,4 @@
--- Table that stores which which cd-service transaction timestamp corresponds to a certain commit hash
+-- Table that stores which cd-service transaction timestamp corresponds to a certain commit hash
 -- on the manifest repo
 CREATE TABLE IF NOT EXISTS commit_transaction_timestamps
 (

--- a/database/migrations/postgres/1726064901745858_transaction_timestamps.up.sql
+++ b/database/migrations/postgres/1726064901745858_transaction_timestamps.up.sql
@@ -1,4 +1,5 @@
--- Table that stores which timestamp
+-- Table that stores which which cd-service transaction timestamp corresponds to a certain commit hash
+-- on the manifest repo
 CREATE TABLE IF NOT EXISTS commit_transaction_timestamps
 (
     commitHash VARCHAR NOT NULL,

--- a/database/migrations/sqlite/1726064901745858_transaction_timestamps.up.sql
+++ b/database/migrations/sqlite/1726064901745858_transaction_timestamps.up.sql
@@ -1,0 +1,7 @@
+-- Table that stores which timestamp
+CREATE TABLE IF NOT EXISTS commit_transaction_timestamps
+(
+    commitHash VARCHAR NOT NULL,
+    transactionTimestamp TIMESTAMP NOT NULL,
+    PRIMARY KEY(commitHash)
+);

--- a/database/migrations/sqlite/1726064901745858_transaction_timestamps.up.sql
+++ b/database/migrations/sqlite/1726064901745858_transaction_timestamps.up.sql
@@ -1,7 +1,1 @@
--- Table that stores which timestamp
-CREATE TABLE IF NOT EXISTS commit_transaction_timestamps
-(
-    commitHash VARCHAR NOT NULL,
-    transactionTimestamp TIMESTAMP NOT NULL,
-    PRIMARY KEY(commitHash)
-);
+../postgres/1726064901745858_transaction_timestamps.up.sql

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -4936,3 +4936,30 @@ func (h *DBHandler) processAllDeploymentRow(ctx context.Context, err error, rows
 	}
 	return deployments, nil
 }
+
+func (h *DBHandler) DBWriteCommitTransactionTimestamp(ctx context.Context, tx *sql.Tx, commitHash string, timestamp time.Time) error {
+	span, _ := tracer.StartSpanFromContext(ctx, "DBWriteCommitTransactionTimestamp")
+	defer span.Finish()
+
+	if h == nil {
+		return nil
+	}
+	if tx == nil {
+		return fmt.Errorf("attempting to write to the commit_transaction_timestamps table without a transaction")
+	}
+
+	insertQuery := h.AdaptQuery(
+		"INSERT INTO commit_transaction_timestamps (commitHash, transactionTimestamp) VALUES (?, ?);",
+	)
+
+	span.SetTag("query", insertQuery)
+	_, err := tx.Exec(
+		insertQuery,
+		commitHash,
+		timestamp,
+	)
+	if err != nil {
+		return fmt.Errorf("DBWriteCommitTransactionTimestamp error executing query: %w", err)
+	}
+	return nil
+}

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -279,7 +279,6 @@ func processEsls(ctx context.Context, repo repository.Repository, dbHandler *db.
 		var transformer repository.Transformer = nil
 		var esl *db.EslEventRow = nil
 		const readonly = true // we just handle the reading here, there's another transaction for writing the result to the db/git
-
 		err := dbHandler.WithTransactionR(ctx, transactionRetries, readonly, func(ctx context.Context, transaction *sql.Tx) error {
 			var err2 error
 			transformer, esl, err2 = handleOneEvent(ctx, transaction, dbHandler, ddMetrics, repo)
@@ -290,7 +289,6 @@ func processEsls(ctx context.Context, repo repository.Repository, dbHandler *db.
 				log.Errorf("skipping esl event, because we could not construct esl object: %v", err)
 				return err
 			}
-
 			log.Errorf("skipping esl event, because it returned an error: %v", err)
 			// after this many tries, we can just skip it:
 			err2 := dbHandler.WithTransactionR(ctx, transactionRetries, false, func(ctx context.Context, transaction *sql.Tx) error {
@@ -305,7 +303,6 @@ func processEsls(ctx context.Context, repo repository.Repository, dbHandler *db.
 			}
 			sleepDuration.Reset()
 		} else {
-
 			if transformer == nil {
 				sleepDuration.Reset()
 				d := sleepDuration.NextBackOff()

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -329,11 +329,11 @@ func processEsls(ctx context.Context, repo repository.Repository, dbHandler *db.
 				} else {
 					measurePushes(ddMetrics, log, false)
 				}
+
+				//Get latest commit. Write esl timestamp and commit hash.
 				commit, err := repo.GetHead()
 				if err != nil {
-					return err2
-				} else {
-					logger.FromContext(ctx).Sugar().Warnf("COmmit ID: %s", commit.Id().String())
+					return err
 				}
 				return dbHandler.DBWriteCommitTransactionTimestamp(ctx, transaction, commit.Id().String(), esl.Created)
 			})

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -328,7 +328,7 @@ func processEsls(ctx context.Context, repo repository.Repository, dbHandler *db.
 				}
 
 				//Get latest commit. Write esl timestamp and commit hash.
-				commit, err := repo.GetHead()
+				commit, err := repo.GetHeadCommit()
 				if err != nil {
 					return err
 				}

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -62,6 +62,7 @@ type Repository interface {
 	StateAt(oid *git.Oid) (*State, error)
 	FetchAndReset(ctx context.Context) error
 	PushRepo(ctx context.Context) error
+	GetHead() (*git.Commit, error)
 }
 
 type TransformerBatchApplyError struct {
@@ -415,6 +416,19 @@ func (r *repository) PushRepo(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (r *repository) GetHead() (*git.Commit, error) {
+	ref, err := r.repository.Head()
+	if err != nil {
+		return nil, fmt.Errorf("Error fetching HEAD: %v", err)
+	}
+	commit, err := r.repository.LookupCommit(ref.Target())
+	if err != nil {
+		return nil, fmt.Errorf("Error transalting into commit: %v", err)
+	}
+	return commit, nil
+
 }
 
 func (r *repository) ApplyTransformersInternal(ctx context.Context, transaction *sql.Tx, transformer Transformer) ([]string, *State, []*TransformerResult, *TransformerBatchApplyError) {

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -62,7 +62,7 @@ type Repository interface {
 	StateAt(oid *git.Oid) (*State, error)
 	FetchAndReset(ctx context.Context) error
 	PushRepo(ctx context.Context) error
-	GetHead() (*git.Commit, error)
+	GetHeadCommit() (*git.Commit, error)
 }
 
 type TransformerBatchApplyError struct {
@@ -418,7 +418,7 @@ func (r *repository) PushRepo(ctx context.Context) error {
 	return nil
 }
 
-func (r *repository) GetHead() (*git.Commit, error) {
+func (r *repository) GetHeadCommit() (*git.Commit, error) {
 	ref, err := r.repository.Head()
 	if err != nil {
 		return nil, fmt.Errorf("Error fetching HEAD: %v", err)


### PR DESCRIPTION
We need to store the relation between commit hash (repo state) and cd-service transaction timestamp (database state), so that we have a 1 to 1 temporal relation between database state and repository state. 

Ref: SRX-R7B9VQ