### PR TITLE
fix(rollout-service): Added info log in the rollout service self manage loop

### DIFF
--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -100,6 +100,7 @@ func (a *ArgoAppProcessor) Consume(ctx context.Context, hlth *setup.HealthReport
 	for {
 		select {
 		case argoOv := <-a.trigger:
+			l.Info("self-manage.trigger")
 			overview := argoOv.Overview
 			for currentApp, currentAppDetails := range argoOv.AppDetails {
 				span, ctx := tracer.StartSpanFromContext(ctx, "ProcessChangedApp")


### PR DESCRIPTION
The rollout service info logs were missing a signal for when the self manage loop consumes a triggered (from kuberpult) event. This PR adds said log.

Ref: SRX-FEUSCN