### PR TITLE
fix(rollout): db max connections in charts

### DIFF
--- a/charts/kuberpult/templates/rollout-service.yaml
+++ b/charts/kuberpult/templates/rollout-service.yaml
@@ -158,10 +158,6 @@ spec:
           value: {{ .Values.db.migrations }}
         - name: KUBERPULT_DB_AUTH_PROXY_PORT
           value: "{{ .Values.db.authProxyPort }}"
-        - name: KUBERPULT_DB_MAX_OPEN_CONNECTIONS
-          value: "{{ .Values.db.connections.manifestRepoExport.maxOpen }}"
-        - name: KUBERPULT_DB_MAX_IDLE_CONNECTIONS
-          value: "{{ .Values.db.connections.manifestRepoExport.maxIdle }}"
 {{- if .Values.datadogTracing.enabled }}
         - name: DD_AGENT_HOST
           valueFrom:
@@ -242,9 +238,9 @@ spec:
               name: kuberpult-db
               key: password
         - name: KUBERPULT_DB_MAX_OPEN_CONNECTIONS
-          value: "{{ .Values.db.connections.cd.maxOpen }}"
+          value: "{{ .Values.db.connections.rollout.maxOpen }}"
         - name: KUBERPULT_DB_MAX_IDLE_CONNECTIONS
-          value: "{{ .Values.db.connections.cd.maxIdle }}"
+          value: "{{ .Values.db.connections.rollout.maxIdle }}"
 {{- end }}
         volumeMounts:
         # We need to mount a writeable tmp directory for argocd connections to work correctly. https://github.com/argoproj/argo-cd/issues/14115

--- a/charts/kuberpult/tests/charts_test.go
+++ b/charts/kuberpult/tests/charts_test.go
@@ -1368,6 +1368,73 @@ frontend:
 	}
 }
 
+func TestHelmChartsKuberpultRolloutEnvVariables(t *testing.T) {
+	tcs := []struct {
+		Name            string
+		Values          string
+		ExpectedEnvs    []core.EnvVar
+		ExpectedMissing []core.EnvVar
+	}{
+		{
+			Name: "Test db max connections",
+			Values: `
+git:
+  url: "testURL"
+ingress:
+  domainName: "kuberpult-example.com"
+rollout:
+  enabled: true
+argocd:
+  server: https://argo:1090
+db:
+  dbOption: "postgreSQL"
+  connections:
+    rollout:
+      maxOpen: 777
+      maxIdle: 321
+`,
+
+			ExpectedEnvs: []core.EnvVar{
+				{
+					Name:  "KUBERPULT_DB_MAX_OPEN_CONNECTIONS",
+					Value: "777",
+				},
+				{
+					Name:  "KUBERPULT_DB_MAX_IDLE_CONNECTIONS",
+					Value: "321",
+				},
+			},
+			ExpectedMissing: []core.EnvVar{},
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			testDirName := t.TempDir()
+			outputFile, err := runHelm(t, []byte(tc.Values), testDirName)
+			if err != nil {
+				t.Fatalf(fmt.Sprintf("%v", err))
+			}
+			if out, err := getDeployments(outputFile); err != nil {
+				t.Fatalf(fmt.Sprintf("%v", err))
+			} else {
+				targetDocument := out["kuberpult-rollout-service"]
+				for _, env := range tc.ExpectedEnvs {
+					if !CheckForEnvVariable(t, env, &targetDocument) {
+						t.Fatalf("Environment variable '%s' with value '%s' was expected, but not found.", env.Name, env.Value)
+					}
+				}
+				for _, env := range tc.ExpectedMissing {
+					if CheckForEnvVariable(t, env, &targetDocument) {
+						t.Fatalf("Found enviroment variable '%s' with value '%s', but was not expecting it.", env.Name, env.Value)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestIngress(t *testing.T) {
 	ingressClassGcePrivate := "gce-private"
 	tcs := []struct {

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -147,8 +147,7 @@ db:
   requests:
     cpu: "100m"
     memory: "200Mi"
-  connections:
-    # You need to ensure that your sql server can handle at least
+  connections:    # You need to ensure that your sql server can handle at least
     # `cd.maxOpen + manifestRepoExport.maxOpen` connections in parallel.
     cd:
       # The cd-service may need to respond to many parallel requests,
@@ -160,6 +159,9 @@ db:
       # It does have grpc endpoints that are very specific for some git operations, which most people will not use.
       maxOpen: 5
       maxIdle: 2
+    rollout:
+      maxOpen: 100
+      maxIdle: 20
 manifestRepoExport:
   image: kuberpult-manifest-repo-export-service
   service:


### PR DESCRIPTION
Remove duplicate environment variable from rollout service's helm chart.
Ref: SRX-4KG7TW