### PR TITLE
chore: implement sync status on cd-service and manifest export

### DIFF
--- a/database/migrations/postgres/1737404419146074_git_sync_status.up.sql
+++ b/database/migrations/postgres/1737404419146074_git_sync_status.up.sql
@@ -1,10 +1,9 @@
 CREATE TABLE IF NOT EXISTS git_sync_status
 (
-    eslVersion SERIAL,
     created TIMESTAMP,
     transformerID  INTEGER,
     envName VARCHAR,
     appName VARCHAR,
     status INTEGER,
-    PRIMARY KEY(eslVersion, appName, envName)
+    PRIMARY KEY(appName, envName)
 );

--- a/database/migrations/postgres/1737404419146074_git_sync_status.up.sql
+++ b/database/migrations/postgres/1737404419146074_git_sync_status.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS git_sync_status
+(
+    eslVersion SERIAL,
+    created TIMESTAMP,
+    transformerID  INTEGER,
+    envName VARCHAR,
+    appName VARCHAR,
+    status INTEGER,
+    PRIMARY KEY(eslVersion, appName, envName)
+);

--- a/database/migrations/sqlite/1737404419146074_git_sync_status.up.sql
+++ b/database/migrations/sqlite/1737404419146074_git_sync_status.up.sql
@@ -1,0 +1,1 @@
+../postgres/1737404419146074_git_sync_status.up.sql

