### PR TITLE
fix(cd-service): Added new check for non existing env

### DIFF
--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1973,6 +1973,9 @@ func (s *State) checkUserPermissions(ctx context.Context, transaction *sql.Tx, e
 	if err != nil {
 		return err
 	}
+	if config == nil {
+		return fmt.Errorf(fmt.Sprintf("checkUserPermissions: environment not found: %s", env))
+	}
 	group := mapper.DeriveGroupName(*config, env)
 
 	if group == "" {


### PR DESCRIPTION
Fixes a nil pointer when a manifest for a non-existing environment is submitted in the /release endpoint.

Ref: SRX-QCRRU1