### PR TITLE
fix(rollout-service): fix diff arog app

### DIFF
--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -331,8 +331,9 @@ func CreateArgoApplication(overview *api.GetOverviewResponse, appName, team stri
 		Server:    env.Config.Argocd.Destination.Server,
 	}
 
-	ignoreDifferences := make([]v1alpha1.ResourceIgnoreDifferences, len(env.Config.Argocd.IgnoreDifferences))
+	var ignoreDifferences []v1alpha1.ResourceIgnoreDifferences = nil
 	if len(env.Config.Argocd.IgnoreDifferences) > 0 {
+		ignoreDifferences = make([]v1alpha1.ResourceIgnoreDifferences, len(env.Config.Argocd.IgnoreDifferences))
 		for index, value := range env.Config.Argocd.IgnoreDifferences {
 			difference := v1alpha1.ResourceIgnoreDifferences{
 				Group:                 value.Group,
@@ -345,10 +346,7 @@ func CreateArgoApplication(overview *api.GetOverviewResponse, appName, team stri
 			}
 			ignoreDifferences[index] = difference
 		}
-	} else {
-		ignoreDifferences = nil
 	}
-
 	//exhaustruct:ignore
 	ObjectMeta := metav1.ObjectMeta{
 		Name:        fmt.Sprintf("%s-%s", env.Name, appName),

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -332,18 +332,23 @@ func CreateArgoApplication(overview *api.GetOverviewResponse, appName, team stri
 	}
 
 	ignoreDifferences := make([]v1alpha1.ResourceIgnoreDifferences, len(env.Config.Argocd.IgnoreDifferences))
-	for index, value := range env.Config.Argocd.IgnoreDifferences {
-		difference := v1alpha1.ResourceIgnoreDifferences{
-			Group:                 value.Group,
-			Kind:                  value.Kind,
-			Name:                  value.Name,
-			Namespace:             value.Namespace,
-			JSONPointers:          value.JsonPointers,
-			JQPathExpressions:     value.JqPathExpressions,
-			ManagedFieldsManagers: value.ManagedFieldsManagers,
+	if len(env.Config.Argocd.IgnoreDifferences) > 0 {
+		for index, value := range env.Config.Argocd.IgnoreDifferences {
+			difference := v1alpha1.ResourceIgnoreDifferences{
+				Group:                 value.Group,
+				Kind:                  value.Kind,
+				Name:                  value.Name,
+				Namespace:             value.Namespace,
+				JSONPointers:          value.JsonPointers,
+				JQPathExpressions:     value.JqPathExpressions,
+				ManagedFieldsManagers: value.ManagedFieldsManagers,
+			}
+			ignoreDifferences[index] = difference
 		}
-		ignoreDifferences[index] = difference
+	} else {
+		ignoreDifferences = nil
 	}
+
 	//exhaustruct:ignore
 	ObjectMeta := metav1.ObjectMeta{
 		Name:        fmt.Sprintf("%s-%s", env.Name, appName),


### PR DESCRIPTION
Our `CreateArgoApplication` function created an argo app in the argo grpc api format.
This function creates an ignore differences empty array if there are no ignore differences items.
However, the apps that come from argocd come with this array as nil if there are no ignore differences.
This causes a lot of unnecessary update requests.

This PR corrects this problem.

Ref: SRX-0F9ZN3