### PR TITLE
feat(ui): New release dialog rollout/gitsync status style and pop-tooltips 

### DIFF
--- a/services/frontend-service/src/ui/components/GitSyncStatusDescription/GitSyncStatusDescription.tsx
+++ b/services/frontend-service/src/ui/components/GitSyncStatusDescription/GitSyncStatusDescription.tsx
@@ -16,19 +16,44 @@ Copyright freiheit.com*/
 
 import React from 'react';
 import { GitSyncStatus } from '../../../api/api';
+import { Tooltip } from '../tooltip/tooltip';
 
+const GIT_SYNC_STATUS_SYNCED_DESCRIPTION =
+    'All changes to this app and environment have been processed and pushed to the manifest repository successfully.';
+
+const GIT_SYNC_STATUS_UNSYNCED_DESCRIPTION =
+    'There are some changes to this app and environment that have been processed by Kuberpult, but are yet to be committed to the manifest repository.';
+const GIT_SYNC_STATUS_FAILED_DESCRIPTION =
+    "There are some changes to this app and environment that have been processed by Kuberpult, but it wasn't possible to push the changes to the manifest repository\nThis requires manual intervention.";
+const GIT_SYNC_STATUS_UNKOWN_DESCRIPTION = 'Kuberpult could not find the git sync status for this app and environment';
 export const GitSyncStatusDescription: React.FC<{ status: number | undefined }> = (props) => {
     const { status } = props;
+    let span = <span className="rollout__description_unknown">? Unknown</span>;
+    let tooltipContent = GIT_SYNC_STATUS_UNKOWN_DESCRIPTION;
     if (status === undefined) {
-        return <span className="rollout__description_unknown">? Unknown</span>;
+        return (
+            <Tooltip tooltipContent={<div className="mdc-tooltip__title_ release__details">{tooltipContent}</div>}>
+                {span}
+            </Tooltip>
+        );
     }
     switch (status) {
         case GitSyncStatus.GIT_SYNC_STATUS_SYNCED:
-            return <span className="rollout__description_successful">✓ Done</span>;
+            span = <span className="rollout__description_successful">✓ Done</span>;
+            tooltipContent = GIT_SYNC_STATUS_SYNCED_DESCRIPTION;
+            break;
         case GitSyncStatus.GIT_SYNC_STATUS_UNSYNCED:
-            return <span className="rollout__description_progressing">↻ In progress</span>;
+            span = <span className="rollout__description_progressing">↻ In progress</span>;
+            tooltipContent = GIT_SYNC_STATUS_UNSYNCED_DESCRIPTION;
+            break;
         case GitSyncStatus.GIT_SYNC_STATUS_ERROR:
-            return <span className="rollout__description_error">! Failed</span>;
+            span = <span className="rollout__description_error">! Failed</span>;
+            tooltipContent = GIT_SYNC_STATUS_FAILED_DESCRIPTION;
+            break;
     }
-    return <span className="rollout__description_unknown">? Unknown</span>;
+    return (
+        <Tooltip tooltipContent={<div className="mdc-tooltip__title_ release__details">{tooltipContent}</div>}>
+            {span}
+        </Tooltip>
+    );
 };

--- a/services/frontend-service/src/ui/components/GitSyncStatusDescription/GitSyncStatusDescription.tsx
+++ b/services/frontend-service/src/ui/components/GitSyncStatusDescription/GitSyncStatusDescription.tsx
@@ -24,8 +24,8 @@ const GIT_SYNC_STATUS_SYNCED_DESCRIPTION =
 const GIT_SYNC_STATUS_UNSYNCED_DESCRIPTION =
     'There are some changes to this app and environment that have been processed by Kuberpult, but are yet to be committed to the manifest repository.';
 const GIT_SYNC_STATUS_FAILED_DESCRIPTION =
