### PR TITLE
feat(ui): cancel planned 'deploy' actions

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -210,6 +210,14 @@ button.button-lock {
 button.mdc-button.env-card-deploy-btn {
     border-radius: $release-dialog-inner-border-radius;
     @extend .text-bold;
+
+    &.button-main.deploy-button-cancel {
+        background-color: var(--mdc-theme-error);
+    }
+
+    &.deploy-button-cancel:not(.button-main) {
+        color: var(--mdc-theme-error);
+    }
 }
 button.mdc-button.env-card-lock-btn {
     border-radius: $release-dialog-inner-border-radius;

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -20,6 +20,7 @@ import {
     addAction,
     getPriorityClassName,
     showSnackbarWarn,
+    useActions,
     useAppDetailsForApp,
     useApplications,
     useCloseReleaseDialog,
@@ -246,6 +247,16 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
         return <div>same version</div>;
     };
 
+    const actions = useActions();
+    const alreadyPlanned = actions.some(
+        (action) =>
+            action.action?.$case === 'deploy' &&
+            action.action.deploy.application === app &&
+            action.action.deploy.environment === env.name
+    );
+    const defaultLabel =
+        releaseDifference < 0 ? 'Update & Lock' : releaseDifference === 0 ? 'Deploy & Lock' : 'Rollback & Lock';
+
     return (
         <li key={env.name} className={classNames('env-card')}>
             <div className="env-card-header">
@@ -309,15 +320,10 @@ export const EnvironmentListItem: React.FC<EnvironmentListItemProps> = ({
                             <ExpandButton
                                 onClickSubmit={deployAndLockClick}
                                 onClickLock={createAppLock}
-                                defaultButtonLabel={
-                                    releaseDifference < 0
-                                        ? 'Update & Lock'
-                                        : releaseDifference === 0
-                                          ? 'Deploy & Lock'
-                                          : 'Rollback & Lock'
-                                }
+                                defaultButtonLabel={alreadyPlanned ? `Cancel ${defaultLabel}` : defaultLabel}
                                 releaseDifference={releaseDifference}
                                 disabled={!allowDeployment}
+                                alreadyPlanned={alreadyPlanned}
                             />
                         </div>
                     </div>
@@ -446,6 +452,18 @@ export const EnvironmentGroupLane: React.FC<{
         (releaseEnvGroup) => releaseEnvGroup.environmentGroupName === environmentGroup.environmentGroupName
     );
 
+    const actions = useActions();
+    const envsWithoutPlannedDeployments = environmentGroup.environments.filter(
+        (env) =>
+            !actions.some(
+                (action) =>
+                    action.action?.$case === 'deploy' &&
+                    action.action.deploy.application === app &&
+                    action.action.deploy.environment === env.name
+            )
+    );
+    const alreadyPlanned = envsWithoutPlannedDeployments.length === 0;
+
     const createEnvGroupLock = React.useCallback(() => {
         environmentGroup.environments.forEach((environment) => {
             addAction({
@@ -465,7 +483,8 @@ export const EnvironmentGroupLane: React.FC<{
     const deployAndLockClick = React.useCallback(
         (shouldLockToo: boolean) => {
             var skippedEnvs: string[] = [];
-            environmentGroup.environments.forEach((environment) => {
+            const envs = alreadyPlanned ? environmentGroup.environments : envsWithoutPlannedDeployments;
+            envs.forEach((environment) => {
                 if (
                     allReleases &&
                     allReleases.length !== 0 &&
@@ -553,9 +572,10 @@ export const EnvironmentGroupLane: React.FC<{
                         <ExpandButton
                             onClickSubmit={deployAndLockClick}
                             onClickLock={createEnvGroupLock}
-                            defaultButtonLabel={'Deploy & Lock'}
+                            defaultButtonLabel={alreadyPlanned ? 'Cancel Deploy & Lock' : 'Deploy & Lock'}
                             disabled={!allowGroupDeployment}
                             releaseDifference={0}
+                            alreadyPlanned={alreadyPlanned}
                         />
                     </div>
                 </div>

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -462,6 +462,14 @@ export const EnvironmentGroupLane: React.FC<{
                     action.action.deploy.environment === env.name
             )
     );
+    const envsWithPlannedDeployments = environmentGroup.environments.filter((env) =>
+        actions.some(
+            (action) =>
+                action.action?.$case === 'deploy' &&
+                action.action.deploy.application === app &&
+                action.action.deploy.environment === env.name
+        )
+    );
     const alreadyPlanned = envsWithoutPlannedDeployments.length === 0;
 
     const createEnvGroupLock = React.useCallback(() => {
@@ -482,7 +490,7 @@ export const EnvironmentGroupLane: React.FC<{
     }, [environmentGroup, app]);
     const deployAndLockClick = React.useCallback(
         (shouldLockToo: boolean) => {
-            var skippedEnvs: string[] = [];
+            var skippedEnvs: string[] = alreadyPlanned ? [] : envsWithPlannedDeployments.map((env) => env.name);
             const envs = alreadyPlanned ? environmentGroup.environments : envsWithoutPlannedDeployments;
             envs.forEach((environment) => {
                 if (
@@ -527,7 +535,16 @@ export const EnvironmentGroupLane: React.FC<{
                 showSnackbarWarn(`Environments skipped: ${skippedEnvs}`);
             }
         },
-        [environmentGroup.environments, allReleases, release.environments, release.version, app]
+        [
+            environmentGroup.environments,
+            allReleases,
+            release.environments,
+            release.version,
+            app,
+            alreadyPlanned,
+            envsWithoutPlannedDeployments,
+            envsWithPlannedDeployments,
+        ]
     );
 
     React.useEffect(() => {

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -1240,8 +1240,8 @@ exports[`Release Dialog Renders the environment locks undeploy version release 1
                         class="first-two"
                       >
                         <button
-                          aria-label="Deploy & Lock"
-                          class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated"
+                          aria-label="Cancel Deploy & Lock"
+                          class="mdc-button button-main env-card-deploy-btn mdc-button--unelevated deploy-button-cancel"
                         >
                           <div
                             class="mdc-button__ripple"
@@ -1249,7 +1249,7 @@ exports[`Release Dialog Renders the environment locks undeploy version release 1
                           <span
                             class="mdc-button__label"
                           >
-                            Deploy & Lock
+                            Cancel Deploy & Lock
                           </span>
                         </button>
                         <button

--- a/services/frontend-service/src/ui/components/button/ExpandButton.test.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.test.tsx
@@ -27,6 +27,7 @@ describe('ExpandButton', () => {
         disabled: false,
         defaultButtonLabel: 'default-button',
         releaseDifference: 0,
+        alreadyPlanned: false,
     };
 
     const getNode = (props: Partial<ExpandButtonProps>): JSX.Element => (
@@ -118,6 +119,46 @@ describe('ExpandButton', () => {
             expectSubmitCalledWith: {},
             expectLockCalledTimes: 0,
             expectedLabel: 'Update only',
+        },
+        {
+            name: 'click expand once, with positive release difference and planned rollback',
+            props: { releaseDifference: 1, alreadyPlanned: true },
+            clickThis: ['.button-expand'],
+            expectExpanded: true,
+            expectSubmitCalledTimes: 0,
+            expectSubmitCalledWith: {},
+            expectLockCalledTimes: 0,
+            expectedLabel: 'Cancel Rollback only',
+        },
+        {
+            name: 'click expand once, with positive release difference and planned update',
+            props: { releaseDifference: -1, alreadyPlanned: true },
+            clickThis: ['.button-expand'],
+            expectExpanded: true,
+            expectSubmitCalledTimes: 0,
+            expectSubmitCalledWith: {},
+            expectLockCalledTimes: 0,
+            expectedLabel: 'Cancel Update only',
+        },
+        {
+            name: 'click cancel deployment button',
+            props: { alreadyPlanned: true },
+            clickThis: ['.deploy-button-cancel'],
+            expectExpanded: false,
+            expectSubmitCalledTimes: 1,
+            expectSubmitCalledWith: true,
+            expectLockCalledTimes: 0,
+            expectedLabel: 'Deploy only',
+        },
+        {
+            name: 'click expand, then cancel deploy button',
+            props: { alreadyPlanned: true },
+            clickThis: ['.button-expand', '.button-popup-deploy.deploy-button-cancel'],
+            expectExpanded: true,
+            expectSubmitCalledTimes: 1,
+            expectSubmitCalledWith: false,
+            expectLockCalledTimes: 0,
+            expectedLabel: 'Cancel Deploy only',
         },
     ];
 

--- a/services/frontend-service/src/ui/components/button/ExpandButton.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.tsx
@@ -17,6 +17,7 @@ import { useCallback, useState } from 'react';
 import * as React from 'react';
 import { Button } from './button';
 import { PlainDialog } from '../dialog/ConfirmationDialog';
+import classNames from 'classnames';
 
 /**
  * Two buttons combined into one.
@@ -30,10 +31,11 @@ export type ExpandButtonProps = {
     defaultButtonLabel: string;
     disabled: boolean;
     releaseDifference: number;
+    alreadyPlanned: boolean;
 };
 
 export const ExpandButton = (props: ExpandButtonProps): JSX.Element => {
-    const { onClickSubmit, onClickLock, releaseDifference } = props;
+    const { onClickSubmit, onClickLock, releaseDifference, alreadyPlanned } = props;
 
     const [expanded, setExpanded] = useState(false);
 
@@ -57,6 +59,9 @@ export const ExpandButton = (props: ExpandButtonProps): JSX.Element => {
         onClickLock();
     }, [onClickLock]);
 
+    const deployLabel =
+        releaseDifference < 0 ? 'Update only' : releaseDifference === 0 ? 'Deploy only' : 'Rollback only';
+
     return (
         <div className={'expand-button'}>
             <div className={'first-two'}>
@@ -64,7 +69,9 @@ export const ExpandButton = (props: ExpandButtonProps): JSX.Element => {
                 <Button
                     onClick={onClickSubmitMain}
                     disabled={props.disabled}
-                    className={'button-main env-card-deploy-btn mdc-button--unelevated'}
+                    className={classNames('button-main', 'env-card-deploy-btn', 'mdc-button--unelevated', {
+                        'deploy-button-cancel': alreadyPlanned,
+                    })}
                     key={'button-first-key'}
                     label={props.defaultButtonLabel}
                     highlightEffect={false}
@@ -90,15 +97,14 @@ export const ExpandButton = (props: ExpandButtonProps): JSX.Element => {
                         <div>
                             <Button
                                 onClick={onClickSubmitAlternative}
-                                className={'button-popup-deploy env-card-deploy-btn mdc-button--unelevated'}
+                                className={classNames(
+                                    'button-popup-deploy',
+                                    'env-card-deploy-btn',
+                                    'mdc-button--unelevated',
+                                    { 'deploy-button-cancel': alreadyPlanned }
+                                )}
                                 key={'button-second-key'}
-                                label={
-                                    releaseDifference < 0
-                                        ? 'Update only'
-                                        : releaseDifference === 0
-                                          ? 'Deploy only'
-                                          : 'Rollback only'
-                                }
+                                label={alreadyPlanned ? `Cancel ${deployLabel}` : deployLabel}
                                 icon={undefined}
                                 highlightEffect={true}
                                 disabled={props.disabled}

--- a/services/frontend-service/src/ui/utils/store.test.tsx
+++ b/services/frontend-service/src/ui/utils/store.test.tsx
@@ -524,6 +524,7 @@ describe('Test addAction duplicate detection', () => {
         name: string;
         firstAction: BatchAction;
         differentAction: BatchAction;
+        shouldCancel: boolean;
     };
 
     const testdata: TestDataStore[] = [
@@ -551,6 +552,7 @@ describe('Test addAction duplicate detection', () => {
                     },
                 },
             },
+            shouldCancel: false,
         },
         {
             name: 'delete environment lock',
@@ -572,6 +574,7 @@ describe('Test addAction duplicate detection', () => {
                     },
                 },
             },
+            shouldCancel: false,
         },
         {
             name: 'create app lock',
@@ -599,6 +602,7 @@ describe('Test addAction duplicate detection', () => {
                     },
                 },
             },
+            shouldCancel: false,
         },
         {
             name: 'delete app lock',
@@ -622,6 +626,7 @@ describe('Test addAction duplicate detection', () => {
                     },
                 },
             },
+            shouldCancel: false,
         },
         {
             name: 'create team lock',
@@ -649,6 +654,7 @@ describe('Test addAction duplicate detection', () => {
                     },
                 },
             },
+            shouldCancel: false,
         },
         {
             name: 'delete team lock',
@@ -672,6 +678,7 @@ describe('Test addAction duplicate detection', () => {
                     },
                 },
             },
+            shouldCancel: false,
         },
         {
             name: 'deploy',
@@ -699,6 +706,7 @@ describe('Test addAction duplicate detection', () => {
                     },
                 },
             },
+            shouldCancel: true,
         },
         {
             name: 'undeploy',
@@ -718,6 +726,7 @@ describe('Test addAction duplicate detection', () => {
                     },
                 },
             },
+            shouldCancel: false,
         },
         {
             name: 'prepare undeploy',
@@ -737,6 +746,7 @@ describe('Test addAction duplicate detection', () => {
                     },
                 },
             },
+            shouldCancel: false,
         },
     ];
 
@@ -756,18 +766,18 @@ describe('Test addAction duplicate detection', () => {
             // when
             addAction(testcase.firstAction);
             // then
-            expect(UpdateAction.get().actions.length).toStrictEqual(1);
+            expect(UpdateAction.get().actions.length).toStrictEqual(testcase.shouldCancel ? 0 : 1);
             //and
-            expect(UpdateSnackbar.get().show).toStrictEqual(true);
+            expect(UpdateSnackbar.get().show).toStrictEqual(!testcase.shouldCancel);
 
             // when
             addAction(testcase.differentAction);
             // then
-            expect(UpdateAction.get().actions.length).toStrictEqual(2);
+            expect(UpdateAction.get().actions.length).toStrictEqual(testcase.shouldCancel ? 1 : 2);
             // when
             addAction(testcase.differentAction);
             // then
-            expect(UpdateAction.get().actions.length).toStrictEqual(2);
+            expect(UpdateAction.get().actions.length).toStrictEqual(testcase.shouldCancel ? 0 : 2);
         });
     });
 });

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -477,7 +477,10 @@ export const addAction = (action: BatchAction): void => {
 
             break;
     }
-    if (isDuplicate) {
+
+    if (isDuplicate && action.action?.$case === 'deploy') {
+        deleteAction(action);
+    } else if (isDuplicate) {
         showSnackbarSuccess('This action was already added.');
     } else {
         UpdateAction.set({ actions: [...UpdateAction.get().actions, action] });


### PR DESCRIPTION
If the environment has a planned deploy then the button will cancel that planned action instead of warning about a duplicate action.
Ref: SRX-3I6YKY
![Screenshot 2025-01-27 at 09 09 16](https://github.com/user-attachments/assets/b58cfe33-b067-49a0-944c-b77e0acae8c9)
