### PR TITLE
fix: improve app details calculate warnings performance

### DIFF
--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -103,11 +103,8 @@ func (o *OverviewServiceServer) GetAppDetails(
 		for idx, r := range rels {
 			uintRels[idx] = uint64(r)
 		}
-		//Does not get the manifest and gets all releases at the same time
+
 		releases, err := o.DBHandler.DBSelectReleasesByVersions(ctx, transaction, appName, uintRels, false)
-		if err != nil {
-			return nil, err
-		}
 		for _, currentRelease := range releases {
 			var tmp = &repository.Release{
 				Version:         currentRelease.ReleaseNumber,

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -105,6 +105,9 @@ func (o *OverviewServiceServer) GetAppDetails(
 		}
 
 		releases, err := o.DBHandler.DBSelectReleasesByVersions(ctx, transaction, appName, uintRels, false)
+		if err != nil {
+			return nil, err
+		}
 		for _, currentRelease := range releases {
 			var tmp = &repository.Release{
 				Version:         currentRelease.ReleaseNumber,

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -103,7 +103,7 @@ func (o *OverviewServiceServer) GetAppDetails(
 		for idx, r := range rels {
 			uintRels[idx] = uint64(r)
 		}
-
+		//Does not get the manifest and gets all releases at the same time
 		releases, err := o.DBHandler.DBSelectReleasesByVersions(ctx, transaction, appName, uintRels, false)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
We already had access to all of this information on the GetAppDEtails endpoint, no need to query the database again

Ref: SRX-E9K6SV