### PR TITLE
fix: reduce number of calls in DeleteEnvFromApp

### DIFF
--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1230,16 +1230,16 @@ func (u *DeleteEnvFromApp) Transform(
 		return "", err
 	}
 
+	now, err := state.DBHandler.DBReadTransactionTimestamp(ctx, transaction)
+	if err != nil {
+		return "", fmt.Errorf("could not get transaction timestamp")
+	}
 	for _, dbReleaseWithMetadata := range releases {
 		newManifests := make(map[string]string)
 		for envName, manifest := range dbReleaseWithMetadata.Manifests.Manifests {
 			if envName != u.Environment {
 				newManifests[envName] = manifest
 			}
-		}
-		now, err := state.DBHandler.DBReadTransactionTimestamp(ctx, transaction)
-		if err != nil {
-			return "", fmt.Errorf("could not get transaction timestamp")
 		}
 		newRelease := db.DBReleaseWithMetaData{
 			ReleaseNumber: dbReleaseWithMetadata.ReleaseNumber,


### PR DESCRIPTION
This pulls the call to get the current timestamp from the DB outside of the for loop.

It should be a little more efficient, but since it's just a "select now()" so it should not make a big difference in time spent.

Ref: SRX-E3IK25