### PR TITLE
feat(ui): add sensible actions for lock button when already locked

### DIFF
--- a/services/frontend-service/src/ui/components/button/ExpandButton.test.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.test.tsx
@@ -29,6 +29,8 @@ describe('ExpandButton', () => {
         releaseDifference: 0,
         deployAlreadyPlanned: false,
         lockAlreadyPlanned: false,
+        hasLocks: false,
+        unlockAlreadyPlanned: false,
     };
 
     const getNode = (props: Partial<ExpandButtonProps>): JSX.Element => (
@@ -180,6 +182,46 @@ describe('ExpandButton', () => {
             expectSubmitCalledWith: {},
             expectLockCalledTimes: 0,
             expectedLabels: ['Cancel Deploy only', 'Lock only'],
+        },
+        {
+            name: 'click expand once, with already existing locks',
+            props: { hasLocks: true },
+            clickThis: ['.button-expand'],
+            expectExpanded: true,
+            expectSubmitCalledTimes: 0,
+            expectSubmitCalledWith: {},
+            expectLockCalledTimes: 0,
+            expectedLabels: ['Remove locks'],
+        },
+        {
+            name: 'click expand once, with already existing locks and planned removal',
+            props: { hasLocks: true, unlockAlreadyPlanned: true },
+            clickThis: ['.button-expand'],
+            expectExpanded: true,
+            expectSubmitCalledTimes: 0,
+            expectSubmitCalledWith: {},
+            expectLockCalledTimes: 0,
+            expectedLabels: ['Keep locks'],
+        },
+        {
+            name: 'click expand once, with already existing locks and new lock planned',
+            props: { hasLocks: true, lockAlreadyPlanned: true },
+            clickThis: ['.button-expand'],
+            expectExpanded: true,
+            expectSubmitCalledTimes: 0,
+            expectSubmitCalledWith: {},
+            expectLockCalledTimes: 0,
+            expectedLabels: ['Cancel Lock only'],
+        },
+        {
+            name: 'click expand once, with already existing locks and new lock planned and planned removal of existing',
+            props: { hasLocks: true, unlockAlreadyPlanned: true, lockAlreadyPlanned: true },
+            clickThis: ['.button-expand'],
+            expectExpanded: true,
+            expectSubmitCalledTimes: 0,
+            expectSubmitCalledWith: {},
+            expectLockCalledTimes: 0,
+            expectedLabels: ['Cancel Lock only'],
         },
     ];
 

--- a/services/frontend-service/src/ui/components/button/ExpandButton.tsx
+++ b/services/frontend-service/src/ui/components/button/ExpandButton.tsx
@@ -33,10 +33,20 @@ export type ExpandButtonProps = {
     releaseDifference: number;
     deployAlreadyPlanned: boolean;
     lockAlreadyPlanned: boolean;
+    hasLocks: boolean;
+    unlockAlreadyPlanned: boolean;
 };
 
 export const ExpandButton = (props: ExpandButtonProps): JSX.Element => {
-    const { onClickSubmit, onClickLock, releaseDifference, deployAlreadyPlanned, lockAlreadyPlanned } = props;
+    const {
+        onClickSubmit,
+        onClickLock,
+        releaseDifference,
+        deployAlreadyPlanned,
+        lockAlreadyPlanned,
+        hasLocks,
+        unlockAlreadyPlanned,
+    } = props;
 
     const [expanded, setExpanded] = useState(false);
 
@@ -62,6 +72,14 @@ export const ExpandButton = (props: ExpandButtonProps): JSX.Element => {
 
     const deployLabel =
         releaseDifference < 0 ? 'Update only' : releaseDifference === 0 ? 'Deploy only' : 'Rollback only';
+
+    const lockLabel = lockAlreadyPlanned
+        ? 'Cancel Lock only'
+        : !hasLocks
+          ? 'Lock only'
+          : unlockAlreadyPlanned
+            ? 'Keep locks'
+            : 'Remove locks';
 
     return (
         <div className={'expand-button'}>
@@ -118,10 +136,12 @@ export const ExpandButton = (props: ExpandButtonProps): JSX.Element => {
                                     'button-popup-lock',
                                     'env-card-lock-btn',
                                     'mdc-button--unelevated',
-                                    { 'deploy-button-cancel': lockAlreadyPlanned }
+                                    {
+                                        'deploy-button-cancel': lockAlreadyPlanned || unlockAlreadyPlanned,
+                                    }
                                 )}
                                 key={'button-third-key'}
-                                label={lockAlreadyPlanned ? 'Cancel Lock only' : 'Lock only'}
+                                label={lockLabel}
                                 icon={undefined}
                                 highlightEffect={true}
                             />

--- a/services/frontend-service/src/ui/utils/store.test.tsx
+++ b/services/frontend-service/src/ui/utils/store.test.tsx
@@ -749,7 +749,7 @@ describe('Test addAction duplicate detection', () => {
                     },
                 },
             },
-            shouldCancel: false,
+            shouldCancel: true,
         },
         {
             name: 'create team lock',

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -481,7 +481,7 @@ export const addAction = (action: BatchAction): void => {
             break;
     }
 
-    const shouldCancel = ['deploy', 'createEnvironmentApplicationLock'];
+    const shouldCancel = ['deploy', 'createEnvironmentApplicationLock', 'deleteEnvironmentApplicationLock'];
     if (isDuplicate && shouldCancel.includes(action.action?.$case || '')) {
         deleteAction(action);
     } else if (isDuplicate) {


### PR DESCRIPTION
If an environment is already locked then the lock button will be used to plan removing those locks as well as canceling the plan.
Ref: SRX-92NLH7
![Screenshot 2025-02-06 at 10 58 32](https://github.com/user-attachments/assets/9c5cbc8b-0843-4ddc-88a4-7f1f4d57dbce)
![Screenshot 2025-02-06 at 10 58 43](https://github.com/user-attachments/assets/aadfc729-acaa-41b9-8e23-30f35bc918e0)
