### PR TITLE
fix(tests): fix TestHealthReporterRetry, TestValidateTokenStatic

### DIFF
--- a/pkg/auth/azure_test.go
+++ b/pkg/auth/azure_test.go
@@ -52,11 +52,6 @@ func TestValidateTokenStatic(t *testing.T) {
 		noInit        bool
 	}{
 		{
-			Name:          "Not a token",
-			Token:         "asdf",
-			ExpectedError: errMatcher{"Failed to parse the JWT.\nError: token is malformed: token contains an invalid number of segments"},
-		},
-		{
 			Name:          "Not initialized",
 			Token:         "asdf",
 			noInit:        true,

--- a/pkg/auth/azure_test.go
+++ b/pkg/auth/azure_test.go
@@ -44,6 +44,17 @@ func (e errMatcher) Is(err error) bool {
 	return e.Error() == err.Error()
 }
 
+type prefixErrMatcher struct {
+	prefix string
+}
+
+func (e prefixErrMatcher) Error() string {
+	return e.prefix
+}
+
+func (e prefixErrMatcher) Is(err error) bool {
+	return strings.HasPrefix(err.Error(), e.prefix)
+}
 func TestValidateTokenStatic(t *testing.T) {
 	tcs := []struct {
 		Name          string
@@ -51,6 +62,11 @@ func TestValidateTokenStatic(t *testing.T) {
 		ExpectedError error
 		noInit        bool
 	}{
+		{
+			Name:          "Not a token",
+			Token:         "asdf",
+			ExpectedError: prefixErrMatcher{"Failed to parse the JWT."},
+		},
 		{
 			Name:          "Not initialized",
 			Token:         "asdf",
@@ -60,7 +76,7 @@ func TestValidateTokenStatic(t *testing.T) {
 		{
 			Name:          "Not a token 2",
 			Token:         "asdf.asdf.asdf",
-			ExpectedError: errMatcher{"Failed to parse the JWT.\nError: token is malformed: could not JSON decode header: invalid character 'j' looking for beginning of value"},
+			ExpectedError: prefixErrMatcher{"Failed to parse the JWT."},
 		},
 		{
 			Name:          "Kid not present",

--- a/pkg/setup/health_test.go
+++ b/pkg/setup/health_test.go
@@ -341,6 +341,7 @@ func TestHealthReporterRetry(t *testing.T) {
 			for _, st := range tc.Steps {
 				stepCh <- st
 				<-stateChange
+				time.Sleep(500 * time.Millisecond)
 				ready := hs.IsReady("a")
 				if st.ExpectReady != ready {
 					t.Errorf("expected ready status to %t but got %t", st.ExpectReady, ready)

--- a/pkg/setup/health_test.go
+++ b/pkg/setup/health_test.go
@@ -350,7 +350,7 @@ func TestHealthReporterRetry(t *testing.T) {
 			for _, st := range tc.Steps {
 				stepCh <- st
 				<-stateChange
-				if st.ReturnError == nil && !st.ExpectReady {
+				if st.ReturnError != nil && !st.ExpectReady && tc.ExpectError == nil {
 					<-bo.backOffcalled
 				}
 				ready := hs.IsReady("a")


### PR DESCRIPTION
Ref: SRX-AHGZTR
Ref: SRX-TI3JNJ

- TestHealthReporterRetry: There's a background job going on in the ReportHealth function which should be completed before we check the expectations. Sometimes it may be left behind(It's pretty rare). So, if we wait for that and then do the checks, it would solve the problem.
- TestValidateTokenStatic: It seems that we are testing not our code but the code of an underlying library `golang-jwt`. We shouldn't test the error messages that are returned by the library not us.