### PR TITLE
fix(cd-service): Remove overview cache recalculation, update overview  on create environment and undeployVersion

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -4881,10 +4881,6 @@ func (h *DBHandler) DBWriteEnvironment(ctx context.Context, tx *sql.Tx, environm
 	if err != nil {
 		return fmt.Errorf("could not write environment %s with config %v to environments table, error: %w", environmentName, environmentConfig, err)
 	}
-	err = h.ForceOverviewRecalculation(ctx, tx)
-	if err != nil {
-		return fmt.Errorf("error while forcing overview recalculation, error: %w", err)
-	}
 	return nil
 }
 

--- a/pkg/db/overview_test.go
+++ b/pkg/db/overview_test.go
@@ -1251,41 +1251,6 @@ func TestUpdateOverviewRelease(t *testing.T) {
 	}
 }
 
-func TestForceOverviewRecalculation(t *testing.T) {
-	tcs := []struct {
-		Name string
-	}{
-		{
-			Name: "Check if ForceOverviewRecalculation creates an empty overview",
-		},
-	}
-
-	for _, tc := range tcs {
-		t.Run("ForceOverviewRecalculation", func(t *testing.T) {
-			t.Parallel()
-			ctx := testutil.MakeTestContext()
-			dbHandler := setupDB(t)
-			err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-				err := dbHandler.ForceOverviewRecalculation(ctx, transaction)
-				if err != nil {
-					return err
-				}
-				latestOverview, err := dbHandler.ReadLatestOverviewCache(ctx, transaction)
-				if err != nil {
-					return err
-				}
-				if !dbHandler.IsOverviewEmpty(latestOverview) {
-					t.Fatalf("%s overview should be empty", tc.Name)
-				}
-				return nil
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
-	}
-}
-
 func makeApps(apps ...*api.Environment_Application) map[string]*api.Environment_Application {
 	var result map[string]*api.Environment_Application = map[string]*api.Environment_Application{}
 	for i := 0; i < len(apps); i++ {

--- a/services/cd-service/pkg/argocd/reposerver/reposerver_test.go
+++ b/services/cd-service/pkg/argocd/reposerver/reposerver_test.go
@@ -18,6 +18,7 @@ package reposerver
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"github.com/freiheit-com/kuberpult/pkg/db"
 	"github.com/freiheit-com/kuberpult/pkg/testutil"
@@ -640,6 +641,9 @@ func SetupRepositoryTestWithDBOptions(t *testing.T, writeEslOnly bool) (reposito
 	)
 	if err != nil {
 		t.Fatal(err)
+	}
+	repo.State().DBHandler.InsertAppFun = func(ctx context.Context, transaction *sql.Tx, appName string, previousEslVersion db.EslVersion, stateChange db.AppStateChange, metaData db.DBAppMetaData) error {
+		return repo.State().DBInsertApplicationWithOverview(ctx, transaction, appName, previousEslVersion, stateChange, metaData)
 	}
 	return repo, &repoCfg
 }

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -7096,6 +7096,9 @@ func SetupRepositoryTestWithDBOptions(t *testing.T, writeEslOnly bool) Repositor
 	if err != nil {
 		t.Fatal(err)
 	}
+	repo.State().DBHandler.InsertAppFun = func(ctx context.Context, transaction *sql.Tx, appName string, previousEslVersion db.EslVersion, stateChange db.AppStateChange, metaData db.DBAppMetaData) error {
+		return repo.State().DBInsertApplicationWithOverview(ctx, transaction, appName, previousEslVersion, stateChange, metaData)
+	}
 	return repo
 }
 func SetupRepositoryTestWithoutDB(t *testing.T, repositoryConfig *RepositoryConfig) Repository {

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -678,6 +678,12 @@ func setupRepositoryTestWithDB(t *testing.T, dbConfig *db.DBConfig) (repository.
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if dbConfig != nil {
+		repo.State().DBHandler.InsertAppFun = func(ctx context.Context, transaction *sql.Tx, appName string, previousEslVersion db.EslVersion, stateChange db.AppStateChange, metaData db.DBAppMetaData) error {
+			return repo.State().DBInsertApplicationWithOverview(ctx, transaction, appName, previousEslVersion, stateChange, metaData)
+		}
+	}
 	return repo, nil
 }
 

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -21,7 +21,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/pkg/mapper"
 	"sync"
 	"sync/atomic"
 
@@ -32,7 +31,6 @@ import (
 	git "github.com/libgit2/git2go/v34"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
 	"github.com/freiheit-com/kuberpult/pkg/db"
@@ -129,61 +127,10 @@ func (o *OverviewServiceServer) getOverview(
 	}
 	result.ManifestRepoUrl = o.RepositoryConfig.URL
 	result.Branch = o.RepositoryConfig.Branch
-	if envs, err := s.GetAllEnvironmentConfigs(ctx, transaction); err != nil {
-		return nil, grpc.InternalError(ctx, err)
-	} else {
-		result.EnvironmentGroups = mapper.MapEnvironmentsToGroups(envs)
-		for envName, config := range envs {
-			var groupName = mapper.DeriveGroupName(config, envName)
-			var envInGroup = getEnvironmentInGroup(result.EnvironmentGroups, groupName, envName)
-			//exhaustruct:ignore
-			argocd := &api.EnvironmentConfig_ArgoCD{}
-			if config.ArgoCd != nil {
-				argocd = mapper.TransformArgocd(*config.ArgoCd)
-			}
-			env := api.Environment{
-				DistanceToUpstream: 0,
-				Priority:           api.Priority_PROD,
-				Name:               envName,
-				Config: &api.EnvironmentConfig{
-					Upstream:         mapper.TransformUpstream(config.Upstream),
-					Argocd:           argocd,
-					EnvironmentGroup: &groupName,
-				},
-				Locks:        map[string]*api.Lock{},
-				Applications: map[string]*api.Environment_Application{},
-			}
-			envInGroup.Config = env.Config
-			if locks, err := s.GetEnvironmentLocks(ctx, transaction, envName); err != nil {
-				return nil, err
-			} else {
-				for lockId, lock := range locks {
-					env.Locks[lockId] = &api.Lock{
-						Message:   lock.Message,
-						LockId:    lockId,
-						CreatedAt: timestamppb.New(lock.CreatedAt),
-						CreatedBy: &api.Actor{
-							Name:  lock.CreatedBy.Name,
-							Email: lock.CreatedBy.Email,
-						},
-					}
-				}
-				envInGroup.Locks = env.Locks
-			}
-
-			if apps, err := s.GetEnvironmentApplications(ctx, transaction, envName); err != nil {
-				return nil, err
-			} else {
-				for _, appName := range apps {
-					app, err2 := s.UpdateOneAppEnvInOverview(ctx, transaction, appName, envName, &config, map[string]*int64{})
-					if err2 != nil {
-						return nil, err2
-					}
-					env.Applications[appName] = app
-				}
-			}
-			envInGroup.Applications = env.Applications
-		}
+	//exhaustruct:ignore
+	err := s.UpdateEnvironmentsInOverview(ctx, transaction, &result)
+	if err != nil {
+		return nil, err
 	}
 	if apps, err := s.GetApplications(ctx, transaction); err != nil {
 		return nil, err
@@ -198,19 +145,6 @@ func (o *OverviewServiceServer) getOverview(
 	}
 
 	return &result, nil
-}
-
-func getEnvironmentInGroup(groups []*api.EnvironmentGroup, groupNameToReturn string, envNameToReturn string) *api.Environment {
-	for _, currentGroup := range groups {
-		if currentGroup.EnvironmentGroupName == groupNameToReturn {
-			for _, currentEnv := range currentGroup.Environments {
-				if currentEnv.Name == envNameToReturn {
-					return currentEnv
-				}
-			}
-		}
-	}
-	return nil
 }
 
 func (o *OverviewServiceServer) StreamOverview(in *api.GetOverviewRequest,

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -127,7 +127,6 @@ func (o *OverviewServiceServer) getOverview(
 	}
 	result.ManifestRepoUrl = o.RepositoryConfig.URL
 	result.Branch = o.RepositoryConfig.Branch
-	//exhaustruct:ignore
 	err := s.UpdateEnvironmentsInOverview(ctx, transaction, &result)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Ref: SRX-09Z4A6

* Removed `ForceOverviewRecalculation`. Instead updated overview accordingly when creating a new environment or a new undeployVersion.