### PR TITLE
fix: only send metrics as background job

### DIFF
--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -776,8 +776,6 @@ func (r *repository) ProcessQueueOnce(ctx context.Context, e transformerBatch, c
 				err = fmt.Errorf("failed to push - this indicates that branch protection is enabled in '%s' on branch '%s'", r.config.URL, r.config.Branch)
 			}
 		}
-		span, ctx = tracer.StartSpanFromContext(ctx, "PostPush")
-		defer span.Finish()
 	}
 
 	r.notify.Notify()


### PR DESCRIPTION
Generating metrics for all apps and all envs can take quite some time.

We previously had some endpoints that directly send the metrics, in order to have the metrics faster. Given how slow the metrics calculations currently are, this is not feasible. We will now send metrics only on the background task "RegularlySendDatadogMetrics".

Ref: SRX-Z8BHWD