### PR TITLE
fix(db): Do not write argo apps if disabled

### DIFF
--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -719,6 +719,9 @@ func (r *repository) afterTransform(ctx context.Context, transaction *sql.Tx, st
 func (r *repository) updateArgoCdApps(ctx context.Context, transaction *sql.Tx, state *State, env string, config config.EnvironmentConfig) error {
 	span, ctx := tracer.StartSpanFromContext(ctx, "updateArgoCdApps")
 	defer span.Finish()
+	if !r.config.ArgoCdGenerateFiles {
+		return nil
+	}
 	fs := state.Filesystem
 	if apps, err := state.GetEnvironmentApplications(ctx, transaction, env); err != nil {
 		return err
@@ -759,22 +762,20 @@ func (r *repository) updateArgoCdApps(ctx context.Context, transaction *sql.Tx, 
 		}
 		spanCollectData.Finish()
 
-		if r.config.ArgoCdGenerateFiles {
-			spanRenderAndWrite, ctx := tracer.StartSpanFromContext(ctx, "RenderAndWrite")
-			defer spanRenderAndWrite.Finish()
-			if manifests, err := argocd.Render(ctx, r.config.URL, r.config.Branch, config, env, appData); err != nil {
-				return err
-			} else {
-				spanWrite, _ := tracer.StartSpanFromContext(ctx, "Write")
-				defer spanWrite.Finish()
-				for apiVersion, content := range manifests {
-					if err := fs.MkdirAll(fs.Join("argocd", string(apiVersion)), 0777); err != nil {
-						return err
-					}
-					target := fs.Join("argocd", string(apiVersion), fmt.Sprintf("%s.yaml", env))
-					if err := util.WriteFile(fs, target, content, 0666); err != nil {
-						return err
-					}
+		spanRenderAndWrite, ctx := tracer.StartSpanFromContext(ctx, "RenderAndWrite")
+		defer spanRenderAndWrite.Finish()
+		if manifests, err := argocd.Render(ctx, r.config.URL, r.config.Branch, config, env, appData); err != nil {
+			return err
+		} else {
+			spanWrite, _ := tracer.StartSpanFromContext(ctx, "Write")
+			defer spanWrite.Finish()
+			for apiVersion, content := range manifests {
+				if err := fs.MkdirAll(fs.Join("argocd", string(apiVersion)), 0777); err != nil {
+					return err
+				}
+				target := fs.Join("argocd", string(apiVersion), fmt.Sprintf("%s.yaml", env))
+				if err := util.WriteFile(fs, target, content, 0666); err != nil {
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
While the helm parameter argocd.generateFiles=false technically worked, it would still request a lot of data that is not necessary. With this change, we reduce the number of queries to the database for the case argocd.generateFiles=false.

Ref: SRX-YNEAHU