### PR TITLE
chore: remove GetGitTags from cd-service

### DIFF
--- a/services/cd-service/pkg/service/git.go
+++ b/services/cd-service/pkg/service/git.go
@@ -57,12 +57,7 @@ type GitServer struct {
 }
 
 func (s *GitServer) GetGitTags(ctx context.Context, _ *api.GetGitTagsRequest) (*api.GetGitTagsResponse, error) {
-	tags, err := repository.GetTags(s.Config, "./repository_tags", ctx)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get tags from repository: %v", err)
-	}
-
-	return &api.GetGitTagsResponse{TagData: tags}, nil
+	return nil, status.Error(codes.Unimplemented, "not implemented.  cd-service")
 }
 
 func (s *GitServer) GetProductSummary(ctx context.Context, in *api.GetProductSummaryRequest) (*api.GetProductSummaryResponse, error) {

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -683,7 +683,7 @@ func (p *GrpcProxy) GetAllEnvTeamLocks(
 func (p *GrpcProxy) GetGitTags(
 	ctx context.Context,
 	in *api.GetGitTagsRequest) (*api.GetGitTagsResponse, error) {
-	return p.GitClient.GetGitTags(ctx, in)
+	return p.ManifestExportServiceGitClient.GetGitTags(ctx, in)
 }
 
 func (p *GrpcProxy) GetProductSummary(


### PR DESCRIPTION
Use manifest-repo's `GetGitTags` instead of cd-service's
Ref: SRX-SH4OGB