### PR TITLE
fix(ci): Added slack notification to trivy-db caching

### DIFF
--- a/.github/workflows/trivy-cache.yml
+++ b/.github/workflows/trivy-cache.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Cache trivy
       run: |
-        exit 1
+        exit 2
         ./trivy/cache_db_image.sh $RETRIES
 
   send-alert:

--- a/.github/workflows/trivy-cache.yml
+++ b/.github/workflows/trivy-cache.yml
@@ -1,5 +1,8 @@
 name: "Trivy DB Caching"
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:
@@ -35,4 +38,20 @@ jobs:
 
     - name: Cache trivy
       run: |
+        exit 1
         ./trivy/cache_db_image.sh $RETRIES
+
+  send-alert:
+    name: "Send alert in cache failed."
+    if: ${{ failure() }}
+    needs: cache
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Run curl to the Slack webhook
+      run: |
+        curl \
+        --request POST \
+        --header "Content-Type: application/json" \
+        --data '{"text": ":warning::warning: Failed daily cache of the trivy-db image in <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>.\n"}' \
+        --fail \
+        ${{ secrets.SLACK_WEBHOOK_SRE_ALERTS_INTERNAL }}


### PR DESCRIPTION
The trivy caching workflow now sends a slack notification if it fails.

Ref: SRX-R4I0PO