### PR TITLE
fix(ui): move minor icon to the start of the title of the release

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseCard/ReleaseCard.tsx
@@ -201,7 +201,7 @@ export const ReleaseCard: React.FC<ReleaseCardProps> = (props) => {
         </div>
     );
 
-    const firstLine = sourceMessage.split('\n')[0] + (isMinor ? '💤' : '');
+    const firstLine = (isMinor ? '💤' : '') + sourceMessage.split('\n')[0];
     return (
         <Tooltip id={app + version} tooltipContent={tooltipContents}>
             <div className={'release-card__container'}>


### PR DESCRIPTION
When it was rendered at the end, it would not be rendered at all depending on the length of the commit message.

Ref: SRX-8WMJ13