### PR TITLE
feat: require database

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -18,11 +18,8 @@
 {{- if .Values.cd.tag }}
 {{ fail "Values.cd.tag cannot be used anymore. We only support the same appVersion for all services at this point."}}
 {{ end -}}
-{{- if not (or (eq .Values.db.dbOption "postgreSQL") (eq .Values.db.dbOption "NO_DB")) }}
-{{ fail ".Values.db.dbOption does not contain a valid value (NO_DB, postgreSQL)."}}
-{{ end -}}
-{{- if (and (.Values.db.cloudSqlProxyEnabled) (eq .Values.db.dbOption "NO_DB")) }}
-{{ fail "Cloudsql proxy cannot be used with NO_DB option"}}
+{{- if not (eq .Values.db.dbOption "postgreSQL") }}
+{{ fail ".Values.db.dbOption does not contain a valid value (Only postgreSQL is allowed from now on)."}}
 {{ end -}}
 ---
 apiVersion: apps/v1
@@ -241,10 +238,10 @@ spec:
           value: "{{ .Values.datadogProfiling.enabled }}"
         - name: KUBERPULT_MAXIMUM_QUEUE_SIZE
           value: "{{ .Values.cd.backendConfig.queueSize }}"
-        - name: KUBERPULT_DB_OPTION # { NO_DB, postgreSQL}
+        - name: KUBERPULT_DB_OPTION # { postgreSQL}
           value: {{ .Values.db.dbOption }}
         - name: KUBERPULT_DB_WRITE_ESL_TABLE_ONLY
-          value: "{{ .Values.db.writeEslTableOnly }}"
+          value: "false"
 {{- if (eq .Values.db.dbOption "postgreSQL") }}
         - name: KUBERPULT_DB_LOCATION
           value: {{ .Values.db.location }}

--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -14,15 +14,12 @@
 
 # Copyright freiheit.com
 
-{{- if not (or (eq .Values.db.dbOption "postgreSQL") (eq .Values.db.dbOption "NO_DB")) }}
-{{ fail ".Values.db.dbOption does not contain a valid value (NO_DB, postgreSQL)."}}
+{{- if not (eq .Values.db.dbOption "postgreSQL") }}
+{{ fail ".Values.db.dbOption does not contain a valid value (postgreSQL)."}}
 {{ end -}}
 
 # the export service is only enabled, if the DB is enabled
 {{- if (eq .Values.db.dbOption "postgreSQL") }}
-
-{{- if eq .Values.db.writeEslTableOnly false }}
-
 
 ---
 apiVersion: apps/v1
@@ -290,5 +287,4 @@ spec:
     app: kuberpult-manifest-repo-export-service
   type: NodePort
 
-{{- end }}
 {{- end }}

--- a/charts/kuberpult/tests/charts_test.go
+++ b/charts/kuberpult/tests/charts_test.go
@@ -179,7 +179,7 @@ ingress:
 			ExpectedEnvs: []core.EnvVar{
 				{
 					Name:  "KUBERPULT_DB_OPTION",
-					Value: "NO_DB",
+					Value: "postgreSQL",
 				},
 			},
 			ExpectedMissing: []core.EnvVar{},
