### PR TITLE
feat(db): string lists inserted into the databse are sorted

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1120,6 +1120,7 @@ func (h *DBHandler) DBInsertRelease(ctx context.Context, transaction *sql.Tx, re
 		envs = append(envs, env)
 	}
 	release.Environments = envs
+	slices.Sort(release.Environments) // we don't really *need* the sorting, it's just for convenience
 	environmentStr, err := json.Marshal(release.Environments)
 	if err != nil {
 		return fmt.Errorf("could not marshal release environments: %w", err)
@@ -5392,6 +5393,7 @@ func (h *DBHandler) DBWriteEnvironment(ctx context.Context, tx *sql.Tx, environm
 	if err != nil {
 		return fmt.Errorf("error while selecting environment %s from database, error: %w", environmentName, err)
 	}
+	slices.Sort(applications) // we don't really *need* the sorting, it's just for convenience
 	applicationsJson, err := json.Marshal(applications)
 	if err != nil {
 		return fmt.Errorf("could not marshal the application names list %v, error: %w", applicationsJson, err)
@@ -5495,6 +5497,7 @@ func (h *DBHandler) DBWriteAllEnvironments(ctx context.Context, transaction *sql
 	span, ctx := tracer.StartSpanFromContext(ctx, "DBWriteAllEnvironments")
 	defer span.Finish()
 
+	slices.Sort(environmentNames) // we don't really *need* the sorting, it's just for convenience
 	jsonToInsert, err := json.Marshal(environmentNames)
 	if err != nil {
 		return fmt.Errorf("could not marshal the environment names list %v, error: %w", environmentNames, err)

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1946,7 +1946,7 @@ func TestReadWriteEnvironment(t *testing.T) {
 			EnvsToWrite: []EnvAndConfig{
 				{
 					EnvironmentName:   "development",
-					EnvironmentConfig: testutil.MakeEnvConfigLatestWithGroup(nil, conversion.FromString("development-group")), // "elaborate config" being the env group
+					EnvironmentConfig: testutil.MakeEnvConfigLatest(nil),
 					Applications:      []string{"zapp", "app1", "capp"},
 				},
 			},
@@ -1954,12 +1954,11 @@ func TestReadWriteEnvironment(t *testing.T) {
 			ExpectedEntry: &DBEnvironment{
 				Version:      1,
 				Name:         "development",
-				Config:       testutil.MakeEnvConfigLatestWithGroup(nil, conversion.FromString("development-group")),
+				Config:       testutil.MakeEnvConfigLatest(nil),
 				Applications: []string{"app1", "capp", "zapp"},
 			},
 		},
 	}
-
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
@@ -1996,7 +1995,6 @@ func TestReadWriteEnvironment(t *testing.T) {
 		})
 	}
 }
-
 func TestReadWriteEslEvent(t *testing.T) {
 	const envName = "dev"
 	const appName = "my-app"

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1941,7 +1941,25 @@ func TestReadWriteEnvironment(t *testing.T) {
 			},
 			EnvToQuery: "development",
 		},
+		{
+			Name: "write one environment and read it, test that it orders applications",
+			EnvsToWrite: []EnvAndConfig{
+				{
+					EnvironmentName:   "development",
+					EnvironmentConfig: testutil.MakeEnvConfigLatestWithGroup(nil, conversion.FromString("development-group")), // "elaborate config" being the env group
+					Applications:      []string{"zapp", "app1", "capp"},
+				},
+			},
+			EnvToQuery: "development",
+			ExpectedEntry: &DBEnvironment{
+				Version:      1,
+				Name:         "development",
+				Config:       testutil.MakeEnvConfigLatestWithGroup(nil, conversion.FromString("development-group")),
+				Applications: []string{"app1", "capp", "zapp"},
+			},
+		},
 	}
+
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
@@ -1978,6 +1996,7 @@ func TestReadWriteEnvironment(t *testing.T) {
 		})
 	}
 }
