### PR TITLE
fix(cd): migration to delete foreign key on deployments and deployment history

### DIFF
--- a/database/migrations/postgres/1720428454051313_fk_deployments.up.sql
+++ b/database/migrations/postgres/1720428454051313_fk_deployments.up.sql
@@ -1,7 +1,7 @@
 DO $$ BEGIN IF NOT EXISTS (
     SELECT column_name
     FROM information_schema.columns
-    WHERE table_name='deployments' and column_name='transformerEslversion'
+    WHERE table_name='deployments' and column_name='transformereslversion'
 ) THEN
 ALTER TABLE deployments
 ADD COLUMN IF NOT EXISTS transformerEslId INTEGER default 0;

--- a/database/migrations/postgres/1720428454051313_fk_deployments.up.sql
+++ b/database/migrations/postgres/1720428454051313_fk_deployments.up.sql
@@ -1,2 +1,9 @@
+DO $$ BEGIN IF NOT EXISTS (
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_name='deployments' and column_name='transformerEslversion'
+) THEN
 ALTER TABLE deployments
 ADD COLUMN IF NOT EXISTS transformerEslId INTEGER default 0;
+end if;
+END $$;

--- a/database/migrations/postgres/1720428454051313_fk_deployments.up.sql
+++ b/database/migrations/postgres/1720428454051313_fk_deployments.up.sql
@@ -1,10 +1,2 @@
-DO $$ BEGIN IF NOT EXISTS (
-    SELECT 'fk_deployments_transformer_id'
-    FROM information_schema.table_constraints
-    WHERE table_name = 'deployments'
-        AND constraint_name = 'fk_deployments_transformer_id'
-) THEN
 ALTER TABLE deployments
-ADD COLUMN IF NOT EXISTS transformerEslId INTEGER CONSTRAINT fk_deployments_transformer_id REFERENCES event_sourcing_light(eslId) default 0;
-end if;
-END $$;
+ADD COLUMN IF NOT EXISTS transformerEslId INTEGER default 0;

--- a/database/migrations/postgres/1738701911056713_delete_fk_constraints.up.sql
+++ b/database/migrations/postgres/1738701911056713_delete_fk_constraints.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE deployments DROP CONSTRAINT IF EXISTS fk_deployments_transformer_id;
+ALTER TABLE deployments_history DROP CONSTRAINT IF EXISTS fk_deployments_transformer_id;


### PR DESCRIPTION
Parallel release trains spawn new transactions. This means that for a release train we will have one outer transaction and N inner transactions (based on the number of parallel processing go routines and number of environments to process). As the outer transaction has not yet been committed, inner transactions will not be able to view the most recent event written to the event_sourcing_light table. This ALWAYS results in a FK violation if anything is deployed by the release train, as the transformer ID that the deployments try to reference does not exist on the current database view of the inner transaction. 

Rolling back the outer transaction causes inner transactions to also be rolled back, so simply removing these fk_constrains works and kuberpult won't be left in an inconsistent state (i.e. deployments exist that don't reference any transformer on the event_sourcing_light table). 

In my opinion, removing the FK constraint is the only solution, as we want to keep using parallel transactions to perform the release trains for different environments in parallel.

Ref: SRX-AC1K9Y