### PR TITLE
fix(frontend-service): Fixed log format

### DIFF
--- a/services/frontend-service/pkg/service/batch.go
+++ b/services/frontend-service/pkg/service/batch.go
@@ -47,7 +47,7 @@ func (b *BatchServiceWithDefaultTimeout) ProcessBatch(ctx context.Context, req *
 		if context.Cause(ctx) == kuberpultTimeoutError {
 			logger.FromContext(ctx).Warn("Context cancelled due to kuberpult timeout")
 		} else {
-			logger.FromContext(ctx).Warn("Context cancelled due %v", zap.Error(context.Cause(ctx)))
+			logger.FromContext(ctx).Sugar().Warnf("Context cancelled due %v", zap.Error(context.Cause(ctx)))
 		}
 	}
 

--- a/services/frontend-service/pkg/service/batch.go
+++ b/services/frontend-service/pkg/service/batch.go
@@ -47,7 +47,7 @@ func (b *BatchServiceWithDefaultTimeout) ProcessBatch(ctx context.Context, req *
 		if context.Cause(ctx) == kuberpultTimeoutError {
 			logger.FromContext(ctx).Warn("Context cancelled due to kuberpult timeout")
 		} else {
-			logger.FromContext(ctx).Sugar().Warnf("Context cancelled due %v", zap.Error(context.Cause(ctx)))
+			logger.FromContext(ctx).Warn("Context cancelled due", zap.Error(context.Cause(ctx)))
 		}
 	}
 


### PR DESCRIPTION
The formating of the logs was incorrect. The error was not being printed.

Ref: SRX-BJVFRL