### PR TITLE
fix(db): Do not run deployment migrations

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1627,10 +1627,6 @@ func (h *DBHandler) RunCustomMigrations(
 	if err != nil {
 		return err
 	}
-	err = h.RunCustomMigrationQueuedApplicationVersions(ctx, writeAllQueuedVersionsFun)
-	if err != nil {
-		return err
-	}
 	err = h.RunCustomMigrationsCommitEvents(ctx, writeAllEventsFun)
 	if err != nil {
 		return err
@@ -2570,40 +2566,6 @@ func (h *DBHandler) needsCommitEventsMigrations(ctx context.Context, transaction
 	return true, nil
 }
 
-func (h *DBHandler) RunCustomMigrationQueuedApplicationVersions(ctx context.Context, writeAllQueuedVersionsFun WriteAllQueuedVersionsFun) error {
-	span, ctx := tracer.StartSpanFromContext(ctx, "RunCustomMigrationQueuedApplicationVersions")
-	defer span.Finish()
-
-	return h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-		needsMigrating, err := h.needsQueuedDeploymentsMigrations(ctx, transaction)
-		if err != nil {
-			return err
-		}
-		if !needsMigrating {
-			return nil
-		}
-
-		err = writeAllQueuedVersionsFun(ctx, transaction, h)
-		if err != nil {
-			return fmt.Errorf("could not get current queued versions to run custom migrations: %w", err)
-		}
-		return nil
-	})
-}
-
-func (h *DBHandler) needsQueuedDeploymentsMigrations(ctx context.Context, transaction *sql.Tx) (bool, error) {
-	l := logger.FromContext(ctx).Sugar()
-	allTeamLocksDb, err := h.DBSelectAnyDeploymentAttempt(ctx, transaction)
-	if err != nil {
-		return true, err
-	}
-	if allTeamLocksDb != nil {
-		l.Infof("There are already queued deployments in the DB - skipping migrations")
-		return false, nil
-	}
-	return true, nil
-}
-
 // NeedsMigrations: Checks if we need migrations for any table.
 func (h *DBHandler) NeedsMigrations(ctx context.Context) (bool, error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "NeedsMigrations")
@@ -2618,7 +2580,6 @@ func (h *DBHandler) NeedsMigrations(ctx context.Context) (bool, error) {
 			(*DBHandler).needsEnvLocksMigrations,
 			(*DBHandler).needsAppLocksMigrations,
 			(*DBHandler).needsTeamLocksMigrations,
-			(*DBHandler).needsQueuedDeploymentsMigrations,
 			(*DBHandler).needsCommitEventsMigrations,
 			(*DBHandler).needsEnvironmentsMigrations,
 			(*DBHandler).needsAllDeploymentsMigrations,


### PR DESCRIPTION
Note that this migration is not technically required. It was just there to provide additional context to the user. It only influences the UI, not what was actually deployed.

For now, we remove it. The migration itself seems fine, but the dection IF the migration is necessary is flawed, leading the cd-service to potentially clone the git repo, even when it is not necessary. And that is a very costly operation with large git repos.

Ref: SRX-YNEAHU