### PR TITLE
fix(rollout-service): revolution tests

### DIFF
--- a/services/rollout-service/pkg/revolution/revolution.go
+++ b/services/rollout-service/pkg/revolution/revolution.go
@@ -28,8 +28,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/freiheit-com/kuberpult/pkg/logger"
 	"github.com/freiheit-com/kuberpult/services/rollout-service/pkg/service"
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )

--- a/services/rollout-service/pkg/revolution/revolution.go
+++ b/services/rollout-service/pkg/revolution/revolution.go
@@ -97,6 +97,7 @@ func (s *Subscriber) subscribeOnce(ctx context.Context, b *service.Broadcast) er
 		}
 	}
 	s.ready()
+	l := logger.FromContext(ctx).With(zap.String("revolution", "processing"))
 	for {
 		select {
 		case <-ctx.Done():
@@ -113,6 +114,7 @@ func (s *Subscriber) subscribeOnce(ctx context.Context, b *service.Broadcast) er
 				ev.ArgocdVersion.DeployedAt.Add(s.maxAge).Before(s.now()) {
 				continue
 			}
+			l.Info("registering event app: " + ev.Key.Application + ", environment: " + ev.Key.Environment)
 			if shouldNotify(s.state[ev.Key], ev) {
 				s.group.Go(s.notify(ctx, ev))
 			}

--- a/services/rollout-service/pkg/revolution/revolution_test.go
+++ b/services/rollout-service/pkg/revolution/revolution_test.go
@@ -133,6 +133,119 @@ func TestRevolution(t *testing.T) {
 							DeployedAt:     time.Date(2024, 2, 14, 12, 15, 0, 0, time.UTC),
 						},
 					},
+
+					KuberpultEvent: &versions.KuberpultEvent{
+						Environment:  "foo",
+						Application:  "bar",
+						IsProduction: true,
+						Version: &versions.VersionInfo{
+							Version:        1,
+							SourceCommitId: "123456",
+							DeployedAt:     time.Date(2024, 2, 15, 12, 15, 0, 0, time.UTC),
+						},
+					},
+
+					ExpectedRequest: nil,
+				},
+			},
+		},
+		{
+			Name: "don't notify on a lone kuberpult event",
+			Now:  time.Unix(123456789, 0).UTC(),
+			Steps: []step{
+				{
+					KuberpultEvent: &versions.KuberpultEvent{
+						Environment:      "fakeprod",
+						Application:      "foo",
+						EnvironmentGroup: "prod",
+						IsProduction:     true,
+						Team:             "bar",
+						Version: &versions.VersionInfo{
+							Version:        1,
+							SourceCommitId: "123456",
+							DeployedAt:     time.Unix(123456789, 0).UTC(),
+						},
+					},
+					ExpectedRequest: nil,
+				},
+			},
+		},
+		{
+			Name: "don't notify on a lone argo event",
+			Now:  time.Unix(123456789, 0).UTC(),
+			Steps: []step{
+				{
+					ArgoEvent: &service.ArgoEvent{
+						Environment:      "foo",
+						Application:      "bar",
+						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
+						HealthStatusCode: health.HealthStatusDegraded,
+						Version: &versions.VersionInfo{
+							Version:        1,
+							SourceCommitId: "123456",
+							DeployedAt:     time.Unix(123456789, 0).UTC(),
+						},
+					},
+					ExpectedRequest: nil,
+				},
+			},
+		},
+		{
+			Name: "don't notify on non production env",
+			Now:  time.Unix(123456789, 0).UTC(),
+			Steps: []step{
+				{
+					ArgoEvent: &service.ArgoEvent{
+						Environment:      "foo",
+						Application:      "bar",
+						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
+						HealthStatusCode: health.HealthStatusHealthy,
+						Version: &versions.VersionInfo{
+							Version:        1,
+							SourceCommitId: "123456",
+							DeployedAt:     time.Unix(123456789, 0).UTC(),
+						},
+					},
+					KuberpultEvent: &versions.KuberpultEvent{
+						Environment:  "foo",
+						Application:  "bar",
+						IsProduction: false,
+						Version: &versions.VersionInfo{
+							Version:        1,
+							SourceCommitId: "123456",
+							DeployedAt:     time.Unix(123456789, 0).UTC(),
+						},
+					},
+					ExpectedRequest: nil,
+				},
+			},
+		},
+		{
+			Name: "don't notify on non production env",
+			Now:  time.Unix(123456789, 0).UTC(),
+			Steps: []step{
+				{
+					ArgoEvent: &service.ArgoEvent{
+						Environment:      "foo",
+						Application:      "bar",
+						SyncStatusCode:   v1alpha1.SyncStatusCodeSynced,
+						HealthStatusCode: health.HealthStatusHealthy,
+						Version: &versions.VersionInfo{
+							Version:        1,
+							SourceCommitId: "123456",
+							DeployedAt:     time.Unix(123456789, 0).UTC(),
+						},
+					},
+					KuberpultEvent: &versions.KuberpultEvent{
+						Environment:  "foo",
+						Application:  "bar",
+						IsProduction: false,
+						Version: &versions.VersionInfo{
+							Version:        1,
+							SourceCommitId: "123456",
+							DeployedAt:     time.Unix(123456789, 0).UTC(),
+						},
+					},
 					ExpectedRequest: nil,
 				},
 			},


### PR DESCRIPTION
The revolution package was lacking unit tests. This PR creates new test cases and fixes a small bug with the test code itself that caused some tests to block/not fail.

We also add a log in the main revolution subscriber for visibility.

Ref: SRX-L5QORI