### PR TITLE
fix: write same committer to git as in cd-service

### DIFF
--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -228,8 +228,8 @@ func Run(ctx context.Context) error {
 	cfg := repository.RepositoryConfig{
 		URL:            gitUrl,
 		Path:           "./repository",
-		CommitterEmail: "noemail@example.com", // TODO will be handled in Ref SRX-PA568W
-		CommitterName:  "noname",
+		CommitterEmail: "kuberpult@freiheit.com",
+		CommitterName:  "kuberpult",
 		Credentials: repository.Credentials{
 			SshKey: gitSshKey,
 		},


### PR DESCRIPTION
This is just a quick-fix, in the future we will make this configurable via helm chart.
For now the committer is always "kuberpult".

Ref: SRX-VESFP9