### PR TITLE
fix(db): get all environment configs at the start of a release train

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -98,6 +98,7 @@ const (
 const (
 	MigrationCommitEventUUID = "00000000-0000-0000-0000-000000000000"
 	MigrationCommitEventHash = "0000000000000000000000000000000000000000"
+	WhereInBatchMax          = 1024
 )
 
 func (h *DBHandler) ShouldUseEslTable() bool {
@@ -4458,6 +4459,23 @@ type DBEnvironmentRow struct {
 	Config  string
 }
 
+func EnvironmentFromRow(ctx context.Context, row *DBEnvironmentRow) (*DBEnvironment, error) {
+	span, _ := tracer.StartSpanFromContext(ctx, "EnvironmentFromRow")
+	defer span.Finish()
+	//exhaustruct:ignore
+	parsedConfig := config.EnvironmentConfig{}
+	err := json.Unmarshal([]byte(row.Config), &parsedConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal the JSON in the database, JSON: %s, error: %w", row.Config, err)
+	}
+	return &DBEnvironment{
+		Created: row.Created,
+		Version: row.Version,
+		Name:    row.Name,
+		Config:  parsedConfig,
+	}, nil
+}
+
 func (h *DBHandler) DBSelectEnvironment(ctx context.Context, tx *sql.Tx, environmentName string) (*DBEnvironment, error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "DBSelectEnvironment")
 	defer span.Finish()
@@ -4500,30 +4518,91 @@ LIMIT 1;
 			}
 			return nil, fmt.Errorf("error scanning the environments table, error: %w", err)
 		}
-
-		//exhaustruct:ignore
-		parsedConfig := config.EnvironmentConfig{}
-		err = json.Unmarshal([]byte(row.Config), &parsedConfig)
+		env, err := EnvironmentFromRow(ctx, &row)
 		if err != nil {
-			return nil, fmt.Errorf("unable to unmarshal the JSON in the database, JSON: %s, error: %w", row.Config, err)
+			return nil, err
 		}
-		err = closeRows(rows)
-		if err != nil {
-			return nil, fmt.Errorf("error while closing database rows, error: %w", err)
-		}
-
-		return &DBEnvironment{
-			Created: row.Created,
-			Version: row.Version,
-			Name:    environmentName,
-			Config:  parsedConfig,
-		}, nil
-	}
-	err = closeRows(rows)
-	if err != nil {
-		return nil, fmt.Errorf("errpr while closing database rows, error: %w", err)
+		return env, nil
 	}
 	return nil, nil
+}
+
+func (h *DBHandler) DBSelectEnvironmentsBatch(ctx context.Context, tx *sql.Tx, environmentNames []string) (*[]DBEnvironment, error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBSelectEnvironmentsBatch")
+	defer span.Finish()
+	if len(environmentNames) > WhereInBatchMax {
+		return nil, fmt.Errorf("SelectEnvironments is not batching queries for now, make sure to not request more than %d environments.", WhereInBatchMax)
+	}
+	if len(environmentNames) == 0 {
+		return &[]DBEnvironment{}, nil
+	}
+
+	selectQuery := h.AdaptQuery(
+		`
+SELECT
+  environments.created AS created,
+  environments.version AS version,
+  environments.name AS name,
+  environments.json AS json
+FROM (
+  SELECT
+    MAX(version) AS latest,
+    name
+  FROM
+    environments
+  GROUP BY
+    name) AS latest
+JOIN
+  environments
+ON
+  latest.latest=environments.version
+  AND latest.name = environments.name
+WHERE
+  environments.name IN (?` + strings.Repeat(",?", len(environmentNames)-1) + `)
+LIMIT ?
+`,
+	)
+	span.SetTag("query", selectQuery)
+	args := []any{}
+	for _, env := range environmentNames {
+		args = append(args, env)
+	}
+	args = append(args, len(environmentNames))
+	rows, err := tx.QueryContext(
+		ctx,
+		selectQuery,
+		args...,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for environments %v, error: %w (query: %s, args: %v)", environmentNames, err, selectQuery, args)
+	}
+
+	defer func(rows *sql.Rows) {
+		err := rows.Close()
+		if err != nil {
+			logger.FromContext(ctx).Sugar().Warnf("error while closing row of environments, error: %w", err)
+		}
+	}(rows)
+
+	envs := []DBEnvironment{}
+	for rows.Next() {
+		//exhaustruct:ignore
+		row := DBEnvironmentRow{}
+		err := rows.Scan(&row.Created, &row.Version, &row.Name, &row.Config)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("error scanning the environments table, error: %w", err)
+		}
+		env, err := EnvironmentFromRow(ctx, &row)
+		if err != nil {
+			return nil, err
+		}
+		envs = append(envs, *env)
+	}
+	return &envs, nil
 }
 
 func (h *DBHandler) DBWriteEnvironment(ctx context.Context, tx *sql.Tx, environmentName string, environmentConfig config.EnvironmentConfig) error {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -2926,7 +2926,8 @@ Environment "acceptance-de" has both upstream.latest and upstream.environment co
 				t.Fatalf("error encountered during setup, but none was expected here, error: %v", err)
 			}
 
