### PR TITLE
fix(cd-service): fix flaky datadog gauge test

### DIFF
--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -4147,6 +4147,11 @@ func TestUpdateDatadogMetricsInternal(t *testing.T) {
 				sort.Strings(actualGauge.Tags)
 				t.Logf("actualGauges:[%v] %v:%v", i, actualGauge.Name, actualGauge.Tags)
 				t.Logf("expectedGauges:[%v] %v:%v", i, expectedGauge.Name, expectedGauge.Tags)
+				if actualGauge.Name == "lastDeployed" {
+					if actualGauge.Value < 1 {
+						actualGauge.Value = 0
+					}
+				}
 
 				if diff := cmp.Diff(actualGauge, expectedGauge, cmpopts.IgnoreFields(statsd.Event{}, "Timestamp")); diff != "" {
 					t.Errorf("[%d] got %v, want %v, diff (-want +got) %s", i, actualGauge, expectedGauge, diff)


### PR DESCRIPTION
Ref: SRX-PXQRS5
lastDeployed is a float time difference. It can be anywhere between 0 and 1. For us if it's less than 1 minute is enough.