--- a/pkg/db/db_sync_status.go
+++ b/pkg/db/db_sync_status.go
@@ -1,0 +1,232 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"time"
+)
+
+type SyncStatus int
+
+const (
+	SYNCED = iota
+	UNSYNCED
+	SYNC_FAILED
+)
+
+type GitSyncData struct {
+	AppName       string
+	EnvName       string
+	TransformerID EslVersion
+	SyncStatus
+}
+
+func (h *DBHandler) DBWriteNewSyncEvent(ctx context.Context, tx *sql.Tx, syncData *GitSyncData) error {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBWriteNewSyncEvent")
+	defer span.Finish()
+	if h == nil {
+		return nil
+	}
+	if tx == nil {
+		return fmt.Errorf("DBWriteNewSyncEvent: no transaction provided")
+	}
+
+	insertQuery := h.AdaptQuery("INSERT INTO git_sync_status (created, transformerid, envName, appName, status)  VALUES (?, ?, ?, ?, ?);")
+	now, err := h.DBReadTransactionTimestamp(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("DBWriteNewSyncEvent unable to get transaction timestamp: %w", err)
+	}
+	span.SetTag("query", insertQuery)
+	_, err = tx.Exec(
+		insertQuery,
+		*now,
+		syncData.TransformerID,
+		syncData.EnvName,
+		syncData.AppName,
+		syncData.SyncStatus)
+
+	if err != nil {
+		return fmt.Errorf("could not write sync event into DB. Error: %w\n", err)
+	}
+	return nil
+}
+
+func (h *DBHandler) DBWriteNewSyncEventBulk(ctx context.Context, tx *sql.Tx, id TransformerID, envApps []EnvApp, status SyncStatus) error {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBWriteNewSyncEventBulk")
+	defer span.Finish()
+	if h == nil {
+		return nil
+	}
+	if tx == nil {
+		return fmt.Errorf("DBWriteNewSyncEventBulk: no transaction provided")
+	}
+	now, err := h.DBReadTransactionTimestamp(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("DBWriteNewSyncEventBulk unable to get transaction timestamp: %w", err)
+	}
+	insertAllQuery := "INSERT INTO git_sync_status (created, transformerid, envName, appName, status) VALUES"
+	for idx, currComb := range envApps {
+		format := " ('%s', %d, '%s', '%s', %d)"
+		if idx == len(envApps)-1 {
+			format += ";"
+		} else {
+			format += ","
+		}
+		insertAllQuery += fmt.Sprintf(format, now.Format(time.RFC3339), id, currComb.EnvName, currComb.AppName, status)
+	}
+	_, err = tx.Exec(
+		insertAllQuery)
+	if err != nil {
+		return fmt.Errorf("could not write sync event into DB. Error: %w\n", err)
+	}
+	return nil
+}
+
+type EnvApp struct {
+	AppName string
+	EnvName string
+}
+
+func (h *DBHandler) DBReadUnsyncedAppsForTransfomerID(ctx context.Context, tx *sql.Tx, id TransformerID) ([]EnvApp, error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBReadUnsyncedAppsForTransfomerID")
+	defer span.Finish()
+	if h == nil {
+		return nil, nil
+	}
+	if tx == nil {
+		return nil, fmt.Errorf("DBReadUnsyncedAppsForTransfomerID: no transaction provided")
+	}
+	selectQuery := h.AdaptQuery(fmt.Sprintf("SELECT appName, envName FROM git_sync_status WHERE transformerid = ? AND status = ? ORDER BY eslVersion;"))
+	rows, err := tx.QueryContext(
+		ctx,
+		selectQuery,
+		id,
+		UNSYNCED,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not get current eslVersion. Error: %w\n", err)
+	}
+	defer func(rows *sql.Rows) {
+		err := rows.Close()
+		if err != nil {
+			logger.FromContext(ctx).Sugar().Warnf("row closing error: %v", err)
+		}
+	}(rows)
+	allCombinations := make([]EnvApp, 0)
+	var currApp string
+	var currEnv string
+	for rows.Next() {
+		err := rows.Scan(&currApp, &currEnv)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("Error table for next eslVersion. Error: %w\n", err)
+		}
+		allCombinations = append(allCombinations, EnvApp{
+			AppName: currApp,
+			EnvName: currEnv,
+		})
+	}
+	err = closeRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	return allCombinations, nil
+}
+
+func (h *DBHandler) DBBulkUpdateUnsyncedApps(ctx context.Context, tx *sql.Tx, id TransformerID, status SyncStatus) error {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBBulkUpdateUnsyncedApps")
+	defer span.Finish()
+	if h == nil {
+		return nil
+	}
+	if tx == nil {
+		return fmt.Errorf("DBBulkUpdateUnsyncedApps: no transaction provided")
+	}
+
+	allCombs, err := h.DBReadUnsyncedAppsForTransfomerID(ctx, tx, id)
+	if err != nil {
+		return fmt.Errorf("DBBulkUpdateUnsyncedApps unable to read unsynced apps: %w", err)
+	}
+	if len(allCombs) == 0 {
+		logger.FromContext(ctx).Sugar().Warnf("Could not update all unsynced apps. Did not find any unsynced apps.")
+		return nil
+	}
+	now, err := h.DBReadTransactionTimestamp(ctx, tx)
+
+	if err != nil {
+		return fmt.Errorf("DBBulkUpdateUnsyncedApps unable to get transaction timestamp: %w", err)
+	}
+
+	insertAllQuery := "INSERT INTO git_sync_status (created, transformerid, envName, appName, status) VALUES"
+	for idx, currComb := range allCombs {
+		format := " ('%s', %d, '%s', '%s', %d)"
+		if idx == len(allCombs)-1 {
+			format += ";"
+		} else {
+			format += ","
+		}
+
+		if err != nil {
+			return fmt.Errorf("DBBulkUpdateUnsyncedApps unable to parse timestamp: %w", err)
+
+		}
+		insertAllQuery += fmt.Sprintf(format, now.Format(time.RFC3339), id, currComb.EnvName, currComb.AppName, status)
+	}
+
+	_, err = tx.Exec(
+		insertAllQuery)
+	if err != nil {
+		return fmt.Errorf("DBBulkUpdateUnsyncedApps: could not write sync events into DB. Error: %w\n", err)
+	}
+	return nil
+}
+
+func (h *DBHandler) DBRetrieveSyncStatus(ctx context.Context, tx *sql.Tx, appName, envName string) (*GitSyncData, error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBRetrieveSyncStatus")
+	defer span.Finish()
+	if h == nil {
+		return nil, nil
+	}
+	if tx == nil {
+		return nil, fmt.Errorf("DBRetrieveSyncStatus: no transaction provided")
+	}
+
+	selectQuerry := h.AdaptQuery("SELECT transformerid, envName, appName, status FROM git_sync_status WHERE appName = ? AND envName= ? ORDER BY eslVersion DESC LIMIT 1;")
+	rows, err := tx.QueryContext(
+		ctx,
+		selectQuerry,
+		appName,
+		envName)
+	if err != nil {
+		return nil, fmt.Errorf("could not get git sync status for %q %q. Error: %w\n", envName, appName, err)
+	}
+
+	defer func(rows *sql.Rows) {
+		err := rows.Close()
+		if err != nil {
+			logger.FromContext(ctx).Sugar().Warnf("row closing error: %v", err)
+		}
+	}(rows)
+
+	var syncData GitSyncData
+	if rows.Next() {
+		err := rows.Scan(&syncData.TransformerID, &syncData.EnvName, &syncData.AppName, &syncData.SyncStatus)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("Error table scanning git_sync_status. Error: %w\n", err)
+		}
+	}
+	err = closeRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	return &syncData, nil
+}