-			prognosis := tc.ReleaseTrain.Prognosis(ctx, repo.State(), nil)
+			configs, _ := repo.State().GetAllEnvironmentConfigs(ctx, nil)
+			prognosis := tc.ReleaseTrain.Prognosis(ctx, repo.State(), nil, configs)
 			if diff := cmp.Diff(prognosis.EnvironmentPrognoses, tc.expectedPrognosis.EnvironmentPrognoses, protocmp.Transform(), protocmp.IgnoreFields(&api.Lock{}, "created_at")); diff != "" {
 				t.Fatalf("release train prognosis is wrong, wanted the result \n%v\n got\n%v\ndiff:\n%s", tc.expectedPrognosis.EnvironmentPrognoses, prognosis.EnvironmentPrognoses, diff)
 			}
@@ -3302,7 +3303,8 @@ skipping "test" because it is already in the version`,
 					}}}},
 			}
 
-			prognosis := releaseTrain.Prognosis(ctx, repo.State(), nil)
+			configs, _ := repo.State().GetAllEnvironmentConfigs(ctx, nil)
+			prognosis := releaseTrain.Prognosis(ctx, repo.State(), nil, configs)
 
 			if !cmp.Equal(prognosis.EnvironmentPrognoses, tc.ExpectedPrognosis.EnvironmentPrognoses) || !cmp.Equal(prognosis.Error, tc.ExpectedPrognosis.Error, cmpopts.EquateErrors()) {
 				t.Fatalf("release train prognosis is wrong, wanted %v, got %v", tc.ExpectedPrognosis, prognosis)

--- a/services/cd-service/pkg/service/release_train_prognosis.go
+++ b/services/cd-service/pkg/service/release_train_prognosis.go
@@ -50,11 +50,19 @@ func (s *ReleaseTrainPrognosisServer) GetReleaseTrainPrognosis(ctx context.Conte
 	var prognosis rp.ReleaseTrainPrognosis
 	if dbHandler.ShouldUseOtherTables() {
 		_ = dbHandler.WithTransaction(ctx, true, func(ctx context.Context, transaction *sql.Tx) error {
-			prognosis = t.Prognosis(ctx, s.Repository.State(), transaction)
+			configs, err := t.Repo.State().GetAllEnvironmentConfigs(ctx, transaction)
+			if err != nil {
+				return nil
+			}
+			prognosis = t.Prognosis(ctx, s.Repository.State(), transaction, configs)
 			return nil
 		})
 	} else {
-		prognosis = t.Prognosis(ctx, s.Repository.State(), nil)
+		configs, err := t.Repo.State().GetAllEnvironmentConfigs(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+		prognosis = t.Prognosis(ctx, s.Repository.State(), nil, configs)
 	}
 
 	if prognosis.Error != nil {


### PR DESCRIPTION
in db.go:
- EnvironmentFromRow extract maping from row to db environment object
- remove extra closeRows calls in DBSelectEnvironment, already handled by
   defer
- add a DBSelectEnvironmentsBatch to query for multple environments at once
  * currently hardcoded to bail at more than 1024 environments
  * would need paging for more

in repository.go:
- use DBSelectEnvironmentsBatch instead of looping over queries

in transformer.go:
- fetch environment configs as early as possible
- reuse those configs e.g. in prognosis

Ref: SRX-YNEAHU