### PR TITLE
fix(ui): deletion of team locks

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -215,7 +215,7 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
     };
     const appRolloutStatus = useRolloutStatus((getter) => getter.getAppStatus(app, deployment?.version, env.name));
     const apps = useApplications().filter((application) => application.name === app);
-    const teamLocks = useTeamLocks(apps);
+    const teamLocks = useTeamLocks(apps).filter((lock) => lock.environment === env.name);
     const appLocks = useAppLocks(apps);
     const appEnvLocks = appLocks.filter((value: DisplayLock) => value.environment === env.name);
 

--- a/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
+++ b/services/frontend-service/src/ui/components/SideBar/SideBar.tsx
@@ -169,6 +169,7 @@ export const getActionDetails = (
                         lock.environment === action.environment
                 ); // 2 Team locks that don't have the same environment or team might, in theory, have the same lock ID, so the lock id does not uniquely identify a lock, but the combination of env + team + ID should.
             const target = findMatchingTeamLock(teamLocks, action.deleteEnvironmentTeamLock);
+
             return {
                 type: ActionTypes.DeleteEnvironmentTeamLock,
                 name: 'Delete Team Lock',

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -518,7 +518,7 @@ export const useTeamNames = (): string[] =>
 export const useApplications = (): OverviewApplication[] => useOverview(({ lightweightApps }) => lightweightApps);
 
 export const useTeamFromApplication = (app: string): string | undefined =>
-    useOverview(({ lightweightApps }) => lightweightApps.find((data) => data.name === app)?.name);
+    useOverview(({ lightweightApps }) => lightweightApps.find((data) => data.name === app)?.team);
 
 // returns warnings from all apps
 export const useAllWarnings = (): Warning[] => {


### PR DESCRIPTION
There were two issues that were fixed:
1) Team locks appeared on all environments, even though it should appear on only one.
2) Team locks could not be deleted.

Ref: SRX-Z8BHWD