### PR TITLE
fix: do not run overview twice when creating environments

### DIFF
--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -2840,7 +2840,8 @@ func (c *CreateEnvironment) Transform(
 	if state.DBHandler.ShouldUseOtherTables() {
 		// write to environments table
 		environmentApplications := make([]string, 0)
-		err = state.DBInsertEnvironmentWithOverview(ctx, transaction, c.Environment, c.Config, environmentApplications)
+		//err = state.DBInsertEnvironmentWithOverview(ctx, transaction, c.Environment, c.Config, environmentApplications)
+		err := state.DBHandler.DBWriteEnvironment(ctx, transaction, c.Environment, c.Config, environmentApplications)
 		if err != nil {
 			return "", fmt.Errorf("unable to write to the environment table, error: %w", err)
 		}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -2840,7 +2840,6 @@ func (c *CreateEnvironment) Transform(
 	if state.DBHandler.ShouldUseOtherTables() {
 		// write to environments table
 		environmentApplications := make([]string, 0)
-		//err = state.DBInsertEnvironmentWithOverview(ctx, transaction, c.Environment, c.Config, environmentApplications)
 		err := state.DBHandler.DBWriteEnvironment(ctx, transaction, c.Environment, c.Config, environmentApplications)
 		if err != nil {
 			return "", fmt.Errorf("unable to write to the environment table, error: %w", err)

--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -1782,6 +1782,17 @@ func TestCreateEnvironmentUpdatesOverview(t *testing.T) {
 			repo := SetupRepositoryTestWithDB(t)
 			state := repo.State()
 			err := state.DBHandler.WithTransaction(ctxWithTime, false, func(ctx context.Context, transaction *sql.Tx) error {
+				err := state.DBHandler.WriteOverviewCache(ctx, transaction, &api.GetOverviewResponse{
+					EnvironmentGroups: nil,
+					GitRevision:       "0000000000000000000000000000000000000000",
+					Branch:            "",
+					ManifestRepoUrl:   "",
+					LightweightApps:   nil,
+				})
+				if err != nil {
+					return err
+				}
+
 				_, _, _, transformerBatchErr := repo.ApplyTransformersInternal(ctx, transaction, tc.Transformers...)
 				if transformerBatchErr != nil {
 					return transformerBatchErr

--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -1782,17 +1782,6 @@ func TestCreateEnvironmentUpdatesOverview(t *testing.T) {
 			repo := SetupRepositoryTestWithDB(t)
 			state := repo.State()
 			err := state.DBHandler.WithTransaction(ctxWithTime, false, func(ctx context.Context, transaction *sql.Tx) error {
-				err := state.DBHandler.WriteOverviewCache(ctx, transaction, &api.GetOverviewResponse{
-					EnvironmentGroups: nil,
-					GitRevision:       "0000000000000000000000000000000000000000",
-					Branch:            "",
-					ManifestRepoUrl:   "",
-					LightweightApps:   nil,
-				})
-				if err != nil {
-					return err
-				}
-
 				_, _, _, transformerBatchErr := repo.ApplyTransformersInternal(ctx, transaction, tc.Transformers...)
 				if transformerBatchErr != nil {
 					return transformerBatchErr


### PR DESCRIPTION
Note that the create environments endpoint is still recalculating the whole overview cache, which is inefficient. This will be fixed in another PR.

Ref: SRX-0F9ZN3