### PR TITLE
fix: Speed up metrics collection by using the overview cache

### DIFF
--- a/pkg/db/overview.go
+++ b/pkg/db/overview.go
@@ -35,7 +35,7 @@ func (h *DBHandler) UpdateOverviewTeamLock(ctx context.Context, transaction *sql
 	if h.IsOverviewEmpty(latestOverview) {
 		return nil
 	}
-	env := getEnvironmentByName(latestOverview.EnvironmentGroups, teamLock.Env)
+	env := GetEnvironmentByName(latestOverview.EnvironmentGroups, teamLock.Env)
 	if env == nil {
 		return fmt.Errorf("could not find environment %s in overview", teamLock.Env)
 	}
@@ -88,7 +88,7 @@ func (h *DBHandler) UpdateOverviewEnvironmentLock(ctx context.Context, transacti
 	if h.IsOverviewEmpty(latestOverview) {
 		return nil
 	}
-	env := getEnvironmentByName(latestOverview.EnvironmentGroups, environmentLock.Env)
+	env := GetEnvironmentByName(latestOverview.EnvironmentGroups, environmentLock.Env)
 	if env == nil {
 		return fmt.Errorf("could not find environment %s in overview", environmentLock.Env)
 	}
@@ -122,7 +122,7 @@ func (h *DBHandler) UpdateOverviewApplicationLock(ctx context.Context, transacti
 	if h.IsOverviewEmpty(latestOverview) {
 		return nil
 	}
-	env := getEnvironmentByName(latestOverview.EnvironmentGroups, applicationLock.Env)
+	env := GetEnvironmentByName(latestOverview.EnvironmentGroups, applicationLock.Env)
 	if env == nil {
 		return fmt.Errorf("could not find environment %s in overview", applicationLock.Env)
 	}
@@ -218,7 +218,7 @@ AND eslversion NOT IN (
 	return nil
 }
 
-func getEnvironmentByName(groups []*api.EnvironmentGroup, envNameToReturn string) *api.Environment {
+func GetEnvironmentByName(groups []*api.EnvironmentGroup, envNameToReturn string) *api.Environment {
 	for _, currentGroup := range groups {
 		for _, currentEnv := range currentGroup.Environments {
 			if currentEnv.Name == envNameToReturn {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -105,7 +105,7 @@ func (err *TransformerBatchApplyError) Is(target error) bool {
 	if err == nil {
 		return target == nil
 	}
-	if target == nil {
+	if target == nil || tgt == nil {
 		return false
 	}
 	// now both target and err are guaranteed to be non-nil
@@ -115,9 +115,12 @@ func (err *TransformerBatchApplyError) Is(target error) bool {
 	return errors.Is(err.TransformerError, tgt.TransformerError)
 }
 
-func (e *TransformerBatchApplyError) Unwrap() error {
+func (err *TransformerBatchApplyError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
 	// Return the inner error.
-	return e.TransformerError
+	return err.TransformerError
 }
 
 func UnwrapUntilTransformerBatchApplyError(err error) *TransformerBatchApplyError {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -268,6 +268,9 @@ func UpdateLockMetrics(ctx context.Context, transaction *sql.Tx, state *State, n
 	if err != nil {
 		return err
 	}
+	if overviewCache == nil {
+		return fmt.Errorf("UpdateLockMetrics could not get overview: nil")
+	}
 
 	for envName := range envConfigs {
 		envFromCache := db.GetEnvironmentByName(overviewCache.EnvironmentGroups, envName)

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1681,6 +1681,9 @@ func (u *UndeployApplication) Transform(
 		if err != nil {
 			return "", fmt.Errorf("UndeployApplication: could not get all environments: %v", err)
 		}
+		if allEnvs == nil {
+			return "", fmt.Errorf("UndeployApplication: all environments nil")
+		}
 		for _, envName := range allEnvs.Environments {
 			env, err := state.DBHandler.DBSelectEnvironment(ctx, transaction, envName)
 			if err != nil {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1835,6 +1835,7 @@ func (u *DeleteEnvFromApp) Transform(
 		if err != nil {
 			return "", fmt.Errorf("Couldn't write environment: %s into environments table, error: %w", u.Environment, err)
 		}
+		t.DeleteEnvFromApp(u.Application, u.Environment)
 	} else {
 
 		fs := state.Filesystem

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1405,314 +1405,480 @@ func verifyContent(fs billy.Filesystem, required []FileWithContent) error {
 	return nil
 }
 
-//func TestApplicationDeploymentEvent(t *testing.T) {
-//	type TestCase struct {
-//		Name             string
-//		Transformers     []Transformer
-//		db               bool
-//		expectedDBEvents []event.Event
-//	}
-//
-//	tcs := []TestCase{
-//		{
-//			Name: "Create a single application version and deploy it",
-//			// no need to bother with environments here
-//			Transformers: []Transformer{
-//				&CreateApplicationVersion{
-//					Application:    "app",
-//					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-//					Manifests: map[string]string{
-//						"staging": "doesn't matter",
-//					},
-//					WriteCommitData: true,
-//					Version:         1,
-//				},
-//				&DeployApplicationVersion{
-//					Application:     "app",
-//					Environment:     "staging",
-//					WriteCommitData: true,
-//					Version:         1,
-//				},
-//			},
-//		},
-//		{
-//			Name: "Trigger a deployment via a relase train with environment target",
-//			Transformers: []Transformer{
-//				&CreateEnvironment{
-//					Environment: "production",
-//					Config: config.EnvironmentConfig{
-//						Upstream: &config.EnvironmentConfigUpstream{
-//							Environment: "staging",
-//						},
-//					},
-//				},
-//				&CreateEnvironment{
-//					Environment: "staging",
-//					Config: config.EnvironmentConfig{
-//						Upstream: &config.EnvironmentConfigUpstream{
-//							Environment: "staging",
-//							Latest:      true,
-//						},
-//					},
-//				},
-//				&CreateApplicationVersion{
-//					Application:    "app",
-//					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
-//					Manifests: map[string]string{
-//						"production": "some production manifest 2",
-//						"staging":    "some staging manifest 2",
-//					},
-//					WriteCommitData: true,
-//					Version:         1,
-//				},
-//				&DeployApplicationVersion{
-//					Environment:     "staging",
-//					Application:     "app",
-//					Version:         1,
-//					WriteCommitData: true,
-//				},
-//				&ReleaseTrain{
-//					Target:          "production",
-//					WriteCommitData: true,
-//				},
-//			},
-//		},
-//		{
-//			Name: "Trigger a deployment via a release train with environment group target without lock",
-//			Transformers: []Transformer{
-//				&CreateEnvironment{
-//					Environment: "production",
-//					Config: config.EnvironmentConfig{
-//						Upstream: &config.EnvironmentConfigUpstream{
-//							Environment: "staging",
-//						},
-//						EnvironmentGroup: conversion.FromString("production-group"),
-//					},
-//				},
-//				&CreateEnvironment{
-//					Environment: "staging",
-//					Config: config.EnvironmentConfig{
-//						Upstream: &config.EnvironmentConfigUpstream{
-//							Environment: "staging",
-//							Latest:      true,
-//						},
-//					},
-//				},
-//				&CreateApplicationVersion{
-//					Application:    "app",
-//					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
-//					Manifests: map[string]string{
-//						"production": "some production manifest 2",
-//						"staging":    "some staging manifest 2",
-//					},
-//					WriteCommitData: true,
-//					Version:         1,
-//				},
-//				&DeployApplicationVersion{
-//					Environment:     "staging",
-//					Application:     "app",
-//					Version:         1,
-//					WriteCommitData: true,
-//				},
-//				&ReleaseTrain{
-//					Target:          "production-group",
-//					WriteCommitData: true,
-//				},
-//			},
-//		},
-//		{
-//			Name: "Trigger a deployment via a release train with environment group target with lock",
-//			Transformers: []Transformer{
-//				&CreateEnvironment{
-//					Environment: "production",
-//					Config: config.EnvironmentConfig{
-//						Upstream: &config.EnvironmentConfigUpstream{
-//							Environment: "staging",
-//						},
-//						EnvironmentGroup: conversion.FromString("production-group"),
-//					},
-//				},
-//				&CreateEnvironment{
-//					Environment: "staging",
-//					Config: config.EnvironmentConfig{
-//						Upstream: &config.EnvironmentConfigUpstream{
-//							Environment: "staging",
-//							Latest:      true,
-//						},
-//					},
-//				},
-//				&CreateApplicationVersion{
-//					Application:    "app",
-//					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
-//					Manifests: map[string]string{
-//						"production": "some production manifest 2",
-//						"staging":    "some staging manifest 2",
-//					},
-//					WriteCommitData: true,
-//					Version:         1,
-//				},
-//				&DeployApplicationVersion{
-//					Environment:     "staging",
-//					Application:     "app",
-//					Version:         1,
-//					WriteCommitData: true,
-//				},
-//				&CreateEnvironmentLock{
-//					Environment: "production",
-//					LockId:      "lock id 1",
-//					Message:     "lock msg 1",
-//				},
-//				&ReleaseTrain{
-//					Target:          "production-group",
-//					WriteCommitData: true,
-//				},
-//			},
-//		},
-//		{
-//			Name: "Block deployments using env lock",
-//			Transformers: []Transformer{
-//				&CreateEnvironment{
-//					Environment: "dev",
-//					Config: config.EnvironmentConfig{
-//						Upstream: &config.EnvironmentConfigUpstream{
-//							Latest: true,
-//						},
-//					},
-//				},
-//				&CreateEnvironment{
-//					Environment: "staging",
-//					Config: config.EnvironmentConfig{
-//						Upstream: &config.EnvironmentConfigUpstream{
-//							Latest: true,
-//						},
-//					},
-//				},
-//				&CreateEnvironmentLock{
-//					Environment: "staging",
-//					LockId:      "lock1",
-//					Message:     "lock staging",
-//				},
-//				&CreateApplicationVersion{
-//					Application:    "myapp",
-//					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
-//					Manifests: map[string]string{
-//						"dev":     "some dev manifest",
-//						"staging": "some staging manifest",
-//					},
-//					WriteCommitData: true,
-//					Version:         3,
-//				},
-//			},
-//		},
-//		{
-//			Name: "Block deployments using app lock",
-//			Transformers: []Transformer{
-//				&CreateEnvironment{
-//					Environment: "dev",
-//					Config: config.EnvironmentConfig{
-//						Upstream: &config.EnvironmentConfigUpstream{
-//							Latest: true,
-//						},
-//					},
-//				},
-//				&CreateEnvironment{
-//					Environment: "staging",
-//					Config: config.EnvironmentConfig{
-//						Upstream: &config.EnvironmentConfigUpstream{
-//							Latest: true,
-//						},
-//					},
-//				},
-//				//&CreateEnvironmentLock{
-//				//	Environment: "staging",
-//				//	LockId:      "lock1",
-//				//	Message:     "lock staging",
-//				//},
-//				&CreateEnvironmentApplicationLock{
-//					Environment: "staging",
-//					Application: "myapp",
-//					LockId:      "lock2",
-//					Message:     "lock myapp",
-//				},
-//				&CreateApplicationVersion{
-//					Application:    "myapp",
-//					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
-//					Manifests: map[string]string{
-//						"dev":     "some dev manifest",
-//						"staging": "some staging manifest",
-//					},
-//					WriteCommitData: true,
-//					Version:         4,
-//				},
-//			},
-//		},
-//		{
-//			Name: "Block deployments using Team lock",
-//			Transformers: []Transformer{
-//				&CreateEnvironment{
-//					Environment: "dev",
-//					Config: config.EnvironmentConfig{
-//						Upstream: &config.EnvironmentConfigUpstream{
-//							Latest: true,
-//						},
-//					},
-//				},
-//				&CreateApplicationVersion{ //Create the team
-//					Application:    "someapp",
-//					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaf",
-//					Manifests: map[string]string{
-//						"dev": "some dev manifest",
-//					},
-//					WriteCommitData: true,
-//					Team:            "sre-team",
-//					Version:         5,
-//				},
-//				&CreateEnvironmentTeamLock{
-//					Environment: "dev",
-//					Team:        "sre-team",
-//					LockId:      "lock2",
-//					Message:     "lock sreteam",
-//				},
-//				&CreateApplicationVersion{
-//					Application:    "myapp",
-//					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
-//					Manifests: map[string]string{
-//						"dev": "some dev manifest",
-//					},
-//					WriteCommitData: true,
-//					Team:            "sre-team",
-//					Version:         6,
-//				},
-//			},
-//		},
-//	}
-//
-//	for _, tc := range tcs {
-//		t.Run(tc.Name, func(t *testing.T) {
-//			tc := tc
-//			t.Parallel()
-//
-//			fakeGen := testutil.NewIncrementalUUIDGenerator()
-//			ctx := testutil.MakeTestContext()
-//			ctx = AddGeneratorToContext(ctx, fakeGen)
-//			var repo Repository
-//			var err error = nil
-//			repo = SetupRepositoryTestWithDB(t)
-//
-//			_, err = db.WithTransactionT(repo.State().DBHandler, ctx, 0, false, func(ctx context.Context, transaction *sql.Tx) (*[]string, error) {
-//				var batchError *TransformerBatchApplyError = nil
-//				_, _, _, batchError = repo.ApplyTransformersInternal(ctx, transaction, tc.Transformers...)
-//				if batchError != nil {
-//					t.Fatalf("2 encountered error but no error is expected here: '%v'", batchError)
-//				}
-//				return nil, nil
-//			})
-//			if err != nil {
-//				t.Fatalf("encountered error but no error is expected here: '%v'", err)
-//			}
-//		})
-//	}
-//}
+func TestApplicationDeploymentEvent(t *testing.T) {
+	type TestCase struct {
+		Name             string
+		Transformers     []Transformer
+		expectedContent  []FileWithContent
+		db               bool
+		expectedDBEvents []event.Event
+	}
+
+	tcs := []TestCase{
+		{
+			Name: "Create a single application version and deploy it",
+			// no need to bother with environments here
+			Transformers: []Transformer{
+				&CreateApplicationVersion{
+					Application:    "app",
+					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Manifests: map[string]string{
+						"staging": "doesn't matter",
+					},
+					WriteCommitData: true,
+				},
+				&DeployApplicationVersion{
+					Application:     "app",
+					Environment:     "staging",
+					WriteCommitData: true,
+					Version:         1,
+				},
+			},
+			expectedContent: []FileWithContent{
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events/00000000-0000-0000-0000-000000000001/application",
+					Content: "app",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events/00000000-0000-0000-0000-000000000001/environment",
+					Content: "staging",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events/00000000-0000-0000-0000-000000000001/eventType",
+					Content: "deployment",
+				},
+			},
+		},
+		{
+			Name: "Trigger a deployment via a relase train with environment target",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "production",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Environment: "staging",
+						},
+					},
+				},
+				&CreateEnvironment{
+					Environment: "staging",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Environment: "staging",
+							Latest:      true,
+						},
+					},
+				},
+				&CreateApplicationVersion{
+					Application:    "app",
+					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					Manifests: map[string]string{
+						"production": "some production manifest 2",
+						"staging":    "some staging manifest 2",
+					},
+					WriteCommitData: true,
+				},
+				&DeployApplicationVersion{
+					Environment:     "staging",
+					Application:     "app",
+					Version:         1,
+					WriteCommitData: true,
+				},
+				&ReleaseTrain{
+					Target:          "production",
+					WriteCommitData: true,
+				},
+			},
+			expectedContent: []FileWithContent{
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/application",
+					Content: "app",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/environment",
+					Content: "production",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/eventType",
+					Content: "deployment",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/source_train_upstream",
+					Content: "staging",
+				},
+			},
+		},
+		{
+			Name: "Trigger a deployment via a release train with environment group target without lock",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "production",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Environment: "staging",
+						},
+						EnvironmentGroup: conversion.FromString("production-group"),
+					},
+				},
+				&CreateEnvironment{
+					Environment: "staging",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Environment: "staging",
+							Latest:      true,
+						},
+					},
+				},
+				&CreateApplicationVersion{
+					Application:    "app",
+					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					Manifests: map[string]string{
+						"production": "some production manifest 2",
+						"staging":    "some staging manifest 2",
+					},
+					WriteCommitData: true,
+					Version:         1,
+				},
+				&DeployApplicationVersion{
+					Environment:     "staging",
+					Application:     "app",
+					Version:         1,
+					WriteCommitData: true,
+				},
+				&ReleaseTrain{
+					Target:          "production-group",
+					WriteCommitData: true,
+				},
+			},
+			expectedContent: []FileWithContent{
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/application",
+					Content: "app",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/environment",
+					Content: "production",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/eventType",
+					Content: "deployment",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/source_train_upstream",
+					Content: "staging",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/source_train_environment_group",
+					Content: "production-group",
+				},
+			},
+		},
+		{
+			Name: "Trigger a deployment via a release train with environment group target with lock",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "production",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Environment: "staging",
+						},
+						EnvironmentGroup: conversion.FromString("production-group"),
+					},
+				},
+				&CreateEnvironment{
+					Environment: "staging",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Environment: "staging",
+							Latest:      true,
+						},
+					},
+				},
+				&CreateApplicationVersion{
+					Application:    "app",
+					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					Manifests: map[string]string{
+						"production": "some production manifest 2",
+						"staging":    "some staging manifest 2",
+					},
+					WriteCommitData: true,
+					Version:         1,
+				},
+				&DeployApplicationVersion{
+					Environment:     "staging",
+					Application:     "app",
+					Version:         1,
+					WriteCommitData: true,
+				},
+				&CreateEnvironmentLock{
+					Environment: "production",
+					LockId:      "lock id 1",
+					Message:     "lock msg 1",
+				},
+				&ReleaseTrain{
+					Target:          "production-group",
+					WriteCommitData: true,
+				},
+			},
+			expectedContent: []FileWithContent{
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/eventType",
+					Content: "deployment",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/eventType",
+					Content: "deployment",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000003/eventType",
+					Content: "replaced-by",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/eventType",
+					Content: "lock-prevented-deployment",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/lock_message",
+					Content: "lock msg 1",
+				},
+			},
+		},
+		{
+			Name: "Block deployments using env lock",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "dev",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Latest: true,
+						},
+					},
+				},
+				&CreateEnvironment{
+					Environment: "staging",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Latest: true,
+						},
+					},
+				},
+				&CreateEnvironmentLock{
+					Environment: "staging",
+					LockId:      "lock1",
+					Message:     "lock staging",
+				},
+				&CreateApplicationVersion{
+					Application:    "myapp",
+					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					Manifests: map[string]string{
+						"dev":     "some dev manifest",
+						"staging": "some staging manifest",
+					},
+					WriteCommitData: true,
+					Version:         3,
+				},
+			},
+			expectedContent: []FileWithContent{
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/eventType",
+					Content: "deployment",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/application",
+					Content: "myapp",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/environment",
+					Content: "dev",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/eventType",
+					Content: "lock-prevented-deployment",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/application",
+					Content: "myapp",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/environment",
+					Content: "staging",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/lock_message",
+					Content: "lock staging",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/lock_type",
+					Content: "environment",
+				},
+			},
+		},
+		{
+			Name: "Block deployments using app lock",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "dev",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Latest: true,
+						},
+					},
+				},
+				&CreateEnvironment{
+					Environment: "staging",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Latest: true,
+						},
+					},
+				},
+				//				&CreateEnvironmentLock{
+				//					Environment: "staging",
+				//					LockId:      "lock1",
+				//					Message:     "lock staging",
+				//				},
+				&CreateEnvironmentApplicationLock{
+					Environment: "staging",
+					Application: "myapp",
+					LockId:      "lock2",
+					Message:     "lock myapp",
+				},
+				&CreateApplicationVersion{
+					Application:    "myapp",
+					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					Manifests: map[string]string{
+						"dev":     "some dev manifest",
+						"staging": "some staging manifest",
+					},
+					WriteCommitData: true,
+					Version:         4,
+				},
+			},
+			expectedContent: []FileWithContent{
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/eventType",
+					Content: "deployment",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/application",
+					Content: "myapp",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/environment",
+					Content: "dev",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/eventType",
+					Content: "lock-prevented-deployment",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/application",
+					Content: "myapp",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/environment",
+					Content: "staging",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/lock_message",
+					Content: "lock myapp",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/lock_type",
+					Content: "application",
+				},
+			},
+		},
+		{
+			Name: "Block deployments using Team lock",
+			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "dev",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Latest: true,
+						},
+					},
+				},
+				&CreateApplicationVersion{ //Create the team
+					Application:    "someapp",
+					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaf",
+					Manifests: map[string]string{
+						"dev": "some dev manifest",
+					},
+					WriteCommitData: true,
+					Team:            "sre-team",
+					Version:         5,
+				},
+				&CreateEnvironmentTeamLock{
+					Environment: "dev",
+					Team:        "sre-team",
+					LockId:      "lock2",
+					Message:     "lock sreteam",
+				},
+				&CreateApplicationVersion{
+					Application:    "myapp",
+					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					Manifests: map[string]string{
+						"dev": "some dev manifest",
+					},
+					WriteCommitData: true,
+					Team:            "sre-team",
+					Version:         6,
+				},
+			},
+			expectedContent: []FileWithContent{
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000003/eventType",
+					Content: "lock-prevented-deployment",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000003/application",
+					Content: "myapp",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000003/environment",
+					Content: "dev",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000003/lock_message",
+					Content: "lock sreteam",
+				},
+				{
+					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000003/lock_type",
+					Content: "team",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			tc := tc
+			t.Parallel()
+
+			fakeGen := testutil.NewIncrementalUUIDGenerator()
+			ctx := testutil.MakeTestContext()
+			ctx = AddGeneratorToContext(ctx, fakeGen)
+			var repo Repository
+			var err error = nil
+			var updatedState *State = nil
+			repo = setupRepositoryTest(t)
+			var batchError *TransformerBatchApplyError = nil
+			_, updatedState, _, batchError = repo.ApplyTransformersInternal(ctx, nil, tc.Transformers...)
+			if batchError != nil {
+				t.Fatalf("2 encountered error but no error is expected here: '%v'", batchError)
+			}
+			if err != nil {
+				t.Fatalf("encountered error but no error is expected here: '%v'", err)
+			}
+			fs := updatedState.Filesystem
+			if err := verifyContent(fs, tc.expectedContent); err != nil {
+				t.Fatalf("Error while verifying content: %v.\nFilesystem content:\n%s", err, strings.Join(listFiles(fs), "\n"))
+			}
+		})
+	}
+}
 
 func TestNextAndPreviousCommitCreation(t *testing.T) {
 	type TestCase struct {

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -93,12 +93,17 @@ func TestUndeployApplicationErrors(t *testing.T) {
 		{
 			Name: "Success",
 			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: envProduction,
+					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: envAcceptance, Latest: true}},
+				},
 				&CreateApplicationVersion{
 					Application: "app1",
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
 					WriteCommitData: true,
+					Version:         1,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -112,12 +117,17 @@ func TestUndeployApplicationErrors(t *testing.T) {
 		{
 			Name: "Create un-deploy Version for un-deployed application should not work",
 			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: envProduction,
+					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: envAcceptance, Latest: true}},
+				},
 				&CreateApplicationVersion{
 					Application: "app1",
 					Manifests: map[string]string{
 						envProduction: "productionmanifest",
 					},
 					WriteCommitData: true,
+					Version:         1,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -130,7 +140,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 				},
 			},
 			expectedError: &TransformerBatchApplyError{
-				Index:            3,
+				Index:            4,
 				TransformerError: errMatcher{"cannot undeploy non-existing application 'app1'"},
 			},
 			expectedCommitMsg: "",
