### PR TITLE
fix(cd-service): new span to measure performance of DeleteEnvFromApp

### DIFF
--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1776,6 +1776,8 @@ func (u *DeleteEnvFromApp) Transform(
 	t TransformerContext,
 	transaction *sql.Tx,
 ) (string, error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DeleteEnvFromApp")
+	defer span.Finish()
 	err := state.checkUserPermissions(ctx, transaction, u.Environment, u.Application, auth.PermissionDeleteEnvironmentApplication, "", u.RBACConfig, true)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
We currently have no span to measure the performance of DeleteEnvFromApp transformer. This PR adds one.

Ref: SRX-7XFFEN