### PR TITLE
fix(ci): do not cancel builds (WIP)

### DIFF
--- a/.github/workflows/execution-plan-snippet-earthly.yml
+++ b/.github/workflows/execution-plan-snippet-earthly.yml
@@ -138,6 +138,7 @@ jobs:
       (needs.stageA_build.result != 'cancelled')  &&
       (needs.execution_plan.outputs.stage_b != 'null')
     strategy:
+      fail-fast: false
       matrix:
         data: ${{fromJSON(needs.execution_plan.outputs.stage_b)}}
     name: ${{ matrix.data.directory }} - Build and Publish


### PR DESCRIPTION
With this change, builds of microservices are not cancelled, only because another microservice failed to build.

The advantage is that we can see issues in service X, even if service Y fails.

Ref: SRX-V6RVYF