### PR TITLE
feat(cli): added ci_link command line argument

### DIFF
--- a/cli/pkg/locks/app_lock_parsing.go
+++ b/cli/pkg/locks/app_lock_parsing.go
@@ -29,6 +29,7 @@ type CreateAppLockCommandLineArguments struct {
 	lockId      cli_utils.RepeatedString
 	message     cli_utils.RepeatedString
 	application cli_utils.RepeatedString
+	ciLink      cli_utils.RepeatedString
 }
 
 func argsValidCreateAppLock(cmdArgs *CreateAppLockCommandLineArguments) (result bool, errorMessage string) {
@@ -44,6 +45,9 @@ func argsValidCreateAppLock(cmdArgs *CreateAppLockCommandLineArguments) (result 
 	if len(cmdArgs.message.Values) > 1 {
 		return false, "the --message arg must be set at most once"
 	}
+	if len(cmdArgs.ciLink.Values) > 1 {
+		return false, "the --ci_link arg must be set at most once"
+	}
 
 	return true, ""
 }
@@ -57,6 +61,7 @@ func readCreateAppLockArgs(args []string) (*CreateAppLockCommandLineArguments, e
 	fs.Var(&cmdArgs.environment, "environment", "the environment to lock")
 	fs.Var(&cmdArgs.message, "message", "lock message")
 	fs.Var(&cmdArgs.application, "application", "application to lock")
+	fs.Var(&cmdArgs.ciLink, "ci_link", "the link to the CI run that created this lock")
 
 	if err := fs.Parse(args); err != nil {
 		return nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)
@@ -84,9 +89,13 @@ func convertToCreateAppLockParams(cmdArgs CreateAppLockCommandLineArguments) (Lo
 		Application:          cmdArgs.application.Values[0],
 		Message:              "",
 		UseDexAuthentication: false, //For now there is no ambiguity as to which endpoint to use
+		CiLink:               nil,
 	}
 	if len(cmdArgs.message.Values) != 0 {
 		rp.Message = cmdArgs.message.Values[0]
+	}
+	if len(cmdArgs.ciLink.Values) == 1 {
+		rp.CiLink = &cmdArgs.ciLink.Values[0]
 	}
 	return &rp, nil
 }

--- a/cli/pkg/locks/app_lock_parsing.go
+++ b/cli/pkg/locks/app_lock_parsing.go
@@ -19,6 +19,7 @@ package locks
 import (
 	"flag"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
@@ -47,6 +48,11 @@ func argsValidCreateAppLock(cmdArgs *CreateAppLockCommandLineArguments) (result 
 	}
 	if len(cmdArgs.ciLink.Values) > 1 {
 		return false, "the --ci_link arg must be set at most once"
+	} else if len(cmdArgs.ciLink.Values) == 1 {
+		_, err := url.ParseRequestURI(cmdArgs.ciLink.Values[0])
+		if err != nil {
+			return false, fmt.Sprintf("provided invalid --ci_link value '%s'", cmdArgs.ciLink.Values[0])
+		}
 	}
 
 	return true, ""

--- a/cli/pkg/locks/app_lock_parsing_test.go
+++ b/cli/pkg/locks/app_lock_parsing_test.go
@@ -109,6 +109,46 @@ func TestReadArgsAppLock(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "environment, lockID, application and ciLink are specified",
+			args: []string{"--environment", "development", "--application", "my-app", "--lockID", "my-lock", "--ci_link", "https://localhost:8000"},
+			expectedCmdArgs: &CreateAppLockCommandLineArguments{
+				environment: cli_utils.RepeatedString{
+					Values: []string{
+						"development",
+					},
+				},
+				lockId: cli_utils.RepeatedString{
+					Values: []string{
+						"my-lock",
+					},
+				},
+				application: cli_utils.RepeatedString{
+					Values: []string{
+						"my-app",
+					},
+				},
+				ciLink: cli_utils.RepeatedString{
+					Values: []string{
+						"https://localhost:8000",
+					},
+				},
+			},
+		},
+		{
+			name: "--ci_link is invalid url",
+			args: []string{"--environment", "development", "--application", "my-app", "--lockID", "my-lock", "--ci_link", "https//localhost:8000"},
+			expectedError: errMatcher{
+				msg: "provided invalid --ci_link value 'https//localhost:8000'",
+			},
+		},
+		{
+			name: "--ci_link is specified twice",
+			args: []string{"--environment", "development", "--application", "my-app", "--lockID", "my-lock", "--ci_link", "https://localhost:8000", "--ci_link", "https://localhost:8000"},
+			expectedError: errMatcher{
+				msg: "the --ci_link arg must be set at most once",
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -273,6 +313,16 @@ func TestParseArgsCreateAppLock(t *testing.T) {
 				LockId:      "my-lock",
 				Application: "my-app",
 				Message:     "this is a very long message",
+			},
+		},
+		{
+			name:    "with environment, lockID, application and ciLink",
+			cmdArgs: []string{"--environment", "development", "--application", "my-app", "--lockID", "my-lock", "--ci_link", "https://localhost:8000"},
+			expectedParams: &CreateAppLockParameters{
+				Environment: "development",
+				LockId:      "my-lock",
+				Application: "my-app",
+				CiLink:      strPtr("https://localhost:8000"),
 			},
 		},
 	}

--- a/cli/pkg/locks/env_lock_parsing.go
+++ b/cli/pkg/locks/env_lock_parsing.go
@@ -19,6 +19,7 @@ package locks
 import (
 	"flag"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
@@ -43,6 +44,11 @@ func argsValidCreateEnvLock(cmdArgs *CreateEnvLockCommandLineArguments) (result 
 	}
 	if len(cmdArgs.ciLink.Values) > 1 {
 		return false, "the --ci_link arg must be set at most once"
+	} else if len(cmdArgs.ciLink.Values) == 1 {
+		_, err := url.ParseRequestURI(cmdArgs.ciLink.Values[0])
+		if err != nil {
+			return false, fmt.Sprintf("provided invalid --ci_link value '%s'", cmdArgs.ciLink.Values[0])
+		}
 	}
 
 	return true, ""

--- a/cli/pkg/locks/env_lock_parsing.go
+++ b/cli/pkg/locks/env_lock_parsing.go
@@ -19,14 +19,16 @@ package locks
 import (
 	"flag"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
 	"strings"
+
+	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
 )
 
 type CreateEnvLockCommandLineArguments struct {
 	environment cli_utils.RepeatedString
 	lockId      cli_utils.RepeatedString
 	message     cli_utils.RepeatedString
+	ciLink      cli_utils.RepeatedString
 }
 
 func argsValidCreateEnvLock(cmdArgs *CreateEnvLockCommandLineArguments) (result bool, errorMessage string) {
@@ -38,6 +40,9 @@ func argsValidCreateEnvLock(cmdArgs *CreateEnvLockCommandLineArguments) (result 
 	}
 	if len(cmdArgs.message.Values) > 1 {
 		return false, "the --message arg must be set at most once"
+	}
+	if len(cmdArgs.ciLink.Values) > 1 {
+		return false, "the --ci_link arg must be set at most once"
 	}
 
 	return true, ""
@@ -52,6 +57,7 @@ func readCreateEnvLockArgs(args []string) (*CreateEnvLockCommandLineArguments, e
 	fs.Var(&cmdArgs.environment, "environment", "the environment to lock")
 	fs.Var(&cmdArgs.lockId, "lockID", "the ID of the lock you are trying to create")
 	fs.Var(&cmdArgs.message, "message", "lock message")
+	fs.Var(&cmdArgs.ciLink, "ci_link", "the link to the CI run that created this lock")
 
 	if err := fs.Parse(args); err != nil {
 		return nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)
@@ -80,9 +86,13 @@ func convertToCreateEnvironmentLockParams(cmdArgs CreateEnvLockCommandLineArgume
 		Environment:          cmdArgs.environment.Values[0],
 		UseDexAuthentication: false, //For now there is no ambiguity as to which endpoint to use
 		Message:              "",
+		CiLink:               nil,
 	}
 	if len(cmdArgs.message.Values) != 0 {
 		rp.Message = cmdArgs.message.Values[0]
+	}
+	if len(cmdArgs.ciLink.Values) == 1 {
+		rp.CiLink = &cmdArgs.ciLink.Values[0]
 	}
 	return &rp, nil
 }

--- a/cli/pkg/locks/env_lock_parsing_test.go
+++ b/cli/pkg/locks/env_lock_parsing_test.go
@@ -120,6 +120,41 @@ func TestReadArgs(t *testing.T) {
 				message: cli_utils.RepeatedString{},
 			},
 		},
+		{
+			name: "environment, lockID and ciLink are specified",
+			args: []string{"--environment", "development", "--lockID", "my-lock", "--ci_link", "https://localhost:8000"},
+			expectedCmdArgs: &CreateEnvLockCommandLineArguments{
+				environment: cli_utils.RepeatedString{
+					Values: []string{
+						"development",
+					},
+				},
+				lockId: cli_utils.RepeatedString{
+					Values: []string{
+						"my-lock",
+					},
+				},
+				ciLink: cli_utils.RepeatedString{
+					Values: []string{
+						"https://localhost:8000",
+					},
+				},
+			},
+		},
+		{
+			name: "--ci_link is invalid url",
+			args: []string{"--environment", "development", "--lockID", "my-lock", "--ci_link", "https//localhost:8000"},
+			expectedError: errMatcher{
+				msg: "provided invalid --ci_link value 'https//localhost:8000'",
+			},
+		},
+		{
+			name: "--ci_link is specified twice",
+			args: []string{"--environment", "development", "--lockID", "my-lock", "--ci_link", "https://localhost:8000", "--ci_link", "https://localhost:8000"},
+			expectedError: errMatcher{
+				msg: "the --ci_link arg must be set at most once",
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -262,6 +297,15 @@ func TestParseArgs(t *testing.T) {
 				Environment: "development",
 				LockId:      "my-lock",
 				Message:     "this is a very long message",
+			},
+		},
+		{
+			name:    "with environment, lockID and ciLink",
+			cmdArgs: []string{"--environment", "development", "--lockID", "my-lock", "--ci_link", "https://localhost:8000"},
+			expectedParams: &CreateEnvironmentLockParameters{
+				Environment: "development",
+				LockId:      "my-lock",
+				CiLink:      strPtr("https://localhost:8000"),
 			},
 		},
 	}

--- a/cli/pkg/locks/group_lock_parsing.go
+++ b/cli/pkg/locks/group_lock_parsing.go
@@ -19,14 +19,16 @@ package locks
 import (
 	"flag"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
 	"strings"
+
+	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
 )
 
 type CreateEnvGroupLockCommandLineArguments struct {
 	environmentGroup cli_utils.RepeatedString
 	lockId           cli_utils.RepeatedString
 	message          cli_utils.RepeatedString
+	ciLink           cli_utils.RepeatedString
 }
 
 func argsValidCreateEnvGroupLock(cmdArgs *CreateEnvGroupLockCommandLineArguments) (result bool, errorMessage string) {
@@ -38,6 +40,9 @@ func argsValidCreateEnvGroupLock(cmdArgs *CreateEnvGroupLockCommandLineArguments
 	}
 	if len(cmdArgs.message.Values) > 1 {
 		return false, "the --message arg must be set at most once"
+	}
+	if len(cmdArgs.ciLink.Values) > 1 {
+		return false, "the --ci_link arg must be set at most once"
 	}
 
 	return true, ""
@@ -52,6 +57,7 @@ func readCreateGroupLockArgs(args []string) (*CreateEnvGroupLockCommandLineArgum
 	fs.Var(&cmdArgs.environmentGroup, "environment-group", "the environment-group to lock")
 	fs.Var(&cmdArgs.lockId, "lockID", "the ID of the lock you are trying to create")
 	fs.Var(&cmdArgs.message, "message", "lock message")
+	fs.Var(&cmdArgs.ciLink, "ci_link", "the link to the CI run that created this lock")
 
 	if err := fs.Parse(args); err != nil {
 		return nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)
@@ -80,9 +86,13 @@ func convertToCreateGroupLockParams(cmdArgs CreateEnvGroupLockCommandLineArgumen
 		EnvironmentGroup:     cmdArgs.environmentGroup.Values[0],
 		UseDexAuthentication: false, //For now there is no ambiguity as to which endpoint to use
 		Message:              "",
+		CiLink:               nil,
 	}
 	if len(cmdArgs.message.Values) != 0 {
 		rp.Message = cmdArgs.message.Values[0]
+	}
+	if len(cmdArgs.ciLink.Values) == 1 {
+		rp.CiLink = &cmdArgs.ciLink.Values[0]
 	}
 	return &rp, nil
 }

--- a/cli/pkg/locks/group_lock_parsing.go
+++ b/cli/pkg/locks/group_lock_parsing.go
@@ -19,6 +19,7 @@ package locks
 import (
 	"flag"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
@@ -43,6 +44,11 @@ func argsValidCreateEnvGroupLock(cmdArgs *CreateEnvGroupLockCommandLineArguments
 	}
 	if len(cmdArgs.ciLink.Values) > 1 {
 		return false, "the --ci_link arg must be set at most once"
+	} else if len(cmdArgs.ciLink.Values) == 1 {
+		_, err := url.ParseRequestURI(cmdArgs.ciLink.Values[0])
+		if err != nil {
+			return false, fmt.Sprintf("provided invalid --ci_link value '%s'", cmdArgs.ciLink.Values[0])
+		}
 	}
 
 	return true, ""

--- a/cli/pkg/locks/group_lock_parsing_test.go
+++ b/cli/pkg/locks/group_lock_parsing_test.go
@@ -107,6 +107,41 @@ func TestReadGroupLockArgs(t *testing.T) {
 				message: cli_utils.RepeatedString{},
 			},
 		},
+		{
+			name: "environment group, lockID and ciLink are specified",
+			args: []string{"--environment-group", "development", "--lockID", "my-lock", "--ci_link", "https://localhost:8000"},
+			expectedCmdArgs: &CreateEnvGroupLockCommandLineArguments{
+				environmentGroup: cli_utils.RepeatedString{
+					Values: []string{
+						"development",
+					},
+				},
+				lockId: cli_utils.RepeatedString{
+					Values: []string{
+						"my-lock",
+					},
+				},
+				ciLink: cli_utils.RepeatedString{
+					Values: []string{
+						"https://localhost:8000",
+					},
+				},
+			},
+		},
+		{
+			name: "--ci_link is invalid url",
+			args: []string{"--environment-group", "development", "--lockID", "my-lock", "--ci_link", "https//localhost:8000"},
+			expectedError: errMatcher{
+				msg: "provided invalid --ci_link value 'https//localhost:8000'",
+			},
+		},
+		{
+			name: "--ci_link is specified twice",
+			args: []string{"--environment-group", "development", "--lockID", "my-lock", "--ci_link", "https//localhost:8000", "--ci_link", "https//localhost:8000"},
+			expectedError: errMatcher{
+				msg: "the --ci_link arg must be set at most once",
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -242,6 +277,15 @@ func TestParseEnvGroupArgs(t *testing.T) {
 				EnvironmentGroup: "development",
 				LockId:           "my-lock",
 				Message:          "this is a very long message",
+			},
+		},
+		{
+			name:    "with environment, lockID and ciLink",
+			cmdArgs: []string{"--environment-group", "development", "--lockID", "my-lock", "--ci_link", "https://localhost:8000"},
+			expectedParams: &CreateEnvironmentGroupLockParameters{
+				EnvironmentGroup: "development",
+				LockId:           "my-lock",
+				CiLink:           strPtr("https://localhost:8000"),
 			},
 		},
 	}

--- a/cli/pkg/locks/lock.go
+++ b/cli/pkg/locks/lock.go
@@ -21,10 +21,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
-	kutil "github.com/freiheit-com/kuberpult/cli/pkg/kuberpult_utils"
 	"net/http"
 	urllib "net/url"
+
+	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
+	kutil "github.com/freiheit-com/kuberpult/cli/pkg/kuberpult_utils"
 )
 
 type LockParameters interface {
@@ -35,6 +36,7 @@ type CreateEnvironmentLockParameters struct {
 	Environment          string
 	LockId               string
 	Message              string
+	CiLink               *string
 	UseDexAuthentication bool
 }
 
@@ -49,6 +51,7 @@ type CreateAppLockParameters struct {
 	LockId               string
 	Message              string
 	Application          string
+	CiLink               *string
 	UseDexAuthentication bool
 }
 type DeleteAppLockParameters struct {
@@ -63,6 +66,7 @@ type CreateTeamLockParameters struct {
 	LockId               string
 	Message              string
 	Team                 string
+	CiLink               *string
 	UseDexAuthentication bool
 }
 
@@ -77,6 +81,7 @@ type CreateEnvironmentGroupLockParameters struct {
 	EnvironmentGroup     string
 	LockId               string
 	Message              string
+	CiLink               *string
 	UseDexAuthentication bool
 }
 type DeleteEnvironmentGroupLockParameters struct {
@@ -87,6 +92,7 @@ type DeleteEnvironmentGroupLockParameters struct {
 
 type LockJsonData struct {
 	Message string `json:"message"`
+	CiLink  string `json:"ciLink,omitempty"`
 }
 
 type HttpInfo struct {
@@ -115,6 +121,10 @@ func HandleLockRequest(requestParams kutil.RequestParameters, authParams kutil.A
 func (e *CreateEnvironmentLockParameters) FillHttpInfo() (*HttpInfo, error) {
 	d := LockJsonData{
 		Message: e.Message,
+	}
+
+	if e.CiLink != nil {
+		d.CiLink = *e.CiLink
 	}
 
 	var jsonData, err = json.Marshal(d)
@@ -150,6 +160,11 @@ func (e *CreateAppLockParameters) FillHttpInfo() (*HttpInfo, error) {
 	d := LockJsonData{
 		Message: e.Message,
 	}
+
+	if e.CiLink != nil {
+		d.CiLink = *e.CiLink
+	}
+
 	var jsonData, err = json.Marshal(d)
 	if err != nil {
 		return nil, fmt.Errorf("Could not marshal CreateAppLockParameters data to json: %w\n", err)
@@ -183,6 +198,11 @@ func (e *CreateTeamLockParameters) FillHttpInfo() (*HttpInfo, error) {
 	d := LockJsonData{
 		Message: e.Message,
 	}
+
+	if e.CiLink != nil {
+		d.CiLink = *e.CiLink
+	}
+
 	var jsonData, err = json.Marshal(d)
 	if err != nil {
 		return nil, fmt.Errorf("Could not marshal CreateTeamLockParameters data to json: %w\n", err)
@@ -216,6 +236,11 @@ func (e *CreateEnvironmentGroupLockParameters) FillHttpInfo() (*HttpInfo, error)
 	d := LockJsonData{
 		Message: e.Message,
 	}
+
+	if e.CiLink != nil {
+		d.CiLink = *e.CiLink
+	}
+
 	var jsonData, err = json.Marshal(d)
 	if err != nil {
 		return nil, fmt.Errorf("Could not marshal CreateEnvironmentGroupLockParameters data to json: %w\n", err)

--- a/cli/pkg/locks/lock.go
+++ b/cli/pkg/locks/lock.go
@@ -121,6 +121,7 @@ func HandleLockRequest(requestParams kutil.RequestParameters, authParams kutil.A
 func (e *CreateEnvironmentLockParameters) FillHttpInfo() (*HttpInfo, error) {
 	d := LockJsonData{
 		Message: e.Message,
+		CiLink:  "",
 	}
 
 	if e.CiLink != nil {
@@ -159,6 +160,7 @@ func (e *DeleteEnvironmentLockParameters) FillHttpInfo() (*HttpInfo, error) {
 func (e *CreateAppLockParameters) FillHttpInfo() (*HttpInfo, error) {
 	d := LockJsonData{
 		Message: e.Message,
+		CiLink:  "",
 	}
 
 	if e.CiLink != nil {
@@ -197,6 +199,7 @@ func (e *DeleteAppLockParameters) FillHttpInfo() (*HttpInfo, error) {
 func (e *CreateTeamLockParameters) FillHttpInfo() (*HttpInfo, error) {
 	d := LockJsonData{
 		Message: e.Message,
+		CiLink:  "",
 	}
 
 	if e.CiLink != nil {
@@ -235,6 +238,7 @@ func (e *DeleteTeamLockParameters) FillHttpInfo() (*HttpInfo, error) {
 func (e *CreateEnvironmentGroupLockParameters) FillHttpInfo() (*HttpInfo, error) {
 	d := LockJsonData{
 		Message: e.Message,
+		CiLink:  "",
 	}
 
 	if e.CiLink != nil {

--- a/cli/pkg/locks/lock_test.go
+++ b/cli/pkg/locks/lock_test.go
@@ -1,0 +1,223 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package locks
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freiheit-com/kuberpult/cli/pkg/kuberpult_utils"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+type mockHttpServer struct {
+	response int
+	header   http.Header
+	body     LockJsonData
+}
+
+func (s *mockHttpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	defer req.Body.Close()
+	if err := json.NewDecoder(req.Body).Decode(&s.body); err != nil {
+		panic(fmt.Errorf("error while parsing the json body in the mock HTTP server, error: %w", err))
+	}
+	s.header = req.Header
+	w.WriteHeader(s.response)
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func intPtr(n uint64) *uint64 {
+	return &n
+}
+
+func TestRequestCreation(t *testing.T) {
+	type testCase struct {
+		name             string
+		params           LockParameters
+		authParams       kuberpult_utils.AuthenticationParameters
+		expectedHeaders  http.Header
+		expectedJson     LockJsonData
+		expectedErrorMsg error
+		responseCode     int
+	}
+
+	tcs := []testCase{
+		{
+			name: "create env lock with message",
+			params: &CreateEnvironmentLockParameters{
+				Environment: "production",
+				LockId:      "a-lock",
+				Message:     "my special message",
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			}, expectedJson: LockJsonData{
+				Message: "my special message",
+			},
+			responseCode: http.StatusOK,
+		},
+		{
+			name: "create env lock with ci link",
+			params: &CreateEnvironmentLockParameters{
+				Environment: "production",
+				LockId:      "a-lock",
+				CiLink:      strPtr("https://localhost:8000"),
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			}, expectedJson: LockJsonData{
+				CiLink: "https://localhost:8000",
+			},
+			responseCode: http.StatusOK,
+		},
+		{
+			name: "create app lock with message",
+			params: &CreateAppLockParameters{
+				Environment: "production",
+				LockId:      "a-lock",
+				Application: "potato",
+				Message:     "my special message",
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			}, expectedJson: LockJsonData{
+				Message: "my special message",
+			},
+			responseCode: http.StatusOK,
+		},
+		{
+			name: "create app lock with ci link",
+			params: &CreateAppLockParameters{
+				Environment: "production",
+				LockId:      "a-lock",
+				Application: "potato",
+				CiLink:      strPtr("https://localhost:8000"),
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			}, expectedJson: LockJsonData{
+				CiLink: "https://localhost:8000",
+			},
+			responseCode: http.StatusOK,
+		},
+		{
+			name: "create team lock with message",
+			params: &CreateTeamLockParameters{
+				Environment: "production",
+				LockId:      "a-lock",
+				Team:        "potato-devs",
+				Message:     "my special message",
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			}, expectedJson: LockJsonData{
+				Message: "my special message",
+			},
+			responseCode: http.StatusOK,
+		},
+		{
+			name: "create team lock with ci link",
+			params: &CreateTeamLockParameters{
+				Environment: "production",
+				LockId:      "a-lock",
+				Team:        "potato-devs",
+				CiLink:      strPtr("https://localhost:8000"),
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			}, expectedJson: LockJsonData{
+				CiLink: "https://localhost:8000",
+			},
+			responseCode: http.StatusOK,
+		},
+		{
+			name: "create group lock with message",
+			params: &CreateEnvironmentGroupLockParameters{
+				EnvironmentGroup: "production",
+				LockId:           "a-lock",
+				Message:          "my special message",
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			}, expectedJson: LockJsonData{
+				Message: "my special message",
+			},
+			responseCode: http.StatusOK,
+		},
+		{
+			name: "create group lock with ci link",
+			params: &CreateEnvironmentGroupLockParameters{
+				EnvironmentGroup: "production",
+				LockId:           "a-lock",
+				CiLink:           strPtr("https://localhost:8000"),
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			}, expectedJson: LockJsonData{
+				CiLink: "https://localhost:8000",
+			},
+			responseCode: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockServer := &mockHttpServer{
+				response: tc.responseCode,
+			}
+			server := httptest.NewServer(mockServer)
+
+			authParams := tc.authParams
+			requestParams := kuberpult_utils.RequestParameters{
+				Url: &server.URL,
+			}
+			err := HandleLockRequest(requestParams, authParams, tc.params)
+			// check errors
+			if tc.expectedErrorMsg != nil {
+				if diff := cmp.Diff(tc.expectedErrorMsg, err, cmpopts.EquateErrors()); diff != "" {
+					t.Fatalf("error mismatch (-want, +got):\n%s", diff)
+				}
+				return
+			}
+
+			// check headers, note that we cannot compare with cmp.Diff because there are some default headers that we shouldn't bother checking (like Accept-Encoding etc)
+			for key, expectedVal := range tc.expectedHeaders {
+				actualVal, ok := mockServer.header[key]
+				if !ok {
+					t.Fatalf("there is a key in the expected headers that does not exist in the received headers\nexpected:\n  %v\nreceived:\n  %v\nmissing key:\n  %s", tc.expectedHeaders, mockServer.header, key)
+				}
+				if diff := cmp.Diff(expectedVal, actualVal); diff != "" {
+					t.Fatalf("there is a mismatch between the expected headers and the received headers\nexpected:\n  %v\nreceived:\n  %v\ndiffering key:\n  %s\ndiff:\n  %s", tc.expectedHeaders, mockServer.header, key, diff)
+				}
+			}
+
+			if mockServer.body != tc.expectedJson {
+				t.Fatalf("there is a mismatch between the expected json and the received json\nexpected:\n	%+v\nreceived:\n	%+v", tc.expectedJson, mockServer.body)
+			}
+		})
+	}
+}

--- a/cli/pkg/locks/team_lock_parsing.go
+++ b/cli/pkg/locks/team_lock_parsing.go
@@ -19,6 +19,7 @@ package locks
 import (
 	"flag"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
@@ -47,6 +48,11 @@ func argsValidCreateTeamLock(cmdArgs *CreateTeamLockCommandLineArguments) (resul
 	}
 	if len(cmdArgs.ciLink.Values) > 1 {
 		return false, "the --ci_link arg must be set at most once"
+	} else if len(cmdArgs.ciLink.Values) == 1 {
+		_, err := url.ParseRequestURI(cmdArgs.ciLink.Values[0])
+		if err != nil {
+			return false, fmt.Sprintf("provided invalid --ci_link value '%s'", cmdArgs.ciLink.Values[0])
+		}
 	}
 
 	return true, ""

--- a/cli/pkg/locks/team_lock_parsing.go
+++ b/cli/pkg/locks/team_lock_parsing.go
@@ -29,6 +29,7 @@ type CreateTeamLockCommandLineArguments struct {
 	lockId      cli_utils.RepeatedString
 	message     cli_utils.RepeatedString
 	team        cli_utils.RepeatedString
+	ciLink      cli_utils.RepeatedString
 }
 
 func argsValidCreateTeamLock(cmdArgs *CreateTeamLockCommandLineArguments) (result bool, errorMessage string) {
@@ -44,6 +45,9 @@ func argsValidCreateTeamLock(cmdArgs *CreateTeamLockCommandLineArguments) (resul
 	if len(cmdArgs.message.Values) > 1 {
 		return false, "the --message arg must be set at most once"
 	}
+	if len(cmdArgs.ciLink.Values) > 1 {
+		return false, "the --ci_link arg must be set at most once"
+	}
 
 	return true, ""
 }
@@ -57,6 +61,7 @@ func readCreateTeamLockArgs(args []string) (*CreateTeamLockCommandLineArguments,
 	fs.Var(&cmdArgs.environment, "environment", "the environment to lock")
 	fs.Var(&cmdArgs.message, "message", "lock message")
 	fs.Var(&cmdArgs.team, "team", "team to lock")
+	fs.Var(&cmdArgs.ciLink, "ci_link", "the link to the CI run that created this lock")
 
 	if err := fs.Parse(args); err != nil {
 		return nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)
@@ -86,9 +91,13 @@ func convertToCreateTeamLockParams(cmdArgs CreateTeamLockCommandLineArguments) (
 		Team:                 cmdArgs.team.Values[0],
 		UseDexAuthentication: true, //For now there is no ambiguity as to which endpoint to use
 		Message:              "",
+		CiLink:               nil,
 	}
 	if len(cmdArgs.message.Values) != 0 {
 		rp.Message = cmdArgs.message.Values[0]
+	}
+	if len(cmdArgs.ciLink.Values) == 1 {
+		rp.CiLink = &cmdArgs.ciLink.Values[0]
 	}
 	return &rp, nil
 }

--- a/cli/pkg/locks/team_lock_parsing_test.go
+++ b/cli/pkg/locks/team_lock_parsing_test.go
@@ -109,6 +109,46 @@ func TestReadArgsTeamLock(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "environment, lockID, team and ciLink are specified",
+			args: []string{"--environment", "development", "--team", "my-team", "--lockID", "my-lock", "--ci_link", "https://localhost:8000"},
+			expectedCmdArgs: &CreateTeamLockCommandLineArguments{
+				environment: cli_utils.RepeatedString{
+					Values: []string{
+						"development",
+					},
+				},
+				lockId: cli_utils.RepeatedString{
+					Values: []string{
+						"my-lock",
+					},
+				},
+				team: cli_utils.RepeatedString{
+					Values: []string{
+						"my-team",
+					},
+				},
+				ciLink: cli_utils.RepeatedString{
+					Values: []string{
+						"https://localhost:8000",
+					},
+				},
+			},
+		},
+		{
+			name: "--ci_link is invalid url",
+			args: []string{"--environment", "development", "--team", "my-team", "--lockID", "my-lock", "--ci_link", "https//localhost:8000"},
+			expectedError: errMatcher{
+				msg: "provided invalid --ci_link value 'https//localhost:8000'",
+			},
+		},
+		{
+			name: "--ci_link is specified twice",
+			args: []string{"--environment", "development", "--team", "my-team", "--lockID", "my-lock", "--ci_link", "https://localhost:8000", "--ci_link", "https://localhost:8000"},
+			expectedError: errMatcher{
+				msg: "the --ci_link arg must be set at most once",
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -275,6 +315,17 @@ func TestParseArgsCreateTeamLock(t *testing.T) {
 				Team:                 "my-team",
 				Message:              "this is a very long message",
 				UseDexAuthentication: true,
+			},
+		},
+		{
+			name:    "with environment, lockID, team and ciLink",
+			cmdArgs: []string{"--environment", "development", "--team", "my-team", "--lockID", "my-lock", "--ci_link", "https://localhost:8000"},
+			expectedParams: &CreateTeamLockParameters{
+				Environment:          "development",
+				LockId:               "my-lock",
+				Team:                 "my-team",
+				UseDexAuthentication: true,
+				CiLink:               strPtr("https://localhost:8000"),
 			},
 		},
 	}

--- a/cli/pkg/release/http.go
+++ b/cli/pkg/release/http.go
@@ -20,10 +20,11 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	kutil "github.com/freiheit-com/kuberpult/cli/pkg/kuberpult_utils"
 	"mime/multipart"
 	"net/http"
 	urllib "net/url"
+
+	kutil "github.com/freiheit-com/kuberpult/cli/pkg/kuberpult_utils"
 )
 
 func prepareHttpRequest(url string, authParams kutil.AuthenticationParameters, parsedArgs ReleaseParameters) (*http.Request, error) {
@@ -95,6 +96,12 @@ func prepareHttpRequest(url string, authParams kutil.AuthenticationParameters, p
 	if parsedArgs.DisplayVersion != nil {
 		if err := writer.WriteField("display_version", *parsedArgs.DisplayVersion); err != nil {
 			return nil, fmt.Errorf("error writing display_version field, error: %w", err)
+		}
+	}
+
+	if parsedArgs.CliLink != nil {
+		if err := writer.WriteField("ci_link", *parsedArgs.CliLink); err != nil {
+			return nil, fmt.Errorf("error writing ci_link field, error: %w", err)
 		}
 	}
 

--- a/cli/pkg/release/http.go
+++ b/cli/pkg/release/http.go
@@ -1,4 +1,5 @@
-/*This file is part of kuberpult.
+/*
+This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -12,8 +13,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright freiheit.com*/
-
+Copyright freiheit.com
+*/
 package release
 
 import (
@@ -99,8 +100,8 @@ func prepareHttpRequest(url string, authParams kutil.AuthenticationParameters, p
 		}
 	}
 
-	if parsedArgs.CliLink != nil {
-		if err := writer.WriteField("ci_link", *parsedArgs.CliLink); err != nil {
+	if parsedArgs.CiLink != nil {
+		if err := writer.WriteField("ci_link", *parsedArgs.CiLink); err != nil {
 			return nil, fmt.Errorf("error writing ci_link field, error: %w", err)
 		}
 	}

--- a/cli/pkg/release/http.go
+++ b/cli/pkg/release/http.go
@@ -1,5 +1,4 @@
-/*
-This file is part of kuberpult.
+/*This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -13,8 +12,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright freiheit.com
-*/
+Copyright freiheit.com*/
+
 package release
 
 import (

--- a/cli/pkg/release/http_test.go
+++ b/cli/pkg/release/http_test.go
@@ -619,6 +619,30 @@ func TestRequestCreation(t *testing.T) {
 			},
 			responseCode: http.StatusOK,
 		},
+		{
+			name: "one environment manifest with ci_link",
+			params: ReleaseParameters{
+				Application: "potato",
+				Manifests: map[string][]byte{
+					"development": []byte("some development manifest"),
+				},
+				CiLink: strPtr("https://localhost:8000"),
+			},
+			expectedMultipartFormValue: map[string][]string{
+				"application": {"potato"},
+				"ci_link":     {"https://localhost:8000"},
+			},
+			expectedMultipartFormFile: map[string][]simpleMultipartFormFileHeader{
+				"manifests[development]": {
+					{
+						filename: "development-manifest",
+						content:  "some development manifest",
+					},
+				},
+			},
+
+			responseCode: http.StatusOK,
+		},
 	}
 
 	for _, tc := range tcs {

--- a/cli/pkg/release/parsing.go
+++ b/cli/pkg/release/parsing.go
@@ -46,6 +46,7 @@ type commandLineArguments struct {
 	signatures           cli_utils.RepeatedString
 	useDexAuthentication bool
 	isPrepublish         bool
+	ciLink               cli_utils.RepeatedString
 }
 
 // checks whether every --environment arg is matched with a --manifest arg
@@ -173,6 +174,10 @@ func argsValid(cmdArgs *commandLineArguments) (result bool, errorMessage string)
 		}
 	}
 
+	if len(cmdArgs.ciLink.Values) > 1 {
+		return false, "the --ci_link arg must be set exactly once"
+	}
+
 	return true, ""
 }
 
@@ -192,6 +197,7 @@ func readArgs(args []string) (*commandLineArguments, error) {
 	fs.Var(&cmdArgs.sourceMessage, "source_message", "the source commit message (must not be set more than once)")
 	fs.Var(&cmdArgs.version, "version", "the release version (must be a positive integer)")
 	fs.Var(&cmdArgs.displayVersion, "display_version", "display version (must be a string between 1 and characters long)")
+	fs.Var(&cmdArgs.ciLink, "ci_link", "the link to the CI run that created this release")
 	fs.BoolVar(&cmdArgs.skipSignatures, "skip_signatures", false, "if set to true, then the command line does not accept the --signature args")
 	fs.Var(&cmdArgs.signatures, "signature", "the name of the file containing the signature of the manifest to be deployed (must be set immediately after --manifest)")
 	fs.BoolVar(&cmdArgs.useDexAuthentication, "use_dex_auth", false, "use /api/release endpoint, if set to true, dex must be enabled and dex token must be provided otherwise the request will be denied")
@@ -258,6 +264,9 @@ func convertToParams(cmdArgs commandLineArguments) (*ReleaseParameters, error) {
 	}
 	if len(cmdArgs.displayVersion.Values) == 1 {
 		rp.DisplayVersion = &cmdArgs.displayVersion.Values[0]
+	}
+	if len(cmdArgs.ciLink.Values) == 1 {
+		rp.CliLink = &cmdArgs.ciLink.Values[0]
 	}
 	for i := range cmdArgs.environments.Values {
 		manifestFile := cmdArgs.manifests.Values[i]

--- a/cli/pkg/release/parsing.go
+++ b/cli/pkg/release/parsing.go
@@ -19,6 +19,7 @@ package release
 import (
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -175,7 +176,12 @@ func argsValid(cmdArgs *commandLineArguments) (result bool, errorMessage string)
 	}
 
 	if len(cmdArgs.ciLink.Values) > 1 {
-		return false, "the --ci_link arg must be set exactly once"
+		return false, "the --ci_link arg must be set at most once"
+	} else if len(cmdArgs.ciLink.Values) == 1 {
+		_, err := url.ParseRequestURI(cmdArgs.ciLink.Values[0])
+		if err != nil {
+			return false, fmt.Sprintf("provided invalid --ci_link value '%s'", cmdArgs.ciLink.Values[0])
+		}
 	}
 
 	return true, ""
@@ -266,7 +272,7 @@ func convertToParams(cmdArgs commandLineArguments) (*ReleaseParameters, error) {
 		rp.DisplayVersion = &cmdArgs.displayVersion.Values[0]
 	}
 	if len(cmdArgs.ciLink.Values) == 1 {
-		rp.CliLink = &cmdArgs.ciLink.Values[0]
+		rp.CiLink = &cmdArgs.ciLink.Values[0]
 	}
 	for i := range cmdArgs.environments.Values {
 		manifestFile := cmdArgs.manifests.Values[i]

--- a/cli/pkg/release/release.go
+++ b/cli/pkg/release/release.go
@@ -18,6 +18,7 @@ package release
 
 import (
 	"fmt"
+
 	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
 
 	kutil "github.com/freiheit-com/kuberpult/cli/pkg/kuberpult_utils"
@@ -35,6 +36,7 @@ type ReleaseParameters struct {
 	SourceMessage        *string
 	Version              *uint64
 	DisplayVersion       *string
+	CliLink              *string
 	UseDexAuthentication bool
 	IsPrepublish         bool
 }

--- a/cli/pkg/release/release.go
+++ b/cli/pkg/release/release.go
@@ -36,7 +36,7 @@ type ReleaseParameters struct {
 	SourceMessage        *string
 	Version              *uint64
 	DisplayVersion       *string
-	CliLink              *string
+	CiLink               *string
 	UseDexAuthentication bool
 	IsPrepublish         bool
 }

--- a/cli/pkg/releasetrain/releasetrain.go
+++ b/cli/pkg/releasetrain/releasetrain.go
@@ -72,7 +72,7 @@ func createHttpRequest(url string, authParams kutil.AuthenticationParameters, pa
 
 	var jsonData []byte
 	if parameters.CiLink != nil {
-		d := &ReleaseTrainJsonData{
+		d := ReleaseTrainJsonData{
 			CiLink: *parameters.CiLink,
 		}
 
@@ -83,6 +83,10 @@ func createHttpRequest(url string, authParams kutil.AuthenticationParameters, pa
 	}
 
 	req, err := http.NewRequest(http.MethodPut, urlStruct.JoinPath(path).String(), bytes.NewBuffer(jsonData))
+
+	if jsonData != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("error creating the HTTP request, error: %w", err)
 	}

--- a/cli/pkg/releasetrain/releasetrain_parsing.go
+++ b/cli/pkg/releasetrain/releasetrain_parsing.go
@@ -27,6 +27,7 @@ import (
 type ReleaseTrainCommandLineArguments struct {
 	targetEnvironment    cli_utils.RepeatedString
 	team                 cli_utils.RepeatedString
+	ciLink               cli_utils.RepeatedString
 	useDexAuthentication bool
 }
 
@@ -37,6 +38,10 @@ func releaseTrainArgsValid(cmdArgs *ReleaseTrainCommandLineArguments) (result bo
 
 	if len(cmdArgs.team.Values) > 1 {
 		return false, "the --team arg must be set at most once"
+	}
+
+	if len(cmdArgs.ciLink.Values) > 1 {
+		return false, "the --ci_link arg must be set at most once"
 	}
 
 	return true, ""
@@ -50,6 +55,7 @@ func readArgs(args []string) (*ReleaseTrainCommandLineArguments, error) {
 	fs.Var(&cmdArgs.targetEnvironment, "target-environment", "the name of the environment to target with the release train (must be set exactly once)")
 	fs.Var(&cmdArgs.team, "team", "the target team. Only specified teams services will be taken into account when conducting the release train")
 	fs.BoolVar(&cmdArgs.useDexAuthentication, "use_dex_auth", false, "if set to true, the /api/* endpoint will be used. Dex must be enabled on the server side and a dex token must be provided, otherwise the request will be denied")
+	fs.Var(&cmdArgs.ciLink, "ci_link", "the link to the CI run that created this release train")
 
 	if err := fs.Parse(args); err != nil {
 		return nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)
@@ -73,6 +79,7 @@ func convertToParams(cmdArgs ReleaseTrainCommandLineArguments) (*ReleaseTrainPar
 
 	rp := ReleaseTrainParameters{
 		Team:                 nil,
+		CiLink:               nil,
 		TargetEnvironment:    cmdArgs.targetEnvironment.Values[0],
 		UseDexAuthentication: cmdArgs.useDexAuthentication,
 	}
@@ -80,6 +87,11 @@ func convertToParams(cmdArgs ReleaseTrainCommandLineArguments) (*ReleaseTrainPar
 	if len(cmdArgs.team.Values) == 1 {
 		rp.Team = &cmdArgs.team.Values[0]
 	}
+
+	if len(cmdArgs.ciLink.Values) == 1 {
+		rp.CiLink = &cmdArgs.ciLink.Values[0]
+	}
+
 	return &rp, nil
 }
 

--- a/cli/pkg/releasetrain/releasetrain_parsing.go
+++ b/cli/pkg/releasetrain/releasetrain_parsing.go
@@ -19,6 +19,7 @@ package releasetrain
 import (
 	"flag"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
@@ -42,6 +43,11 @@ func releaseTrainArgsValid(cmdArgs *ReleaseTrainCommandLineArguments) (result bo
 
 	if len(cmdArgs.ciLink.Values) > 1 {
 		return false, "the --ci_link arg must be set at most once"
+	} else if len(cmdArgs.ciLink.Values) == 1 {
+		_, err := url.ParseRequestURI(cmdArgs.ciLink.Values[0])
+		if err != nil {
+			return false, fmt.Sprintf("provided invalid --ci_link value '%s'", cmdArgs.ciLink.Values[0])
+		}
 	}
 
 	return true, ""

--- a/cli/pkg/releasetrain/releasetrain_parsing_test.go
+++ b/cli/pkg/releasetrain/releasetrain_parsing_test.go
@@ -114,6 +114,42 @@ func TestReadArgsReleaseTrain(t *testing.T) {
 				useDexAuthentication: true,
 			},
 		},
+		{
+			name: "ci_link is specified",
+			args: []string{"--target-environment", "development", "--team", "test-team", "--ci_link", "https://localhost:8000"},
+			expectedCmdArgs: &ReleaseTrainCommandLineArguments{
+				targetEnvironment: cli_utils.RepeatedString{
+					Values: []string{
+						"development",
+					},
+				},
+				team: cli_utils.RepeatedString{
+					Values: []string{
+						"test-team",
+					},
+				},
+				ciLink: cli_utils.RepeatedString{
+					Values: []string{
+						"https://localhost:8000",
+					},
+				},
+				useDexAuthentication: false,
+			},
+		},
+		{
+			name: "--ci_link is invalid url",
+			args: []string{"--target-environment", "development", "--team", "test-team", "--ci_link", "https//localhost:8000"},
+			expectedError: errMatcher{
+				msg: "provided invalid --ci_link value 'https//localhost:8000'",
+			},
+		},
+		{
+			name: "--ci_link is specified twice",
+			args: []string{"--target-environment", "development", "--team", "test-team", "--ci_link", "https//localhost:8000", "--ci_link", "https//localhost:8000"},
+			expectedError: errMatcher{
+				msg: "the --ci_link arg must be set at most once",
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -159,6 +195,16 @@ func TestParseArgsReleaseTrainLock(t *testing.T) {
 				Team:                 makeStringPointer("my-team"),
 				TargetEnvironment:    "development",
 				UseDexAuthentication: false,
+			},
+		},
+		{
+			name:    "target, team and ciLink",
+			cmdArgs: []string{"--target-environment", "development", "--team", "my-team", "--ci_link", "https://localhost:8000"},
+			expectedParams: ReleaseTrainParameters{
+				Team:                 makeStringPointer("my-team"),
+				TargetEnvironment:    "development",
+				UseDexAuthentication: false,
+				CiLink:               makeStringPointer("https://localhost:8000"),
 			},
 		},
 		{

--- a/cli/pkg/releasetrain/releasetrain_test.go
+++ b/cli/pkg/releasetrain/releasetrain_test.go
@@ -1,0 +1,120 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package releasetrain
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freiheit-com/kuberpult/cli/pkg/kuberpult_utils"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+type mockHttpServer struct {
+	response int
+	header   http.Header
+	body     ReleaseTrainJsonData
+}
+
+func (s *mockHttpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	defer req.Body.Close()
+	if err := json.NewDecoder(req.Body).Decode(&s.body); err != nil {
+		panic(fmt.Errorf("error while parsing the json body in the mock HTTP server, error: %w", err))
+	}
+	s.header = req.Header
+	w.WriteHeader(s.response)
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func intPtr(n uint64) *uint64 {
+	return &n
+}
+
+func TestRequestCreation(t *testing.T) {
+	type testCase struct {
+		name             string
+		params           ReleaseTrainParameters
+		authParams       kuberpult_utils.AuthenticationParameters
+		expectedHeaders  http.Header
+		expectedJson     ReleaseTrainJsonData
+		expectedErrorMsg error
+		responseCode     int
+	}
+
+	tcs := []testCase{
+		{
+			name: "with ci link",
+			params: ReleaseTrainParameters{
+				TargetEnvironment: "production",
+				CiLink:            strPtr("https://localhost:8000"),
+			},
+			expectedHeaders: http.Header{
+				"Content-Type": {"application/json"},
+			}, expectedJson: ReleaseTrainJsonData{
+				CiLink: "https://localhost:8000",
+			},
+			responseCode: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockServer := &mockHttpServer{
+				response: tc.responseCode,
+			}
+			server := httptest.NewServer(mockServer)
+
+			authParams := tc.authParams
+			requestParams := kuberpult_utils.RequestParameters{
+				Url: &server.URL,
+			}
+			err := HandleReleaseTrain(requestParams, authParams, tc.params)
+			// check errors
+			if tc.expectedErrorMsg != nil {
+				if diff := cmp.Diff(tc.expectedErrorMsg, err, cmpopts.EquateErrors()); diff != "" {
+					t.Fatalf("error mismatch (-want, +got):\n%s", diff)
+				}
+				return
+			}
+
+			// check headers, note that we cannot compare with cmp.Diff because there are some default headers that we shouldn't bother checking (like Accept-Encoding etc)
+			for key, expectedVal := range tc.expectedHeaders {
+				actualVal, ok := mockServer.header[key]
+				if !ok {
+					t.Fatalf("there is a key in the expected headers that does not exist in the received headers\nexpected:\n  %v\nreceived:\n  %v\nmissing key:\n  %s", tc.expectedHeaders, mockServer.header, key)
+				}
+				if diff := cmp.Diff(expectedVal, actualVal); diff != "" {
+					t.Fatalf("there is a mismatch between the expected headers and the received headers\nexpected:\n  %v\nreceived:\n  %v\ndiffering key:\n  %s\ndiff:\n  %s", tc.expectedHeaders, mockServer.header, key, diff)
+				}
+			}
+
+			if mockServer.body != tc.expectedJson {
+				t.Fatalf("there is a mismatch between the expected json and the received json\nexpected:\n	%+v\nreceived:\n	%+v", tc.expectedJson, mockServer.body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
There was no option for providing a ci_link in the cli.
Added this parameter as a command line argument to the following commands:
 - release
 - release-train
 - create-env-lock
 - create-app-lock
 - create-team-lock
 - create-group-lock

Also added unit tests to test this feature.
Ref: SRX-G46ZAL