### PR TITLE
fix: deploy buttons for groups with 0 release envs

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.tsx
@@ -476,7 +476,8 @@ export const EnvironmentGroupLane: React.FC<{
         )
     );
     const alreadyPlanned =
-        envsWithoutPlannedDeployments.filter((env) => release.environments.includes(env.name)).length === 0;
+        envsWithoutPlannedDeployments.filter((env) => release.environments.includes(env.name)).length === 0 &&
+        environmentGroup.environments.filter((env) => release.environments.includes(env.name)).length > 0;
 
     const createEnvGroupLock = React.useCallback(() => {
         environmentGroup.environments.forEach((environment) => {


### PR DESCRIPTION
When the environment group has no environment configured in the release, it shouldn't show "Cancel".
Ref: SRX-3I6YKY