### PR TITLE
fix(rollout-service): new retry strategy for kuberpult events

### DIFF
--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -89,7 +89,7 @@ func (a *ArgoAppProcessor) Push(ctx context.Context, last *ArgoOverview) {
 	case a.trigger <- a.lastOverview:
 		l.Info("argocd.pushed")
 	default:
-		l.Info("argocd.push-failed")
+		l.Warn("argocd.push-failed")
 	}
 }
 

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -100,6 +100,7 @@ func (a *ArgoAppProcessor) Consume(ctx context.Context, hlth *setup.HealthReport
 	for {
 		select {
 		case argoOv := <-a.trigger:
+			l.Info("self-manage.trigger")
 			overview := argoOv.Overview
 			for currentApp, currentAppDetails := range argoOv.AppDetails {
 				span, ctx := tracer.StartSpanFromContext(ctx, "ProcessChangedApp")

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -89,6 +89,7 @@ func (a *ArgoAppProcessor) Push(ctx context.Context, last *ArgoOverview) {
 	case a.trigger <- a.lastOverview:
 		l.Info("argocd.pushed")
 	default:
+		l.Info("argocd.push-failed")
 	}
 }
 

--- a/services/rollout-service/pkg/argo/argo_test.go
+++ b/services/rollout-service/pkg/argo/argo_test.go
@@ -19,10 +19,11 @@ package argo
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"io"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
 
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -99,11 +100,13 @@ type mockArgoProcessor struct {
 	ManageArgoAppsFilter  []string
 }
 
-func (a *mockArgoProcessor) Push(ctx context.Context, last *ArgoOverview) {
+func (a *mockArgoProcessor) Push(ctx context.Context, last *ArgoOverview) error {
 	a.lastOverview = last
 	select {
 	case a.trigger <- a.lastOverview:
+		return nil
 	default:
+		return fmt.Errorf("failed to push to mock argo app")
 	}
 }
 


### PR DESCRIPTION
Currently the rollout service loses updates from the cd-service if the self-manage thread is busy handling argo updates. This PR adds two different changes to help this problem:
* When events fail to be pushed they are stored and pushed along the next update;
* The channel used for pushes was given a capacity of 5 instead of 0 to improve push success rate;

Ref: SRX-FEUSCN