@@ -400,37 +400,6 @@ argocd:
 			ExpectedMissing: []core.EnvVar{},
 		},
 		{
-			Name: "Database disabled",
-			Values: `
-git:
-  url: "testURL"
-ingress:
-  domainName: "kuberpult-example.com"
-db:
-  dbOption: NO_DB
-`,
-			ExpectedEnvs: []core.EnvVar{},
-			ExpectedMissing: []core.EnvVar{
-
-				{
-					Name:  "KUBERPULT_DB_LOCATION",
-					Value: "",
-				},
-				{
-					Name:  "KUBERPULT_DB_NAME",
-					Value: "",
-				},
-				{
-					Name:  "KUBERPULT_DB_USER_NAME",
-					Value: "",
-				},
-				{
-					Name:  "KUBERPULT_DB_USER_PASSWORD",
-					Value: "",
-				},
-			},
-		},
-		{
 			Name: "Database postgreSQL enabled 1",
 			Values: `
 git:
@@ -531,50 +500,6 @@ db:
 				{
 					Name:  "KUBERPULT_DB_WRITE_ESL_TABLE_ONLY",
 					Value: "false",
-				},
-			},
-			ExpectedMissing: []core.EnvVar{
-				{
-					Name:  "KUBERPULT_DB_NAME",
-					Value: "",
-				},
-				{
-					Name:  "KUBERPULT_DB_USER_NAME",
-					Value: "does",
-				},
-				{
-					Name:  "KUBERPULT_DB_USER_PASSWORD",
-					Value: "not",
-				},
-			},
-		},
-		{
-			Name: "Database writeEslTableOnly=true",
-			Values: `
-git:
-  url: "testURL"
-ingress:
-  domainName: "kuberpult-example.com"
-db:
-  dbOption: postgreSQL
-  location: /kp/database
-  dbName: does
-  dbUser: not
-  dbPassword: matter
-  writeEslTableOnly: true
-`,
-			ExpectedEnvs: []core.EnvVar{
-				{
-					Name:  "KUBERPULT_DB_OPTION",
-					Value: "postgreSQL",
-				},
-				{
-					Name:  "KUBERPULT_DB_LOCATION",
-					Value: "/kp/database",
-				},
-				{
-					Name:  "KUBERPULT_DB_WRITE_ESL_TABLE_ONLY",
-					Value: "true",
 				},
 			},
 			ExpectedMissing: []core.EnvVar{
@@ -942,38 +867,6 @@ db:
 				},
 			},
 			ExpectedMissing: []core.EnvVar{},
-		},
-		{
-			Name: "Database disabled",
-			Values: `
-git:
-  url: "testURL"
-ingress:
-  domainName: "kuberpult-example.com"
-db:
-  dbOption: NO_DB
-  writeEslTableOnly: false
-`,
-			ExpectedEnvs: []core.EnvVar{},
-			ExpectedMissing: []core.EnvVar{
-
-				{
-					Name:  "KUBERPULT_DB_LOCATION",
-					Value: "",
-				},
-				{
-					Name:  "KUBERPULT_DB_NAME",
-					Value: "",
-				},
-				{
-					Name:  "KUBERPULT_DB_USER_NAME",
-					Value: "",
-				},
-				{
-					Name:  "KUBERPULT_DB_USER_PASSWORD",
-					Value: "",
-				},
-			},
 		},
 		{
 			Name: "Database postgreSQL enabled 1",

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -94,9 +94,9 @@ cd:
     create: false   # Add backend config for health checks on GKE only
     timeoutSec: 300  # 30sec is the default on gcp loadbalancers, however kuberpult needs more with parallel requests. It is the time how long the loadbalancer waits for kuberpult to finish calls to the rest endpoint "release"
     queueSize: 5
-# Disabling the queue is as of now an experimental feature. It's only possible to use with db.writeEslTableOnly=false.
+# Disabling the queue is as of now an experimental feature.
 # With the queue, the cd-service processes only one request at a time, which is very much required when using git.
-# With the database enabled, this is not required anymore.
+# With the database, this is not required anymore.
     disableQueue: false
   resources:
     limits:
@@ -118,29 +118,21 @@ cd:
       timeoutSeconds: 5
       failureThreshold: 10
       initialDelaySeconds: 5
-# The Database is not ready for use on production and the helm options might change in the near future.
 db:
   location: "127.0.0.1"
   authProxyPort: 5432
-# As the Database feature is still work in progress, for now we recommend to set:
-# dbOption: "NO_DB"
-# Other valid values are "postgreSQL".
-# If you do want to try out the database, for now use
-# writeEslTableOnly: true
-  dbOption: "NO_DB"
-# k8sServiceAccountName is required if `dbOption = "postgreSQL"`, otherwise it's ignored.
+# The Database feature is now required:
+  dbOption: "postgreSQL"
+# k8sServiceAccountName is required.
 # k8sServiceAccountName is the name of the kubernetes service account.
   k8sServiceAccountName: "k8sServiceAccountName"
-# cloudSqlProxyEnabled enables the cloudsql proxy. Not possible with `dbOption = "NO_DB"`.
+# cloudSqlProxyEnabled enables the cloudsql proxy.
   cloudSqlProxyEnabled: false
   dbConnectionName: "connectioname"
   dbName: "databaseName"
   dbUser: "username"
   dbPassword: "password"
   migrations: /migrations
-  # If set to true, kuberpult will write only the ESL table.
-  # This is useful to already collect historical data in the database, while waiting for the full database implementation.
-  writeEslTableOnly: false
   # SSL mode to be used by the database
   sslMode: verify-full
   requests:

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,15 +1,11 @@
 # Database
 
-## The Database feature is not ready for production yet
-
-However, you can already prepare for the database feature,
-see [Preparation](#preparation)
-
+## The Database feature is now required
 
 ## Background
 
-Kuberpult is switching over to use a database. The rough timeline to have the database production-ready is summer 2024.
-As of now Kuberpult is using the manifest repository to store data.
+Kuberpult switched over to use a database.
+In the past, Kuberpult was using the manifest repository to store data.
 This worked fine for a while, and it had the added bonus
 that ArgoCD is reading from the same manifest git repository.
 
@@ -21,10 +17,6 @@ Therefore, we will use a database and not rely on git anymore in the future.
 
 Git will still be used as an *output* of kuberpult, but not as the source of truth.
 
-As of now, kuberpult still supports the option to not have the database,
-but this option will be removed in a few weeks with another breaking change in kuberpult.
-
-
 ## Preparation
 
 Our recommendation is to enable the database mode in 2 steps:
@@ -32,6 +24,7 @@ Our recommendation is to enable the database mode in 2 steps:
 ### Step 1: writeEslTableOnly=true
 
 Enable the Database with `db.dbOption: "postgreSQL"` and `db.writeEslTableOnly: true`.
+This requires kuberpult version <= 10.3.10.
 This means that kuberpult will connect to the DB, but only write one table.
 Kuberpult will not read from the database in this state,
 so the manifest-repository is still considered the source of truth.


### PR DESCRIPTION
Ref: SRX-NMC7OD

BREAKING CHANGE: The postgreSQL Database is now required.

The helm-parameter `db.writeEslTableOnly` is not supported anymore.
The helm-parameter `db.dbOption` now only supports the option "postgreSQL", which is now also the default.

See docs/database.md for details.

Note that there is now some "dead code", especially in the cd-service that deals with git. This will be removed later on.