-    "There are some changes to this app and environment that have been processed by Kuberpult, but it wasn't possible to push the changes to the manifest repository\nThis requires manual intervention.";
-const GIT_SYNC_STATUS_UNKOWN_DESCRIPTION = 'Kuberpult could not find the git sync status for this app and environment';
+    "There are some changes to this app and environment that have been processed by Kuberpult, but it wasn't possible to push the changes to the manifest repository. This requires manual intervention.";
+const GIT_SYNC_STATUS_UNKOWN_DESCRIPTION = 'Kuberpult could not find the git sync status for this app and environment.';
 export const GitSyncStatusDescription: React.FC<{ status: number | undefined }> = (props) => {
     const { status } = props;
     let span = <span className="rollout__description_unknown">? Unknown</span>;

--- a/services/frontend-service/src/ui/components/GitSyncStatusDescription/GitSyncStatusDescription.tsx
+++ b/services/frontend-service/src/ui/components/GitSyncStatusDescription/GitSyncStatusDescription.tsx
@@ -26,6 +26,7 @@ const GIT_SYNC_STATUS_UNSYNCED_DESCRIPTION =
 const GIT_SYNC_STATUS_FAILED_DESCRIPTION =
     "There are some changes to this app and environment that have been processed by Kuberpult, but it wasn't possible to push the changes to the manifest repository. This requires manual intervention.";
 const GIT_SYNC_STATUS_UNKOWN_DESCRIPTION = 'Kuberpult could not find the git sync status for this app and environment.';
+
 export const GitSyncStatusDescription: React.FC<{ status: number | undefined }> = (props) => {
     const { status } = props;
     let span = <span className="rollout__description_unknown">? Unknown</span>;

--- a/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/ReleaseDialog.scss
@@ -116,6 +116,7 @@ Copyright freiheit.com*/
                 display: flex;
                 flex-direction: row;
                 justify-content: space-between;
+                align-items: center;
 
                 .release-environment {
                     border-radius: $border-radius-large;

--- a/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
+++ b/services/frontend-service/src/ui/components/ReleaseDialog/__snapshots__/ReleaseDialog.test.tsx.snap
@@ -208,11 +208,20 @@ exports[`Release Dialog Renders the environment locks normal release 1`] = `
                     <div
                       class="env-card-locks"
                     >
-                      <span
-                        class="rollout__description_pending"
+                      <div
+                        class="tooltip-container"
+                        data-tooltip-delay-hide="50"
+                        data-tooltip-html="<div class=\\"mdc-tooltip__title_ release__details\\">ArgoCD has not yet picked up these changes.</div>"
+                        data-tooltip-id="kuberpult-tooltip"
+                        data-tooltip-place="bottom"
+                        id="tooltip"
                       >
-                        ⧖ Pending
-                      </span>
+                        <span
+                          class="rollout__description_pending"
+                        >
+                          ⧖ Pending
+                        </span>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -514,11 +523,20 @@ exports[`Release Dialog Renders the environment locks normal release with deploy
                     <div
                       class="env-card-locks"
                     >
-                      <span
-                        class="rollout__description_pending"
+                      <div
+                        class="tooltip-container"
+                        data-tooltip-delay-hide="50"
+                        data-tooltip-html="<div class=\\"mdc-tooltip__title_ release__details\\">ArgoCD has not yet picked up these changes.</div>"
+                        data-tooltip-id="kuberpult-tooltip"
+                        data-tooltip-place="bottom"
+                        id="tooltip"
                       >
-                        ⧖ Pending
-                      </span>
+                        <span
+                          class="rollout__description_pending"
+                        >
+                          ⧖ Pending
+                        </span>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -820,11 +838,20 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                     <div
                       class="env-card-locks"
                     >
-                      <span
-                        class="rollout__description_pending"
+                      <div
+                        class="tooltip-container"
+                        data-tooltip-delay-hide="50"
+                        data-tooltip-html="<div class=\\"mdc-tooltip__title_ release__details\\">ArgoCD has not yet picked up these changes.</div>"
+                        data-tooltip-id="kuberpult-tooltip"
+                        data-tooltip-place="bottom"
+                        id="tooltip"
                       >
-                        ⧖ Pending
-                      </span>
+                        <span
+                          class="rollout__description_pending"
+                        >
+                          ⧖ Pending
+                        </span>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -993,11 +1020,20 @@ exports[`Release Dialog Renders the environment locks two envs release 1`] = `
                           </button>
                         </div>
                       </div>
-                      <span
-                        class="rollout__description_progressing"
+                      <div
+                        class="tooltip-container"
+                        data-tooltip-delay-hide="50"
+                        data-tooltip-html="<div class=\\"mdc-tooltip__title_ release__details\\">ArgoCD has picked up these changes for this application on this environment, but has not applied them yet. This process might take a while.</div>"
+                        data-tooltip-id="kuberpult-tooltip"
+                        data-tooltip-place="bottom"
+                        id="tooltip"
                       >
-                        ↻ In progress
-                      </span>
+                        <span
+                          class="rollout__description_progressing"
+                        >
+                          ↻ In progress
+                        </span>
+                      </div>
                     </div>
                   </div>
                   <div

--- a/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.scss
+++ b/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.scss
@@ -18,7 +18,6 @@ Copyright freiheit.com*/
     font-weight: bold;
     font-size: 13px;
     padding: 4px;
-
     margin-right: 15px;
     border-radius: 12px;
     display: block;

--- a/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.scss
+++ b/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.scss
@@ -14,14 +14,16 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright freiheit.com*/
 .rollout__description {
-    border: 1px solid #eee;
+    border: 6px solid #eee;
     font-weight: bold;
     font-size: 13px;
     padding: 4px;
-    margin: -2px;
-    border-radius: 6px;
+    /* margin: -2px; */
+    margin-right: 15px;
+    border-radius: 12px;
     display: block;
     text-align: center;
+    height: max-content;
 }
 
 .rollout__description_unknown {

--- a/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.scss
+++ b/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.scss
@@ -18,7 +18,7 @@ Copyright freiheit.com*/
     font-weight: bold;
     font-size: 13px;
     padding: 4px;
-    /* margin: -2px; */
+
     margin-right: 15px;
     border-radius: 12px;
     display: block;

--- a/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.scss
+++ b/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.scss
@@ -18,6 +18,7 @@ Copyright freiheit.com*/
     font-weight: bold;
     font-size: 13px;
     padding: 4px;
+
     margin-right: 15px;
     border-radius: 12px;
     display: block;

--- a/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.tsx
+++ b/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.tsx
@@ -14,20 +14,50 @@ along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>
 
 Copyright freiheit.com*/
 import { RolloutStatus } from '../../../api/api';
+import React from 'react';
+import { Tooltip } from '../tooltip/tooltip';
+
+const ROLLOUT_STATUS_UNKNOWN_DESCRIPTION =
+    "ArgoCD hasn't reported any information about this application on this environment.";
+
+const ROLLOUT_STATUS_SUCCESFUL_DESCRIPTION = 'ArgoCD has successfully synced this application this environment.';
+const ROLLOUT_STATUS_PROGRESSING_DESCRIPTION =
+    'ArgoCD has picked up these changes for this application on this environment, but has not applied them yet. This process might take a while.';
+const ROLLOUT_STATUS_PENDING_DESCRIPTION = 'ArgoCD has not yet picked up these changes.';
+const ROLLOUT_STATUS_ERROR_DESCRIPTION = 'ArgoCD has applied these changes, but some error has occurred';
+const ROLLOUT_STATUS_UNHEALTHY_DESCRIPTION =
+    'ArgoCD applied the changes successfully, but the application is unhealthy';
 
 export const RolloutStatusDescription: React.FC<{ status: RolloutStatus }> = (props) => {
     const { status } = props;
+
+    let span = <span className="rollout__description_unknown">? Unknown</span>;
+    let tooltipContent = ROLLOUT_STATUS_UNKNOWN_DESCRIPTION;
     switch (status) {
         case RolloutStatus.ROLLOUT_STATUS_SUCCESFUL:
-            return <span className="rollout__description_successful">✓ Done</span>;
+            span = <span className="rollout__description_successful">✓ Done</span>;
+            tooltipContent = ROLLOUT_STATUS_SUCCESFUL_DESCRIPTION;
+            break;
         case RolloutStatus.ROLLOUT_STATUS_PROGRESSING:
-            return <span className="rollout__description_progressing">↻ In progress</span>;
+            span = <span className="rollout__description_progressing">↻ In progress</span>;
+            tooltipContent = ROLLOUT_STATUS_PROGRESSING_DESCRIPTION;
+            break;
         case RolloutStatus.ROLLOUT_STATUS_PENDING:
-            return <span className="rollout__description_pending">⧖ Pending</span>;
+            span = <span className="rollout__description_pending">⧖ Pending</span>;
+            tooltipContent = ROLLOUT_STATUS_PENDING_DESCRIPTION;
+            break;
         case RolloutStatus.ROLLOUT_STATUS_ERROR:
-            return <span className="rollout__description_error">! Failed</span>;
+            span = <span className="rollout__description_error">! Failed</span>;
+            tooltipContent = ROLLOUT_STATUS_ERROR_DESCRIPTION;
+            break;
         case RolloutStatus.ROLLOUT_STATUS_UNHEALTHY:
-            return <span className="rollout__description_unhealthy">⚠ Unhealthy</span>;
+            span = <span className="rollout__description_unhealthy">⚠ Unhealthy</span>;
+            tooltipContent = ROLLOUT_STATUS_UNHEALTHY_DESCRIPTION;
+            break;
     }
-    return <span className="rollout__description_unknown">? Unknown</span>;
+    return (
+        <Tooltip tooltipContent={<div className="mdc-tooltip__title_ release__details">{tooltipContent}</div>}>
+            {span}
+        </Tooltip>
+    );
 };

--- a/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.tsx
+++ b/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.tsx
@@ -24,9 +24,9 @@ const ROLLOUT_STATUS_SUCCESFUL_DESCRIPTION = 'ArgoCD has successfully synced thi
 const ROLLOUT_STATUS_PROGRESSING_DESCRIPTION =
     'ArgoCD has picked up these changes for this application on this environment, but has not applied them yet. This process might take a while.';
 const ROLLOUT_STATUS_PENDING_DESCRIPTION = 'ArgoCD has not yet picked up these changes.';
-const ROLLOUT_STATUS_ERROR_DESCRIPTION = 'ArgoCD has applied these changes, but some error has occurred';
+const ROLLOUT_STATUS_ERROR_DESCRIPTION = 'ArgoCD has applied these changes, but some error has occurred.';
 const ROLLOUT_STATUS_UNHEALTHY_DESCRIPTION =
-    'ArgoCD applied the changes successfully, but the application is unhealthy';
+    'ArgoCD applied the changes successfully, but the application is unhealthy.';
 
 export const RolloutStatusDescription: React.FC<{ status: RolloutStatus }> = (props) => {
     const { status } = props;

--- a/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.tsx
+++ b/services/frontend-service/src/ui/components/RolloutStatusDescription/RolloutStatusDescription.tsx
@@ -24,6 +24,7 @@ const ROLLOUT_STATUS_SUCCESFUL_DESCRIPTION = 'ArgoCD has successfully synced thi
 const ROLLOUT_STATUS_PROGRESSING_DESCRIPTION =
     'ArgoCD has picked up these changes for this application on this environment, but has not applied them yet. This process might take a while.';
 const ROLLOUT_STATUS_PENDING_DESCRIPTION = 'ArgoCD has not yet picked up these changes.';
+
 const ROLLOUT_STATUS_ERROR_DESCRIPTION = 'ArgoCD has applied these changes, but some error has occurred.';
 const ROLLOUT_STATUS_UNHEALTHY_DESCRIPTION =
     'ArgoCD applied the changes successfully, but the application is unhealthy.';


### PR DESCRIPTION
Fixed CSS on rollout/git sync status inside rollout service from:
![Screenshot 2025-02-27 at 10 26 53](https://github.com/user-attachments/assets/3b9fd5f9-cb70-4d0b-9acb-564ab24ee724)
to:
![Screenshot 2025-02-27 at 10 27 35](https://github.com/user-attachments/assets/461fa932-1ed3-4844-a119-ee17441e45e4)

Also added tooltip descriptions for every Rollout and Git Sync Status:
![Screenshot 2025-02-27 at 10 33 32](https://github.com/user-attachments/assets/056f2582-d7e4-48bd-92db-4e013b63810d)
![Screenshot 2025-02-27 at 10 33 48](https://github.com/user-attachments/assets/72862ca1-b0ab-470c-b8d1-3d311a49537d)
![Screenshot 2025-02-27 at 10 34 45](https://github.com/user-attachments/assets/a4f61bd0-5740-4575-af9c-01fcdf28fdde)


Ref: SRX-YO3HLA