@@ -148,6 +158,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 						envAcceptance: "acceptance",
 					},
 					WriteCommitData: true,
+					Version:         1,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -177,6 +188,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 						envAcceptance: "acceptance",
 					},
 					WriteCommitData: true,
+					Version:         1,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -206,6 +218,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 						envAcceptance: "acceptance",
 					},
 					WriteCommitData: true,
+					Version:         1,
 				},
 				&CreateEnvironmentLock{
 					Environment: "acceptance",
@@ -221,7 +234,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 			},
 			expectedError: &TransformerBatchApplyError{
 				Index:            4,
-				TransformerError: errMatcher{"UndeployApplication(repo): error cannot un-deploy application 'app1' the release 'acceptance' is not un-deployed: 'environments/acceptance/applications/app1/version/undeploy'"},
+				TransformerError: errMatcher{"UndeployApplication(db): error cannot un-deploy application 'app1' the current release 'acceptance' is not un-deployed"},
 			},
 			expectedCommitMsg: "",
 		},
@@ -242,6 +255,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 						envAcceptance: "acceptance",
 					},
 					WriteCommitData: true,
+					Version:         1,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -265,6 +279,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 						envAcceptance: "acceptance",
 					},
 					WriteCommitData: true,
+					Version:         1,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -289,6 +304,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 						envProduction: "productionmanifest",
 					},
 					WriteCommitData: true,
