### PR TITLE
fix: allow disabling the request queue

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -229,6 +229,8 @@ spec:
 {{- end }}
         - name: KUBERPULT_GIT_NETWORK_TIMEOUT
           value: "{{ .Values.git.networkTimeout }}"
+        - name: KUBERPULT_DISABLE_QUEUE
+          value: "{{ .Values.cd.backendConfig.disableQueue }}"
         - name: KUBERPULT_GIT_WRITE_COMMIT_DATA
           value: "{{ .Values.git.enableWritingCommitData }}"
         - name: KUBERPULT_GIT_MAXIMUM_COMMITS_PER_PUSH

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -93,6 +93,10 @@ cd:
     create: false   # Add backend config for health checks on GKE only
     timeoutSec: 300  # 30sec is the default on gcp loadbalancers, however kuberpult needs more with parallel requests. It is the time how long the loadbalancer waits for kuberpult to finish calls to the rest endpoint "release"
     queueSize: 5
+# Disabling the queue is as of now an experimental feature. It's only possible to use with db.writeEslTableOnly=false.
+# With the queue, the cd-service processes only one request at a time, which is very much required when using git.
+# With the database enabled, this is not required anymore.
+    disableQueue: false
   resources:
     limits:
       cpu: 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     image: europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult/kuberpult-cd-service:local
     environment:
       - LOG_LEVEL=INFO
+      - KUBERPULT_DISABLE_QUEUE=true
       - KUBERPULT_GIT_URL=/kp/kuberpult/repository_remote
       - KUBERPULT_DB_LOCATION=postgres
       - KUBERPULT_DB_NAME=kuberpult

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -107,6 +107,8 @@ type Config struct {
 	DbSslMode            string   `default:"verify-full" split_words:"true"`
 	MinorRegexes         string   `default:"" split_words:"true"`
 	AllowedDomains       []string `split_words:"true"`
+
+	DisableQueue bool `required:"true" split_words:"true"`
 }
 
 func (c *Config) storageBackend() repository.StorageBackend {
@@ -326,6 +328,8 @@ func RunServer() {
 			ArgoCdGenerateFiles:   c.ArgoCdGenerateFiles,
 			DBHandler:             dbHandler,
 			CloudRunClient:        cloudRunClient,
+
+			DisableQueue: c.DisableQueue,
 		}
 
 		repo, repoQueue, err := repository.New2(ctx, cfg)

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -1093,7 +1093,6 @@ func (r *repository) FetchAndReset(ctx context.Context) error {
 
 func (r *repository) Apply(ctx context.Context, transformers ...Transformer) error {
 	if r.config.DisableQueue && r.DB.ShouldUseOtherTables() {
-		logger.FromContext(ctx).Info("queue disabled")
 		changes, err := db.WithTransactionT(r.DB, ctx, 2, false, func(ctx context.Context, transaction *sql.Tx) (*TransformerResult, error) {
 			subChanges, applyErr := r.ApplyTransformers(ctx, transaction, transformers...)
 			if applyErr != nil {
@@ -1119,7 +1118,6 @@ func (r *repository) Apply(ctx context.Context, transformers ...Transformer) err
 		r.notify.Notify()
 		return nil
 	} else {
-		logger.FromContext(ctx).Info("queue enabled")
 		eCh := r.applyDeferred(ctx, transformers...)
 		select {
 		case err := <-eCh:

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -1117,6 +1117,7 @@ func (r *repository) Apply(ctx context.Context, transformers ...Transformer) err
 			}
 		}
 		r.notify.Notify()
+		return nil
 	} else {
 		logger.FromContext(ctx).Info("queue enabled")
 		eCh := r.applyDeferred(ctx, transformers...)


### PR DESCRIPTION
This introduces a new helm option "cd.backendConfig.disableQueue`. When true, the cd-service processes incoming requests in parallel.

Ref: SRX-YNEAHU