### PR TITLE
fix: create-environment should not overwrite applications

### DIFF
--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1968,7 +1968,7 @@ func TestReadWriteEnvironment(t *testing.T) {
 
 			for _, envToWrite := range tc.EnvsToWrite {
 				err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-					err := dbHandler.DBWriteEnvironment(ctx, transaction, envToWrite.EnvironmentName, envToWrite.EnvironmentConfig, envToWrite.Applications)
+					err := dbHandler.DBWriteEnvironment(ctx, transaction, envToWrite.EnvironmentName, envToWrite.EnvironmentConfig, envToWrite.Applications, nil)
 					if err != nil {
 						return fmt.Errorf("error while writing environment, error: %w", err)
 					}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -2466,7 +2466,7 @@ func (s *State) DBInsertApplicationWithOverview(ctx context.Context, transaction
 
 func (s *State) DBInsertEnvironmentWithOverview(ctx context.Context, tx *sql.Tx, environmentName string, environmentConfig config.EnvironmentConfig, applications []string) error {
 	h := s.DBHandler
-	err := h.DBWriteEnvironment(ctx, tx, environmentName, environmentConfig, applications)
+	err := h.DBWriteEnvironment(ctx, tx, environmentName, environmentConfig, applications, nil)
 	if err != nil {
 		return err
 	}

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -830,7 +830,7 @@ func (c *CreateApplicationVersion) Transform(
 				}
 			}
 			if envInfo != nil && !found {
-				err = state.DBHandler.DBWriteEnvironment(ctx, transaction, env, envInfo.Config, append(envInfo.Applications, c.Application))
+				err = state.DBHandler.DBWriteEnvironment(ctx, transaction, env, envInfo.Config, append(envInfo.Applications, c.Application), &envInfo.Version)
 				if err != nil {
 					return "", GetCreateReleaseGeneralFailure(err)
 				}
@@ -1723,7 +1723,7 @@ func (u *UndeployApplication) Transform(
 				}
 			}
 			t.AddAppEnv(u.Application, envName, dbApp.Metadata.Team)
-			err = state.DBHandler.DBWriteEnvironment(ctx, transaction, envName, env.Config, newEnvApps)
+			err = state.DBHandler.DBWriteEnvironment(ctx, transaction, envName, env.Config, newEnvApps, &env.Version)
 			if err != nil {
 				return "", fmt.Errorf("UndeployApplication: could not write environment: %v", err)
 			}
@@ -2838,9 +2838,20 @@ func (c *CreateEnvironment) Transform(
 		return "", err
 	}
 	if state.DBHandler.ShouldUseOtherTables() {
+		// first read the env to see if it has applications:
+		existingEnvironment, err := state.DBHandler.DBSelectEnvironment(ctx, transaction, c.Environment)
+		if err != nil {
+			return "", fmt.Errorf("could not select environment %s from database, error: %w", c.Environment, err)
+		}
+
 		// write to environments table
 		environmentApplications := make([]string, 0)
-		err := state.DBHandler.DBWriteEnvironment(ctx, transaction, c.Environment, c.Config, environmentApplications)
+		var version *int64
+		if existingEnvironment != nil {
+			environmentApplications = existingEnvironment.Applications
+			version = &existingEnvironment.Version
+		}
+		err = state.DBHandler.DBWriteEnvironment(ctx, transaction, c.Environment, c.Config, environmentApplications, version)
 		if err != nil {
 			return "", fmt.Errorf("unable to write to the environment table, error: %w", err)
 		}

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -170,6 +170,8 @@ export const getAppDetails = (appName: string, authHeader: AuthHeader): void => 
         .overviewService()
         .GetAppDetails({ appName: appName }, authHeader)
         .then((result: GetAppDetailsResponse) => {
+            // eslint-disable-next-line no-console
+            console.info('SU DEBUG: getappdetails: ', result);
             const d = updateAppDetails.get();
             d[appName] = { details: result, appDetailState: AppDetailsState.READY, updatedAt: new Date(Date.now()) };
             updateAppDetails.set(d);

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -170,8 +170,6 @@ export const getAppDetails = (appName: string, authHeader: AuthHeader): void => 
         .overviewService()
         .GetAppDetails({ appName: appName }, authHeader)
         .then((result: GetAppDetailsResponse) => {
-            // eslint-disable-next-line no-console
-            console.info('SU DEBUG: getappdetails: ', result);
             const d = updateAppDetails.get();
             d[appName] = { details: result, appDetailState: AppDetailsState.READY, updatedAt: new Date(Date.now()) };
             updateAppDetails.set(d);

--- a/services/manifest-repo-export-service/pkg/repository/transformer_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer_test.go
@@ -826,7 +826,7 @@ func TestReleaseTrain(t *testing.T) {
 						Environment: "staging",
 						Latest:      true,
 					},
-				}, []string{appName})
+				}, []string{appName}, nil)
 				if err != nil {
 					return err
 				}
@@ -834,7 +834,7 @@ func TestReleaseTrain(t *testing.T) {
 					Upstream: &config.EnvironmentConfigUpstream{
 						Environment: "staging",
 					},
-				}, []string{appName})
+				}, []string{appName}, nil)
 				if err != nil {
 					return err
 				}
@@ -1719,7 +1719,7 @@ func TestCreateUndeployApplicationVersion(t *testing.T) {
 					ArgoCd:           nil,
 					EnvironmentGroup: nil,
 				}
-				err = dbHandler.DBWriteEnvironment(ctx, transaction, envAcceptance, envConfig, []string{})
+				err = dbHandler.DBWriteEnvironment(ctx, transaction, envAcceptance, envConfig, []string{}, nil)
 				if err != nil {
 					return err
 				}
@@ -2590,11 +2590,11 @@ func TestCreateUndeployLogic(t *testing.T) {
 					t.Fatal(err2)
 				}
 
-				err2 = dbHandler.DBWriteEnvironment(ctx, transaction, envAcceptance, envAcceptanceConfig, []string{appName})
+				err2 = dbHandler.DBWriteEnvironment(ctx, transaction, envAcceptance, envAcceptanceConfig, []string{appName}, nil)
 				if err2 != nil {
 					return err2
 				}
-				err2 = dbHandler.DBWriteEnvironment(ctx, transaction, envAcceptance2, envAcceptance2Config, []string{appName})
+				err2 = dbHandler.DBWriteEnvironment(ctx, transaction, envAcceptance2, envAcceptance2Config, []string{appName}, nil)
 				if err2 != nil {
 					return err2
 				}
@@ -3013,11 +3013,11 @@ func TestUndeployLogic(t *testing.T) {
 				if err2 != nil {
 					t.Fatal(err2)
 				}
-				err2 = dbHandler.DBWriteEnvironment(ctx, transaction, envAcceptance, environmentConfigAcceptance, []string{appName})
+				err2 = dbHandler.DBWriteEnvironment(ctx, transaction, envAcceptance, environmentConfigAcceptance, []string{appName}, nil)
 				if err2 != nil {
 					return err2
 				}
-				err2 = dbHandler.DBWriteEnvironment(ctx, transaction, envAcceptance2, environmentConfigAcceptance2, []string{appName})
+				err2 = dbHandler.DBWriteEnvironment(ctx, transaction, envAcceptance2, environmentConfigAcceptance2, []string{appName}, nil)
 				if err2 != nil {
 					return err2
 				}

--- a/services/manifest-repo-export-service/pkg/service/git_test.go
+++ b/services/manifest-repo-export-service/pkg/service/git_test.go
@@ -114,7 +114,7 @@ func setupDBFixtures(ctx context.Context, dbHandler *db.DBHandler, transaction *
 			Upstream: &config.EnvironmentConfigUpstream{
 				Latest: true,
 			},
-		}, fixtureAppications)
+		}, fixtureAppications, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Before this change, update an existing environment would set the applications column to be empty.
That in turn resulted into GetAppDetails not returning all the deployments.

Ref: SRX-0F9ZN3