### PR TITLE
fix: write correct version after custom migration

### DIFF
--- a/services/manifest-repo-export-service/pkg/service/migration.go
+++ b/services/manifest-repo-export-service/pkg/service/migration.go
@@ -105,7 +105,7 @@ func (s *MigrationServer) RunMigrations(ctx context.Context, kuberpultVersion *a
 			}
 
 			// 2) Store that we did run the migration:
-			return migrations.DBUpsertCustomMigrationCutoff(s.DBHandler, ctx, transaction, kuberpultVersion)
+			return migrations.DBUpsertCustomMigrationCutoff(s.DBHandler, ctx, transaction, m.Version)
 		})
 		if err != nil {
 			return onErr(fmt.Errorf("RunMigrations: error for version %s: %w", migrations2.FormatKuberpultVersion(m.Version), err))


### PR DESCRIPTION
This bug effectively made the manifest-export-service slower to start up, as it would repeat migrations that were already done on the last startup.

Ref: SRX-V6RVYF