--- a/pkg/db/db_sync_status.go
+++ b/pkg/db/db_sync_status.go
@@ -109,7 +109,7 @@ func (h *DBHandler) DBReadUnsyncedAppsForTransfomerID(ctx context.Context, tx *s
 	if tx == nil {
 		return nil, fmt.Errorf("DBReadUnsyncedAppsForTransfomerID: no transaction provided")
 	}
-	selectQuery := h.AdaptQuery(fmt.Sprintf("SELECT appName, envName FROM git_sync_status WHERE transformerid = ? AND status = ? ORDER BY eslVersion;"))
+	selectQuery := h.AdaptQuery("SELECT appName, envName FROM git_sync_status WHERE transformerid = ? AND status = ? ORDER BY eslVersion;")
 	rows, err := tx.QueryContext(
 		ctx,
 		selectQuery,

--- a/pkg/db/db_sync_status.go
+++ b/pkg/db/db_sync_status.go
@@ -34,7 +34,7 @@ const (
 	SYNC_FAILED
 )
 
-const BULK_INSERT_BATCH_SIZE = 500 //500 is an arbi
+const BULK_INSERT_BATCH_SIZE = 500
 
 type GitSyncData struct {
 	AppName       string

--- a/pkg/db/db_sync_status.go
+++ b/pkg/db/db_sync_status.go
@@ -18,7 +18,7 @@ const (
 	SYNC_FAILED
 )
 
-const BULK_INSERT_BATCH_SIZE = 2
+const BULK_INSERT_BATCH_SIZE = 500
 
 type GitSyncData struct {
 	AppName       string

--- a/pkg/db/db_sync_status.go
+++ b/pkg/db/db_sync_status.go
@@ -1,3 +1,18 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
 package db
 
 import (

--- a/pkg/db/db_sync_status.go
+++ b/pkg/db/db_sync_status.go
@@ -1,4 +1,5 @@
-/*This file is part of kuberpult.
+/*
+This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -12,7 +13,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright freiheit.com*/
+Copyright freiheit.com
+*/
 package db
 
 import (
@@ -217,7 +219,7 @@ func (h *DBHandler) DBRetrieveSyncStatus(ctx context.Context, tx *sql.Tx, appNam
 	return &syncData, nil
 }
 
-// These queries can get long. Because of this, we insert these values in batches of BULK_INSERT_BATCH_SIZE
+// These queries can get long. Because of this, we insert these values in batches
 func (h *DBHandler) executeBulkInsert(ctx context.Context, tx *sql.Tx, allEnvApps []EnvApp, now time.Time, id TransformerID, status SyncStatus, batchSize int) error {
 	queryPrefix := "INSERT INTO git_sync_status (created, transformerid, envName, appName, status) VALUES"
 	currentQuery := queryPrefix

--- a/pkg/db/db_sync_status.go
+++ b/pkg/db/db_sync_status.go
@@ -1,5 +1,4 @@
-/*
-This file is part of kuberpult.
+/*This file is part of kuberpult.
 
 Kuberpult is free software: you can redistribute it and/or modify
 it under the terms of the Expat(MIT) License as published by
@@ -13,8 +12,8 @@ MIT License for more details.
 You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
-Copyright freiheit.com
-*/
+Copyright freiheit.com*/
+
 package db
 
 import (

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -814,6 +814,7 @@ func (r *repository) ApplyTransformersInternal(ctx context.Context, transaction 
 				AuthorName:  user.Name,
 				AuthorEmail: user.Email,
 			}
+			transfomerId := db.EslVersion(0)
 			if r.DB.ShouldUseEslTable() {
 				err = r.DB.DBWriteEslEventInternal(ctx, t.GetDBEventType(), transaction, t, eventMetadata)
 				if err != nil {
@@ -854,8 +855,8 @@ func (r *repository) ApplyTransformersInternal(ctx context.Context, transaction 
 						}
 						return nil, nil, nil, &applyErr
 					}
-
 				}
+				transfomerId = internal.EslVersion
 			}
 
 			if msg, subChanges, err := RunTransformer(ctxWithTime, t, state, transaction); err != nil {
@@ -867,6 +868,26 @@ func (r *repository) ApplyTransformersInternal(ctx context.Context, transaction 
 			} else {
 				commitMsg = append(commitMsg, msg)
 				changes = append(changes, subChanges)
+				//Sync Status Update
+				envApps := make([]db.EnvApp, 0)
+				for _, currentResult := range subChanges.ChangedApps {
+					if currentResult.App == "" || currentResult.Env == "" {
+						logger.FromContext(ctx).Sugar().Warnf("Empty changed app or environment: App = '%s', Env = '%s'", currentResult.App, currentResult.Env)
+						continue
+					}
+					envApps = append(envApps, db.EnvApp{
+						AppName: currentResult.App,
+						EnvName: currentResult.Env,
+					})
+				}
+				err := state.DBHandler.DBWriteNewSyncEventBulk(ctx, transaction, db.TransformerID(transfomerId), envApps, db.UNSYNCED)
+				if err != nil {
+					return nil, nil, nil, &TransformerBatchApplyError{
+						TransformerError: fmt.Errorf("failed writing new sync events for transformer '%d': %w", int(transfomerId), err),
+						Index:            -1,
+					}
+				}
+				logger.FromContext(ctx).Sugar().Infof("Transformer modified %d app/envs", len(envApps))
 			}
 		}
 		return commitMsg, state, changes, nil

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -413,6 +413,13 @@ func processEsls(ctx context.Context, repo repository.Repository, dbHandler *db.
 				if err3 != nil {
 					return err3
 				}
+
+				//If we fail to process the transformer, we say that SYNC has failed
+				err3 = dbHandler.DBBulkUpdateUnsyncedApps(ctx, transaction, db.TransformerID(esl.EslVersion), db.SYNC_FAILED)
+				if err3 != nil {
+					return err3
+				}
+
 				return db.DBWriteCutoff(dbHandler, ctx, transaction, esl.EslVersion)
 			})
 			if err2 != nil {
@@ -453,11 +460,23 @@ func processEsls(ctx context.Context, repo repository.Repository, dbHandler *db.
 				return dbHandler.DBWriteCommitTransactionTimestamp(ctx, transaction, commitId.String(), esl.Created)
 			})
 			if err != nil {
+				//If we fail to push to repo or to update the cutoff, we say that SYNC has failed
+				err = dbHandler.WithTransactionR(ctx, 2, false, func(ctx context.Context, transaction *sql.Tx) error {
+					return dbHandler.DBBulkUpdateUnsyncedApps(ctx, transaction, db.TransformerID(esl.EslVersion), db.SYNC_FAILED)
+				})
 				err3 := repo.FetchAndReset(ctx)
 				if err3 != nil {
 					d := sleepDuration.NextBackOff()
 					logger.FromContext(ctx).Sugar().Warnf("error fetching repo, will try again in %v", d)
 					time.Sleep(d)
+				}
+			} else {
+				//After a successful transformer processing and pushing to manifest repo, we write that apps are now SYNCED
+				err = dbHandler.WithTransactionR(ctx, 2, false, func(ctx context.Context, transaction *sql.Tx) error {
+					return dbHandler.DBBulkUpdateUnsyncedApps(ctx, transaction, db.TransformerID(esl.EslVersion), db.SYNCED)
+				})
+				if err != nil {
+					logger.FromContext(ctx).Sugar().Warnf("Failed writing sync status after successful operation! Repo has been updated, but sync status has not. Error: %v", err)
 				}
 			}
 		}


### PR DESCRIPTION
cd-service now writes to git_sync_data table upon transformer execution
manifest-export-service now writes to git_sync_data table upon transformer execution or failure
Ref: SRX-IV81DS