### PR TITLE
chore(registry): remove unnecassary github registry

### DIFF
--- a/.github/workflows/execution-plan-snippet-earthly.yml
+++ b/.github/workflows/execution-plan-snippet-earthly.yml
@@ -93,12 +93,6 @@ jobs:
           cat > credential.json << EOF
           ${{ secrets.GCP_ARTIFACT_REGISTRY_PUSH_JSON_KEY }}
           EOF
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v3
         with:
@@ -171,12 +165,6 @@ jobs:
           cat > credential.json << EOF
           ${{ secrets.GCP_ARTIFACT_REGISTRY_PUSH_JSON_KEY }}
           EOF
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v3
         with:
@@ -201,7 +189,7 @@ jobs:
           # We only want the image tag, but the exec-planner only provides the full image name,
           # so we extract everything after the ":"
           TAG=$(echo ${{matrix.data.image}} | cut -d ':' -f 2)
-          EARTHLY_DISABLE_REMOTE_REGISTRY_PROXY=true PARENT_CONTAINER=$TAG ARTIFACT_REGISTRY_MIRROR=true IMAGE_REGISTRY=ghcr.io/freiheit-com/kuberpult ${{ matrix.data.command }}
+          EARTHLY_DISABLE_REMOTE_REGISTRY_PROXY=true PARENT_CONTAINER=$TAG ARTIFACT_REGISTRY_MIRROR=true IMAGE_REGISTRY=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult ${{ matrix.data.command }}
       - name: Post build actions
         uses: ./.github/actions/post-build-action
         with:

--- a/.github/workflows/execution-plan-snippet.yml
+++ b/.github/workflows/execution-plan-snippet.yml
@@ -65,9 +65,7 @@ jobs:
         data: ${{fromJSON(needs.execution_plan.outputs.stage_a)}}
     name: ${{ matrix.data.directory }} - Build and Publish
     runs-on: ubuntu-latest
-    # we want to publish to the ghcr.io registry. For this we need to have package:write rights
     permissions:
-      packages: write
       contents: read
     steps:
       - name: Install earthly
@@ -92,12 +90,6 @@ jobs:
           cat > credential.json << EOF
           ${{ secrets.GCP_ARTIFACT_REGISTRY_PUSH_JSON_KEY }}
           EOF
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v3
         with:
@@ -144,9 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.data.image }}
-    # we want to publish to the ghcr.io registry. For this we need to have package:write rights
     permissions:
-      packages: write
       contents: read
     steps:
       - name: Checkout repository
@@ -167,12 +157,6 @@ jobs:
           cat > credential.json << EOF
           ${{ secrets.GCP_ARTIFACT_REGISTRY_PUSH_JSON_KEY }}
           EOF
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v3
         with:
@@ -197,7 +181,7 @@ jobs:
           # We only want the image tag, but the exec-planner only provides the full image name,
           # so we extract everything after the ":"
           TAG=$(echo ${{matrix.data.image}} | cut -d ':' -f 2)
-          EARTHLY_DISABLE_REMOTE_REGISTRY_PROXY=true PARENT_CONTAINER=$TAG ARTIFACT_REGISTRY_MIRROR=true IMAGE_REGISTRY=ghcr.io/freiheit-com/kuberpult ${{ matrix.data.command }}
+          EARTHLY_DISABLE_REMOTE_REGISTRY_PROXY=true PARENT_CONTAINER=$TAG ARTIFACT_REGISTRY_MIRROR=true IMAGE_REGISTRY=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult ${{ matrix.data.command }}
       - name: Post build actions
         uses: ./.github/actions/post-build-action
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,25 +22,31 @@ jobs:
       uses: earthly/actions-setup@v1
       with:
           version: v0.8.13
+    - name: Setup Image tag
+      if: inputs.trigger == 'pull-request' || inputs.trigger == 'main'
+      run: |
+        if [[ ${{ inputs.trigger }} == "pull-request" ]]; then
+          echo "IMAGE_TAG_KUBERPULT=pr-$(make version)" >> $GITHUB_ENV
+        elif [[ ${{ inputs.trigger }} == "main" ]]
+          echo "IMAGE_TAG_KUBERPULT=main-$(make version)" >> $GITHUB_ENV
+        fi
     - name: Setup environment
       if: inputs.trigger == 'pull-request' || inputs.trigger == 'main'
       run: |
