### PR TITLE
chore(ui): all app locks from locks page are now accessing the all app locks endpoint

### DIFF
--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -314,6 +314,7 @@ func (o *OverviewServiceServer) GetOverview(
 
 func (o *OverviewServiceServer) GetAllAppLocks(ctx context.Context,
 	in *api.GetAllAppLocksRequest) (*api.GetAllAppLocksResponse, error) {
+
 	span, ctx := tracer.StartSpanFromContext(ctx, "GetAllAppLocks")
 	defer span.Finish()
 
@@ -352,7 +353,7 @@ func (o *OverviewServiceServer) GetAllAppLocks(ctx context.Context,
 				},
 			})
 		}
-		
+
 		return &response, nil
 	})
 }

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -314,7 +314,6 @@ func (o *OverviewServiceServer) GetOverview(
 
 func (o *OverviewServiceServer) GetAllAppLocks(ctx context.Context,
 	in *api.GetAllAppLocksRequest) (*api.GetAllAppLocksResponse, error) {
-	
 	span, ctx := tracer.StartSpanFromContext(ctx, "GetAllAppLocks")
 	defer span.Finish()
 
@@ -353,6 +352,7 @@ func (o *OverviewServiceServer) GetAllAppLocks(ctx context.Context,
 				},
 			})
 		}
+		
 		return &response, nil
 	})
 }

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -314,7 +314,13 @@ func (o *OverviewServiceServer) GetOverview(
 
 func (o *OverviewServiceServer) GetAllAppLocks(ctx context.Context,
 	in *api.GetAllAppLocksRequest) (*api.GetAllAppLocksResponse, error) {
+<<<<<<< HEAD
 
+=======
+	// Get all Environments
+	// For each environment, get all applications
+	// Get all app locks for that environment
+>>>>>>> 0a159ccd (Implement new endpoint for getting all app locks)
 	span, ctx := tracer.StartSpanFromContext(ctx, "GetAllAppLocks")
 	defer span.Finish()
 
@@ -353,7 +359,6 @@ func (o *OverviewServiceServer) GetAllAppLocks(ctx context.Context,
 				},
 			})
 		}
