### PR TITLE
feat: filter deployment history by a time frame

### DIFF
--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -447,7 +447,10 @@ message GetAllEnvTeamLocksResponse {
   map<string, AllTeamLocks> all_team_locks = 2; //EnvName -> All team locks for that env
 }
 
-message DeploymentHistoryRequest {}
+message DeploymentHistoryRequest {
+  google.protobuf.Timestamp start_date = 1;
+  google.protobuf.Timestamp end_date = 2;
+}
 
 message DeploymentHistoryResponse {
   string deployment = 1;

--- a/services/frontend-service/src/assets/_components.scss
+++ b/services/frontend-service/src/assets/_components.scss
@@ -48,5 +48,6 @@ Copyright freiheit.com*/
 @import 'src/ui/components/EnvironmentConfigDialog/EnvironmentConfigDialog';
 @import 'src/ui/components/CommitInfo/CommitInfo';
 @import 'src/ui/components/EslWarnings/EslWarnings';
+@import 'src/ui/components/Compliance/Compliance';
 @import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 @import url('https://fonts.googleapis.com/icon?family=Inter');

--- a/services/frontend-service/src/ui/Pages/Compliance/CompliancePage.tsx
+++ b/services/frontend-service/src/ui/Pages/Compliance/CompliancePage.tsx
@@ -13,13 +13,25 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright freiheit.com*/
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Compliance } from '../../components/Compliance/Compliance';
 import { TopAppBar } from '../../components/TopAppBar/TopAppBar';
 
-export const CompliancePage: React.FC = () => (
-    <div>
-        <TopAppBar showAppFilter={false} showTeamFilter={false} showWarningFilter={false} />
-        <Compliance />
-    </div>
-);
+export const CompliancePage: React.FC = () => {
+    const saveFile = useCallback((lines: string[]) => {
+        const filename = 'deployments.csv';
+        const file = new File(lines, filename);
+        const anchor = document.createElement('a');
+        anchor.href = URL.createObjectURL(file);
+        anchor.download = filename;
+        anchor.click();
+        URL.revokeObjectURL(anchor.href);
+    }, []);
+
+    return (
+        <div>
+            <TopAppBar showAppFilter={false} showTeamFilter={false} showWarningFilter={false} />
+            <Compliance saveFile={saveFile} />
+        </div>
+    );
+};

--- a/services/frontend-service/src/ui/components/Compliance/Compliance.scss
+++ b/services/frontend-service/src/ui/components/Compliance/Compliance.scss
@@ -1,0 +1,3 @@
+.compliance-content > * {
+    margin-right: 20px;
+}

--- a/services/frontend-service/src/ui/components/Compliance/Compliance.scss
+++ b/services/frontend-service/src/ui/components/Compliance/Compliance.scss
@@ -1,3 +1,18 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
 .compliance-content > * {
     margin-right: 20px;
 }

--- a/services/frontend-service/src/ui/components/Compliance/Compliance.test.tsx
+++ b/services/frontend-service/src/ui/components/Compliance/Compliance.test.tsx
@@ -13,7 +13,7 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright freiheit.com*/
-import { from, Observable } from 'rxjs';
+import { from } from 'rxjs';
 import { SnackbarStatus, UpdateSnackbar } from '../../utils/store';
 import { Compliance } from './Compliance';
 import { fireEvent, render } from '@testing-library/react';
