### PR TITLE
fix: only run half the metrics

### DIFF
--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -469,8 +469,8 @@ func RunServer() {
 					Name:     "ddmetrics",
 					Run: func(ctx context.Context, reporter *setup.HealthReporter) error {
 						reporter.ReportReady("sending metrics")
-						repository.RegularlySendDatadogMetrics(repo, 300, func(repository2 repository.Repository) {
-							repository.GetRepositoryStateAndUpdateMetrics(ctx, repository2)
+						repository.RegularlySendDatadogMetrics(repo, 300, func(repository2 repository.Repository, even bool) {
+							repository.GetRepositoryStateAndUpdateMetrics(ctx, repository2, even)
 						})
 						return nil
 					},


### PR DESCRIPTION
This is a performance optimization.
We run the metrics every 5 minutes.
With this change, only half the apps will be handled each run. So effectively this means that the metrics are only updated every 10 minutes.

This also reverts https://github.com/freiheit-com/kuberpult/pull/2107


Ref: SRX-Z8BHWD