### PR TITLE
fix(ci): fix flaky test diff

### DIFF
--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -4148,8 +4148,8 @@ func TestUpdateDatadogMetricsInternal(t *testing.T) {
 				t.Logf("actualGauges:[%v] %v:%v", i, actualGauge.Name, actualGauge.Tags)
 				t.Logf("expectedGauges:[%v] %v:%v", i, expectedGauge.Name, expectedGauge.Tags)
 
-				if diff := cmp.Diff(actualGauge, expectedGauge, cmpopts.IgnoreFields(statsd.Event{}, "Timestamp")); diff != "" {
-					t.Errorf("[%d] got %v, want %v, diff (-want +got) %s", i, actualGauge, expectedGauge, diff)
+				if diff := cmp.Diff(expectedGauge, actualGauge, cmpopts.IgnoreFields(statsd.Event{}, "Timestamp")); diff != "" {
+					t.Errorf("[%d] want %v, got %v, diff (-want +got) %s", i, expectedGauge, actualGauge, diff)
 				}
 			}
 		})

--- a/services/cd-service/pkg/service/version.go
+++ b/services/cd-service/pkg/service/version.go
@@ -62,13 +62,6 @@ func (o *VersionServiceServer) GetVersion(
 				in.GitRevision, in.Application, in.Environment, err)
 		}
 		res, err := db.WithTransactionT[api.GetVersionResponse](dbHandler, ctx, 1, true, func(ctx context.Context, tx *sql.Tx) (*api.GetVersionResponse, error) {
-			// The gitRevision field is actually not a proper git revision.
-			// Instead, it has the release number stored with leading zeroes.
-			releaseVersion, err := reposerver.FromRevision(in.GitRevision)
-			if err != nil {
-				return nil, fmt.Errorf("could not parse GitRevision '%s' for app '%s' in env '%s': %w",
-					in.GitRevision, in.Application, in.Environment, err)
-			}
 			deployment, err := dbHandler.DBSelectSpecificDeployment(ctx, tx, in.Environment, in.Application, releaseVersion)
 			if err != nil || deployment == nil {
 				return nil, fmt.Errorf("no deployment found for env='%s' and app='%s': %w", in.Environment, in.Application, err)

--- a/services/cd-service/pkg/service/version.go
+++ b/services/cd-service/pkg/service/version.go
@@ -54,6 +54,13 @@ func (o *VersionServiceServer) GetVersion(
 	state := o.Repository.State()
 	dbHandler := state.DBHandler
 	if dbHandler.ShouldUseOtherTables() {
+		// The gitRevision field is actually not a proper git revision.
+		// Instead, it has the release number stored with leading zeroes.
+		releaseVersion, err := reposerver.FromRevision(in.GitRevision)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse GitRevision '%s' for app '%s' in env '%s': %w",
+				in.GitRevision, in.Application, in.Environment, err)
+		}
 		res, err := db.WithTransactionT[api.GetVersionResponse](dbHandler, ctx, 1, true, func(ctx context.Context, tx *sql.Tx) (*api.GetVersionResponse, error) {
 			// The gitRevision field is actually not a proper git revision.
 			// Instead, it has the release number stored with leading zeroes.


### PR DESCRIPTION
When merging for Wawi support two sequential exec plans on main failed due to this flaky test.

The test has our usual order of (+want,-got) switched which was fixed.
The test is flaky because the `lastDeployment` gauges have a timestamp for a value which can be different from 0.

This PR only fixes the order of the diff.

Ref: SRX-0F9ZN3