-
 		return &response, nil
 	})
 }

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -314,13 +314,7 @@ func (o *OverviewServiceServer) GetOverview(
 
 func (o *OverviewServiceServer) GetAllAppLocks(ctx context.Context,
 	in *api.GetAllAppLocksRequest) (*api.GetAllAppLocksResponse, error) {
-<<<<<<< HEAD
-
-=======
-	// Get all Environments
-	// For each environment, get all applications
-	// Get all app locks for that environment
->>>>>>> 0a159ccd (Implement new endpoint for getting all app locks)
+	
 	span, ctx := tracer.StartSpanFromContext(ctx, "GetAllAppLocks")
 	defer span.Finish()
 

--- a/services/frontend-service/src/ui/App/index.test.tsx
+++ b/services/frontend-service/src/ui/App/index.test.tsx
@@ -18,7 +18,7 @@ import { render } from '@testing-library/react';
 import { Spy } from 'spy4js';
 import { AzureAuthSub } from '../utils/AzureAuthProvider';
 import { Observable } from 'rxjs';
-import { emptyAppLocks, UpdateOverview } from '../utils/store';
+import { UpdateOverview } from '../utils/store';
 import { MemoryRouter } from 'react-router-dom';
 
 Spy.mockModule('../components/NavigationBar/NavigationBar', 'NavigationBar');

--- a/services/frontend-service/src/ui/App/index.test.tsx
+++ b/services/frontend-service/src/ui/App/index.test.tsx
@@ -18,7 +18,7 @@ import { render } from '@testing-library/react';
 import { Spy } from 'spy4js';
 import { AzureAuthSub } from '../utils/AzureAuthProvider';
 import { Observable } from 'rxjs';
-import { UpdateOverview } from '../utils/store';
+import { emptyAppLocks, UpdateOverview } from '../utils/store';
 import { MemoryRouter } from 'react-router-dom';
 
 Spy.mockModule('../components/NavigationBar/NavigationBar', 'NavigationBar');
@@ -30,6 +30,7 @@ Spy.mockModule('../utils/AzureAuthProvider', 'AzureAuthProvider');
 
 const mock_GetConfig = Spy('Config');
 const mock_StreamOverview = Spy('Overview');
+const mock_GetAllAppLocks = Spy('AllAppLocks');
 const mock_StreamStatus = Spy('Status');
 
 jest.mock('../utils/GrpcApi', () => ({
@@ -41,6 +42,7 @@ jest.mock('../utils/GrpcApi', () => ({
             }),
             overviewService: () => ({
                 StreamOverview: () => mock_StreamOverview(),
+                GetAllAppLocks: () => mock_GetAllAppLocks(),
             }),
             rolloutService: () => ({
                 StreamStatus: () => mock_StreamStatus(),
@@ -73,6 +75,7 @@ describe('App uses the API', () => {
                 observer.next({ applications: 'test-application' });
             })
         );
+        mock_GetAllAppLocks.returns(Promise.resolve('test'));
         mock_GetConfig.returns(Promise.resolve('test-config'));
         AzureAuthSub.set({ authReady: true });
         mock_StreamStatus.returns(
@@ -102,6 +105,7 @@ describe('App uses the API', () => {
                 observer.next({});
             })
         );
+        mock_GetAllAppLocks.returns(Promise.resolve('test'));
         mock_GetConfig.returns(Promise.resolve('test-config'));
         AzureAuthSub.set({ authReady: true });
 

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -124,7 +124,7 @@ export const App: React.FC = () => {
                                 UpdateAllApplicationLocks.set(res.allAppLocks);
                             })
                             .catch((e) => {
-                                PanicOverview.set({ error: JSON.stringify({ msg: 'error in streamoverview', e }) });
+                                PanicOverview.set({ error: JSON.stringify({ msg: 'error in GetAllAppLocks', e }) });
                             });
                     },
                     (error) => {

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -24,6 +24,7 @@ import {
     FlushRolloutStatus,
     PanicOverview,
     showSnackbarWarn,
+    UpdateAllApplicationLocks,
     updateAppDetails,
     UpdateFrontendConfig,
     UpdateOverview,
@@ -116,6 +117,17 @@ export const App: React.FC = () => {
                             }
                         });
                         updateAppDetails.set(details);
+                        // Get App Locks
+                        api.overviewService()
+                            .GetAllAppLocks({}, authHeader)
+                            .then((res) => {
+                                UpdateAllApplicationLocks.set(res.allAppLocks);
+                                // eslint-disable-next-line no-console
+                                console.log(res);
+                            })
+                            .catch((e) => {
+                                PanicOverview.set({ error: JSON.stringify({ msg: 'error in streamoverview', e }) });
+                            });
                     },
                     (error) => {
                         PanicOverview.set({ error: JSON.stringify({ msg: 'error in streamoverview', error }) });

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -122,8 +122,6 @@ export const App: React.FC = () => {
                             .GetAllAppLocks({}, authHeader)
                             .then((res) => {
                                 UpdateAllApplicationLocks.set(res.allAppLocks);
-                                // eslint-disable-next-line no-console
-                                console.log(res);
                             })
                             .catch((e) => {
                                 PanicOverview.set({ error: JSON.stringify({ msg: 'error in streamoverview', e }) });

--- a/services/frontend-service/src/ui/Pages/Locks/LocksPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Locks/LocksPage.test.tsx
@@ -17,13 +17,14 @@ import { render, renderHook } from '@testing-library/react';
 import { LocksPage } from './LocksPage';
 import {
     DisplayLock,
+    UpdateAllApplicationLocks,
     UpdateOverview,
     useAllLocks,
     useEnvironmentLock,
     useFilteredEnvironmentLockIDs,
 } from '../../utils/store';
 import { MemoryRouter } from 'react-router-dom';
-import { Environment, OverviewApplication, Priority } from '../../../api/api';
+import { AllAppLocks, Environment, OverviewApplication, Priority } from '../../../api/api';
 import { fakeLoadEverything, enableDexAuth } from '../../../setupTests';
 
 describe('LocksPage', () => {
@@ -332,6 +333,9 @@ describe('Test app locks', () => {
         name: string;
         envs: Environment[];
         OverviewApps: OverviewApplication[];
+        AppLocks: {
+            [key: string]: AllAppLocks;
+        };
         sortOrder: 'oldestToNewest' | 'newestToOldest';
         expectedLockIDs: string[];
     }
@@ -343,6 +347,7 @@ describe('Test app locks', () => {
             OverviewApps: [],
             sortOrder: 'oldestToNewest',
             expectedLockIDs: [],
+            AppLocks: {},
         },
         {
             name: 'get one lock',
@@ -366,6 +371,15 @@ describe('Test app locks', () => {
                     priority: 0,
                 },
             ],
+            AppLocks: {
+                integration: {
+                    appLocks: {
+                        foo: {
+                            locks: [{ message: 'locktest', lockId: 'ui-v2-1337' }],
+                        },
+                    },
+                },
+            },
             sortOrder: 'oldestToNewest',
             expectedLockIDs: ['ui-v2-1337'],
         },
@@ -407,6 +421,31 @@ describe('Test app locks', () => {
                     priority: 0,
                 },
             ],
+            AppLocks: {
+                integration: {
+                    appLocks: {
+                        foo: {
+                            locks: [
+                                {
+                                    message: 'locktest',
+                                    lockId: 'ui-v2-1337',
+                                    createdAt: new Date(1995, 11, 17),
+                                },
+                                {
+                                    message: 'lockfoo',
+                                    lockId: 'ui-v2-123',
+                                    createdAt: new Date(1995, 11, 16),
+                                },
+                                {
+                                    message: 'lockbar',
+                                    lockId: 'ui-v2-321',
+                                    createdAt: new Date(1995, 11, 15),
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
             sortOrder: 'newestToOldest',
             expectedLockIDs: ['ui-v2-1337', 'ui-v2-123', 'ui-v2-321'],
         },
@@ -460,6 +499,35 @@ describe('Test app locks', () => {
                     priority: 0,
                 },
             ],
+            AppLocks: {
+                integration: {
+                    appLocks: {
+                        foo: {
+                            locks: [
+                                {
+                                    message: 'lockbar',
+                                    lockId: 'ui-v2-321',
+                                    createdAt: new Date(1995, 11, 15),
+                                },
+                            ],
+                        },
+                        bar: {
+                            locks: [
+                                {
+                                    message: 'lockfoo',
+                                    lockId: 'ui-v2-123',
+                                    createdAt: new Date(1995, 11, 16),
+                                },
+                                {
+                                    message: 'locktest',
+                                    lockId: 'ui-v2-1337',
+                                    createdAt: new Date(1995, 11, 17),
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
             sortOrder: 'oldestToNewest',
             expectedLockIDs: ['ui-v2-321', 'ui-v2-123', 'ui-v2-1337'],
         },
@@ -480,6 +548,7 @@ describe('Test app locks', () => {
                     },
                 ],
             });
+            UpdateAllApplicationLocks.set(testcase.AppLocks);
 
             // when
             const obtained = renderHook(() => useAllLocks().appLocks).result.current;

--- a/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
@@ -84,9 +84,8 @@ export const LocksPage: React.FC = () => {
     teamLocks = useMemo(() => sortLocks(teamLocks, 'oldestToNewest'), [teamLocks]);
     allAppLocks.forEach((appLocksForEnv, env): void => {
         const currAppLocks = new Map<string, Locks>(Object.entries(appLocksForEnv.appLocks));
-
         currAppLocks.forEach((currentAppInfo, app) => {
-            currentAppInfo.locks.map((lock) => {
+            currentAppInfo.locks.map((lock) =>
                 allAppLocksDisplay.push({
                     date: lock.createdAt,
                     environment: env,
@@ -95,8 +94,8 @@ export const LocksPage: React.FC = () => {
                     message: lock.message,
                     authorName: lock.createdBy?.name,
                     authorEmail: lock.createdBy?.email,
-                });
-            });
+                })
+            );
         });
     });
     allAppLocksDisplay.flat().filter((lock) => searchCustomFilter(appNameParam, lock.application));

--- a/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
@@ -16,8 +16,10 @@ Copyright freiheit.com*/
 import React, { useMemo } from 'react';
 import { LocksTable } from '../../components/LocksTable/LocksTable';
 import {
+    DisplayLock,
     searchCustomFilter,
     sortLocks,
+    useAllApplicationLocks,
     useApplications,
     useEnvironments,
     useGlobalLoadingState,
@@ -25,6 +27,7 @@ import {
 } from '../../utils/store';
 import { useSearchParams } from 'react-router-dom';
 import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
+import { Locks } from '../../../api/api';
 
 const applicationFieldHeaders = [
     'Date',
@@ -45,6 +48,7 @@ export const LocksPage: React.FC = () => {
     const appNameParam = params.get('application');
     const envs = useEnvironments();
     const allApps = useApplications();
+    const allAppLocks = new Map(Object.entries(useAllApplicationLocks((map) => map)));
     let teamLocks = useTeamLocks(allApps);
     const envLocks = useMemo(
         () =>
@@ -65,37 +69,65 @@ export const LocksPage: React.FC = () => {
             ),
         [envs]
     );
+    const allAppLocksDisplay:
+        | DisplayLock[]
+        | {
+              date: Date | undefined;
+              environment: string;
+              application: string;
+              lockId: string;
+              message: string;
+              authorName: string | undefined;
+              authorEmail: string | undefined;
+          }[] = [];
 
     teamLocks = useMemo(() => sortLocks(teamLocks, 'oldestToNewest'), [teamLocks]);
+    allAppLocks.forEach((appLocksForEnv, env): void => {
+        const currAppLocks = new Map<string, Locks>(Object.entries(appLocksForEnv.appLocks));
 
-    //Goes through all envs and all apps and checks for locks for each app
-    const appLocks = useMemo(
-        () =>
-            sortLocks(
-                Object.values(envs)
-                    .map((env) =>
-                        allApps
-                            .map((app) =>
-                                env.appLocks[app.name]
-                                    ? env.appLocks[app.name].locks.map((lock) => ({
-                                          date: lock.createdAt,
-                                          environment: env.name,
-                                          application: app.name,
-                                          lockId: lock.lockId,
-                                          message: lock.message,
-                                          authorName: lock.createdBy?.name,
-                                          authorEmail: lock.createdBy?.email,
-                                      }))
-                                    : []
-                            )
-                            .flat()
-                    )
-                    .flat()
-                    .filter((lock) => searchCustomFilter(appNameParam, lock.application)),
-                'oldestToNewest'
-            ),
-        [appNameParam, envs, allApps]
-    );
+        currAppLocks.forEach((currentAppInfo, app) => {
+            currentAppInfo.locks.map((lock) => {
+                allAppLocksDisplay.push({
+                    date: lock.createdAt,
+                    environment: env,
+                    application: app,
+                    lockId: lock.lockId,
+                    message: lock.message,
+                    authorName: lock.createdBy?.name,
+                    authorEmail: lock.createdBy?.email,
+                });
+            });
+        });
+    });
+    allAppLocksDisplay.flat().filter((lock) => searchCustomFilter(appNameParam, lock.application));
+    // //Goes through all envs and all apps and checks for locks for each app
+    // const appLocks = useMemo(
+    //     () =>
+    //         sortLocks(
+    //             Object.values(envs)
+    //                 .map((env) =>
+    //                     allApps
+    //                         .map((app) =>
+    //                             env.appLocks[app.name]
+    //                                 ? env.appLocks[app.name].locks.map((lock) => ({
+    //                                       date: lock.createdAt,
+    //                                       environment: env.name,
+    //                                       application: app.name,
+    //                                       lockId: lock.lockId,
+    //                                       message: lock.message,
+    //                                       authorName: lock.createdBy?.name,
+    //                                       authorEmail: lock.createdBy?.email,
+    //                                   }))
+    //                                 : []
+    //                         )
+    //                         .flat()
+    //                 )
+    //                 .flat()
+    //                 .filter((lock) => searchCustomFilter(appNameParam, lock.application)),
+    //             'oldestToNewest'
+    //         ),
+    //     [appNameParam, envs, allApps]
+    // );
 
     const element = useGlobalLoadingState();
     if (element) {
@@ -106,7 +138,11 @@ export const LocksPage: React.FC = () => {
             <TopAppBar showAppFilter={true} showTeamFilter={false} showWarningFilter={false} />
             <main className="main-content">
                 <LocksTable headerTitle="Environment Locks" columnHeaders={environmentFieldHeaders} locks={envLocks} />
-                <LocksTable headerTitle="Application Locks" columnHeaders={applicationFieldHeaders} locks={appLocks} />
+                <LocksTable
+                    headerTitle="Application Locks"
+                    columnHeaders={applicationFieldHeaders}
+                    locks={allAppLocksDisplay}
+                />
                 <LocksTable headerTitle="Team Locks" columnHeaders={teamFieldHeaders} locks={teamLocks} />
             </main>
         </div>

--- a/services/frontend-service/src/ui/utils/store.test.tsx
+++ b/services/frontend-service/src/ui/utils/store.test.tsx
@@ -25,10 +25,12 @@ import {
     SnackbarStatus,
     UpdateAction,
     updateActions,
+    UpdateAllApplicationLocks,
     updateAppDetails,
     UpdateOverview,
     UpdateRolloutStatus,
     UpdateSnackbar,
+    useAllApplicationLocks,
     useLocksConflictingWithActions,
     useLocksSimilarTo,
     useNavigateWithSearchParams,
@@ -36,6 +38,7 @@ import {
     useRolloutStatus,
 } from './store';
 import {
+    AllAppLocks,
     BatchAction,
     Environment,
     EnvironmentGroup,
@@ -59,6 +62,7 @@ describe('Test useLocksSimilarTo', () => {
         inputAction: BatchAction; // the action we are rendering currently in the sidebar
         expectedLocks: AllLocks;
         OverviewApps: OverviewApplication[];
+        AppLocks: { [key: string]: AllAppLocks };
     };
 
     const testdata: TestDataStore[] = [
@@ -74,6 +78,7 @@ describe('Test useLocksSimilarTo', () => {
                 },
             },
             OverviewApps: [],
+            AppLocks: {},
             inputEnvGroups: [],
             expectedLocks: {
                 appLocks: [],
@@ -93,6 +98,7 @@ describe('Test useLocksSimilarTo', () => {
                 },
             },
             OverviewApps: [],
+            AppLocks: {},
             inputEnvGroups: [
                 {
                     environments: [
@@ -130,6 +136,7 @@ describe('Test useLocksSimilarTo', () => {
                 },
             },
             OverviewApps: [],
+            AppLocks: {},
             inputEnvGroups: [
                 {
                     environments: [
@@ -178,6 +185,15 @@ describe('Test useLocksSimilarTo', () => {
                     deleteEnvironmentLock: {
                         environment: 'dev',
                         lockId: 'l1',
+                    },
+                },
+            },
+            AppLocks: {
+                dev: {
+                    appLocks: {
+                        betty: {
+                            locks: [makeLock({ lockId: 'l1' })],
+                        },
                     },
                 },
             },
@@ -236,6 +252,15 @@ describe('Test useLocksSimilarTo', () => {
                     team: 'test-team',
                 },
             ],
+            AppLocks: {
+                dev: {
+                    appLocks: {
+                        betty: {
+                            locks: [makeLock({ lockId: 'l1' })],
+                        },
+                    },
+                },
+            },
             inputEnvGroups: [
                 {
                     environments: [
@@ -314,6 +339,7 @@ describe('Test useLocksSimilarTo', () => {
                 lightweightApps: testcase.OverviewApps,
                 environmentGroups: testcase.inputEnvGroups,
             });
+            UpdateAllApplicationLocks.set(testcase.AppLocks);
             // when
             const actions = renderHook(() => useLocksSimilarTo(testcase.inputAction)).result.current;
             // then
@@ -803,6 +829,9 @@ describe('Test useLocksConflictingWithActions', () => {
         expectedEnvLocks: DisplayLock[];
         environments: Environment[];
         OverviewApps: OverviewApplication[];
+        AppLocks: {
+            [key: string]: AllAppLocks;
+        };
     };
 
     const testdata: TestDataStore[] = [
@@ -813,6 +842,7 @@ describe('Test useLocksConflictingWithActions', () => {
             expectedEnvLocks: [],
             environments: [],
             OverviewApps: [],
+            AppLocks: {},
         },
         {
             name: 'deploy action and related app lock and env lock',
@@ -860,6 +890,20 @@ describe('Test useLocksConflictingWithActions', () => {
                     priority: 0,
                 },
             ],
+            AppLocks: {
+                dev: {
+                    appLocks: {
+                        app1: {
+                            locks: [
+                                makeLock({
+                                    lockId: 'app-lock-id',
+                                    message: 'i do not like this app',
+                                }),
+                            ],
+                        },
+                    },
+                },
+            },
             expectedAppLocks: [
                 makeDisplayLock({
                     lockId: 'app-lock-id',
@@ -890,7 +934,7 @@ describe('Test useLocksConflictingWithActions', () => {
                         $case: 'deploy',
                         deploy: {
                             environment: 'dev',
-                            application: 'app1',
+                            application: 'app2',
                             version: 1,
                             ignoreAllLocks: false,
                             lockBehavior: LockBehavior.IGNORE,
@@ -922,6 +966,20 @@ describe('Test useLocksConflictingWithActions', () => {
                     priority: 0,
                 },
             ],
+            AppLocks: {
+                staging: {
+                    appLocks: {
+                        anotherapp: {
+                            locks: [
+                                makeLock({
+                                    lockId: 'app-lock-id',
+                                    message: 'i do not like this app',
+                                }),
+                            ],
+                        },
+                    },
+                },
+            },
             expectedAppLocks: [],
             expectedEnvLocks: [],
         },
@@ -942,7 +1000,7 @@ describe('Test useLocksConflictingWithActions', () => {
                     },
                 ],
             });
-
+            UpdateAllApplicationLocks.set(testcase.AppLocks);
             // when
             const actualLocks = renderHook(() => useLocksConflictingWithActions()).result.current;
             // then

--- a/services/frontend-service/src/ui/utils/store.test.tsx
+++ b/services/frontend-service/src/ui/utils/store.test.tsx
@@ -30,7 +30,6 @@ import {
     UpdateOverview,
     UpdateRolloutStatus,
     UpdateSnackbar,
-    useAllApplicationLocks,
     useLocksConflictingWithActions,
     useLocksSimilarTo,
     useNavigateWithSearchParams,

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -33,6 +33,7 @@ import {
     GetFailedEslsResponse,
     GetAppDetailsResponse,
     OverviewApplication,
+    AllAppLocks,
 } from '../../api/api';
 import * as React from 'react';
 import { useCallback, useMemo } from 'react';
@@ -75,10 +76,16 @@ const emptyOverview: EnhancedOverview = {
     branch: '',
     manifestRepoUrl: '',
 };
+
 const [useOverview, UpdateOverview_] = createStore(emptyOverview);
 export const UpdateOverview = UpdateOverview_; // we do not want to export "useOverview". The store.tsx should act like a facade to the data.
 
 export const useOverviewLoaded = (): boolean => useOverview(({ loaded }) => loaded);
+
+export const emptyAppLocks: { [key: string]: AllAppLocks } = {};
+export const [useAllApplicationLocks, UpdateAllApplicationLocks] = createStore<{ [key: string]: AllAppLocks }>(
+    emptyAppLocks
+);
 
 type TagsResponse = {
     response: GetGitTagsResponse;


### PR DESCRIPTION
It does not remove the app locks from the overview. See [2182](https://github.com/freiheit-com/kuberpult/pull/2182)
Ref: SRX-JTRV7H