### PR TITLE
feat(ui): allow canceling planned locks

### DIFF
--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -222,6 +222,10 @@ button.mdc-button.env-card-deploy-btn {
 button.mdc-button.env-card-lock-btn {
     border-radius: $release-dialog-inner-border-radius;
     @extend .text-bold;
+
+    &.deploy-button-cancel:not(.button-main) {
+        color: var(--mdc-theme-error);
+    }
 }
 
 .release-dialog-environment-group-lane {

--- a/services/frontend-service/src/ui/components/button/ExpandButton.test.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.test.tsx
@@ -27,7 +27,8 @@ describe('ExpandButton', () => {
         disabled: false,
         defaultButtonLabel: 'default-button',
         releaseDifference: 0,
-        alreadyPlanned: false,
+        deployAlreadyPlanned: false,
+        lockAlreadyPlanned: false,
     };
 
     const getNode = (props: Partial<ExpandButtonProps>): JSX.Element => (
@@ -46,7 +47,7 @@ describe('ExpandButton', () => {
         expectSubmitCalledTimes: number;
         expectSubmitCalledWith: Object; // only relevant if expectCalledTimes != 0
         expectLockCalledTimes: number;
-        expectedLabel: string;
+        expectedLabels: string[];
     };
 
     const data: TestData[] = [
@@ -58,7 +59,7 @@ describe('ExpandButton', () => {
             expectSubmitCalledTimes: 0,
             expectSubmitCalledWith: {},
             expectLockCalledTimes: 0,
-            expectedLabel: 'Deploy only',
+            expectedLabels: ['Deploy only'],
         },
         {
             name: 'click expand twice',
@@ -68,7 +69,7 @@ describe('ExpandButton', () => {
             expectSubmitCalledTimes: 0,
             expectSubmitCalledWith: {},
             expectLockCalledTimes: 0,
-            expectedLabel: 'Deploy only',
+            expectedLabels: ['Deploy only'],
         },
         {
             name: 'click Main button',
@@ -78,7 +79,7 @@ describe('ExpandButton', () => {
             expectSubmitCalledTimes: 1,
             expectSubmitCalledWith: true,
             expectLockCalledTimes: 0,
-            expectedLabel: 'Deploy only',
+            expectedLabels: ['Deploy only'],
         },
         {
             name: 'click expand, then alternative button',
@@ -88,7 +89,7 @@ describe('ExpandButton', () => {
             expectSubmitCalledTimes: 1,
             expectSubmitCalledWith: false,
             expectLockCalledTimes: 0,
-            expectedLabel: 'Deploy only',
+            expectedLabels: ['Deploy only'],
         },
         {
             name: 'click expand, then lock button',
@@ -98,7 +99,7 @@ describe('ExpandButton', () => {
             expectSubmitCalledTimes: 0,
             expectSubmitCalledWith: true,
             expectLockCalledTimes: 1,
-            expectedLabel: 'Deploy only',
+            expectedLabels: ['Deploy only'],
         },
         {
             name: 'click expand once, with positive release difference',
@@ -108,7 +109,7 @@ describe('ExpandButton', () => {
             expectSubmitCalledTimes: 0,
             expectSubmitCalledWith: {},
             expectLockCalledTimes: 0,
-            expectedLabel: 'Rollback only',
+            expectedLabels: ['Rollback only'],
         },
         {
             name: 'click expand once, with positive release difference',
@@ -118,47 +119,67 @@ describe('ExpandButton', () => {
             expectSubmitCalledTimes: 0,
             expectSubmitCalledWith: {},
             expectLockCalledTimes: 0,
-            expectedLabel: 'Update only',
+            expectedLabels: ['Update only'],
         },
         {
             name: 'click expand once, with positive release difference and planned rollback',
-            props: { releaseDifference: 1, alreadyPlanned: true },
+            props: { releaseDifference: 1, deployAlreadyPlanned: true, lockAlreadyPlanned: true },
             clickThis: ['.button-expand'],
             expectExpanded: true,
             expectSubmitCalledTimes: 0,
             expectSubmitCalledWith: {},
             expectLockCalledTimes: 0,
-            expectedLabel: 'Cancel Rollback only',
+            expectedLabels: ['Cancel Rollback only', 'Cancel Lock only'],
         },
         {
             name: 'click expand once, with positive release difference and planned update',
-            props: { releaseDifference: -1, alreadyPlanned: true },
+            props: { releaseDifference: -1, deployAlreadyPlanned: true },
             clickThis: ['.button-expand'],
             expectExpanded: true,
             expectSubmitCalledTimes: 0,
             expectSubmitCalledWith: {},
             expectLockCalledTimes: 0,
-            expectedLabel: 'Cancel Update only',
+            expectedLabels: ['Cancel Update only'],
         },
         {
             name: 'click cancel deployment button',
-            props: { alreadyPlanned: true },
+            props: { deployAlreadyPlanned: true, lockAlreadyPlanned: true },
             clickThis: ['.deploy-button-cancel'],
             expectExpanded: false,
             expectSubmitCalledTimes: 1,
             expectSubmitCalledWith: true,
             expectLockCalledTimes: 0,
-            expectedLabel: 'Deploy only',
+            expectedLabels: ['Deploy only'],
         },
         {
             name: 'click expand, then cancel deploy button',
-            props: { alreadyPlanned: true },
+            props: { deployAlreadyPlanned: true },
             clickThis: ['.button-expand', '.button-popup-deploy.deploy-button-cancel'],
             expectExpanded: true,
             expectSubmitCalledTimes: 1,
             expectSubmitCalledWith: false,
             expectLockCalledTimes: 0,
-            expectedLabel: 'Cancel Deploy only',
+            expectedLabels: ['Cancel Deploy only', 'Lock only'],
+        },
+        {
+            name: 'click expand once, with a lock already planned but no deploy',
+            props: { lockAlreadyPlanned: true },
+            clickThis: ['.button-expand'],
+            expectExpanded: true,
+            expectSubmitCalledTimes: 0,
+            expectSubmitCalledWith: {},
+            expectLockCalledTimes: 0,
+            expectedLabels: ['Deploy only', 'Cancel Lock only'],
+        },
+        {
+            name: 'click expand once, with a deploy already planned but no lock',
+            props: { deployAlreadyPlanned: true },
+            clickThis: ['.button-expand'],
+            expectExpanded: true,
+            expectSubmitCalledTimes: 0,
+            expectSubmitCalledWith: {},
+            expectLockCalledTimes: 0,
+            expectedLabels: ['Cancel Deploy only', 'Lock only'],
         },
     ];
 
@@ -183,7 +204,7 @@ describe('ExpandButton', () => {
             if (expectedCount > 0) {
                 const buttons = Array.from(document.getElementsByClassName('mdc-button__label'));
                 const labels = buttons.map((button) => button.textContent);
-                expect(labels).toEqual(expect.arrayContaining([testcase.expectedLabel]));
+                expect(labels).toEqual(expect.arrayContaining(testcase.expectedLabels));
             }
 
             expect(mySubmitSpy).toHaveBeenCalledTimes(testcase.expectSubmitCalledTimes);

--- a/services/frontend-service/src/ui/components/button/ExpandButton.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.tsx
@@ -31,11 +31,12 @@ export type ExpandButtonProps = {
     defaultButtonLabel: string;
     disabled: boolean;
     releaseDifference: number;
-    alreadyPlanned: boolean;
+    deployAlreadyPlanned: boolean;
+    lockAlreadyPlanned: boolean;
 };
 
 export const ExpandButton = (props: ExpandButtonProps): JSX.Element => {
-    const { onClickSubmit, onClickLock, releaseDifference, alreadyPlanned } = props;
+    const { onClickSubmit, onClickLock, releaseDifference, deployAlreadyPlanned, lockAlreadyPlanned } = props;
 
     const [expanded, setExpanded] = useState(false);
 
@@ -70,7 +71,7 @@ export const ExpandButton = (props: ExpandButtonProps): JSX.Element => {
                     onClick={onClickSubmitMain}
                     disabled={props.disabled}
                     className={classNames('button-main', 'env-card-deploy-btn', 'mdc-button--unelevated', {
-                        'deploy-button-cancel': alreadyPlanned,
+                        'deploy-button-cancel': lockAlreadyPlanned && deployAlreadyPlanned,
                     })}
                     key={'button-first-key'}
                     label={props.defaultButtonLabel}
@@ -101,10 +102,10 @@ export const ExpandButton = (props: ExpandButtonProps): JSX.Element => {
                                     'button-popup-deploy',
                                     'env-card-deploy-btn',
                                     'mdc-button--unelevated',
-                                    { 'deploy-button-cancel': alreadyPlanned }
+                                    { 'deploy-button-cancel': deployAlreadyPlanned }
                                 )}
                                 key={'button-second-key'}
-                                label={alreadyPlanned ? `Cancel ${deployLabel}` : deployLabel}
+                                label={deployAlreadyPlanned ? `Cancel ${deployLabel}` : deployLabel}
                                 icon={undefined}
                                 highlightEffect={true}
                                 disabled={props.disabled}
@@ -113,9 +114,14 @@ export const ExpandButton = (props: ExpandButtonProps): JSX.Element => {
                         <div>
                             <Button
                                 onClick={onClickSubmitLockOnly}
-                                className={'button-popup-lock env-card-lock-btn mdc-button--unelevated'}
+                                className={classNames(
+                                    'button-popup-lock',
+                                    'env-card-lock-btn',
+                                    'mdc-button--unelevated',
+                                    { 'deploy-button-cancel': lockAlreadyPlanned }
+                                )}
                                 key={'button-third-key'}
-                                label={'Lock only'}
+                                label={lockAlreadyPlanned ? 'Cancel Lock only' : 'Lock only'}
                                 icon={undefined}
                                 highlightEffect={true}
                             />

--- a/services/frontend-service/src/ui/utils/store.test.tsx
+++ b/services/frontend-service/src/ui/utils/store.test.tsx
@@ -602,7 +602,7 @@ describe('Test addAction duplicate detection', () => {
                     },
                 },
             },
-            shouldCancel: false,
+            shouldCancel: true,
         },
         {
             name: 'delete app lock',

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -480,7 +480,8 @@ export const addAction = (action: BatchAction): void => {
             break;
     }
 
-    if (isDuplicate && action.action?.$case === 'deploy') {
+    const shouldCancel = ['deploy', 'createEnvironmentApplicationLock'];
+    if (isDuplicate && shouldCancel.includes(action.action?.$case || '')) {
         deleteAction(action);
     } else if (isDuplicate) {
         showSnackbarSuccess('This action was already added.');


### PR DESCRIPTION
Allow canceling planned locks with the buttons changing styles to indicate their behavior.
Ref: SRX-JWS0HZ
![Screenshot 2025-02-05 at 14 37 31](https://github.com/user-attachments/assets/bab27232-b41d-405f-b776-fec5d6c8f860)
![Screenshot 2025-02-05 at 14 37 39](https://github.com/user-attachments/assets/5212867a-168a-4c10-bac6-614b0c990063)