-
-        if ! docker manifest inspect ${IMAGE_REGISTRY}/kuberpult-cd-service:$(make version) > /dev/null; then
+        if ! docker manifest inspect ${IMAGE_REGISTRY}/kuberpult-cd-service:${IMAGE_TAG_KUBERPULT} > /dev/null; then
           echo "No valid images found in the registry for the backend service"
           exit 1
         fi
 
-        if ! docker manifest inspect ${IMAGE_REGISTRY}/kuberpult-frontend-service:$(make version) > /dev/null; then
+        if ! docker manifest inspect ${IMAGE_REGISTRY}/kuberpult-frontend-service:${IMAGE_TAG_KUBERPULT} > /dev/null; then
           echo "No valid images found in the registry for the frontend service"
           exit 1
         fi
 
-        if ! docker manifest inspect ${IMAGE_REGISTRY}/kuberpult-rollout-service:$(make version) > /dev/null; then
+        if ! docker manifest inspect ${IMAGE_REGISTRY}/kuberpult-rollout-service:${IMAGE_TAG_KUBERPULT} > /dev/null; then
           echo "No valid images found in the registry for the rollout service"
           exit 1
         fi
-        echo "IMAGE_TAG_KUBERPULT=$(make version)" >> $GITHUB_ENV
     - name: Print environment
       run: |
         echo Using registry: $IMAGE_REGISTRY

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         if [[ ${{ inputs.trigger }} == "pull-request" ]]; then
           echo "IMAGE_TAG_KUBERPULT=pr-$(make version)" >> $GITHUB_ENV
-        elif [[ ${{ inputs.trigger }} == "main" ]]
+        elif [[ ${{ inputs.trigger }} == "main" ]]; then
           echo "IMAGE_TAG_KUBERPULT=main-$(make version)" >> $GITHUB_ENV
         fi
     - name: Setup environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,6 @@ jobs:
           dry: true
           ghr: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run helm chart tests
         run: |
           make -C charts/kuberpult test-helm
@@ -51,11 +45,6 @@ jobs:
           echo 'If this step fails, ensure that the main github action is done. We rely on it to get the docker images.'
           git fetch --tags # this should have been done by the checkout action before.
           make tag-cli-release-image RELEASE_IMAGE_TAG=v$RELEASE_IMAGE_VERSION
-        env:
-          RELEASE_IMAGE_VERSION: ${{ steps.new-semrel-version.outputs.version }}
-      - name: Re-tag service images with release version for github docker registry
-        run: |
-          make tag-release-images RELEASE_IMAGE_TAG=v$RELEASE_IMAGE_VERSION DOCKER_REGISTRY_URI=ghcr.io/freiheit-com/kuberpult
         env:
           RELEASE_IMAGE_VERSION: ${{ steps.new-semrel-version.outputs.version }}
       - name: Create release

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -20,20 +20,28 @@ jobs:
       uses: earthly/actions-setup@v1
       with:
           version: v0.8.13
+    - name: Setup Image tag
+      if: inputs.trigger == 'pull-request' || inputs.trigger == 'main'
+      run: |
+        if [[ ${{ inputs.trigger }} == "pull-request" ]]; then
+          echo "IMAGE_TAG_KUBERPULT=pr-$(make version)" >> $GITHUB_ENV
+        elif [[ ${{ inputs.trigger }} == "main" ]]; then
+          echo "IMAGE_TAG_KUBERPULT=main-$(make version)" >> $GITHUB_ENV
+        fi
     - name: Check if tag exists
       if: inputs.trigger == 'pull-request' || inputs.trigger == 'main'
       run: |
-        if ! docker manifest inspect ${IMAGE_REGISTRY}/kuberpult-cd-service:$(make version) > /dev/null; then
+        if ! docker manifest inspect ${IMAGE_REGISTRY}/kuberpult-cd-service:${IMAGE_TAG_KUBERPULT} > /dev/null; then
           echo "No valid images found in the registry for the backend service"
           exit 1
         fi
 
-        if ! docker manifest inspect ${IMAGE_REGISTRY}/kuberpult-frontend-service:$(make version) > /dev/null; then
+        if ! docker manifest inspect ${IMAGE_REGISTRY}/kuberpult-frontend-service:${IMAGE_TAG_KUBERPULT} > /dev/null; then
           echo "No valid images found in the registry for the frontend service"
           exit 1
         fi
 
