### PR TITLE
fix(cd-service): sync all_app_locks with app_locks

### DIFF
--- a/database/migrations/postgres/1733135388406786_fix_all_app_locks.up.sql
+++ b/database/migrations/postgres/1733135388406786_fix_all_app_locks.up.sql
@@ -1,0 +1,40 @@
+WITH combinations AS (
+  SELECT
+    DISTINCT environment,
+    appname
+  FROM
+    all_app_locks ),
+latest_app_locks_versions AS (
+  SELECT MAX(eslversion) AS latest,
+      envname,
+      appname,
+      lockID FROM app_locks GROUP BY envname, appname, lockId
+),
+new_data AS (
+  SELECT
+    c.environment,
+    c.appname,
+    JSON_BUILD_OBJECT('appLocks', COALESCE(JSON_AGG(t.lockID) FILTER (WHERE t.lockID IS NOT NULL), '[]'::json)) AS json
+  FROM
+    combinations c
+  LEFT JOIN (SELECT al.eslversion, al.envname, al.appname, al.lockId FROM latest_app_locks_versions la
+  JOIN app_locks al ON al.eslversion=la.latest AND al.envname=la.envname AND al.appname=la.appname AND al.lockId=la.lockId WHERE deleted=false) AS t
+  ON
+    c.environment = t.envname
+    AND c.appname = t.appname
+  GROUP BY
+    c.environment,
+    c.appname ),
+latest_versions AS (
+  SELECT
+    environment,
+    appname,
+    COALESCE(MAX(version), 0) AS max_version
+  FROM
+    all_app_locks
+  GROUP BY
+    environment,
+    appname )
+INSERT INTO all_app_locks (version, created, environment, appname, json)
+SELECT max_version + 1, now(), lv.environment, lv.appname, t.json FROM new_data t LEFT JOIN latest_versions lv ON t.environment = lv.environment AND t.appname = lv.appname;
+INSERT INTO overview_cache (timestamp, json) VALUES (now(), '{}');

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -460,6 +460,7 @@ func RunServer() {
 					reposerver.Register(srv, repo, cfg)
 					if dbHandler != nil {
 						api.RegisterCommitDeploymentServiceServer(srv, &service.CommitDeploymentServer{DBHandler: dbHandler})
+						overviewSrv.GetOverview(ctx, &api.GetOverviewRequest{})
 					}
 				},
 			},

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1614,6 +1614,10 @@ func (u *UndeployApplication) Transform(
 						return "", err
 					}
 				}
+				err = state.DBHandler.DBWriteAllAppLocks(ctx, transaction, locks.Version, env, u.Application, []string{})
+				if err != nil {
+					return "", err
+				}
 				continue
 			}
 			return "", fmt.Errorf("UndeployApplication(db): error cannot un-deploy application '%v' the release '%v' is not un-deployed", u.Application, env)


### PR DESCRIPTION
Ref: SRX-0F9ZN3

* Previously when we undeployed an application we deleted the app_locks but didn't delete the all_app_locks.
* Since all_app_locks may not be in sync with app_locks we should have a migration that syncs them with each other.
* Previously, when the overview_cache was empty at startup we had to wait for the rollout-service to trigger it, which would take about 15 minutes. Now, we trigger it at the startup of the cd-service.