### PR TITLE
fix(export-service): Update transformer eslversion upon failed esl event retry

### DIFF
--- a/pkg/db/db_sync_status.go
+++ b/pkg/db/db_sync_status.go
@@ -261,7 +261,7 @@ func (h *DBHandler) DBBulkUpdateAllDeployments(ctx context.Context, tx *sql.Tx, 
 	query := h.AdaptQuery("UPDATE deployments SET transformereslversion = ? WHERE transformereslversion= ?;")
 	_, err := tx.ExecContext(ctx, query, newId, oldId)
 	if err != nil {
-		return fmt.Errorf("could not update deployments from %q to %q. Error: %w\n", oldId, newId, err)
+		return onErr(fmt.Errorf("could not update deployments from %q to %q. Error: %w\n", oldId, newId, err))
 	}
 	return nil
 }

--- a/pkg/db/db_sync_status.go
+++ b/pkg/db/db_sync_status.go
@@ -248,6 +248,24 @@ func (h *DBHandler) DBBulkUpdateAllApps(ctx context.Context, tx *sql.Tx, newId, 
 	return h.executeBulkInsert(ctx, tx, allCombs, *now, newId, status, BULK_INSERT_BATCH_SIZE)
 }
 
+func (h *DBHandler) DBBulkUpdateAllDeployments(ctx context.Context, tx *sql.Tx, newId, oldId TransformerID) error {
+	span, ctx, onErr := tracing.StartSpanFromContext(ctx, "DBBulkUpdateAllDeployments")
+	defer span.Finish()
+	if h == nil {
+		return nil
+	}
+	if tx == nil {
+		return onErr(fmt.Errorf("DBBulkUpdateAllDeployments: no transaction provided"))
+	}
+
+	query := h.AdaptQuery("UPDATE deployments SET transformereslversion = ? WHERE transformereslversion= ?;")
+	_, err := tx.ExecContext(ctx, query, newId, oldId)
+	if err != nil {
+		return fmt.Errorf("could not update deployments from %q to %q. Error: %w\n", oldId, newId, err)
+	}
+	return nil
+}
+
 func (h *DBHandler) DBRetrieveAppsByStatus(ctx context.Context, tx *sql.Tx, status SyncStatus) ([]GitSyncData, error) {
 	span, ctx, onErr := tracing.StartSpanFromContext(ctx, "DBRetrieveSyncStatus")
 	defer span.Finish()

--- a/services/manifest-repo-export-service/pkg/service/git.go
+++ b/services/manifest-repo-export-service/pkg/service/git.go
@@ -364,9 +364,10 @@ func (s *GitServer) RetryFailedEvent(ctx context.Context, in *api.RetryFailedEve
 		if err != nil {
 			logger.FromContext(ctx).Sugar().Warnf("Could not send git sync status metrics to datadog. Error: %v", err)
 		}
+
 		return nil
 	})
-
+	s.Repository.Notify().Notify() //Notify sync statuses have changed
 	return response, onErr(err)
 }
 

--- a/services/manifest-repo-export-service/pkg/service/git.go
+++ b/services/manifest-repo-export-service/pkg/service/git.go
@@ -356,6 +356,10 @@ func (s *GitServer) RetryFailedEvent(ctx context.Context, in *api.RetryFailedEve
 		if err != nil {
 			return err
 		}
+		err = dbHandler.DBBulkUpdateAllDeployments(ctx, transaction, db.TransformerID(internal.EslVersion), db.TransformerID(failedEvent.TransformerEslVersion))
+		if err != nil {
+			return err
+		}
 		err = repository.MeasureGitSyncStatus(ctx, s.Config.DDMetrics, dbHandler)
 		if err != nil {
 			logger.FromContext(ctx).Sugar().Warnf("Could not send git sync status metrics to datadog. Error: %v", err)


### PR DESCRIPTION
When the git sync status is enabled, we are able to retry events that might have failed on the manifest export service.
When we retry an event, we pickup the failed event, copy it into the event_sourcing_light table, but with a new eslVersion, so that the manifest export service can naturally pick it up.
An issue arises when certain deployments depend on these failed events. The way the manifest export service detects which deployments to write to git is by filtering the deployments table by the deployments that the transformer that is currently being processed has generated. If the event is retried, a new eslVersion is given to the event and we lose the reference to the deployments.
So if, for example, a release train transformer with tID: X fails and gets retried, it gets given another tID: Y, but the deployments do not get updated. As such, when we process the retried event, it queries the database: "which deployments were generated by transformer with ID: Y", and we get the answer: None. As such, the transformer successfully executes and the apps appear synced, when in reality nothing was deployed/pushed to the git repo

Ref: SRX-8FMYI8