+
 func TestReadWriteEslEvent(t *testing.T) {
 	const envName = "dev"
 	const appName = "my-app"
@@ -2233,12 +2252,22 @@ func TestReadWriteAllEnvironments(t *testing.T) {
 			Name: "create entries with increasing length",
 			AllEnvsToWrite: [][]string{
 				{"development"},
-				{"development", "staging"},
-				{"development", "staging", "production"},
+				{"development", "production"},
+				{"development", "production", "staging"},
 			},
 			ExpectedEntry: &DBAllEnvironments{
 				Version:      3,
-				Environments: []string{"development", "staging", "production"},
+				Environments: []string{"development", "production", "staging"},
+			},
+		},
+		{
+			Name: "ensure that environments are sorted",
+			AllEnvsToWrite: [][]string{
+				{"staging", "development", "production"},
+			},
+			ExpectedEntry: &DBAllEnvironments{
+				Version:      1,
+				Environments: []string{"development", "production", "staging"},
 			},
 		},
 	}
@@ -2280,6 +2309,65 @@ func TestReadWriteAllEnvironments(t *testing.T) {
 	}
 }
 
+func TestReadWriteAllApplications(t *testing.T) {
+	type TestCase struct {
+		Name           string
+		AllAppsToWrite [][]string
+		ExpectedEntry  *AllApplicationsGo
+	}
+
+	testCases := []TestCase{
+		{
+			Name: "test that app are ordered",
+			AllAppsToWrite: [][]string{
+				{"my_app", "ze_app", "the_app"},
+			},
+			ExpectedEntry: &AllApplicationsGo{
+				Version: 1,
+				AllApplicationsJson: AllApplicationsJson{
+					Apps: []string{"my_app", "the_app", "ze_app"},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.MakeTestContext()
+			dbHandler := setupDB(t)
+
+			for version, allApps := range tc.AllAppsToWrite {
+				err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+					err := dbHandler.DBWriteAllApplications(ctx, transaction, int64(version), allApps)
+					if err != nil {
+						return fmt.Errorf("error while writing application, error: %w", err)
+					}
+					return nil
+				})
+				if err != nil {
+					t.Fatalf("error while running the transaction for writing all applications %v to the database, error: %v", allApps, err)
+				}
+			}
+
+			allAppsEntry, err := WithTransactionT(dbHandler, ctx, DefaultNumRetries, true, func(ctx context.Context, transaction *sql.Tx) (*AllApplicationsGo, error) {
+				allAppsEntry, err := dbHandler.DBSelectAllApplications(ctx, transaction)
+				if err != nil {
+					return nil, fmt.Errorf("error while selecting application entry, error: %w", err)
+				}
+				return allAppsEntry, nil
+			})
+
+			if err != nil {
+				t.Fatalf("error while running the transaction for selecting the target all applications, error: %v", err)
+			}
+			if diff := cmp.Diff(allAppsEntry, tc.ExpectedEntry, cmpopts.IgnoreFields(AllApplicationsGo{}, "Created")); diff != "" {
+				t.Fatalf("the received entry is different from expected\n  expected: %v\n  received: %v\n  diff: %s\n", tc.ExpectedEntry, allAppsEntry, diff)
+			}
+		})
+	}
+}
+
 func TestReadReleasesByApp(t *testing.T) {
 
 	tcs := []struct {
@@ -2308,6 +2396,27 @@ func TestReadReleasesByApp(t *testing.T) {
 					App:           "app1",
 					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest1"}},
 					Environments:  []string{"dev"},
+				},
+			},
+		},
+		{
+			Name: "Retrieved release has ordered environments",
+			Releases: []DBReleaseWithMetaData{
+				{
+					EslVersion:    1,
+					ReleaseNumber: 10,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest1", "staging": "manfest2", "production": "manfest2"}},
+				},
+			},
+			AppName: "app1",
+			Expected: []*DBReleaseWithMetaData{
+				{
+					EslVersion:    1,
+					ReleaseNumber: 10,
+					App:           "app1",
+					Manifests:     DBReleaseManifests{Manifests: map[string]string{"dev": "manifest1", "staging": "manfest2", "production": "manfest2"}},
+					Environments:  []string{"dev", "production", "staging"},
 				},
 			},
 		},


### PR DESCRIPTION
## Features:

The following columns have lists of strings which are now sorted:
* `environments.applications`
* `releases.environments`
* `all_environments.json`
The column `all_apps.json` was already being previously sorted.

## Tests:
4 new test cases were added for each of the tables testing that string lists are ordered when inserted.
The `all_apps` table had no write and read test suite so a new one was created with the corresponding test case.

Ref: SRX-FEUSCN