### PR TITLE
fix(db): test complex lock queries

### DIFF
--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1452,6 +1452,181 @@ func TestReadAllActiveApplicationLock(t *testing.T) {
 	}
 }
 
+func TestReadAllActiveTeamLock(t *testing.T) {
+
+	type testLockInfo struct {
+		Env         string
+		LockID      string
+		Message     string
+		TeamName    string
+		AuthorName  string
+		AuthorEmail string
+		CiLink      string
+	}
+
+	tcs := []struct {
+		Name                string
+		TeamName            string
+		SetupLocks          []testLockInfo
+		DeleteLocks         []testLockInfo
+		ExpectedActiveLocks []TeamLock
+	}{
+		{
+			Name:     "Read one lock",
+			TeamName: "my-team",
+			SetupLocks: []testLockInfo{
+				{
+					Env:         "dev",
+					LockID:      "dev-team-lock",
+					Message:     "My team lock on dev for my-team",
+					AuthorName:  "myself",
+					AuthorEmail: "myself@example.com",
+					TeamName:    "my-team",
+					CiLink:      "www.test.com",
+				},
+			},
+			DeleteLocks: []testLockInfo{},
+			ExpectedActiveLocks: []TeamLock{
+				{
+					Env:        "dev",
+					LockID:     "dev-team-lock",
+					EslVersion: 1,
+					Deleted:    false,
+					Team:       "my-team",
+					Metadata: LockMetadata{
+						Message:        "My team lock on dev for my-team",
+						CreatedByName:  "myself",
+						CreatedByEmail: "myself@example.com",
+						CiLink:         "www.test.com",
+					},
+				},
+			},
+		},
+		{
+			Name:     "Don't read deleted lock",
+			TeamName: "my-team",
+			SetupLocks: []testLockInfo{
+				{
+					Env:         "dev",
+					LockID:      "dev-team-lock",
+					Message:     "My team lock on dev for my-team",
+					AuthorName:  "myself",
+					AuthorEmail: "myself@example.com",
+					TeamName:    "my-team",
+					CiLink:      "www.test.com",
+				},
+			},
+			DeleteLocks: []testLockInfo{
+				{
+					Env:         "dev",
+					LockID:      "dev-team-lock",
+					Message:     "My team lock on dev for my-team",
+					AuthorName:  "myself",
+					AuthorEmail: "myself@example.com",
+					TeamName:    "my-team",
+					CiLink:      "www.test.com",
+				},
+			},
+			ExpectedActiveLocks: nil,
+		},
+		{
+			Name:     "Only read active locks",
+			TeamName: "my-team",
+			SetupLocks: []testLockInfo{
+				{
+					Env:         "dev",
+					LockID:      "dev-team-lock",
+					Message:     "My team lock on dev for my-team",
+					AuthorName:  "myself",
+					AuthorEmail: "myself@example.com",
+					TeamName:    "my-team",
+					CiLink:      "www.test.com",
+				},
+				{
+					Env:         "staging",
+					LockID:      "staging-team-lock",
+					Message:     "My team lock on staging for my-team",
+					AuthorName:  "myself",
+					AuthorEmail: "myself@example.com",
+					TeamName:    "my-team",
+					CiLink:      "www.test.com",
+				},
+			},
+			DeleteLocks: []testLockInfo{
+				{
+					Env:         "staging",
+					LockID:      "staging-team-lock",
+					Message:     "My team lock on staging for my-team",
+					AuthorName:  "myself",
+					AuthorEmail: "myself@example.com",
+					TeamName:    "my-team",
+					CiLink:      "www.test.com",
+				},
+			},
+			ExpectedActiveLocks: []TeamLock{
+				{
+					Env:        "dev",
+					LockID:     "dev-team-lock",
+					EslVersion: 1,
+					Deleted:    false,
+					Team:       "my-team",
+					Metadata: LockMetadata{
+						Message:        "My team lock on dev for my-team",
+						CreatedByName:  "myself",
+						CreatedByEmail: "myself@example.com",
+						CiLink:         "www.test.com",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.MakeTestContext()
+
+			dbHandler := setupDB(t)
+			err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+
+				for _, lockInfo := range tc.SetupLocks {
+					err := dbHandler.DBWriteTeamLock(ctx, transaction, lockInfo.LockID, lockInfo.Env, lockInfo.TeamName, LockMetadata{
+						CreatedByName:  lockInfo.AuthorName,
+						CreatedByEmail: lockInfo.AuthorEmail,
+						Message:        lockInfo.Message,
+						CiLink:         lockInfo.CiLink,
+					})
+					if err != nil {
+						return err
+					}
+
+				}
+
+				for _, lockInfo := range tc.DeleteLocks {
+					err := dbHandler.DBDeleteTeamLock(ctx, transaction, lockInfo.Env, lockInfo.TeamName, lockInfo.LockID)
+					if err != nil {
+						return err
+					}
+				}
+
+				activeLocks, err := dbHandler.DBSelectAllActiveTeamLocksForTeam(ctx, transaction, tc.TeamName)
+				if err != nil {
+					return err
+				}
+
+				if diff := cmp.Diff(tc.ExpectedActiveLocks, activeLocks, cmpopts.IgnoreFields(TeamLock{}, "Created")); diff != "" {
+					t.Fatalf("error mismatch (-want, +got):\n%s", diff)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("transaction error: %v", err)
+			}
+		})
+	}
+}
+
 func TestDeleteApplicationLock(t *testing.T) {
 	tcs := []struct {
 		Name          string

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1277,6 +1277,181 @@ func TestReadWriteApplicationLock(t *testing.T) {
 	}
 }
 
+func TestReadAllActiveApplicationLock(t *testing.T) {
+
+	type testLockInfo struct {
+		Env         string
+		LockID      string
+		Message     string
+		AppName     string
+		AuthorName  string
+		AuthorEmail string
+		CiLink      string
+	}
+
+	tcs := []struct {
+		Name                string
+		AppName             string
+		SetupLocks          []testLockInfo
+		DeleteLocks         []testLockInfo
+		ExpectedActiveLocks []ApplicationLock
+	}{
+		{
+			Name:    "Read one lock",
+			AppName: "my-app",
+			SetupLocks: []testLockInfo{
+				{
+					Env:         "dev",
+					LockID:      "dev-app-lock",
+					Message:     "My application lock on dev for my-app",
+					AuthorName:  "myself",
+					AuthorEmail: "myself@example.com",
+					AppName:     "my-app",
+					CiLink:      "www.test.com",
+				},
+			},
+			DeleteLocks: []testLockInfo{},
+			ExpectedActiveLocks: []ApplicationLock{
+				{
+					Env:        "dev",
+					LockID:     "dev-app-lock",
+					EslVersion: 1,
+					Deleted:    false,
+					App:        "my-app",
+					Metadata: LockMetadata{
+						Message:        "My application lock on dev for my-app",
+						CreatedByName:  "myself",
+						CreatedByEmail: "myself@example.com",
+						CiLink:         "www.test.com",
+					},
+				},
+			},
+		},
+		{
+			Name:    "Don't read deleted lock",
+			AppName: "my-app",
+			SetupLocks: []testLockInfo{
+				{
+					Env:         "dev",
+					LockID:      "dev-app-lock",
+					Message:     "My application lock on dev for my-app",
+					AuthorName:  "myself",
+					AuthorEmail: "myself@example.com",
+					AppName:     "my-app",
+					CiLink:      "www.test.com",
+				},
+			},
+			DeleteLocks: []testLockInfo{
+				{
+					Env:         "dev",
+					LockID:      "dev-app-lock",
+					Message:     "My application lock on dev for my-app",
+					AuthorName:  "myself",
+					AuthorEmail: "myself@example.com",
+					AppName:     "my-app",
+					CiLink:      "www.test.com",
+				},
+			},
+			ExpectedActiveLocks: nil,
+		},
+		{
+			Name:    "Only read not deleted locks",
+			AppName: "my-app",
+			SetupLocks: []testLockInfo{
+				{
+					Env:         "dev",
+					LockID:      "dev-app-lock",
+					Message:     "My application lock on dev for my-app",
+					AuthorName:  "myself",
+					AuthorEmail: "myself@example.com",
+					AppName:     "my-app",
+					CiLink:      "www.test.com",
+				},
+				{
+					Env:         "staging",
+					LockID:      "dev-app-lock",
+					Message:     "My application lock on dev for my-app",
+					AuthorName:  "myself",
+					AuthorEmail: "myself@example.com",
+					AppName:     "my-app",
+					CiLink:      "www.test.com",
+				},
+			},
+			DeleteLocks: []testLockInfo{
+				{
+					Env:         "staging",
+					LockID:      "dev-app-lock",
+					Message:     "My application lock on dev for my-app",
+					AuthorName:  "myself",
+					AuthorEmail: "myself@example.com",
+					AppName:     "my-app",
+					CiLink:      "www.test.com",
+				},
+			},
+			ExpectedActiveLocks: []ApplicationLock{
+				{
+					Env:        "dev",
+					LockID:     "dev-app-lock",
+					EslVersion: 1,
+					Deleted:    false,
+					App:        "my-app",
+					Metadata: LockMetadata{
+						Message:        "My application lock on dev for my-app",
+						CreatedByName:  "myself",
+						CreatedByEmail: "myself@example.com",
+						CiLink:         "www.test.com",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.MakeTestContext()
+
+			dbHandler := setupDB(t)
+			err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+
+				for _, lockInfo := range tc.SetupLocks {
+					err := dbHandler.DBWriteApplicationLock(ctx, transaction, lockInfo.LockID, lockInfo.Env, lockInfo.AppName, LockMetadata{
+						CreatedByName:  lockInfo.AuthorName,
+						CreatedByEmail: lockInfo.AuthorEmail,
+						Message:        lockInfo.Message,
+						CiLink:         lockInfo.CiLink,
+					})
+					if err != nil {
+						return err
+					}
+
+				}
+
+				for _, lockInfo := range tc.DeleteLocks {
+					err := dbHandler.DBDeleteApplicationLock(ctx, transaction, lockInfo.Env, lockInfo.AppName, lockInfo.LockID)
+					if err != nil {
+						return err
+					}
+				}
+
+				activeLocks, err := dbHandler.DBSelectAllActiveAppLocksForApp(ctx, transaction, tc.AppName)
+				if err != nil {
+					return err
+				}
+
+				if diff := cmp.Diff(tc.ExpectedActiveLocks, activeLocks, cmpopts.IgnoreFields(ApplicationLock{}, "Created")); diff != "" {
+					t.Fatalf("error mismatch (-want, +got):\n%s", diff)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("transaction error: %v", err)
+			}
+		})
+	}
+}
+
 func TestDeleteApplicationLock(t *testing.T) {
 	tcs := []struct {
 		Name          string


### PR DESCRIPTION
There were multiple complex queries without unit tests. This PR adds tests to 3 complex queries related to locks.

Ref: SRX-THO0EO