### PR TITLE
chore: make it easier to see release versions in test data

### DIFF
--- a/infrastructure/scripts/create-testdata/create-release.sh
+++ b/infrastructure/scripts/create-testdata/create-release.sh
@@ -77,6 +77,7 @@ metadata:
 data:
   key: value
   random: "${randomValue}"
+  releaseVersion: "${release_version}"
 ---
 EOF
   echo "wrote file ${file}"


### PR DESCRIPTION
The random value in the testdata is not guaranteed to be unique, so we add the release number which is unique
and it is also helpful for the human observer.

Ref: SRX-78FWXB