+					Version:         1,
 				},
 				&CreateUndeployApplicationVersion{
 					Application: "app1",
@@ -300,6 +316,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 					SourceAuthor:    "",
 					SourceMessage:   "",
 					WriteCommitData: true,
+					Version:         3,
 				},
 				&UndeployApplication{
 					Application: "app1",
@@ -317,19 +334,26 @@ func TestUndeployApplicationErrors(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			repo := setupRepositoryTest(t)
-			commitMsg, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), nil, tc.Transformers...)
-			if diff := cmp.Diff(tc.expectedError, err, cmpopts.EquateErrors()); diff != "" {
-				t.Fatalf("error mismatch (-want, +got):\n%s", diff)
-			}
-
+			repo := SetupRepositoryTestWithDB(t)
+			ctx := testutil.MakeTestContext()
+			commitMsgPtr, _ := db.WithTransactionT(repo.State().DBHandler, ctx, 0, false, func(ctx context.Context, transaction *sql.Tx) (*[]string, error) {
+				commitMsg, _, _, err := repo.ApplyTransformersInternal(ctx, transaction, tc.Transformers...)
+				if diff := cmp.Diff(tc.expectedError, err, cmpopts.EquateErrors()); diff != "" {
+					t.Fatalf("error mismatch (-want, +got):\n%s", diff)
+					return nil, nil
+				}
+				return &commitMsg, nil
+			})
+			commitMsg := *commitMsgPtr
 			actualMsg := ""
 			if len(commitMsg) > 0 {
 				actualMsg = commitMsg[len(commitMsg)-1]
 			}
+
 			if diff := cmp.Diff(tc.expectedCommitMsg, actualMsg); diff != "" {
 				t.Errorf("commit message mismatch (-want, +got):\n%s", diff)
 			}
+
 		})
 	}
 }


### PR DESCRIPTION
We already have the number of locks in the overview cache,
so there's no need to calculate it again.

This also removes some dead code.

Ref: SRX-Z8BHWD