@@ -51,10 +51,8 @@ describe('Compliance', () => {
         const startDate = container.querySelector('input#start-date');
         const endDate = container.querySelector('input#end-date');
 
-        if (endDate instanceof HTMLInputElement)
-            fireEvent.change(endDate, { target: { value: '2001-12-09' } });
-        if (startDate instanceof HTMLInputElement)
-            fireEvent.change(startDate, { target: { value: '2025-01-20' } });
+        if (endDate instanceof HTMLInputElement) fireEvent.change(endDate, { target: { value: '2001-12-09' } });
+        if (startDate instanceof HTMLInputElement) fireEvent.change(startDate, { target: { value: '2025-01-20' } });
 
         downloadButton?.click();
 
@@ -69,12 +67,10 @@ describe('Compliance', () => {
         const startDate = container.querySelector('input#start-date');
         const endDate = container.querySelector('input#end-date');
         const content = ['test', 'test2'];
-        mockStreamDeploymentHistory.returns(from(content.map(line => ({ deployment: line }))));
+        mockStreamDeploymentHistory.returns(from(content.map((line) => ({ deployment: line }))));
 
-        if (endDate instanceof HTMLInputElement)
-            fireEvent.change(endDate, { target: { value: '2025-01-21' } });
-        if (startDate instanceof HTMLInputElement)
-            fireEvent.change(startDate, { target: { value: '2025-01-20' } });
+        if (endDate instanceof HTMLInputElement) fireEvent.change(endDate, { target: { value: '2025-01-21' } });
+        if (startDate instanceof HTMLInputElement) fireEvent.change(startDate, { target: { value: '2025-01-20' } });
 
         downloadButton?.click();
 

--- a/services/frontend-service/src/ui/components/Compliance/Compliance.test.tsx
+++ b/services/frontend-service/src/ui/components/Compliance/Compliance.test.tsx
@@ -1,0 +1,83 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+import { from, Observable } from 'rxjs';
+import { SnackbarStatus, UpdateSnackbar } from '../../utils/store';
+import { Compliance } from './Compliance';
+import { fireEvent, render } from '@testing-library/react';
+import { Spy } from 'spy4js';
+
+const mockStreamDeploymentHistory = Spy('StreamDeploymentHistory');
+const mockSaveFile = jest.fn();
+
+jest.mock('../../utils/GrpcApi', () => ({
+    get useApi() {
+        return {
+            overviewService: () => ({
+                StreamDeploymentHistory: () => mockStreamDeploymentHistory(),
+            }),
+        };
+    },
+}));
+
+describe('Compliance', () => {
+    const getNode = () => <Compliance saveFile={mockSaveFile} />;
+    const getWrapper = () => render(getNode());
+
+    it('shows an error with no dates selected', () => {
+        const { container } = getWrapper();
+        const downloadButton = container.querySelector('button');
+        downloadButton?.click();
+        expect(UpdateSnackbar.get().show).toBe(true);
+        expect(UpdateSnackbar.get().status).toBe(SnackbarStatus.ERROR);
+        expect(UpdateSnackbar.get().content).toBe('Cannot download deployment history without a start and end date.');
+    });
+
+    it('shows an error with an end date from before the start date', () => {
+        const { container } = getWrapper();
+        const downloadButton = container.querySelector('button');
+        const startDate = container.querySelector('input#start-date');
+        const endDate = container.querySelector('input#end-date');
+
+        if (endDate instanceof HTMLInputElement)
+            fireEvent.change(endDate, { target: { value: '2001-12-09' } });
+        if (startDate instanceof HTMLInputElement)
+            fireEvent.change(startDate, { target: { value: '2025-01-20' } });
+
+        downloadButton?.click();
+
+        expect(UpdateSnackbar.get().show).toBe(true);
+        expect(UpdateSnackbar.get().status).toBe(SnackbarStatus.ERROR);
+        expect(UpdateSnackbar.get().content).toBe('Cannot have an end date that happens before the start date.');
+    });
+
+    it('downloads the file received by the server', () => {
+        const { container } = getWrapper();
+        const downloadButton = container.querySelector('button');
+        const startDate = container.querySelector('input#start-date');
+        const endDate = container.querySelector('input#end-date');
+        const content = ['test', 'test2'];
+        mockStreamDeploymentHistory.returns(from(content.map(line => ({ deployment: line }))));
+
+        if (endDate instanceof HTMLInputElement)
+            fireEvent.change(endDate, { target: { value: '2025-01-21' } });
+        if (startDate instanceof HTMLInputElement)
+            fireEvent.change(startDate, { target: { value: '2025-01-20' } });
+
+        downloadButton?.click();
+
+        expect(mockSaveFile).toHaveBeenCalledWith(content);
+    });
+});

--- a/services/frontend-service/src/ui/components/Compliance/Compliance.tsx
+++ b/services/frontend-service/src/ui/components/Compliance/Compliance.tsx
@@ -13,40 +13,70 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright freiheit.com*/
-import React, { useCallback } from 'react';
+import React, { ChangeEvent, useCallback, useState } from 'react';
 import { Button } from '../button';
 import { useApi } from '../../utils/GrpcApi';
+import { showSnackbarError } from '../../utils/store';
 
-export const Compliance: React.FC = () => {
+export type ComplianceProps = {
+    saveFile: (lines: string[]) => void;
+};
+
+export const Compliance: React.FC<ComplianceProps> = ({ saveFile }) => {
     const api = useApi;
+    const [startDate, setStartDate] = useState<Date>();
+    const [endDate, setEndDate] = useState<Date>();
 
     const onClick = useCallback(() => {
+        if (!startDate || !endDate) {
+            showSnackbarError('Cannot download deployment history without a start and end date.');
+            return;
+        }
+        if (endDate < startDate) {
+            showSnackbarError('Cannot have an end date that happens before the start date.');
+            return;
+        }
+
         const content: string[] = [];
         api.overviewService()
-            .StreamDeploymentHistory({})
+            .StreamDeploymentHistory({ startDate, endDate })
             .subscribe({
                 next: (res) => {
                     content.push(res.deployment);
                 },
-                complete: () => {
-                    const filename = 'deployments.csv';
-                    const file = new File(content, filename);
-                    const anchor = document.createElement('a');
-                    anchor.href = URL.createObjectURL(file);
-                    anchor.download = filename;
-                    anchor.click();
-                    URL.revokeObjectURL(anchor.href);
-                },
+                complete: () => saveFile(content),
             });
-    }, [api]);
+    }, [api, endDate, startDate, saveFile]);
+
+    const onStartDateChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+        setStartDate(e.target.valueAsDate ?? undefined);
+    }, []);
+
+    const onEndDateChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+        setEndDate(e.target.valueAsDate ?? undefined);
+    }, []);
 
     return (
         <div>
-            <main className="main-content">
+            <main className="main-content compliance-content">
+                <span>From:</span>
+                <input
+                    type="date"
+                    id="start-date"
+                    className="mdc-button mdc-button--outlined"
+                    onChange={onStartDateChange}
+                />
+                <span>To:</span>
+                <input
+                    type="date"
+                    id="end-date"
+                    className="mdc-button mdc-button--outlined"
+                    onChange={onEndDateChange}
+                />
                 <Button
                     onClick={onClick}
-                    className={'button-main mdc-button--unelevated'}
-                    label="Download CSV"
+                    className="button-main env-card-deploy-btn mdc-button--unelevated"
+                    label="Download Deployment History CSV"
                     highlightEffect={false}
                 />
             </main>


### PR DESCRIPTION
Adds a way to select the time frame for which you want to download the deployment history.
Ref: SRX-4I9LE6
![Screenshot 2025-02-03 at 11 48 11](https://github.com/user-attachments/assets/da626485-9da5-4b8a-9f3d-d8fd7f8ed112)
