### PR TITLE
fix(charts): manifest-repo-export-service pod now stores manifest repo in an emptyDir volume 

### DIFF
--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -239,8 +239,7 @@ spec:
           # The repository volume, an emptyDir, is mounted to the kp directory.
           # The manifest-repo-export-service creates the repository inside this directory in /kp/repository.
           # We mount the volume to the parent because kubernetes volumes belong to root.
-          # This way the container can create /kp/repository himself.
-          # DO NOT USE /kp TO STORE ANYTHING ELSE
+          # This way the container can create /kp/repository itself without any permission issues.
           mountPath: /kp/
         - name: ssh
           mountPath: /etc/ssh

--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -236,6 +236,11 @@ spec:
           value: "{{ .Values.git.releaseVersionsLimit }}"
         volumeMounts:
         - name: repository
+          # The repository volume, an emptyDir, is mounted to the kp directory.
+          # The manifest-repo-export-service creates the repository inside this directory in /kp/repository.
+          # We mount the volume to the parent because kubernetes volumes belong to root.
+          # This way the container can create /kp/repository himself.
+          # DO NOT USE /kp TO STORE ANYTHING ELSE
           mountPath: /kp/
         - name: ssh
           mountPath: /etc/ssh

--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -235,6 +235,8 @@ spec:
         - name: KUBERPULT_RELEASE_VERSIONS_LIMIT
           value: "{{ .Values.git.releaseVersionsLimit }}"
         volumeMounts:
+        - name: repository
+          mountPath: /kp/
         - name: ssh
           mountPath: /etc/ssh
 {{- if .Values.datadogProfiling.enabled }}
@@ -252,7 +254,7 @@ spec:
         # EmptyDir has the nice advantage, that it triggers a restart of the pod and creates a new volume when the current one is full
         # Because of an issue in gitlib2, this actually happens.
         emptyDir:
-          sizeLimit: 10Gi
+          sizeLimit: 30Gi
       - name: ssh
         secret:
           secretName: kuberpult-ssh


### PR DESCRIPTION
Altered the mount point of the emptyDir volume for the manifeset-repo-export-service pod.
It now mounts to the home folder so that the service can create the repo from scratch and be the owner.
Altered the size from 10Gi to 30Gi.
The relevant documentation was added to the chart.

Ref: SRX-F26M7C