### PR TITLE
fix: add docker.env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ services/cd-service/known_hosts
 services/cd-service/repository_checked_out/
 CHANGELOG.tmp.md
 vendor/
+docker.env


### PR DESCRIPTION
The docker.env file is used to supply environment variables to docker compose. This is used for example when testing datadog integrations where we need the datadog api key.

Ref: SRX-V6RVYF