### PR TITLE
fix(ui): Allow apps without release to be deleted

### DIFF
--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -375,7 +375,7 @@ export const ReadyServiceLane: React.FC<{
                 showSnackbarError('Internal Error: Cannot prepare to undeploy or actual undeploy in unknown state.');
                 break;
         }
-    }, [application.name, appDetails?.application?.undeploySummary]);
+    }, [application.name, appDetails?.application?.undeploySummary, allReleases.length]);
     let minorReleases = useMinorsForApp(application.name);
     if (!minorReleases) {
         minorReleases = [];

--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -334,6 +334,23 @@ export const ReadyServiceLane: React.FC<{
     const deployedReleases = [...new Set(allDeployedReleaseNumbers.map((v) => v).sort((n1, n2) => n2 - n1))];
 
     const prepareUndeployOrUndeploy = React.useCallback(() => {
+        if (allReleases.length === 0) {
+            // if there are no releases, we have to first create the undeploy release
+            // and then undeploy:
+            addAction({
+                action: {
+                    $case: 'prepareUndeploy',
+                    prepareUndeploy: { application: application.name },
+                },
+            });
+            addAction({
+                action: {
+                    $case: 'undeploy',
+                    undeploy: { application: application.name },
+                },
+            });
+            return;
+        }
         switch (appDetails?.application?.undeploySummary) {
             case UndeploySummary.UNDEPLOY:
                 addAction({


### PR DESCRIPTION
Apps should always have releases.
However, due to bug with deleting apps, some apps have no releases.

For these apps, it was impossible to undeploy them, because the undeploy endpoint expects at least 1 release.

With this change, we add actions for both prepareUndeploy and undeploy into the planned actions.

Ref: SRX-LZZMFQ