### PR TITLE
chore: change deprecated prettier rule

### DIFF
--- a/services/frontend-service/.prettierrc
+++ b/services/frontend-service/.prettierrc
@@ -4,6 +4,6 @@
     "tabWidth": 4,
     "singleQuote": true,
     "trailingComma": "es5",
-    "jsxBracketSameLine": true,
+    "bracketSameLine": true,
     "parser": "typescript"
 }


### PR DESCRIPTION
The `jsxBracketSameLine` was deprecated in favour of `bracketSameLine` as shown [here](https://prettier.io/docs/options/#deprecated-jsx-brackets).
Ref: SRX-JWS0HZ