### PR TITLE
feat(manifest-export): configurable empty dir size

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -50,7 +50,6 @@ spec:
       labels:
         app: kuberpult-cd-service
 {{- if .Values.datadogTracing.enabled }}
-        tags.datadoghq.com/env: {{ .Values.datadogTracing.environment }}
         tags.datadoghq.com/service: kuberpult-cd-service
         tags.datadoghq.com/version: {{ $.Chart.AppVersion }}
 {{- end }}
@@ -143,7 +142,7 @@ spec:
             memory: "{{ .Values.cd.resources.requests.memory }}"
         env:
         - name: KUBERPULT_GIT_URL
-          value: {{ required ".Values.git.url is required" .Values.git.url | quote }}
+          value: {{ .Values.git.url | quote }}
         - name: KUBERPULT_GIT_BRANCH
           value: {{ .Values.git.branch | quote }}
         - name: KUBERPULT_VERSION
@@ -322,7 +321,7 @@ spec:
         # EmptyDir has the nice advantage, that it triggers a restart of the pod and creates a new volume when the current one is full
         # Because of an issue in gitlib2, this actually happens.
         emptyDir:
-          sizeLimit: 30Gi
+          sizeLimit: {{ .Values.git.emptyDirSize }}
       - name: ssh
         secret:
           secretName: kuberpult-ssh

--- a/charts/kuberpult/templates/manifest-repo-export-service.yaml
+++ b/charts/kuberpult/templates/manifest-repo-export-service.yaml
@@ -264,7 +264,7 @@ spec:
         # EmptyDir has the nice advantage, that it triggers a restart of the pod and creates a new volume when the current one is full
         # Because of an issue in gitlib2, this actually happens.
         emptyDir:
-          sizeLimit: 30Gi
+          sizeLimit: {{ .Values.git.emptyDirSize }}
       - name: ssh
         secret:
           secretName: kuberpult-ssh

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -73,6 +73,9 @@ git:
   # Recommendation: Only activate this option, if frequent database backups are made and if the git repo takes up too many resources.
   minimizeExportedData: false
 
+  # The size of the volume that stores the local data for the git repository
+  emptyDirSize: 30Gi
+
 hub: europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
 kubernetesEngine: "GKE"
 


### PR DESCRIPTION
Making empty dir size for repository volume mount  configurable

Ref : SRX-4RL2SE