### PR TITLE
fix(manifest-repo-export-service): measure pushes write when nothing to push

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -49,7 +49,7 @@ This metric measures each failure in the manifest-repo-export-service to push to
 It measures 0 if there are currently no failures, and 1 if there are.
 
 This metric is allways written, even if there is nothing for kuberpult to push.
-In case kuberpult has nothing to push this metric writes 0.
+In case kuberpult has nothing to push this metric writes 0 every `manifestRepoExport.eslProcessingIdleTimeSeconds` seconds.
 
 
 #### Monitoring Processing Delay

--- a/docs/database.md
+++ b/docs/database.md
@@ -48,7 +48,8 @@ Metric `Kuberpult.manifest_export_push_failures`.
 This metric measures each failure in the manifest-repo-export-service to push to the git repository.
 It measures 0 if there are currently no failures, and 1 if there are.
 
-This metric is only written, if there is something for kuberpult to push.
+This metric is allways written, even if there is nothing for kuberpult to push.
+In case kuberpult has nothing to push this metric writes 0.
 
 
 #### Monitoring Processing Delay

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -322,6 +322,7 @@ func processEsls(ctx context.Context, repo repository.Repository, dbHandler *db.
 			if transformer == nil {
 				sleepDuration.Reset()
 				d := sleepDuration.NextBackOff()
+				measurePushes(ddMetrics, log, false)
 				logger.FromContext(ctx).Sugar().Warnf("event processing skipped, will try again in %v", d)
 				time.Sleep(d)
 				continue


### PR DESCRIPTION
The `measurePushes` method sends metrics to datadog about wether the manifest repo export service successfully pushed to git.
This PR makes the service write the metric, as a success, even when there are no pushes.

Ref: SRX-PLAY6B