### PR TITLE
fix: add tracing for metrics collection

### DIFF
--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -227,7 +227,7 @@ func UpdateDatadogMetrics(ctx context.Context, transaction *sql.Tx, state *State
 }
 
 func UpdateChangedAppMetrics(ctx context.Context, changes *TransformerResult, now time.Time) error {
-	span, ctx := tracer.StartSpanFromContext(ctx, "UpdateChangedAppMetrics")
+	span, _ := tracer.StartSpanFromContext(ctx, "UpdateChangedAppMetrics")
 	defer span.Finish()
 	if changes != nil && ddMetrics != nil {
 		for i := range changes.ChangedApps {


### PR DESCRIPTION
Collecting metrics for all envs/apps/locks takes significant time, so we add some spans around it.

Ref: SRX-Z8BHWD