### PR TITLE
fix(db): test complex deployments queries

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1935,7 +1935,7 @@ func (h *DBHandler) DBSelectAllLatestDeploymentsForApplication(ctx context.Conte
 	return processAllLatestDeploymentsForApp(rows)
 }
 
-func (h *DBHandler) DBSelectAllLatestDeployments(ctx context.Context, tx *sql.Tx, envName string) (map[string]*int64, error) {
+func (h *DBHandler) DBSelectAllLatestDeploymentsOnEnvironment(ctx context.Context, tx *sql.Tx, envName string) (map[string]*int64, error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "DBSelectAllLatestDeployments")
 	defer span.Finish()
 

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1055,6 +1055,60 @@ func TestReadAllLatestDeployment(t *testing.T) {
 				"app1": version(7),
 			},
 		},
+		{
+			Name:    "Select latest deployment",
+			EnvName: "dev",
+			SetupDeployments: []*Deployment{
+				{
+					App:           "app1",
+					Env:           "dev",
+					EslVersion:    2,
+					Version:       version(7),
+					TransformerID: 0,
+				},
+				{
+					App:           "app1",
+					Env:           "dev",
+					EslVersion:    3,
+					Version:       version(8),
+					TransformerID: 0,
+				},
+			},
+			ExpectedDeployments: map[string]*int64{
+				"app1": version(8),
+			},
+		},
+		{
+			Name:    "Select multiple deployments",
+			EnvName: "dev",
+			SetupDeployments: []*Deployment{
+				{
+					App:           "app1",
+					Env:           "dev",
+					EslVersion:    2,
+					Version:       version(7),
+					TransformerID: 0,
+				},
+				{
+					App:           "app2",
+					Env:           "dev",
+					EslVersion:    2,
+					Version:       version(8),
+					TransformerID: 0,
+				},
+				{
+					App:           "app3",
+					Env:           "staging",
+					EslVersion:    2,
+					Version:       version(8),
+					TransformerID: 0,
+				},
+			},
+			ExpectedDeployments: map[string]*int64{
+				"app1": version(7),
+				"app2": version(8),
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -1078,7 +1132,7 @@ func TestReadAllLatestDeployment(t *testing.T) {
 					}
 				}
 
-				latestDeployments, err := dbHandler.DBSelectAllLatestDeployments(ctx, transaction, tc.EnvName)
+				latestDeployments, err := dbHandler.DBSelectAllLatestDeploymentsOnEnvironment(ctx, transaction, tc.EnvName)
 				if err != nil {
 					return err
 				}

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -892,7 +892,6 @@ func TestReadWriteDeployment(t *testing.T) {
 }
 
 func TestReadAllLatestDeploymentForApplication(t *testing.T) {
-	// TEST DBSelectAllLatestDeploymentsForApplication
 	tcs := []struct {
 		Name                string
 		AppName             string
@@ -963,6 +962,13 @@ func TestReadAllLatestDeploymentForApplication(t *testing.T) {
 				},
 				{
 					App:           "app1",
+					Env:           "staging",
+					EslVersion:    2,
+					Version:       version(5),
+					TransformerID: 0,
+				},
+				{
+					App:           "app2",
 					Env:           "staging",
 					EslVersion:    2,
 					Version:       version(5),

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -1716,7 +1716,7 @@ func (s *State) DeleteQueuedVersionIfExists(ctx context.Context, transaction *sq
 }
 func (s *State) GetAllLatestDeployments(ctx context.Context, transaction *sql.Tx, environment string, allApps []string) (map[string]*int64, error) {
 	if s.DBHandler.ShouldUseOtherTables() {
-		return s.DBHandler.DBSelectAllLatestDeployments(ctx, transaction, environment)
+		return s.DBHandler.DBSelectAllLatestDeploymentsOnEnvironment(ctx, transaction, environment)
 	} else {
 		var result = make(map[string]*int64)
 		for _, appName := range allApps {


### PR DESCRIPTION
There were multiple complex queries without unit tests. This PR adds tests to 3 complex queries related to deployments.
This PR also changes the name of one database method to be more explicit. The naming for the two involved db methods changed as follows:

| Previous Name | Current Name |
|---|---|
| DBSelectAllLatestDeploymentsForApplication | DBSelectAllLatestDeploymentsForApplication  |
| DBSelectAllLatestDeployments | DBSelectAllLatestDeploymentsOnEnvironment |

Ref: SRX-THO0EO