### PR TITLE
fix: set group properly in the environments table

### DIFF
--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -524,7 +524,12 @@ message EnvironmentConfig {
 
   Upstream upstream = 1;
   ArgoCD argocd  = 2;
-  optional string environment_group = 3;
+
+  // Buf somehow generates the wrong go annotation in this case.
+  // To fix it, we changed the spelling, but now violate a linter rule.
+  // So we disable the rule, according to https://buf.build/docs/lint/overview/#comment-ignores
+  // buf:lint:ignore FIELD_LOWER_SNAKE_CASE
+  optional string environmentGroup = 3; // buf:lint:ignore FIELD_LOWER_SNAKE_CASE
 }
 
 

--- a/pkg/buf.yaml
+++ b/pkg/buf.yaml
@@ -21,6 +21,7 @@ deps:
 lint:
   use:
     - BASIC
+  allow_comment_ignores: true
   except:
     - "ENUM_VALUE_PREFIX"
     - "ENUM_ZERO_VALUE_SUFFIX"

--- a/services/frontend-service/buf.yaml
+++ b/services/frontend-service/buf.yaml
@@ -14,9 +14,7 @@
 
 # Copyright freiheit.com
 
-version: v1
+version: v1beta1
 name: buf.build/freiheit-com/kuberpult
 deps:
 - buf.build/googleapis/googleapis
-lint:
-  allow_comment_ignores: true

--- a/services/frontend-service/buf.yaml
+++ b/services/frontend-service/buf.yaml
@@ -14,7 +14,9 @@
 
 # Copyright freiheit.com
 
-version: v1beta1
+version: v1
 name: buf.build/freiheit-com/kuberpult
 deps:
 - buf.build/googleapis/googleapis
+lint:
+  allow_comment_ignores: true

--- a/services/frontend-service/pkg/handler/commit_deployments_test.go
+++ b/services/frontend-service/pkg/handler/commit_deployments_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
@@ -101,7 +102,8 @@ func TestHandleCommitDeployments(t *testing.T) {
 			if w.Code != tc.expectedStatusCode {
 				t.Errorf("expected status code %d, got %d", tc.expectedStatusCode, w.Code)
 			}
-			if diff := cmp.Diff(tc.expectedResponse, w.Body.String()); diff != "" {
+			body := strings.ReplaceAll(w.Body.String(), ", ", ",")
+			if diff := cmp.Diff(tc.expectedResponse, body); diff != "" {
 				t.Errorf("response mismatch (-want, +got):\\n%s", diff)
 			}
 		})

--- a/services/frontend-service/pkg/handler/handle_test.go
+++ b/services/frontend-service/pkg/handler/handle_test.go
@@ -481,7 +481,7 @@ func TestServer_Handle(t *testing.T) {
   "upstream": {
     "latest": true
   },
-  "environment_group": "*"
+  "environmentGroup": "*"
 }
 `},
 					},


### PR DESCRIPTION
This fixes a problem in the frontend service,
where the json.Unmarshal is using the wrong protobuf field.

The problem occured in the frontend-service environments.go
`err := json.Unmarshal([]byte(config[0]), &envConfig)`

Ref: SRX-0F9ZN3