### PR TITLE
fix(rollout-service): fixed version comparison in broadcast's app state

### DIFF
--- a/services/rollout-service/pkg/service/broadcast.go
+++ b/services/rollout-service/pkg/service/broadcast.go
@@ -19,9 +19,10 @@ package service
 import (
 	"context"
 	"errors"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"sync"
 	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
 	"github.com/freiheit-com/kuberpult/pkg/conversion"
@@ -57,7 +58,7 @@ func (a *appState) applyArgoEvent(ev *ArgoEvent) *BroadcastEvent {
 }
 
 func (a *appState) applyKuberpultEvent(ev *versions.KuberpultEvent) *BroadcastEvent {
-	if !a.argocdVersion.Equal(ev.Version) || a.isProduction == nil || *a.isProduction != ev.IsProduction {
+	if !a.kuberpultVersion.Equal(ev.Version) || a.isProduction == nil || *a.isProduction != ev.IsProduction {
 		a.kuberpultVersion = ev.Version
 		a.environmentGroup = ev.EnvironmentGroup
 		a.team = ev.Team


### PR DESCRIPTION
In the `applyKuberpultEvent` method of the `Broadcast`'s `appState` we were incorrectly comparing the argocd state with the kuberpult state.

This meant that if argocd had one version deployed, and a request was received from the cd-service (kuberpultEvent) to update a deployment to that same version, we would not update the `appState` to that version, causing a split between the rollout-service's inner state kuberpult version and the real kuberpult version.

The consequence would be that later, we could generate an argo notification to deploy to the earlier version that the rollout service has in its inner state, while both the cd-service "wanted" the more recent one deployed.
 
Ref: SRX-0F9ZN3