### PR TITLE
fix: improve "upstream/latest" release trains

### DIFF
--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -2079,6 +2079,9 @@ func (s *State) GetEnvironmentApplicationsFromDB(ctx context.Context, transactio
 	if err != nil {
 		return nil, err
 	}
+	if envInfo == nil {
+		return nil, fmt.Errorf("environment %s not found", environment)
+	}
 	if envInfo.Applications == nil {
 		return make([]string, 0), nil
 	}


### PR DESCRIPTION
Previously the release train to "latest" would consider all apps.
Now it only considers apps that exist (have a release) in the target env.

Ref: SRX-LEIHOZ