### PR TITLE
fix: continue if app is not found in overview

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1089,14 +1089,15 @@ func (h *DBHandler) DBWriteAllApplications(ctx context.Context, transaction *sql
 		return fmt.Errorf("DBWriteAllApplications unable to get transaction timestamp: %w", err)
 	}
 	span.SetTag("query", insertQuery)
+	nextVersion := previousVersion + 1
 	_, err = transaction.Exec(
 		insertQuery,
-		previousVersion+1,
+		nextVersion,
 		*now,
 		jsonToInsert)
 
 	if err != nil {
-		return fmt.Errorf("could not insert all apps into DB. Error: %w\n", err)
+		return fmt.Errorf("could not insert all apps into DB with version=%d Error: %w\n", nextVersion, err)
 	}
 	return nil
 }

--- a/pkg/db/overview.go
+++ b/pkg/db/overview.go
@@ -253,7 +253,19 @@ func (h *DBHandler) UpdateOverviewRelease(ctx context.Context, transaction *sql.
 		if release.Deleted {
 			return nil
 		}
-		return fmt.Errorf("could not find application '%s' in overview", release.App)
+		selectApp, err := h.DBSelectApp(ctx, transaction, release.App)
+		if err != nil {
+			return fmt.Errorf("could not find application '%s' in apps table: %w", release.App, err)
+		}
+		app = &api.Application{
+			Name:            release.App,
+			Releases:        []*api.Release{},
+			SourceRepoUrl:   "", // TODO
+			Team:            selectApp.Metadata.Team,
+			UndeploySummary: 0,
+			Warnings:        []*api.Warning{},
+		}
+		latestOverview.Applications[release.App] = app
 	}
 	apiRelease := &api.Release{
 		PrNumber:        extractPrNumber(release.Metadata.SourceMessage),

--- a/pkg/db/transactions.go
+++ b/pkg/db/transactions.go
@@ -128,6 +128,8 @@ func withTransactionAllOptions[T any](h *DBHandler, ctx context.Context, opts tr
 				maxRetries: opts.maxRetries - 1,
 				readonly:   opts.readonly,
 			}, f)
+		} else {
+			logger.FromContext(ctx).Sugar().Warnf("%s transaction failed, will NOT retry error: %v", msg, e)
 		}
 		return nil, e
 	}
@@ -168,7 +170,7 @@ func IsRetryablePostgresError(err error) bool {
 	}
 	codeStr := string(pgErr.Code)
 	// for a list of all postgres error codes, see https://www.postgresql.org/docs/9.3/errcodes-appendix.html
