### PR TITLE
fix: increase retries in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider localhost:8080/healthz"]
       interval: 1s
       timeout: 5s
-      retries: 5
+      retries: 50
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
If the manifest export needs to clone a big manifest repository, it can take longer to start up.

So we increase the retries in docker-compose.

Ref: SRX-V6RVYF