### PR TITLE
fix(rollout-service): improved logging

### DIFF
--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -292,7 +292,7 @@ func runBackgroundTask(ctx context.Context, config BackgroundTaskConfig, cancel 
 	} else {
 		select {
 		case <-ctx.Done():
-			// task finished with no error and context was cancelled, normal shutdown
+			logger.FromContext(ctx).Info("Background task terminated with shutdown signal: " + config.Name)
 		default:
 			logger.FromContext(ctx).Warn("Background task terminated without error or shutdown signal: " + config.Name)
 		}

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -289,6 +289,13 @@ func runBackgroundTask(ctx context.Context, config BackgroundTaskConfig, cancel 
 	defer cancel()
 	if err := config.Run(ctx, reporter); err != nil {
 		logger.FromContext(ctx).Error("background.error", zap.Error(err), zap.String("job", config.Name))
+	} else {
+		select {
+		case <-ctx.Done():
+			// task finished with no error and context was cancelled, normal shutdown
+		default:
+			logger.FromContext(ctx).Warn("Background task terminated without error or shutdown signal: " + config.Name)
+		}
 	}
 }
 

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -290,6 +290,7 @@ func runServer(ctx context.Context, config Config) error {
 		},
 	})
 
+	fmt.Println("OUCH")
 	setup.Run(ctx, setup.ServerConfig{
 		HTTP: []setup.HTTPConfig{
 			{

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -290,7 +290,6 @@ func runServer(ctx context.Context, config Config) error {
 		},
 	})
 
-	fmt.Println("OUCH")
 	setup.Run(ctx, setup.ServerConfig{
 		HTTP: []setup.HTTPConfig{
 			{


### PR DESCRIPTION
The rollout service is crashing and the logs do not provide useful feedback.
This PR adds logs to improve visibility in the kuberpult background task shutdown process.

Ref: SRX-FEUSCN