-	return strings.HasPrefix(codeStr, "40")
+	return strings.HasPrefix(codeStr, "40") || strings.HasPrefix(codeStr, "23505")
 }
 
 func UnwrapUntilPostgresError(err error) *pq.Error {

--- a/pkg/db/transactions_test.go
+++ b/pkg/db/transactions_test.go
@@ -18,7 +18,6 @@ package db
 
 import (
 	"fmt"
-	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
 	"github.com/google/go-cmp/cmp"
 	"github.com/lib/pq"
 	"testing"
@@ -117,10 +116,6 @@ func TestIsNotRetryableErrorEndlessLoop(t *testing.T) {
 		},
 		{
 			InputCode:         fmt.Errorf("other2: %w", fmt.Errorf("foobar: %w", &pq.Error{Code: pq.ErrorCode("40000")})),
-			ExpectedRetryable: true,
-		},
-		{
-			InputCode:         repository.GetCreateReleaseGeneralFailure(fmt.Errorf("other2: %w", fmt.Errorf("foobar: %w", &pq.Error{Code: pq.ErrorCode("23505")}))),
 			ExpectedRetryable: true,
 		},
 	}

--- a/pkg/db/transactions_test.go
+++ b/pkg/db/transactions_test.go
@@ -18,6 +18,7 @@ package db
 
 import (
 	"fmt"
+	"github.com/freiheit-com/kuberpult/services/cd-service/pkg/repository"
 	"github.com/google/go-cmp/cmp"
 	"github.com/lib/pq"
 	"testing"
@@ -116,6 +117,10 @@ func TestIsNotRetryableErrorEndlessLoop(t *testing.T) {
 		},
 		{
 			InputCode:         fmt.Errorf("other2: %w", fmt.Errorf("foobar: %w", &pq.Error{Code: pq.ErrorCode("40000")})),
+			ExpectedRetryable: true,
+		},
+		{
+			InputCode:         repository.GetCreateReleaseGeneralFailure(fmt.Errorf("other2: %w", fmt.Errorf("foobar: %w", &pq.Error{Code: pq.ErrorCode("23505")}))),
 			ExpectedRetryable: true,
 		},
 	}

--- a/services/cd-service/pkg/repository/error.go
+++ b/services/cd-service/pkg/repository/error.go
@@ -22,7 +22,8 @@ import (
 )
 
 type CreateReleaseError struct {
-	response api.CreateReleaseResponse
+	response   api.CreateReleaseResponse
+	innerError error
 }
 
 func (e *CreateReleaseError) Error() string {
@@ -44,11 +45,17 @@ func (e *CreateReleaseError) Is(target error) bool {
 	return proto.Equal(e.Response(), tgt.Response())
 }
 
+func (e *CreateReleaseError) Unwrap() error {
+	// Return the inner error.
+	return e.innerError
+}
+
 func GetCreateReleaseGeneralFailure(err error) *CreateReleaseError {
 	response := api.CreateReleaseResponseGeneralFailure{
 		Message: err.Error(),
 	}
 	return &CreateReleaseError{
+		innerError: err,
 		response: api.CreateReleaseResponse{
 			Response: &api.CreateReleaseResponse_GeneralFailure{
 				GeneralFailure: &response,
@@ -60,6 +67,7 @@ func GetCreateReleaseGeneralFailure(err error) *CreateReleaseError {
 func GetCreateReleaseAlreadyExistsSame() *CreateReleaseError {
 	response := api.CreateReleaseResponseAlreadyExistsSame{}
 	return &CreateReleaseError{
+		innerError: nil,
 		response: api.CreateReleaseResponse{
 			Response: &api.CreateReleaseResponse_AlreadyExistsSame{
 				AlreadyExistsSame: &response,
@@ -74,6 +82,7 @@ func GetCreateReleaseAlreadyExistsDifferent(firstDifferingField api.DifferingFie
 		Diff:                diff,
 	}
 	return &CreateReleaseError{
+		innerError: nil,
 		response: api.CreateReleaseResponse{
 			Response: &api.CreateReleaseResponse_AlreadyExistsDifferent{
 				AlreadyExistsDifferent: &response,
@@ -85,6 +94,7 @@ func GetCreateReleaseAlreadyExistsDifferent(firstDifferingField api.DifferingFie
 func GetCreateReleaseTooOld() *CreateReleaseError {
 	response := api.CreateReleaseResponseTooOld{}
 	return &CreateReleaseError{
+		innerError: nil,
 		response: api.CreateReleaseResponse{
 			Response: &api.CreateReleaseResponse_TooOld{
 				TooOld: &response,
@@ -100,6 +110,7 @@ func GetCreateReleaseAppNameTooLong(appName string, regExp string, maxLen uint32
 		MaxLen:  maxLen,
 	}
 	return &CreateReleaseError{
+		innerError: nil,
 		response: api.CreateReleaseResponse{
 			Response: &api.CreateReleaseResponse_TooLong{
 				TooLong: &response,

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -115,6 +115,11 @@ func (err *TransformerBatchApplyError) Is(target error) bool {
 	return errors.Is(err.TransformerError, tgt.TransformerError)
 }
 
+func (e *TransformerBatchApplyError) Unwrap() error {
+	// Return the inner error.
+	return e.TransformerError
+}
+
 func UnwrapUntilTransformerBatchApplyError(err error) *TransformerBatchApplyError {
 	for {
 		var applyErr *TransformerBatchApplyError

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -487,7 +487,7 @@ func (c *CreateApplicationVersion) Transform(
 			allApps.Apps = append(allApps.Apps, c.Application)
 			err := state.DBHandler.DBWriteAllApplications(ctx, transaction, allApps.Version, allApps.Apps)
 			if err != nil {
-				return "", GetCreateReleaseGeneralFailure(fmt.Errorf("could not write all apps"))
+				return "", GetCreateReleaseGeneralFailure(fmt.Errorf("could not write all apps: %w", err))
 			}
 
 			//We need to check that this is not an app that has been previously deleted


### PR DESCRIPTION
Ref: SRX-YNEAHU

* The /release endpoint continues even if in an edge case, the app was not found in the overview.
* The postgres error 23505 is now considered retryable. This happens especially in the /release endpoint