-        if ! docker manifest inspect ${IMAGE_REGISTRY}/kuberpult-rollout-service:$(make version) > /dev/null; then
+        if ! docker manifest inspect ${IMAGE_REGISTRY}/kuberpult-rollout-service:${IMAGE_TAG_KUBERPULT} > /dev/null; then
           echo "No valid images found in the registry for the rollout service"
           exit 1
         fi

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -45,7 +45,6 @@ jobs:
           echo "No valid images found in the registry for the rollout service"
           exit 1
         fi
-        echo "IMAGE_TAG_KUBERPULT=$(make version)" >> $GITHUB_ENV
     - name: Run trivy scan
       run: |
         cd trivy

--- a/Earthfile
+++ b/Earthfile
@@ -138,6 +138,8 @@ integration-test:
 
     ARG --required kuberpult_version
     ENV VERSION=$kuberpult_version
+    ARG --required charts_version
+    ENV CHARTS_VERSION=$charts_version
     RUN envsubst < Chart.yaml.tpl > Chart.yaml
 
     WITH DOCKER --compose docker-compose-k3s.yml

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ all-services:
 	earthly +all-services --tag=$(VERSION)
 
 integration-test:
-	earthly -P +integration-test --kuberpult_version=$(VERSION)
+	earthly -P +integration-test --kuberpult_version=$(IMAGE_TAG_KUBERPULT) --charts_version=$(VERSION)
 
 pull-service-image/%:
 	docker pull $(DOCKER_REGISTRY_URI)/$*:$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ all-services:
 	earthly +all-services --tag=$(VERSION)
 
 integration-test:
-	earthly -P +integration-test --kuberpult_version=$(IMAGE_TAG_KUBERPULT)
+	earthly -P +integration-test --kuberpult_version=$(VERSION)
 
 pull-service-image/%:
 	docker pull $(DOCKER_REGISTRY_URI)/$*:$(VERSION)

--- a/README.md
+++ b/README.md
@@ -53,14 +53,12 @@ Both *environments* and *microservices* can be `locked`.
 ## Public releases of Kuberpult
 
 ### Docker Registries
