### PR TITLE
fix: move custom migrations to manifest-export

### DIFF
--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -149,6 +149,8 @@ spec:
           value: {{ .Values.argocd.generateFiles | quote }}
         - name: KUBERPULT_NETWORK_TIMEOUT_SECONDS
           value: {{ .Values.manifestRepoExport.networkTimeoutSeconds | quote }}
+        - name: KUBERPULT_VERSION
+          value: {{ $.Chart.AppVersion | quote}}
         - name: LOG_FORMAT
           value: {{ .Values.log.format | quote }}
         - name: LOG_LEVEL

--- a/database/migrations/postgres/1733938275776162_migrationcutoff.up.sql
+++ b/database/migrations/postgres/1733938275776162_migrationcutoff.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS custom_migration_cutoff
+(
+    migration_done_at TIMESTAMP NOT NULL,
+    kuberpult_version varchar(100) PRIMARY KEY -- the version as it appears on GitHub, e.g. "1.2.3"
+);

--- a/database/migrations/sqlite/1733938275776162_migrationcutoff.up.sql
+++ b/database/migrations/sqlite/1733938275776162_migrationcutoff.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS custom_migration_cutoff
+(
+    migration_done_at TIMESTAMP NOT NULL,
+    kuberpult_version varchar(100) PRIMARY KEY -- the version as it appears on GitHub, e.g. "1.2.3"
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       - KUBERPULT_DB_MAX_OPEN_CONNECTIONS=5
       - KUBERPULT_DB_MAX_IDLE_CONNECTIONS=1
       - KUBERPULT_MINIMIZE_EXPORTED_DATA=true
+      - KUBERPULT_VERSION=v0.1.2
     volumes:
       - ./services/cd-service:/kp/kuberpult
       - ./database:/kp/database

--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -375,6 +375,24 @@ service VersionService {
   rpc GetManifests (GetManifestsRequest) returns (GetManifestsResponse) {}
 }
 
+service MigrationService {
+  rpc EnsureCustomMigrationApplied (EnsureCustomMigrationAppliedRequest) returns (EnsureCustomMigrationAppliedResponse) {}
+}
+
+message EnsureCustomMigrationAppliedRequest {
+  KuberpultVersion version = 1;
+}
+
+message EnsureCustomMigrationAppliedResponse {
+  bool migrationsApplied = 1;
+}
+
+message KuberpultVersion {
+  int32 major = 1;
+  int32 minor = 2;
+  int32 patch = 3;
+}
+
 service OverviewService {
   rpc GetOverview (GetOverviewRequest) returns (GetOverviewResponse) {}
   rpc StreamOverview (GetOverviewRequest) returns (stream GetOverviewResponse) {}

--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -384,7 +384,7 @@ message EnsureCustomMigrationAppliedRequest {
 }
 
 message EnsureCustomMigrationAppliedResponse {
-  bool migrationsApplied = 1;
+  bool migrations_applied = 1;
 }
 
 message KuberpultVersion {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1216,7 +1216,7 @@ func (h *DBHandler) needsCommitEventsMigrations(ctx context.Context, transaction
 	return true, nil
 }
 
-// NeedsMigrations: Checks if we need migrations for any table.
+// NeedsMigrations checks if we need migrations for any table.
 func (h *DBHandler) NeedsMigrations(ctx context.Context) (bool, error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "NeedsMigrations")
 	defer span.Finish()

--- a/pkg/tracing/span.go
+++ b/pkg/tracing/span.go
@@ -1,0 +1,38 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package tracing
+
+import (
+	"context"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+type OnErrFunc = func(err error) error
+
+// StartSpanFromContext is the same as tracer.StartSpanFromContext, but also returns an onError function that tags the span as error
+// You should call the onErrorFunc when the span should be marked as failed.
+func StartSpanFromContext(ctx context.Context, name string) (tracer.Span, context.Context, OnErrFunc) {
+	mySpan, ctx := tracer.StartSpanFromContext(ctx, name)
+	onErr := func(err error) error {
+		if err == nil {
+			return nil
+		}
+		mySpan.Finish(tracer.WithError(err))
+		return err
+	}
+	return mySpan, ctx, onErr
+}

--- a/services/manifest-repo-export-service/pkg/migrations/migration.go
+++ b/services/manifest-repo-export-service/pkg/migrations/migration.go
@@ -1,0 +1,123 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"github.com/freiheit-com/kuberpult/pkg/api/v1"
+	"github.com/freiheit-com/kuberpult/pkg/db"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+type OnErrFunc = func(err error) error
+
+// StartSpanFromContext is the same as tracer.StartSpanFromContext, but also returns an onError function that tags the span as error
+// You should call the onErrorFunc when the span should be marked as failed.
+func StartSpanFromContext(ctx context.Context, name string) (tracer.Span, context.Context, OnErrFunc) {
+	mySpan, ctx := tracer.StartSpanFromContext(ctx, name)
+	onErr := func(err error) error {
+		if err == nil {
+			return nil
+		}
+		mySpan.Finish(tracer.WithError(err))
+		return err
+	}
+	return mySpan, ctx, onErr
+}
+
+func DBReadCustomMigrationCutoff(h *db.DBHandler, ctx context.Context, transaction *sql.Tx, requestedVersion *api.KuberpultVersion) (*api.KuberpultVersion, error) {
+	span, ctx, onErr := StartSpanFromContext(ctx, "DBReadCustomMigrationCutoff")
+	defer span.Finish()
+
+	requestedVersionString := FormatKuberpultVersion(requestedVersion)
+
+	selectQuery := h.AdaptQuery(`
+SELECT kuberpult_version
+FROM custom_migration_cutoff
+WHERE kuberpult_version=?
+LIMIT 1;`)
+	span.SetTag("query", selectQuery)
+	span.SetTag("requestedVersion", requestedVersionString)
+	rows, err := transaction.QueryContext(
+		ctx,
+		selectQuery,
+		requestedVersionString,
+	)
+	if err != nil {
+		return nil, onErr(fmt.Errorf("could not query cutoff table from DB. Error: %w\n", err))
+	}
+	defer func(rows *sql.Rows) {
+		err := rows.Close()
+		if err != nil {
+			logger.FromContext(ctx).Sugar().Warnf("migration_cutoff: row closing error: %v", err)
+		}
+	}(rows)
+
+	if !rows.Next() {
+		return nil, nil
+	}
+	var rawVersion string
+	err = rows.Scan(&rawVersion)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, onErr(fmt.Errorf("migration_cutoff: Error scanning row from DB. Error: %w\n", err))
+	}
+	err = rows.Close()
+	if err != nil {
+		return nil, onErr(fmt.Errorf("migration_cutoff: row closing error: %v\n", err))
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, onErr(fmt.Errorf("migration_cutoff: row has error: %v\n", err))
+	}
+
+	var kuberpultVersion *api.KuberpultVersion
+	kuberpultVersion, err = ParseKuberpultVersion(rawVersion)
+	if err != nil {
+		return nil, onErr(fmt.Errorf("migration_cutoff: Error parsing kuberpult version. Error: %w", err))
+	}
+	return kuberpultVersion, nil
+}
+
+func DBWriteCustomMigrationCutoff(h *db.DBHandler, ctx context.Context, tx *sql.Tx, kuberpultVersion *api.KuberpultVersion) error {
+	span, ctx, onErr := StartSpanFromContext(ctx, "DBWriteCustomMigrationCutoff")
+	defer span.Finish()
+
+	timestamp, err := h.DBReadTransactionTimestamp(ctx, tx)
+	if err != nil {
+		return onErr(fmt.Errorf("DBWriteCustomMigrationCutoff: Error reading transaction timestamp from DB. Error: %w", err))
+	}
+
+	insertQuery := h.AdaptQuery("INSERT INTO custom_migration_cutoff (migration_done_at, kuberpult_version) VALUES (?, ?);")
+	span.SetTag("query", insertQuery)
+
+	_, err = tx.Exec(
+		insertQuery,
+		timestamp,
+		FormatKuberpultVersion(kuberpultVersion),
+	)
+	if err != nil {
+		return onErr(fmt.Errorf("could not write to cutoff table from DB. Error: %w\n", err))
+	}
+	return nil
+}

--- a/services/manifest-repo-export-service/pkg/migrations/migration_test.go
+++ b/services/manifest-repo-export-service/pkg/migrations/migration_test.go
@@ -1,0 +1,157 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"github.com/freiheit-com/kuberpult/pkg/db"
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
+	"github.com/freiheit-com/kuberpult/services/manifest-repo-export-service/pkg/repository"
+	"google.golang.org/protobuf/testing/protocmp"
+	"os/exec"
+	"path"
+	"testing"
+
+	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRunMigrations(t *testing.T) {
+	type TestCase struct {
+		name                     string
+		kuberpultVersionToInsert *api.KuberpultVersion
+		kuberpultVersionToQuery  *api.KuberpultVersion
+		expectedVersion          *api.KuberpultVersion
+		expectedError            error
+	}
+
+	tcs := []TestCase{
+		{
+			name:                     "should read nothing if nothing was written",
+			kuberpultVersionToInsert: nil,
+			kuberpultVersionToQuery:  CreateKuberpultVersion(0, 1, 2),
+			expectedVersion:          nil,
+			expectedError:            nil,
+		},
+		{
+			name:                     "should read nothing if a different version was written",
+			kuberpultVersionToInsert: CreateKuberpultVersion(2, 3, 4),
+			kuberpultVersionToQuery:  CreateKuberpultVersion(0, 1, 2),
+			expectedVersion:          nil,
+			expectedError:            nil,
+		},
+		{
+			name:                     "should read the same version that was written",
+			kuberpultVersionToInsert: CreateKuberpultVersion(0, 1, 2),
+			kuberpultVersionToQuery:  CreateKuberpultVersion(0, 1, 2),
+			expectedVersion:          CreateKuberpultVersion(0, 1, 2),
+			expectedError:            nil,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			repo, _ := setupRepositoryTestWithPath(t)
+
+			ctx := testutil.MakeTestContext()
+			dbHandler := repo.State().DBHandler
+
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+
+				if tc.kuberpultVersionToInsert != nil {
+					err := DBWriteCustomMigrationCutoff(dbHandler, ctx, transaction, tc.kuberpultVersionToInsert)
+					if err != nil {
+						t.Fatal("unexpected error when writing cutoff: %w", err)
+					}
+				}
+
+				returnedVersion, err := DBReadCustomMigrationCutoff(dbHandler, ctx, transaction, tc.kuberpultVersionToQuery)
+
+				if err != nil {
+					t.Fatal("unexpected error: %w", err)
+				}
+				if diff := cmp.Diff(tc.expectedVersion, returnedVersion, protocmp.Transform()); diff != "" {
+					t.Errorf("error mismatch (-want, +got):\n%s", diff)
+				}
+				return nil
+			})
+		})
+	}
+}
+
+func setupRepositoryTestWithPath(t *testing.T) (repository.Repository, string) {
+	ctx := context.Background()
+	migrationsPath, err := testutil.CreateMigrationsPath(4)
+	if err != nil {
+		t.Fatalf("CreateMigrationsPath error: %v", err)
+	}
+	dbConfig := &db.DBConfig{
+		MigrationsPath: migrationsPath,
+		DriverName:     "sqlite3",
+	}
+
+	dir := t.TempDir()
+	remoteDir := path.Join(dir, "remote")
+	localDir := path.Join(dir, "local")
+	cmd := exec.Command("git", "init", "--bare", remoteDir)
+	err = cmd.Start()
+	if err != nil {
+		t.Errorf("could not start git init")
+		return nil, ""
+	}
+	err = cmd.Wait()
+	if err != nil {
+		t.Errorf("could not wait for git init to finish")
+		return nil, ""
+	}
+
+	repoCfg := repository.RepositoryConfig{
+		URL:                  remoteDir,
+		Path:                 localDir,
+		CommitterEmail:       "kuberpult@freiheit.com",
+		CommitterName:        "kuberpult",
+		ArgoCdGenerateFiles:  true,
+		ReleaseVersionLimit:  2,
+		MinimizeExportedData: false,
+	}
+
+	if dbConfig != nil {
+		dbConfig.DbHost = dir
+
+		migErr := db.RunDBMigrations(ctx, *dbConfig)
+		if migErr != nil {
+			t.Fatal(migErr)
+		}
+
+		dbHandler, err := db.Connect(ctx, *dbConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+		repoCfg.DBHandler = dbHandler
+	}
+
+	repo, err := repository.New(
+		testutil.MakeTestContext(),
+		repoCfg,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, remoteDir
+}

--- a/services/manifest-repo-export-service/pkg/migrations/types.go
+++ b/services/manifest-repo-export-service/pkg/migrations/types.go
@@ -24,6 +24,20 @@ import (
 )
 
 func ParseKuberpultVersion(version string) (*api.KuberpultVersion, error) {
+
+	splitDash := strings.Split(version, "-")
+	if len(splitDash) == 4 {
+		// we have a version in the form of pr-v11.6.10-7-g08f811e8
+		// we need to find the second part in "pr-v11.6.10-7"
+		// See the top-level Makefile and how the version is supplied to earthly in the line
+		// "earthly -P +integration-test --kuberpult_version=$(IMAGE_TAG_KUBERPULT)"
+		version = splitDash[1]
+	} else if len(splitDash) == 1 {
+		// this is the normal case, we don't have to remove parts
+	} else {
+		return nil, fmt.Errorf("invalid version, expected 0 or 3 dashes")
+	}
+
 	version = strings.TrimPrefix(version, "v")
 	split := strings.Split(version, ".")
 	if len(split) != 3 {

--- a/services/manifest-repo-export-service/pkg/migrations/types.go
+++ b/services/manifest-repo-export-service/pkg/migrations/types.go
@@ -1,0 +1,65 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package migrations
+
+import (
+	"fmt"
+	"github.com/freiheit-com/kuberpult/pkg/api/v1"
+	"strconv"
+	"strings"
+)
+
+func ParseKuberpultVersion(version string) (*api.KuberpultVersion, error) {
+	version = strings.TrimPrefix(version, "v")
+	split := strings.Split(version, ".")
+	if len(split) != 3 {
+		return nil, fmt.Errorf("migration_cutoff: Error parsing kuberpult version '%s', must have 3 dots", version)
+	}
+	majorRaw := split[0]
+	minorRaw := split[1]
+	patchRaw := split[2]
+
+	ma, err := strconv.ParseUint(majorRaw, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("migration_cutoff: Error parsing kuberpult major version'%s'. Error: %w", majorRaw, err)
+	}
+	mi, err := strconv.ParseUint(minorRaw, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("migration_cutoff: Error parsing kuberpult major version'%s'. Error: %w", majorRaw, err)
+	}
+	pa, err := strconv.ParseUint(patchRaw, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("migration_cutoff: Error parsing kuberpult major version'%s'. Error: %w", majorRaw, err)
+	}
+	return &api.KuberpultVersion{
+		Major: int32(ma),
+		Minor: int32(mi),
+		Patch: int32(pa),
+	}, nil
+}
+
+func CreateKuberpultVersion(major, minor, patch int) *api.KuberpultVersion {
+	return &api.KuberpultVersion{
+		Major: int32(major),
+		Minor: int32(minor),
+		Patch: int32(patch),
+	}
+}
+
+func FormatKuberpultVersion(version *api.KuberpultVersion) string {
+	return fmt.Sprintf("%d.%d.%d", version.Major, version.Minor, version.Patch)
+}

--- a/services/manifest-repo-export-service/pkg/migrations/types_test.go
+++ b/services/manifest-repo-export-service/pkg/migrations/types_test.go
@@ -1,0 +1,77 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package migrations
+
+import (
+	"fmt"
+	"google.golang.org/protobuf/testing/protocmp"
+	"testing"
+
+	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseKuberpultVersion(t *testing.T) {
+	type TestCase struct {
+		name                  string
+		kuberpultVersionInput string
+		expectedVersion       *api.KuberpultVersion
+		expectedError         error
+	}
+
+	tcs := []TestCase{
+		{
+			name:                  "should read middle part for pr version",
+			kuberpultVersionInput: "pr-v11.6.10-7-g08f811e8",
+			expectedVersion:       CreateKuberpultVersion(11, 6, 10),
+			expectedError:         nil,
+		},
+		{
+			name:                  "should read middle part for main version",
+			kuberpultVersionInput: "main-v12.1.2-7-g08f811e8",
+			expectedVersion:       CreateKuberpultVersion(12, 1, 2),
+			expectedError:         nil,
+		},
+		{
+			name:                  "invalid number of dashes",
+			kuberpultVersionInput: "main-main-v12.1.2-7-g08f811e8",
+			expectedVersion:       nil,
+			expectedError:         fmt.Errorf("invalid version, expected 0 or 3 dashes"),
+		},
+		{
+			name:                  "0 dashes also works",
+			kuberpultVersionInput: "v12.1.2",
+			expectedVersion:       CreateKuberpultVersion(12, 1, 2),
+			expectedError:         nil,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actualVersion, actualErr := ParseKuberpultVersion(tc.kuberpultVersionInput)
+
+			if diff := cmp.Diff(tc.expectedVersion, actualVersion, protocmp.Transform()); diff != "" {
+				t.Errorf("version mismatch (-want, +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.expectedError, actualErr, protocmp.Transform()); diff != "" {
+				t.Errorf("error mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/services/manifest-repo-export-service/pkg/service/git_test.go
+++ b/services/manifest-repo-export-service/pkg/service/git_test.go
@@ -19,8 +19,6 @@ package service
 import (
 	"context"
 	"database/sql"
-	"os/exec"
-	"path"
 	"sort"
 	"testing"
 	"time"
@@ -43,35 +41,6 @@ import (
 	"github.com/freiheit-com/kuberpult/pkg/conversion"
 	rp "github.com/freiheit-com/kuberpult/services/manifest-repo-export-service/pkg/repository"
 )
-
-func setupRepositoryTestWithoutDB(t *testing.T) (rp.Repository, error) {
-	dir := t.TempDir()
-	remoteDir := path.Join(dir, "remote")
-	localDir := path.Join(dir, "local")
-	cmd := exec.Command("git", "init", "--bare", remoteDir)
-	cmd.Start()
-	cmd.Wait()
-	t.Logf("test created dir: %s", localDir)
-
-	repoCfg := rp.RepositoryConfig{
-		URL:                  remoteDir,
-		Path:                 localDir,
-		CommitterEmail:       "kuberpult@freiheit.com",
-		CommitterName:        "kuberpult",
-		ArgoCdGenerateFiles:  true,
-		MinimizeExportedData: false,
-	}
-	repoCfg.DBHandler = nil
-
-	repo, err := rp.New(
-		testutil.MakeTestContext(),
-		repoCfg,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return repo, nil
-}
 
 func setupDBFixtures(ctx context.Context, dbHandler *db.DBHandler, transaction *sql.Tx) error {
 	err := dbHandler.DBWriteMigrationsTransformer(ctx, transaction)

--- a/services/manifest-repo-export-service/pkg/service/migration.go
+++ b/services/manifest-repo-export-service/pkg/service/migration.go
@@ -1,0 +1,125 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package service
+
+/**
+The basic idea is to store kuberpult version numbers alongside of custom sql migrations.
+("custom" means here that pure SQL is not enough, we need so go-code)
+Each migration gets assigned a number, and all finished migrations are stored in the database.
+*/
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
+	"github.com/freiheit-com/kuberpult/pkg/db"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
+	"github.com/freiheit-com/kuberpult/services/manifest-repo-export-service/pkg/migrations"
+)
+
+type MigrationFunc func(ctx context.Context) error
+
+type Migration struct {
+	Version   *api.KuberpultVersion
+	Migration MigrationFunc
+}
+
+type MigrationServer struct {
+	DBHandler *db.DBHandler
+}
+
+// GetAllMigrations returns an array of ALL migrations (already applied or not)
+func GetAllMigrations() []*Migration {
+	return []*Migration{
+		// This is where we list all required custom migrations
+		// Will be filled in Ref SRX-V6RVYF
+	}
+}
+
+func (s *MigrationServer) EnsureCustomMigrationApplied(ctx context.Context, in *api.EnsureCustomMigrationAppliedRequest) (*api.EnsureCustomMigrationAppliedResponse, error) {
+	log := logger.FromContext(ctx).Sugar()
+
+	if in.Version == nil {
+		return nil, fmt.Errorf("kuberpult version is nil")
+	}
+
+	// 1) Check if migrations are done:
+	dbDone, err := s.CustomMigrationsDone(ctx, in.Version)
+	if err != nil {
+		return nil, fmt.Errorf("could not check if migrations are done: %w", err)
+	}
+	if dbDone {
+		log.Warn("SU DEBUG: EnsureCustomMigrationApplied end 1 nothing to do")
+		return &api.EnsureCustomMigrationAppliedResponse{
+			MigrationsApplied: true,
+		}, nil
+	}
+
+	err = s.RunMigrations(ctx, in.Version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to run migrations: %w", err)
+	}
+
+	return &api.EnsureCustomMigrationAppliedResponse{
+		MigrationsApplied: false,
+	}, nil
+}
+
+func (s *MigrationServer) CustomMigrationsDone(ctx context.Context, version *api.KuberpultVersion) (bool, error) {
+	type Done struct {
+		done bool
+	}
+	dbVersion, err := db.WithTransactionT(s.DBHandler, ctx, 0, true, func(ctx context.Context, transaction *sql.Tx) (*api.KuberpultVersion, error) {
+		dbVersion, tErr := migrations.DBReadCustomMigrationCutoff(s.DBHandler, ctx, transaction, version)
+		if tErr != nil {
+			return nil, tErr
+		}
+		return dbVersion, nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("could not check if migrations are done: %w", err)
+	}
+	if dbVersion == version {
+		return true, nil
+	}
+	log := logger.FromContext(ctx).Sugar()
+	log.Infof("CustomMigrationsDone diff: %s!=%s", dbVersion, version)
+	return false, nil
+}
+
+func (s *MigrationServer) RunMigrations(ctx context.Context, kuberpultVersion *api.KuberpultVersion) error {
+	log := logger.FromContext(ctx).Sugar()
+
+	if kuberpultVersion == nil {
+		return fmt.Errorf("RunMigrations: kuberpult version is nil")
+	}
+
+	log.Infof("Starting to run all migrations...")
+	all := GetAllMigrations()
+	for _, m := range all {
+		err := m.Migration(ctx)
+		if err != nil {
+			return fmt.Errorf("error during migration for version %s: %w", migrations.FormatKuberpultVersion(m.Version), err)
+		}
+	}
+	log.Infof("All migrations are applied.")
+
+	return s.DBHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+		return migrations.DBWriteCustomMigrationCutoff(s.DBHandler, ctx, transaction, kuberpultVersion)
+	})
+}

--- a/services/manifest-repo-export-service/pkg/service/migration.go
+++ b/services/manifest-repo-export-service/pkg/service/migration.go
@@ -81,9 +81,6 @@ func (s *MigrationServer) EnsureCustomMigrationApplied(ctx context.Context, in *
 }
 
 func (s *MigrationServer) CustomMigrationsDone(ctx context.Context, version *api.KuberpultVersion) (bool, error) {
-	type Done struct {
-		done bool
-	}
 	dbVersion, err := db.WithTransactionT(s.DBHandler, ctx, 0, true, func(ctx context.Context, transaction *sql.Tx) (*api.KuberpultVersion, error) {
 		dbVersion, tErr := migrations.DBReadCustomMigrationCutoff(s.DBHandler, ctx, transaction, version)
 		if tErr != nil {

--- a/services/manifest-repo-export-service/pkg/service/migration_test.go
+++ b/services/manifest-repo-export-service/pkg/service/migration_test.go
@@ -1,0 +1,64 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package service
+
+import (
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
+	"github.com/freiheit-com/kuberpult/services/manifest-repo-export-service/pkg/migrations"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
+)
+
+func TestRunMigrations(t *testing.T) {
+	type TestCase struct {
+		name             string
+		kuberpultVersion *api.KuberpultVersion
+		expectedError    error
+	}
+
+	tcs := []TestCase{
+		{
+			name:             "empty migrations should succeed",
+			kuberpultVersion: migrations.CreateKuberpultVersion(0, 1, 2),
+			expectedError:    nil,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			repo, _ := setupRepositoryTestWithPath(t)
+
+			ctx := testutil.MakeTestContext()
+			dbHandler := repo.State().DBHandler
+
+			migrationServer := MigrationServer{
+				DBHandler: dbHandler,
+			}
+
+			err := migrationServer.RunMigrations(ctx, tc.kuberpultVersion)
+
+			if diff := cmp.Diff(tc.expectedError, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("error mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
By "custom migrations" we mean those db migrations that can not be solved by plain SQL, so they are implemented in go.

This provides the basic setup to move the custom migrations to the manifest-export-service.
* It creates a new endpoint to accept migrations, however the endpoint is not called yet.
* It provides the setup like reading/writing to the custom_migration_cutoff table

However, this change does not include actually moving the migrations from cd- to export-service. This will be done in a separate PR.

Ref: SRX-V6RVYF