### PR TITLE
fix(trivy): run trivy as late as possible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,19 +63,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.semrel.outputs.version }}
-      - name: Append vulnerability reports to release
-        run: |
-          echo $VERSION
-          earthly ./trivy+scan-all --kuberpult_version=v${VERSION}
-          gh release upload v$VERSION trivy/kuberpult-v${VERSION}-reports.tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.semrel.outputs.version }}
       - name: Append postgres migrations to release
         run: |
           cd database/migrations
           tar -czhf postgres_migrations.tar.gz postgres/
           gh release upload v$VERSION ./postgres_migrations.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.semrel.outputs.version }}
+      - name: Append vulnerability reports to release
+        run: |
+          echo $VERSION
+          earthly ./trivy+scan-all --kuberpult_version=v${VERSION}
+          gh release upload v$VERSION trivy/kuberpult-v${VERSION}-reports.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.semrel.outputs.version }}


### PR DESCRIPTION
As of now we have an issue with rate limiting for trivy. This is a workaround, so that we can easier create releases, even when trivy does not work.

Ref: SRX-2CSAEK