-Kuberpult's docker images are currently available in 2 docker registries: (Example with version 0.4.55)
+Kuberpult's docker images are currently available in one docker registry: (Example with version 0.4.55)
 * `docker pull europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult/kuberpult-frontend-service:0.4.55` ([Link for Kuberpult devs](https://console.cloud.google.com/artifacts/docker/fdc-public-docker-registry/europe-west3/kuberpult/kuberpult-frontend-service))
-* `docker pull ghcr.io/freiheit-com/kuberpult/kuberpult-frontend-service:0.4.55` ([Link for Kuberpult devs](https://github.com/freiheit-com/kuberpult/pkgs/container/kuberpult%2Fkuberpult-frontend-service))
-And the same applies for the `kuberpult-cd-service` - just replace "frontend" by "cd".
 
-We may deprecate one of the registries in the future for simplicity.
-
-If you're using Kuberpult's helm chart, generally you don't have to worry about that.
+#### Deprecation Notes
+We used to maintain another docker registry on github as well. However, we are not maintaining it anymore and it will be removed in future releases. 
+Please use the google registry to retrieve kuberpult images.
 
 ### GitHub Releases
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Kuberpult's docker images are currently available in one docker registry: (Examp
 * `docker pull europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult/kuberpult-frontend-service:0.4.55` ([Link for Kuberpult devs](https://console.cloud.google.com/artifacts/docker/fdc-public-docker-registry/europe-west3/kuberpult/kuberpult-frontend-service))
 
 #### Deprecation Notes
-We used to maintain another docker registry on github as well. However, we are not maintaining it anymore and it will be removed in future releases. 
+We used to maintain another docker registry on github as well: ghcr.io/freiheit-com/kuberpult/ . However, we are not maintaining it anymore and it will be removed in future releases. 
 Please use the google registry to retrieve kuberpult images.
 
 ### GitHub Releases

--- a/charts/kuberpult/Chart.yaml.tpl
+++ b/charts/kuberpult/Chart.yaml.tpl
@@ -30,7 +30,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "${VERSION}"
+version: "${CHARTS_VERSION}"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kuberpult/Earthfile
+++ b/charts/kuberpult/Earthfile
@@ -45,7 +45,7 @@ chart.yaml:
 
     COPY Chart.yaml.tpl .
 
-    RUN env VERSION=$VERSION envsubst < Chart.yaml.tpl > Chart.yaml
+    RUN env VERSION=$VERSION CHARTS_VERSION=$VERSION envsubst < Chart.yaml.tpl > Chart.yaml
 
     SAVE ARTIFACT Chart.yaml AS LOCAL Chart.yaml
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -17,7 +17,7 @@
 include ../Makefile.variables
 
 build-pr:
-	earthly --push +build-pr --VERSION=$(VERSION)
+	earthly --push +build-pr --VERSION=pr-$(VERSION)
 
 build-main:
 	earthly --push +build-main --VERSION=$(VERSION)

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -20,4 +20,4 @@ build-pr:
 	earthly --push +build-pr --VERSION=pr-$(VERSION)
 
 build-main:
-	earthly --push +build-main --VERSION=$(VERSION)
+	earthly --push +build-main --VERSION=main-$(VERSION)

--- a/services/cd-service/Earthfile
+++ b/services/cd-service/Earthfile
@@ -51,7 +51,7 @@ release:
 
 build-pr:
     ARG --required tag
-    ARG registry="ghcr.io/freiheit-com/kuberpult"
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     ARG mirror="false"
     ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
 
@@ -59,7 +59,7 @@ build-pr:
 
 build-main:
     ARG --required tag
-    ARG registry="ghcr.io/freiheit-com/kuberpult"
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     ARG mirror="false"
     ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
 

--- a/services/cd-service/Makefile
+++ b/services/cd-service/Makefile
@@ -21,7 +21,7 @@ include ../../Makefile.variables
 MAKEFLAGS += --no-builtin-rules
 
 export CGO_ENABLED=1
-IMAGE_REGISTRY?=ghcr.io/freiheit-com/kuberpult
+IMAGE_REGISTRY?=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
 IMAGENAME?=$(IMAGE_REGISTRY)/kuberpult-cd-service:$(VERSION)
 ARTIFACT_REGISTRY_IMAGE_NAME=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult/kuberpult-cd-service:${VERSION}
 
@@ -64,7 +64,7 @@ build: bin/main
 
 build-pr:
 	echo "build on pull request"
-	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=pr-$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 build-main:
 	echo "build on main"

--- a/services/cd-service/Makefile
+++ b/services/cd-service/Makefile
@@ -68,7 +68,7 @@ build-pr:
 
 build-main:
 	echo "build on main"
-	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=main-$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 .PHONY: cleanup-pr
 cleanup-pr:

--- a/services/cloudrun-service/Earthfile
+++ b/services/cloudrun-service/Earthfile
@@ -45,7 +45,7 @@ release:
 
 build-pr:
     ARG --required tag
-    ARG registry="ghcr.io/freiheit-com/kuberpult"
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     ARG mirror="false"
     ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
 
@@ -53,7 +53,7 @@ build-pr:
 
 build-main:
     ARG --required tag
-    ARG registry="ghcr.io/freiheit-com/kuberpult"
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     ARG mirror="false"
     ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
 

--- a/services/cloudrun-service/Makefile
+++ b/services/cloudrun-service/Makefile
@@ -20,7 +20,7 @@ MAKEFLAGS += --no-builtin-rules
 
 export CGO_ENABLED=0
 
-IMAGE_REGISTRY?=ghcr.io/freiheit-com/kuberpult
+IMAGE_REGISTRY?=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
 GO := go
 GO_FILES := $(shell find . -type f -name '*.go')
 PKG_GO_FILES := $(shell find ../../pkg/ -type f -name '*.go')
@@ -45,7 +45,7 @@ build: bin/main
 
 build-pr:
 	echo "build on pull request"
-	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=pr-$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 build-main:
 	echo "build on main"

--- a/services/cloudrun-service/Makefile
+++ b/services/cloudrun-service/Makefile
@@ -49,7 +49,7 @@ build-pr:
 
 build-main:
 	echo "build on main"
-	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=main-$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 .PHONY: cleanup-pr
 cleanup-pr:

--- a/services/frontend-service/Earthfile
+++ b/services/frontend-service/Earthfile
@@ -84,12 +84,12 @@ docker-ui:
 
 release-ui:
     FROM +docker-ui
-    ARG registry="ghcr.io/freiheit-com/kuberpult"
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     SAVE IMAGE --push $registry/kuberpult-ui:local
 
 build-pr:
     ARG --required tag
-    ARG registry="ghcr.io/freiheit-com/kuberpult"
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     ARG mirror="false"
     ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
 
@@ -97,7 +97,7 @@ build-pr:
 
 build-main:
     ARG --required tag
-    ARG registry="ghcr.io/freiheit-com/kuberpult"
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     ARG mirror="false"
     ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
 

--- a/services/frontend-service/Makefile
+++ b/services/frontend-service/Makefile
@@ -21,7 +21,7 @@ MAKEFLAGS += --no-builtin-rules
 
 export CGO_ENABLED=0
 
-IMAGE_REGISTRY?=ghcr.io/freiheit-com/kuberpult
+IMAGE_REGISTRY?=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
 GO := go
 
 GO_FILES := $(shell find . -type f -name '*.go')
@@ -59,7 +59,7 @@ build: bin/main
 
 build-pr:
 	echo "build on pull request"
-	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=pr-$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 build-main:
 	echo "build on main"

--- a/services/frontend-service/Makefile
+++ b/services/frontend-service/Makefile
@@ -63,7 +63,7 @@ build-pr:
 
 build-main:
 	echo "build on main"
-	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=main-$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 .PHONY: cleanup-pr
 cleanup-pr:

--- a/services/manifest-repo-export-service/Earthfile
+++ b/services/manifest-repo-export-service/Earthfile
@@ -49,7 +49,7 @@ release:
 
 build-pr:
     ARG --required tag
-    ARG registry="ghcr.io/freiheit-com/kuberpult"
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     ARG mirror="false"
     ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
 
@@ -57,7 +57,7 @@ build-pr:
 
 build-main:
     ARG --required tag
-    ARG registry="ghcr.io/freiheit-com/kuberpult"
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     ARG mirror="false"
     ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
 

--- a/services/manifest-repo-export-service/Makefile
+++ b/services/manifest-repo-export-service/Makefile
@@ -21,7 +21,7 @@ include ../../Makefile.variables
 MAKEFLAGS += --no-builtin-rules
 
 export CGO_ENABLED=1
-IMAGE_REGISTRY?=ghcr.io/freiheit-com/kuberpult
+IMAGE_REGISTRY?=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
 IMAGENAME?=$(IMAGE_REGISTRY)/kuberpult-manifest-repo-export-service:$(VERSION)
 ARTIFACT_REGISTRY_IMAGE_NAME=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult/kuberpult-manifest-repo-export-service:${VERSION}
 
@@ -62,7 +62,7 @@ build: bin/main
 
 build-pr:
 	echo "build on pull request"
-	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=pr-$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 build-main:
 	echo "build on main"

--- a/services/manifest-repo-export-service/Makefile
+++ b/services/manifest-repo-export-service/Makefile
@@ -66,7 +66,7 @@ build-pr:
 
 build-main:
 	echo "build on main"
-	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=main-$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 .PHONY: cleanup-pr
 cleanup-pr:

--- a/services/rollout-service/Earthfile
+++ b/services/rollout-service/Earthfile
@@ -45,7 +45,7 @@ release:
 
 build-pr:
     ARG --required tag
-    ARG registry="ghcr.io/freiheit-com/kuberpult"
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     ARG mirror="false"
     ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
 
@@ -53,7 +53,7 @@ build-pr:
 
 build-main:
     ARG --required tag
-    ARG registry="ghcr.io/freiheit-com/kuberpult"
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
     ARG mirror="false"
     ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
 

--- a/services/rollout-service/Makefile
+++ b/services/rollout-service/Makefile
@@ -21,7 +21,7 @@ MAKEFLAGS += --no-builtin-rules
 
 export CGO_ENABLED=0
 
-IMAGE_REGISTRY?=ghcr.io/freiheit-com/kuberpult
+IMAGE_REGISTRY?=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
 GO := go
 GO_FILES := $(shell find . -type f -name '*.go')
 PKG_GO_FILES := $(shell find ../../pkg/ -type f -name '*.go')
@@ -47,7 +47,7 @@ build: bin/main
 
 build-pr:
 	echo "build on pull request"
-	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=pr-$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 build-main:
 	echo "build on main"

--- a/services/rollout-service/Makefile
+++ b/services/rollout-service/Makefile
@@ -51,7 +51,7 @@ build-pr:
 
 build-main:
 	echo "build on main"
-	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+	$(EARTHLY) --push +build-main --registry=$(IMAGE_REGISTRY) --tag=main-$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
 
 .PHONY: cleanup-pr
 cleanup-pr:


### PR DESCRIPTION
Ref: SRX-82AUA2

New Images on PRs and Main have `pr-` and `main-` prefix before their image tag.
    
BREAKING CHANGE: The old github registry will not be used anymore. Use Google registry instead.