### PR TITLE
fix: reduce number of queries to get releases

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -566,7 +566,7 @@ func (h *DBHandler) DBSelectAnyRelease(ctx context.Context, tx *sql.Tx, ignorePr
 		ctx,
 		selectQuery,
 	)
-	processedRows, err := h.processReleaseRows(ctx, err, rows, ignorePrepublishes, true)
+	processedRows, err := h.processReleaseRows(ctx, err, rows, ignorePrepublishes, false)
 	if err != nil {
 		return nil, err
 	}
@@ -822,7 +822,7 @@ func (h *DBHandler) DBSelectReleasesByAppLatestEslVersion(ctx context.Context, t
 		deleted,
 	)
 
-	return h.processReleaseRows(ctx, err, rows, ignorePrepublishes, true)
+	return h.processReleaseRows(ctx, err, rows, ignorePrepublishes, false)
 }
 
 func (h *DBHandler) DBSelectAllReleasesOfApp(ctx context.Context, tx *sql.Tx, app string) (*DBAllReleasesWithMetaData, error) {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -623,15 +623,6 @@ func (h *DBHandler) DBSelectReleasesByVersions(ctx context.Context, tx *sql.Tx, 
 		return []*DBReleaseWithMetaData{}, nil
 	}
 	repeatedQuestionMarks := strings.Repeat(",?", len(releaseVersions)-1)
-	//	selectQuery := h.AdaptQuery(fmt.Sprintf(
-	//		`
-	//SELECT eslVersion, created, appName, metadata, releaseVersion, deleted, environments
-	//FROM releases
-	//WHERE appName=? AND releaseVersion IN (?` + repeatedQuestionMarks + `)
-	//ORDER BY eslVersion DESC
-	//LIMIT ?;
-	//`))
-
 	selectQuery := h.AdaptQuery(`
 
 	SELECT DISTINCT
@@ -639,7 +630,6 @@ func (h *DBHandler) DBSelectReleasesByVersions(ctx context.Context, tx *sql.Tx, 
 		releases.created,
 		releases.appName,
 		releases.metadata,
--- 		releases.manifests,
 		releases.releaseVersion,
 		releases.deleted,
 		releases.environments

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1040,7 +1040,6 @@ func (h *DBHandler) processReleaseRows(ctx context.Context, err error, rows *sql
 	if err != nil {
 		return nil, err
 	}
-	logger.FromContext(ctx).Sugar().Warnf("DONE WITH manifests=%v", withManifests)
 	return result, nil
 }
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1019,10 +1019,8 @@ func (h *DBHandler) processReleaseRows(ctx context.Context, err error, rows *sql
 			if err != nil {
 				return nil, fmt.Errorf("Error during json unmarshal of manifests for releases. Error: %w. Data: %s\n", err, metadataStr)
 			}
-			row.Manifests = manifestData
-		} else {
-			row.Manifests = manifestData
 		}
+		row.Manifests = manifestData
 		environments := make([]string, 0)
 		if environmentsStr.Valid && environmentsStr.String != "" {
 			err = json.Unmarshal(([]byte)(environmentsStr.String), &environments)

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -2512,16 +2512,15 @@ func (s *State) UpdateTopLevelAppInOverview(ctx context.Context, transaction *sq
 		}
 		rels = retrievedReleasesOfApp
 	}
-	for _, id := range rels {
-		if rel, err := s.GetApplicationRelease(ctx, transaction, appName, id); err != nil {
-			return err
-		} else {
+
+	if releasesInDb, err := s.GetApplicationReleasesDB(ctx, transaction, appName, rels); err != nil {
+		return err
+	} else {
+		for _, rel := range releasesInDb {
 			if rel == nil {
 				// ignore
 			} else {
 				release := rel.ToProto()
-				release.Version = id
-				release.UndeployVersion = rel.UndeployVersion
 				app.Releases = append(app.Releases, release)
 			}
 		}
@@ -3117,6 +3116,36 @@ func (s *State) IsUndeployVersionFromManifest(application string, version uint64
 		return false, nil
 	}
 	return true, nil
+}
+
+func (s *State) GetApplicationReleasesDB(ctx context.Context, transaction *sql.Tx, application string, versions []uint64) ([]*Release, error) {
+	if s.DBHandler.ShouldUseOtherTables() {
+		rels, err := s.DBHandler.DBSelectReleasesByVersions(ctx, transaction, application, versions, true)
+		if err != nil {
+			return nil, fmt.Errorf("could not get release of app %s: %v", application, err)
+		}
+		if rels == nil {
+			return nil, nil
+		}
+		var result []*Release
+		for _, rel := range rels {
+			r := &Release{
+				Version:         rel.ReleaseNumber,
+				UndeployVersion: rel.Metadata.UndeployVersion,
+				SourceAuthor:    rel.Metadata.SourceAuthor,
+				SourceCommitId:  rel.Metadata.SourceCommitId,
+				SourceMessage:   rel.Metadata.SourceMessage,
+				CreatedAt:       rel.Created,
+				DisplayVersion:  rel.Metadata.DisplayVersion,
+				IsMinor:         rel.Metadata.IsMinor,
+				IsPrepublish:    rel.Metadata.IsPrepublish,
+			}
+			result = append(result, r)
+		}
+		return result, nil
+	} else {
+		return nil, fmt.Errorf("unsupported operation, need to enable the DB")
+	}
 }
 
 func (s *State) GetApplicationRelease(ctx context.Context, transaction *sql.Tx, application string, version uint64) (*Release, error) {

--- a/services/cd-service/pkg/service/git_test.go
+++ b/services/cd-service/pkg/service/git_test.go
@@ -17,6 +17,7 @@ Copyright freiheit.com*/
 package service
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"testing"
@@ -237,7 +238,7 @@ func TestGetProductOverview(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error setting up repository test: %v", err)
 			}
-			sv := &GitServer{OverviewService: &OverviewServiceServer{Repository: repo, Shutdown: shutdown}}
+			sv := &GitServer{OverviewService: &OverviewServiceServer{Repository: repo, Shutdown: shutdown, Context: context.Background()}}
 
 			for _, transformer := range tc.Setup {
 				repo.Apply(testutil.MakeTestContext(), transformer)
@@ -831,7 +832,7 @@ func TestGetCommitInfo(t *testing.T) {
 				DBHandler:           repo.State().DBHandler,
 			}
 			sv := &GitServer{
-				OverviewService: &OverviewServiceServer{Repository: repo, Shutdown: shutdown},
+				OverviewService: &OverviewServiceServer{Repository: repo, Shutdown: shutdown, Context: context.Background()},
 				Config:          config,
 				PageSize:        uint64(pageSize),
 			}

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -640,6 +640,7 @@ func TestOverviewService(t *testing.T) {
 			svc := &OverviewServiceServer{
 				Repository: repo,
 				Shutdown:   shutdown,
+				Context:    context.Background(),
 			}
 			tc.Test(t, svc)
 			if tc.DB {
@@ -972,6 +973,7 @@ func TestOverviewServiceFromCommit(t *testing.T) {
 			svc := &OverviewServiceServer{
 				Repository: repo,
 				Shutdown:   shutdown,
+				Context:    context.Background(),
 			}
 
 			ov, err := svc.GetOverview(testutil.MakeTestContext(), &api.GetOverviewRequest{})


### PR DESCRIPTION
This reduces the number of queries to the releases table, roughly by a factor of 25 (average number of releases per app).

This also reduces the number of cases where we actually load all the manifests from the releases table.
And it fixes a few tests that had a nil context.

Ref: SRX-LEIHOZ