### PR TITLE
fix(cd-service): empty list of regexes when no regex provided

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,6 @@ services:
       - KUBERPULT_ALLOW_LONG_APP_NAMES=true
       - KUBERPULT_ARGO_CD_GENERATE_FILES=true
       - KUBERPULT_DB_SSL_MODE=disable
-      - KUBERPULT_MINOR_REGEXES=^.*exampleRegexForMinors:.*$,^secondExampleRegexForMinors:.*$
       - KUBERPULT_DB_MAX_OPEN_CONNECTIONS=10
       - KUBERPULT_DB_MAX_IDLE_CONNECTIONS=5
     ports:

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -205,13 +205,15 @@ func RunServer() {
 			ctx = context.WithValue(ctx, repository.DdMetricsKey, ddMetrics)
 		}
 		minorRegexes := []*regexp.Regexp{}
-		for _, minorRegexStr := range strings.Split(c.MinorRegexes, ",") {
-			regex, err := regexp.Compile(minorRegexStr)
-			if err != nil {
-				logger.FromContext(ctx).Sugar().Warnf("Invalid regex input: %s", minorRegexStr)
-				continue
+		if c.MinorRegexes != "" {
+			for _, minorRegexStr := range strings.Split(c.MinorRegexes, ",") {
+				regex, err := regexp.Compile(minorRegexStr)
+				if err != nil {
+					logger.FromContext(ctx).Sugar().Warnf("Invalid regex input: %s", minorRegexStr)
+					continue
+				}
+				minorRegexes = append(minorRegexes, regex)
 			}
-			minorRegexes = append(minorRegexes, regex)
 		}
 
 		// If the tracer is not started, calling this function is a no-op.

--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -159,6 +159,14 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
                     <span>Author:</span> {sourceAuthor}
                 </div>
             )}
+            {isMinor && (
+                <div>
+                    <span>
+                        '💤' icon means that this release is a minor release; it has no changes to the manifests
+                        comparing to the previous release.
+                    </span>
+                </div>
+            )}
             {isPrepublish && (
                 <div className="prerelease__description">
                     <span>This is a pre-release. It doesn't have any manifests. It can't be deployed anywhere.</span>


### PR DESCRIPTION
Ref: SRX-8WMJ13

- When no `KUBERPULT_MINOR_REGEXES` env var provided, The list of minor regexes to use should be empty
- Added a description for minor regexes to the tooltip

<img width="559" alt="Screenshot 2024-10-01 at 15 11 09" src="https://github.com/user-attachments/assets/f5cdcd56-2e74-473a-a731-892215b91060">
