### PR TITLE
fix(ui): Continue rendering if a release was not found

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -18,9 +18,9 @@ import React from 'react';
 import {
     useCurrentlyDeployedAtGroup,
     useOpenReleaseDialog,
-    useReleaseOrThrow,
     useRolloutStatus,
     EnvironmentGroupExtended,
+    useReleaseOrLog,
 } from '../../utils/store';
 import { Tooltip } from '../tooltip/tooltip';
 import { EnvironmentGroupChipList } from '../chip/EnvironmentGroupChip';
@@ -136,12 +136,16 @@ const useDeploymentStatus = (
 export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
     const { className, app, version } = props;
     // the ReleaseCard only displays actual releases, so we can assume that it exists here:
-    const release = useReleaseOrThrow(app, version);
-    const { createdAt, sourceMessage, sourceAuthor, undeployVersion, isMinor, isPrepublish } = release;
     const openReleaseDialog = useOpenReleaseDialog(app, version);
     const deployedAt = useCurrentlyDeployedAtGroup(app, version);
 
     const [rolloutEnvs, mostInteresting] = useDeploymentStatus(app, deployedAt);
+
+    const release = useReleaseOrLog(app, version);
+    if (!release) {
+        return null;
+    }
+    const { createdAt, sourceMessage, sourceAuthor, undeployVersion, isMinor, isPrepublish } = release;
 
     const tooltipContents = (
         <div className="mdc-tooltip__title_ release__details">

--- a/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCardMini/ReleaseCardMini.tsx
@@ -15,7 +15,7 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 Copyright freiheit.com*/
 import classNames from 'classnames';
 import React from 'react';
-import { useOpenReleaseDialog, useReleaseOrThrow } from '../../utils/store';
+import { useOpenReleaseDialog, useReleaseOrLog } from '../../utils/store';
 import { EnvironmentGroupChipList } from '../chip/EnvironmentGroupChip';
 import { undeployTooltipExplanation } from '../ReleaseDialog/ReleaseDialog';
 import { FormattedDate } from '../FormattedDate/FormattedDate';
@@ -30,11 +30,18 @@ export type ReleaseCardMiniProps = {
 export const ReleaseCardMini: React.FC<ReleaseCardMiniProps> = (props) => {
     const { className, app, version } = props;
     // the ReleaseCardMini only displays actual releases, so we can assume that it exists here:
-    const { createdAt, sourceMessage, sourceAuthor, undeployVersion, isMinor } = useReleaseOrThrow(app, version);
+    const firstRelease = useReleaseOrLog(app, version);
     const openReleaseDialog = useOpenReleaseDialog(app, version);
+    const release = useReleaseOrLog(app, version);
+    if (!firstRelease) {
+        return null;
+    }
+    if (!release) {
+        return null;
+    }
+    const { createdAt, sourceMessage, sourceAuthor, undeployVersion, isMinor } = firstRelease;
     const displayedMessage = undeployVersion ? 'Undeploy Version' : sourceMessage + (isMinor ? '💤' : '');
     const displayedTitle = undeployVersion ? undeployTooltipExplanation : '';
-    const release = useReleaseOrThrow(app, version);
     return (
         <div className={classNames('release-card-mini', className)} onClick={openReleaseDialog}>
             <div className={classNames('release__details-mini', className)}>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -23,7 +23,7 @@ import {
     useEnvironmentGroups,
     useReleaseDifference,
     useReleaseOptional,
-    useReleaseOrThrow,
+    useReleaseOrLog,
     useRolloutStatus,
     useTeamFromApplication,
 } from '../../utils/store';
@@ -377,9 +377,12 @@ export const undeployTooltipExplanation =
 export const ReleaseDialog: React.FC<ReleaseDialogProps> = (props) => {
     const { app, className, version } = props;
     // the ReleaseDialog is only opened when there is a release, so we can assume that it exists here:
-    const release = useReleaseOrThrow(app, version);
+    const release = useReleaseOrLog(app, version);
     const team = useTeamFromApplication(app) || '';
     const closeReleaseDialog = useCloseReleaseDialog();
+    if (!release) {
+        return null;
+    }
 
     const dialog: JSX.Element | '' = (
         <PlainDialog

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -920,10 +920,12 @@ export const sortLocks = (displayLocks: DisplayLock[], sorting: 'oldestToNewest'
 export const useRelease = (application: string, version: number): Release | undefined =>
     useOverview(({ applications }) => applications[application]?.releases?.find((r) => r.version === version));
 
-export const useReleaseOrThrow = (application: string, version: number): Release => {
+export const useReleaseOrLog = (application: string, version: number): Release | undefined => {
     const release = useRelease(application, version);
     if (!release) {
-        throw new Error('Release cannot be found for app ' + application + ' version ' + version);
+        // eslint-disable-next-line no-console
+        console.error('Release cannot be found for app ' + application + ' version ' + version);
+        return undefined;
     }
     return release;
 };


### PR DESCRIPTION
This fixes an issue where the UI does not render anything if it cannot find a release.
Instead of "giving up", kuberpult now logs the issue in the console.

Ref: SRX-4WQBET