### PR TITLE
fix(db): reduce calls to releases tables

### DIFF
--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -787,9 +787,14 @@ type SlowTransformer struct {
 func (s *SlowTransformer) GetDBEventType() db.EventType {
 	return "invalid"
 }
-func (p *SlowTransformer) SetEslVersion(_ db.TransformerID) {
+func (s *SlowTransformer) SetEslVersion(_ db.TransformerID) {
 	//Does nothing
 }
+
+func (s *SlowTransformer) GetEslVersion() db.TransformerID {
+	return 0
+}
+
 func (s *SlowTransformer) Transform(ctx context.Context, state *State, transformerContext TransformerContext, transaction *sql.Tx) (string, error) {
 	s.started <- struct{}{}
 	<-s.finished
@@ -800,6 +805,10 @@ type EmptyTransformer struct{}
 
 func (p *EmptyTransformer) SetEslVersion(_ db.TransformerID) {
 	//Does nothing
+}
+
+func (p *EmptyTransformer) GetEslVersion() db.TransformerID {
+	return 0
 }
 
 func (p *EmptyTransformer) GetDBEventType() db.EventType {
@@ -814,6 +823,10 @@ type PanicTransformer struct{}
 
 func (p *PanicTransformer) GetDBEventType() db.EventType {
 	return "invalid"
+}
+
+func (p *PanicTransformer) GetEslVersion() db.TransformerID {
+	return 0
 }
 
 func (p *PanicTransformer) SetEslVersion(_ db.TransformerID) {
@@ -840,6 +853,10 @@ func (p *ErrorTransformer) SetEslVersion(_ db.TransformerID) {
 	//Does nothing
 }
 
+func (p *ErrorTransformer) GetEslVersion() db.TransformerID {
+	return 0
+}
+
 type InvalidJsonTransformer struct{}
 
 func (p *InvalidJsonTransformer) GetDBEventType() db.EventType {
@@ -848,6 +865,10 @@ func (p *InvalidJsonTransformer) GetDBEventType() db.EventType {
 
 func (p *InvalidJsonTransformer) SetEslVersion(_ db.TransformerID) {
 	//Does nothing
+}
+
+func (p *InvalidJsonTransformer) GetEslVersion() db.TransformerID {
+	return 0
 }
 
 func (p *InvalidJsonTransformer) Transform(ctx context.Context, state *State, transformerContext TransformerContext, transaction *sql.Tx) (string, error) {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -362,6 +362,7 @@ type Transformer interface {
 	Transform(ctx context.Context, state *State, t TransformerContext, transaction *sql.Tx) (commitMsg string, e error)
 	GetDBEventType() db.EventType
 	SetEslVersion(eslVersion db.TransformerID)
+	GetEslVersion() db.TransformerID
 }
 
 type TransformerContext interface {
@@ -473,6 +474,10 @@ func (c *CreateApplicationVersion) GetDBEventType() db.EventType {
 
 func (c *CreateApplicationVersion) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
+}
+
+func (c *CreateApplicationVersion) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
 }
 
 type ctxMarkerGenerateUuid struct{}
@@ -1275,6 +1280,10 @@ func (c *CreateUndeployApplicationVersion) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
 }
 
+func (c *CreateUndeployApplicationVersion) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
 func (c *CreateUndeployApplicationVersion) Transform(
 	ctx context.Context,
 	state *State,
@@ -1476,6 +1485,10 @@ func (u *UndeployApplication) GetDBEventType() db.EventType {
 
 func (u *UndeployApplication) SetEslVersion(id db.TransformerID) {
 	u.TransformerEslVersion = id
+}
+
+func (c *UndeployApplication) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
 }
 
 func (u *UndeployApplication) Transform(
@@ -1691,8 +1704,12 @@ func (u *DeleteEnvFromApp) GetDBEventType() db.EventType {
 	return db.EvtDeleteEnvFromApp
 }
 
-func (c *DeleteEnvFromApp) SetEslVersion(id db.TransformerID) {
-	c.TransformerEslVersion = id
+func (u *DeleteEnvFromApp) SetEslVersion(id db.TransformerID) {
+	u.TransformerEslVersion = id
+}
+
+func (u *DeleteEnvFromApp) GetEslVersion() db.TransformerID {
+	return u.TransformerEslVersion
 }
 
 func (u *DeleteEnvFromApp) Transform(
@@ -1805,6 +1822,10 @@ func (c *CleanupOldApplicationVersions) GetDBEventType() db.EventType {
 
 func (c *CleanupOldApplicationVersions) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
+}
+
+func (c *CleanupOldApplicationVersions) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
 }
 
 // Finds old releases for an application
@@ -1931,6 +1952,10 @@ func (c *CreateEnvironmentLock) GetDBEventType() db.EventType {
 
 func (c *CreateEnvironmentLock) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
+}
+
+func (c *CreateEnvironmentLock) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
 }
 
 func (s *State) checkUserPermissions(ctx context.Context, transaction *sql.Tx, env, application, action, team string, RBACConfig auth.RBACConfig, checkTeam bool) error {
@@ -2127,6 +2152,10 @@ func (c *DeleteEnvironmentLock) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
 }
 
+func (c *DeleteEnvironmentLock) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
 func (c *DeleteEnvironmentLock) Transform(
 	ctx context.Context,
 	state *State,
@@ -2210,6 +2239,10 @@ func (c *CreateEnvironmentGroupLock) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
 }
 
+func (c *CreateEnvironmentGroupLock) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
 func (c *CreateEnvironmentGroupLock) Transform(
 	ctx context.Context,
 	state *State,
@@ -2265,6 +2298,11 @@ func (c *DeleteEnvironmentGroupLock) GetDBEventType() db.EventType {
 func (c *DeleteEnvironmentGroupLock) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
 }
+
+func (c *DeleteEnvironmentGroupLock) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
 func (c *DeleteEnvironmentGroupLock) Transform(
 	ctx context.Context,
 	state *State,
@@ -2312,6 +2350,10 @@ func (c *CreateEnvironmentApplicationLock) GetDBEventType() db.EventType {
 
 func (c *CreateEnvironmentApplicationLock) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
+}
+
+func (c *CreateEnvironmentApplicationLock) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
 }
 
 func (c *CreateEnvironmentApplicationLock) Transform(
@@ -2424,6 +2466,10 @@ func (c *DeleteEnvironmentApplicationLock) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
 }
 
+func (c *DeleteEnvironmentApplicationLock) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
 func (c *DeleteEnvironmentApplicationLock) Transform(
 	ctx context.Context,
 	state *State,
@@ -2500,6 +2546,10 @@ func (c *CreateEnvironmentTeamLock) GetDBEventType() db.EventType {
 
 func (c *CreateEnvironmentTeamLock) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
+}
+
+func (c *CreateEnvironmentTeamLock) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
 }
 
 func (c *CreateEnvironmentTeamLock) Transform(
@@ -2639,6 +2689,10 @@ func (c *DeleteEnvironmentTeamLock) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
 }
 
+func (c *DeleteEnvironmentTeamLock) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
 func (c *DeleteEnvironmentTeamLock) Transform(
 	ctx context.Context,
 	state *State,
@@ -2719,6 +2773,10 @@ func (c *CreateEnvironment) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
 }
 
+func (c *CreateEnvironment) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
 func (c *CreateEnvironment) Transform(
 	ctx context.Context,
 	state *State,
@@ -2791,6 +2849,11 @@ func (c *DeleteEnvironment) GetDBEventType() db.EventType {
 func (c *DeleteEnvironment) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
 }
+
+func (c *DeleteEnvironment) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
 func (c *DeleteEnvironment) Transform(
 	ctx context.Context,
 	state *State,
@@ -2961,6 +3024,10 @@ func (c *DeployApplicationVersion) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
 }
 
+func (c *DeployApplicationVersion) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
 type DeployApplicationVersionSource struct {
 	TargetGroup *string `json:"targetGroup"`
 	Upstream    string  `json:"upstream"`
@@ -3019,17 +3086,13 @@ func (c *DeployApplicationVersion) Transform(
 			return "", err
 		}
 
-		appDir := applicationDirectory(fs, c.Application)
-
-		team, err := util.ReadFile(fs, fs.Join(appDir, "team"))
-
-		if errors.Is(err, os.ErrNotExist) {
-			teamLocks = map[string]Lock{} //If we do not find the team file, there is no team for application, meaning there can't be any team locks
-		} else {
-			teamLocks, err = state.GetEnvironmentTeamLocks(ctx, transaction, c.Environment, string(team))
-			if err != nil {
-				return "", err
-			}
+		team, err := state.GetApplicationTeamOwner(ctx, transaction, c.Application)
+		if err != nil {
+			return "", fmt.Errorf("could not determine team for deployment: %w", err)
+		}
+		teamLocks, err = state.GetEnvironmentTeamLocks(ctx, transaction, c.Environment, string(team))
+		if err != nil {
+			return "", err
 		}
 		if len(envLocks) > 0 || len(appLocks) > 0 || len(teamLocks) > 0 {
 			if c.WriteCommitData {
@@ -3401,6 +3464,10 @@ func (c *ReleaseTrain) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
 }
 
+func (c *ReleaseTrain) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
 type Overview struct {
 	App     string
 	Version uint64
@@ -3660,9 +3727,11 @@ func (c *ReleaseTrain) Transform(
 		return "", grpc.PublicError(ctx, fmt.Errorf("could not get all releases of all apps %w", err))
 	}
 
-	if state.DBHandler.ShouldUseOtherTables() && isEnvGroup {
+	if state.DBHandler.ShouldUseOtherTables() && isEnvGroup && state.DBHandler.AllowParallelTransactions() {
 		releaseTrainErrGroup, _ := errgroup.WithContext(ctx)
-		releaseTrainErrGroup.SetLimit(state.MaxNumThreads)
+		if state.MaxNumThreads > 0 {
+			releaseTrainErrGroup.SetLimit(state.MaxNumThreads)
+		}
 		for _, envName := range envNames {
 			trainGroup := conversion.FromString(targetGroupName)
 			envNameLocal := envName
@@ -3704,21 +3773,14 @@ func (c *ReleaseTrain) Transform(
 
 func (c *ReleaseTrain) runEnvReleaseTrainBackground(ctx context.Context, state *State, t TransformerContext, envName string, trainGroup *string, envGroupConfigs map[string]config.EnvironmentConfig, configs map[string]config.EnvironmentConfig, releases map[string][]int64) error {
 	err := state.DBHandler.WithTransactionR(ctx, 2, false, func(ctx context.Context, transaction2 *sql.Tx) error {
-		internal, err := state.DBHandler.DBReadEslEventInternal(ctx, transaction2, false)
-		if err != nil {
-			return err
-		}
-		if internal == nil {
-			return fmt.Errorf("could not find esl event that was just inserted")
-		}
-		err = t.Execute(ctx, &envReleaseTrain{
+		err := t.Execute(ctx, &envReleaseTrain{
 			Parent:                 c,
 			Env:                    envName,
 			EnvConfigs:             configs,
 			EnvGroupConfigs:        envGroupConfigs,
 			WriteCommitData:        c.WriteCommitData,
 			TrainGroup:             trainGroup,
-			TransformerEslVersion:  db.TransformerID(internal.EslVersion),
+			TransformerEslVersion:  c.TransformerEslVersion,
 			CiLink:                 c.CiLink,
 			AllLatestReleasesCache: releases,
 		}, transaction2)
@@ -3747,6 +3809,10 @@ func (c *envReleaseTrain) GetDBEventType() db.EventType {
 
 func (c *envReleaseTrain) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
+}
+
+func (c *envReleaseTrain) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
 }
 
 func (c *envReleaseTrain) prognosis(ctx context.Context, state *State, transaction *sql.Tx, allLatestReleases AllLatestReleasesCache) ReleaseTrainEnvironmentPrognosis {
@@ -4263,6 +4329,10 @@ func (c *skippedServices) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
 }
 
+func (c *skippedServices) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
+}
+
 func (c *skippedServices) Transform(
 	ctx context.Context,
 	_ *State,
@@ -4292,6 +4362,10 @@ func (c *skippedService) GetDBEventType() db.EventType {
 
 func (c *skippedService) SetEslVersion(id db.TransformerID) {
 	c.TransformerEslVersion = id
+}
+
+func (c *skippedService) GetEslVersion() db.TransformerID {
+	return c.TransformerEslVersion
 }
 
 func (c *skippedService) Transform(_ context.Context, _ *State, _ TransformerContext, _ *sql.Tx) (string, error) {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -4142,10 +4142,12 @@ func (c *envReleaseTrain) Transform(
 		}
 		for appName := range prognosis.AppsPrognoses {
 			releases := prognosis.AllLatestReleases[appName]
+			var release uint64
 			if releases == nil {
-				return "", fmt.Errorf("error getting latest release for app '%s' - no release found", appName)
+				release = 0
+			} else {
+				release = uint64(releases[len(releases)-1])
 			}
-			release := uint64(releases[len(releases)-1])
 			releaseDir := releasesDirectoryWithVersion(state.Filesystem, appName, release)
 			eventMessage := ""
 			if len(prognosis.Locks) > 0 {

--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -299,7 +299,7 @@ func TestTransformerWritesEslDataRoundTrip(t *testing.T) {
 			t.Logf("detected dir: %s - err=%v", dir, err)
 			t.Parallel()
 			ctx := testutil.MakeTestContext()
-			repo := SetupRepositoryTestWithDBOptions(t, true)
+			repo, _ := SetupRepositoryTestWithDBOptions(t, true)
 			r := repo.(*repository)
 			row := &db.EslEventRow{}
 			err = repo.Apply(ctx, setupTransformers...)

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -3331,7 +3331,10 @@ skipping "test" because it is already in the version`,
 			configs, _ := repo.State().GetAllEnvironmentConfigs(ctx, nil)
 			prognosis := releaseTrain.Prognosis(ctx, repo.State(), nil, configs)
 
-			if !cmp.Equal(prognosis.EnvironmentPrognoses, tc.ExpectedPrognosis.EnvironmentPrognoses) || !cmp.Equal(prognosis.Error, tc.ExpectedPrognosis.Error, cmpopts.EquateErrors()) {
+			//if diff := cmp.Diff(a, tc.wantClientApp, cmpopts.IgnoreFields(DexRewriteURLRoundTripper{}, "T")); diff != "" {
+			opts := cmpopts.IgnoreFields(ReleaseTrainEnvironmentPrognosis{}, "AllLatestReleases")
+			if !cmp.Equal(prognosis.EnvironmentPrognoses, tc.ExpectedPrognosis.EnvironmentPrognoses, opts) ||
+				!cmp.Equal(prognosis.Error, tc.ExpectedPrognosis.Error, cmpopts.EquateErrors()) {
 				t.Fatalf("release train prognosis is wrong, wanted %v, got %v", tc.ExpectedPrognosis, prognosis)
 			}
 

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1409,12 +1409,35 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 	type TestCase struct {
 		Name             string
 		Transformers     []Transformer
-		expectedContent  []FileWithContent
 		db               bool
-		expectedDBEvents []event.Event
+		expectedDBEvents []db.EventRow // the events that the last transformer created
 	}
 
 	tcs := []TestCase{
+		{
+			Name: "Create a single application version without deploying it",
+			// no need to bother with environments here
+			Transformers: []Transformer{
+				&CreateApplicationVersion{
+					Application:    "app",
+					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Manifests: map[string]string{
+						"staging": "doesn't matter",
+					},
+					WriteCommitData: true,
+					Version:         1,
+				},
+			},
+			expectedDBEvents: []db.EventRow{
+				{
+					Uuid:          "00000000-0000-0000-0000-000000000001",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					EventType:     "new-release",
+					EventJson:     "{}",
+					TransformerID: 1,
+				},
+			},
+		},
 		{
 			Name: "Create a single application version and deploy it",
 			// no need to bother with environments here
@@ -1426,6 +1449,7 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 						"staging": "doesn't matter",
 					},
 					WriteCommitData: true,
+					Version:         1,
 				},
 				&DeployApplicationVersion{
 					Application:     "app",
@@ -1434,23 +1458,18 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 					Version:         1,
 				},
 			},
-			expectedContent: []FileWithContent{
+			expectedDBEvents: []db.EventRow{
 				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events/00000000-0000-0000-0000-000000000001/application",
-					Content: "app",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events/00000000-0000-0000-0000-000000000001/environment",
-					Content: "staging",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events/00000000-0000-0000-0000-000000000001/eventType",
-					Content: "deployment",
+					Uuid:          "00000000-0000-0000-0000-000000000002",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					EventType:     "deployment",
+					EventJson:     "{}",
+					TransformerID: 2,
 				},
 			},
 		},
 		{
-			Name: "Trigger a deployment via a relase train with environment target",
+			Name: "Trigger a deployment via a release train with environment target",
 			Transformers: []Transformer{
 				&CreateEnvironment{
 					Environment: "production",
@@ -1477,6 +1496,7 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 						"staging":    "some staging manifest 2",
 					},
 					WriteCommitData: true,
+					Version:         1,
 				},
 				&DeployApplicationVersion{
 					Environment:     "staging",
@@ -1489,22 +1509,13 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 					WriteCommitData: true,
 				},
 			},
-			expectedContent: []FileWithContent{
+			expectedDBEvents: []db.EventRow{
 				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/application",
-					Content: "app",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/environment",
-					Content: "production",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/eventType",
-					Content: "deployment",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/source_train_upstream",
-					Content: "staging",
+					Uuid:       "00000000-0000-0000-0000-000000000005",
+					CommitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					EventType:  "deployment",
+					//EventJson:     "{}",
+					TransformerID: 5,
 				},
 			},
 		},
@@ -1550,26 +1561,13 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 					WriteCommitData: true,
 				},
 			},
-			expectedContent: []FileWithContent{
+			expectedDBEvents: []db.EventRow{
 				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/application",
-					Content: "app",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/environment",
-					Content: "production",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/eventType",
-					Content: "deployment",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/source_train_upstream",
-					Content: "staging",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/source_train_environment_group",
-					Content: "production-group",
+					Uuid:          "00000000-0000-0000-0000-000000000005",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					EventType:     "deployment",
+					EventJson:     "{}",
+					TransformerID: 5,
 				},
 			},
 		},
@@ -1620,26 +1618,13 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 					WriteCommitData: true,
 				},
 			},
-			expectedContent: []FileWithContent{
+			expectedDBEvents: []db.EventRow{
 				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/eventType",
-					Content: "deployment",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/eventType",
-					Content: "deployment",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000003/eventType",
-					Content: "replaced-by",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/eventType",
-					Content: "lock-prevented-deployment",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000004/lock_message",
-					Content: "lock msg 1",
+					Uuid:          "00000000-0000-0000-0000-000000000005",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					EventType:     "lock-prevented-deployment",
+					EventJson:     "{}",
+					TransformerID: 6,
 				},
 			},
 		},
@@ -1678,38 +1663,27 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 					Version:         3,
 				},
 			},
-			expectedContent: []FileWithContent{
+			expectedDBEvents: []db.EventRow{
 				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/eventType",
-					Content: "deployment",
+					Uuid:          "00000000-0000-0000-0000-000000000001",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					EventType:     "new-release",
+					EventJson:     "{}",
+					TransformerID: 4,
 				},
 				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/application",
-					Content: "myapp",
+					Uuid:          "00000000-0000-0000-0000-000000000002",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					EventType:     "deployment",
+					EventJson:     "{}",
+					TransformerID: 4,
 				},
 				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/environment",
-					Content: "dev",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/eventType",
-					Content: "lock-prevented-deployment",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/application",
-					Content: "myapp",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/environment",
-					Content: "staging",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/lock_message",
-					Content: "lock staging",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/lock_type",
-					Content: "environment",
+					Uuid:          "00000000-0000-0000-0000-000000000003",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					EventType:     "lock-prevented-deployment",
+					EventJson:     "{}",
+					TransformerID: 4,
 				},
 			},
 		},
@@ -1754,38 +1728,27 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 					Version:         4,
 				},
 			},
-			expectedContent: []FileWithContent{
+			expectedDBEvents: []db.EventRow{
 				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/eventType",
-					Content: "deployment",
+					Uuid:          "00000000-0000-0000-0000-000000000001",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					EventType:     "new-release",
+					EventJson:     "{}",
+					TransformerID: 4,
 				},
 				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/application",
-					Content: "myapp",
+					Uuid:          "00000000-0000-0000-0000-000000000002",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					EventType:     "deployment",
+					EventJson:     "{}",
+					TransformerID: 4,
 				},
 				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000001/environment",
-					Content: "dev",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/eventType",
-					Content: "lock-prevented-deployment",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/application",
-					Content: "myapp",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/environment",
-					Content: "staging",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/lock_message",
-					Content: "lock myapp",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000002/lock_type",
-					Content: "application",
+					Uuid:          "00000000-0000-0000-0000-000000000003",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					EventType:     "lock-prevented-deployment",
+					EventJson:     "{}",
+					TransformerID: 4,
 				},
 			},
 		},
@@ -1827,26 +1790,20 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 					Version:         6,
 				},
 			},
-			expectedContent: []FileWithContent{
+			expectedDBEvents: []db.EventRow{
 				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000003/eventType",
-					Content: "lock-prevented-deployment",
+					Uuid:          "00000000-0000-0000-0000-000000000004",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					EventType:     "new-release",
+					EventJson:     "{}",
+					TransformerID: 4,
 				},
 				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000003/application",
-					Content: "myapp",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000003/environment",
-					Content: "dev",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000003/lock_message",
-					Content: "lock sreteam",
-				},
-				{
-					Path:    "commits/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab/events/00000000-0000-0000-0000-000000000003/lock_type",
-					Content: "team",
+					Uuid:          "00000000-0000-0000-0000-000000000005",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+					EventType:     "lock-prevented-deployment",
+					EventJson:     "{}",
+					TransformerID: 4,
 				},
 			},
 		},
@@ -1860,22 +1817,46 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 			fakeGen := testutil.NewIncrementalUUIDGenerator()
 			ctx := testutil.MakeTestContext()
 			ctx = AddGeneratorToContext(ctx, fakeGen)
-			var repo Repository
 			var err error = nil
-			var updatedState *State = nil
-			repo = setupRepositoryTest(t)
-			var batchError *TransformerBatchApplyError = nil
-			_, updatedState, _, batchError = repo.ApplyTransformersInternal(ctx, nil, tc.Transformers...)
-			if batchError != nil {
-				t.Fatalf("2 encountered error but no error is expected here: '%v'", batchError)
+			repo, dbHandler := SetupRepositoryTestWithDBOptions(t, false)
+			var lastTransformerId db.TransformerID = -1
+			for index, transformer := range tc.Transformers {
+				_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, tx *sql.Tx) error {
+					var batchError *TransformerBatchApplyError = nil
+					_, _, _, batchError = repo.ApplyTransformersInternal(ctx, tx, transformer)
+					if batchError != nil {
+						t.Fatalf("encountered error but no error is expected here: %d '%v'", index, batchError)
+					}
+					lastTransformerId = transformer.GetEslVersion()
+					return nil
+				})
 			}
+
+			t.Logf("last Transformer id: %v", lastTransformerId)
+
+			commitEvents, _ := db.WithTransactionT[[]db.EventRow](dbHandler, ctx, 0, true, func(ctx context.Context, tx *sql.Tx) (*[]db.EventRow, error) {
+				events, err := dbHandler.DBSelectAllCommitEventsForTransformerID(ctx, tx, lastTransformerId)
+				if err != nil {
+					t.Fatalf("2 encountered error but no error is expected here: '%v'", err)
+				}
+				return &events, nil
+			})
+
 			if err != nil {
 				t.Fatalf("encountered error but no error is expected here: '%v'", err)
 			}
-			fs := updatedState.Filesystem
-			if err := verifyContent(fs, tc.expectedContent); err != nil {
-				t.Fatalf("Error while verifying content: %v.\nFilesystem content:\n%s", err, strings.Join(listFiles(fs), "\n"))
+
+			if diff := cmp.Diff(tc.expectedDBEvents, *commitEvents, cmpopts.IgnoreFields(db.EventRow{}, "Timestamp", "EventJson")); diff != "" {
+				t.Errorf("result mismatch (-want, +got):\n%s", diff)
 			}
+			if diff := cmp.Diff(len(tc.expectedDBEvents), len(*commitEvents)); diff != "" {
+				t.Errorf("result mismatch in number of events (-want, +got):\n%s", diff)
+			}
+
+			//fs := updatedState.Filesystem
+			//if err := verifyContent(fs, tc.expectedContent); err != nil {
+			//	t.Fatalf("Error while verifying content: %v.\nFilesystem content:\n%s", err, strings.Join(listFiles(fs), "\n"))
+			//}
 		})
 	}
 }
@@ -2988,7 +2969,6 @@ func TestReleaseTrainWithCommit(t *testing.T) {
 		ExpectedPrognosis  ReleaseTrainPrognosis
 		testTeamPermission bool
 	}{
-
 		{
 			Name:               "User is not on the team of the application",
 			testTeamPermission: true,
@@ -3332,8 +3312,8 @@ skipping "test" because it is already in the version`,
 			prognosis := releaseTrain.Prognosis(ctx, repo.State(), nil, configs)
 
 			//if diff := cmp.Diff(a, tc.wantClientApp, cmpopts.IgnoreFields(DexRewriteURLRoundTripper{}, "T")); diff != "" {
-			opts := cmpopts.IgnoreFields(ReleaseTrainEnvironmentPrognosis{}, "AllLatestReleases")
-			if !cmp.Equal(prognosis.EnvironmentPrognoses, tc.ExpectedPrognosis.EnvironmentPrognoses, opts) ||
+			//opts := cmpopts.IgnoreFields(ReleaseTrainEnvironmentPrognosis{}, "AllLatestReleases")
+			if !cmp.Equal(prognosis.EnvironmentPrognoses, tc.ExpectedPrognosis.EnvironmentPrognoses) ||
 				!cmp.Equal(prognosis.Error, tc.ExpectedPrognosis.Error, cmpopts.EquateErrors()) {
 				t.Fatalf("release train prognosis is wrong, wanted %v, got %v", tc.ExpectedPrognosis, prognosis)
 			}
@@ -7074,11 +7054,11 @@ func makeTransformersForDelete(numVersions uint64) []Transformer {
 }
 
 func SetupRepositoryTestWithDB(t *testing.T) Repository {
-	r := SetupRepositoryTestWithDBOptions(t, false)
+	r, _ := SetupRepositoryTestWithDBOptions(t, false)
 	return r
 }
 
-func SetupRepositoryTestWithDBOptions(t *testing.T, writeEslOnly bool) Repository {
+func SetupRepositoryTestWithDBOptions(t *testing.T, writeEslOnly bool) (Repository, *db.DBHandler) {
 	ctx := context.Background()
 	migrationsPath, err := testutil.CreateMigrationsPath(4)
 	if err != nil {
@@ -7097,12 +7077,12 @@ func SetupRepositoryTestWithDBOptions(t *testing.T, writeEslOnly bool) Repositor
 	err = cmd.Start()
 	if err != nil {
 		t.Fatalf("error starting %v", err)
-		return nil
+		return nil, nil
 	}
 	err = cmd.Wait()
 	if err != nil {
 		t.Fatalf("error waiting %v", err)
-		return nil
+		return nil, nil
 	}
 	t.Logf("test created dir: %s", localDir)
 
@@ -7133,8 +7113,9 @@ func SetupRepositoryTestWithDBOptions(t *testing.T, writeEslOnly bool) Repositor
 	if err != nil {
 		t.Fatal(err)
 	}
-	return repo
+	return repo, dbHandler
 }
+
 func SetupRepositoryTestWithoutDB(t *testing.T, repositoryConfig *RepositoryConfig) Repository {
 	dir := t.TempDir()
 	remoteDir := path.Join(dir, "remote")


### PR DESCRIPTION
We already queried all releases during the prognosis, now we do not query the latest release again.

This also fixed:
* a bug where deployments ignored team locks
* a bug where the release trains hangs forever, if `cd.maxNumberOfThreads` is 0.
* adapted tests to use the db instead of git
* adapted test that run release train in parallel to work with sqlite (we can't just do multiple transactions with sqlite)

Ref: SRX-M65AQ8