### PR TITLE
fix(rollout-service): Add new line in log

### DIFF
--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -116,7 +116,7 @@ func RunServer() {
 		return runServer(ctx, config)
 	})
 	if err != nil {
-		fmt.Printf("error: %v %#v", err, err)
+		fmt.Printf("error: %v %#v\n", err, err)
 	}
 }
 


### PR DESCRIPTION
The main RunServer function for the rollout service did not log general errors. This happened because the print did not have a new line which did not flush the buffer.

Ref: SRX-UVTOID