### PR TITLE
fix(cd-service): improve get app details deployments

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -5071,7 +5071,7 @@ func (h *DBHandler) DBSelectLatestDeploymentAttemptOnAllEnvironments(ctx context
 		return nil, nil
 	}
 	if tx == nil {
-		return nil, fmt.Errorf("DBSelectLatestDeploymentAttemptOfAllApps: no transaction provided")
+		return nil, fmt.Errorf("DBSelectLatestDeploymentAttemptOnAllEnvironments: no transaction provided")
 	}
 	query := h.AdaptQuery(
 		`

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -5063,6 +5063,50 @@ func (h *DBHandler) DBSelectLatestDeploymentAttemptOfAllApps(ctx context.Context
 	return h.processDeploymentAttemptsRows(ctx, rows, err)
 }
 
+func (h *DBHandler) DBSelectLatestDeploymentAttemptOnAllEnvironments(ctx context.Context, tx *sql.Tx, appName string) ([]*QueuedDeployment, error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBSelectLatestDeploymentAttemptOnAllEnvironments")
+	defer span.Finish()
+
+	if h == nil {
+		return nil, nil
+	}
+	if tx == nil {
+		return nil, fmt.Errorf("DBSelectLatestDeploymentAttemptOfAllApps: no transaction provided")
+	}
+	query := h.AdaptQuery(
+		`
+	SELECT DISTINCT
+		deployment_attempts.eslversion,
+		deployment_attempts.created,
+		deployment_attempts.envname,
+		deployment_attempts.appname,
+		deployment_attempts.queuedReleaseVersion
+	FROM (
+		SELECT
+			MAX(eslversion) AS latestRelease,
+			appname,
+			envname
+		FROM
+			"deployment_attempts"
+		GROUP BY
+			envname, appname) AS latest
+	JOIN
+		deployment_attempts AS deployment_attempts
+	ON
+		latest.latestRelease=deployment_attempts.eslVersion
+		AND latest.envname=deployment_attempts.envname
+		AND latest.appname=deployment_attempts.appname
+	WHERE deployment_attempts.appname=?
+	ORDER BY deployment_attempts.eslversion DESC;
+	`)
+	span.SetTag("query", query)
+	rows, err := tx.QueryContext(
+		ctx,
+		query,
+		appName)
+	return h.processDeploymentAttemptsRows(ctx, rows, err)
+}
+
 func (h *DBHandler) DBWriteDeploymentAttempt(ctx context.Context, tx *sql.Tx, envName, appName string, version *int64, skipOverview bool) error {
 	span, ctx := tracer.StartSpanFromContext(ctx, "DBWriteDeploymentAttempt")
 	defer span.Finish()

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -218,8 +218,6 @@ func (o *OverviewServiceServer) GetAppDetails(
 			if queuedDeployment.Version != nil {
 				parsedInt := uint64(*queuedDeployment.Version)
 				queuedVersions[queuedDeployment.Env] = &parsedInt
-			} else {
-				queuedVersions[queuedDeployment.Env] = nil
 			}
 		}
 		for envName, currentDeployment := range deployments {

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -212,6 +212,7 @@ func (o *OverviewServiceServer) GetAppDetails(
 			return nil, err
 		}
 
+		// Cache queued versions to check with deployments
 		queuedVersions := make(map[string]*uint64)
 		for _, queuedDeployment := range queuedDeployments {
 			parsedInt := uint64(*queuedDeployment.Version)
@@ -249,16 +250,17 @@ func (o *OverviewServiceServer) GetAppDetails(
 					},
 				}
 
-				if deploymentRelease != nil {
-					deployment.UndeployVersion = deploymentRelease.Metadata.UndeployVersion
-				}
-
 				queuedVersion, ok := queuedVersions[envName]
 				if !ok || queuedVersion == nil {
 					deployment.QueuedVersion = 0
 				} else {
 					deployment.QueuedVersion = *queuedVersion
 				}
+
+				if deploymentRelease != nil {
+					deployment.UndeployVersion = deploymentRelease.Metadata.UndeployVersion
+				}
+
 				response.Deployments[envName] = deployment
 			}
 		}

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -260,7 +260,6 @@ func (o *OverviewServiceServer) GetAppDetails(
 				if deploymentRelease != nil {
 					deployment.UndeployVersion = deploymentRelease.Metadata.UndeployVersion
 				}
-
 				response.Deployments[envName] = deployment
 			}
 		}

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -215,8 +215,12 @@ func (o *OverviewServiceServer) GetAppDetails(
 		// Cache queued versions to check with deployments
 		queuedVersions := make(map[string]*uint64)
 		for _, queuedDeployment := range queuedDeployments {
-			parsedInt := uint64(*queuedDeployment.Version)
-			queuedVersions[queuedDeployment.Env] = &parsedInt
+			if queuedDeployment.Version != nil {
+				parsedInt := uint64(*queuedDeployment.Version)
+				queuedVersions[queuedDeployment.Env] = &parsedInt
+			} else {
+				queuedVersions[queuedDeployment.Env] = nil
+			}
 		}
 		for envName, currentDeployment := range deployments {
 

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -153,10 +153,10 @@ func (o *OverviewServiceServer) GetAppDetails(
 			return nil, fmt.Errorf("unable to retrieve manifests for environments %v from the database, error: %w", dbAllEnvs.Environments, err)
 		}
 
-		envMap := make(map[string]*db.DBEnvironment)
+		envMap := make(map[string]db.DBEnvironment)
 		envConfigs := make(map[string]config.EnvironmentConfig)
 		for _, env := range *envs {
-			envMap[env.Name] = &env
+			envMap[env.Name] = env
 			envConfigs[env.Name] = env.Config
 		}
 
@@ -217,9 +217,6 @@ func (o *OverviewServiceServer) GetAppDetails(
 
 			environment, ok := envMap[envName]
 			if !ok {
-				return nil, fmt.Errorf("could not obtain environment %s for app %s", envName, appName)
-			}
-			if environment == nil {
 				logger.FromContext(ctx).Sugar().Warnf("could not obtain environment %s for app %s: %w", envName, appName, err)
 				continue
 			}


### PR DESCRIPTION
The `GetAppDetails` endpoint collects information about the deployments of an app.
One of these is the latest queued version. Currently the endpoint would evaluate one deployment at a time and, when it was decided to be a valid deployment, the database would be queried for this deployment's latest queued version.

This PR queries the database for all latest deployment attempts. Then when analyzing each deployment it just pulls from this information cached in a map.

This might slow down `GetAppDetails` requests that have no current deployments (since before we would not query the queued versions for invalid deployments). This will translate in improved performance. And in most cases, most apps will have deployments

Ref: SRX-016Y9E