### PR TITLE
feat(cli): adding dry-run parameter for release endpoint

### DIFF
--- a/cli/pkg/cmd/handlers.go
+++ b/cli/pkg/cmd/handlers.go
@@ -82,7 +82,9 @@ func HandleReleaseDiff(kpClientParams kutil.RequestParameters, args kutil.Authen
 		return ReturnCodeFailure
 	}
 
-	var resp *GetManifestsResponse = &GetManifestsResponse{}
+	var resp *GetManifestsResponse = &GetManifestsResponse{
+		Manifests: nil,
+	}
 	err = json.Unmarshal([]byte(body), &resp)
 	if err != nil {
 		log.Printf("error while unmarshalling manifests, error: %v", err)

--- a/cli/pkg/cmd/handlers.go
+++ b/cli/pkg/cmd/handlers.go
@@ -17,7 +17,12 @@ Copyright freiheit.com*/
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+	sorting2 "github.com/freiheit-com/kuberpult/cli/pkg/sorting"
+	"github.com/google/go-cmp/cmp"
 	"log"
+	"os"
 
 	"github.com/freiheit-com/kuberpult/cli/pkg/cli_utils"
 	"github.com/freiheit-com/kuberpult/cli/pkg/deployments"
@@ -37,6 +42,15 @@ func handleRelease(kpClientParams kuberpultClientParameters, args []string) Retu
 		return ReturnCodeInvalidArguments
 	}
 
+	if parsedArgs.DryRun {
+		_, err := fmt.Fprintf(os.Stderr, "This is a dry-run.\n"+
+			"I will print out the diff of the manifests you supplied, compared to the latest release in kuberpults database.\n"+
+			"The minus sign (-) stands for the existing release in kuberpults DB, and the plus sign (+) stands for the manifests you supplied as parameters.\n")
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	authParams := kutil.AuthenticationParameters{
 		IapToken:    kpClientParams.iapToken,
 		DexToken:    kpClientParams.dexToken,
@@ -50,10 +64,48 @@ func handleRelease(kpClientParams kuberpultClientParameters, args []string) Retu
 		HttpTimeout: cli_utils.HttpDefaultTimeout,
 	}
 
-	if err = rl.Release(requestParameters, authParams, *parsedArgs); err != nil {
-		log.Printf("error on release, error: %v", err)
+	if parsedArgs.DryRun {
+		return HandleReleaseDiff(requestParameters, authParams, *parsedArgs)
+	} else {
+		if err = rl.Release(requestParameters, authParams, *parsedArgs); err != nil {
+			log.Printf("error on release, error: %v", err)
+			return ReturnCodeFailure
+		}
+	}
+	return ReturnCodeSuccess
+}
+
+func HandleReleaseDiff(kpClientParams kutil.RequestParameters, args kutil.AuthenticationParameters, parsedArgs rl.ReleaseParameters) ReturnCode {
+	body, err := rl.GetManifests(kpClientParams, args, parsedArgs)
+	if err != nil {
+		log.Printf("error on getting manifests, error: %v", err)
 		return ReturnCodeFailure
 	}
+
+	var resp *GetManifestsResponse = &GetManifestsResponse{}
+	err = json.Unmarshal([]byte(body), &resp)
+	if err != nil {
+		log.Printf("error while unmarshalling manifests, error: %v", err)
+		return ReturnCodeFailure
+	}
+
+	// We sort by environment name to maintain a stable sorting:
+	sortedKeys := sorting2.SortKeys(parsedArgs.Manifests)
+	for keyIndex := range sortedKeys {
+		envName := sortedKeys[keyIndex]
+		inputManifestBytes := parsedArgs.Manifests[envName]
+		inputManifest := string(inputManifestBytes)
+		val, ok := resp.Manifests[envName]
+		var gottenManifest string
+		if !ok {
+			gottenManifest = ""
+		} else {
+			gottenManifest = val.Content
+		}
+		diff := cmp.Diff(gottenManifest, inputManifest)
+		fmt.Printf("Diff for the manifest on environment '%s':\n%s", envName, diff)
+	}
+
 	return ReturnCodeSuccess
 }
 

--- a/cli/pkg/cmd/parsing.go
+++ b/cli/pkg/cmd/parsing.go
@@ -30,6 +30,7 @@ type commandLineArguments struct {
 	authorName  cli_utils.RepeatedString
 	retries     cli_utils.RepeatedInt
 	timeout     cli_utils.RepeatedInt
+	dryRun      bool
 }
 
 func readArgs(args []string) (*commandLineArguments, []string, error) {

--- a/cli/pkg/cmd/parsing.go
+++ b/cli/pkg/cmd/parsing.go
@@ -30,7 +30,6 @@ type commandLineArguments struct {
 	authorName  cli_utils.RepeatedString
 	retries     cli_utils.RepeatedInt
 	timeout     cli_utils.RepeatedInt
-	dryRun      bool
 }
 
 func readArgs(args []string) (*commandLineArguments, []string, error) {

--- a/cli/pkg/cmd/types.go
+++ b/cli/pkg/cmd/types.go
@@ -1,0 +1,30 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package cmd
+
+/**
+The types here are necessary because we do not have the protobuf types integrated in the "cli" directory.
+These types are a small subset of api.proto.
+*/
+
+type Manifest struct {
+	Content string `protobuf:"bytes,2,opt,name=content,proto3" json:"content,omitempty"`
+}
+
+type GetManifestsResponse struct {
+	Manifests map[string]*Manifest `protobuf:"bytes,2,rep,name=manifests,proto3" json:"manifests,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+}

--- a/cli/pkg/release/parsing.go
+++ b/cli/pkg/release/parsing.go
@@ -48,6 +48,7 @@ type commandLineArguments struct {
 	useDexAuthentication bool
 	isPrepublish         bool
 	ciLink               cli_utils.RepeatedString
+	dryRun               bool
 }
 
 // checks whether every --environment arg is matched with a --manifest arg
@@ -105,7 +106,7 @@ func argsValid(cmdArgs *commandLineArguments) (result bool, errorMessage string)
 	}
 
 	if len(cmdArgs.environments.Values) == 0 {
-		return false, "the args --enviornment and --manifest must be set at least once"
+		return false, "the args --environment and --manifest must be set at least once"
 	}
 
 	if len(cmdArgs.team.Values) > 1 {
@@ -208,6 +209,7 @@ func readArgs(args []string) (*commandLineArguments, error) {
 	fs.Var(&cmdArgs.signatures, "signature", "the name of the file containing the signature of the manifest to be deployed (must be set immediately after --manifest)")
 	fs.BoolVar(&cmdArgs.useDexAuthentication, "use_dex_auth", false, "use /api/release endpoint, if set to true, dex must be enabled and dex token must be provided otherwise the request will be denied")
 	fs.BoolVar(&cmdArgs.isPrepublish, "prepublish", false, "if set to true, it will create a prepublish release")
+	fs.BoolVar(&cmdArgs.dryRun, "dry-run", false, "Run in dry-run mode, do not publish, but return the manifest diff instead")
 
 	if err := fs.Parse(args); err != nil {
 		return nil, fmt.Errorf("error while parsing command line arguments, error: %w", err)
@@ -297,6 +299,8 @@ func convertToParams(cmdArgs commandLineArguments) (*ReleaseParameters, error) {
 	}
 	rp.UseDexAuthentication = cmdArgs.useDexAuthentication
 	rp.IsPrepublish = cmdArgs.isPrepublish
+	rp.DryRun = cmdArgs.dryRun
+
 	return &rp, nil
 }
 

--- a/cli/pkg/release/parsing_test.go
+++ b/cli/pkg/release/parsing_test.go
@@ -74,7 +74,7 @@ func TestReadArgs(t *testing.T) {
 			name: "only --application is properly provided but without --environment and --manifest",
 			args: []string{"--skip_signatures", "--application", "potato"},
 			expectedError: errMatcher{
-				msg: "the args --enviornment and --manifest must be set at least once",
+				msg: "the args --environment and --manifest must be set at least once",
 			},
 		},
 		{
@@ -714,10 +714,10 @@ func TestParseArgs(t *testing.T) {
 	tcs := []testCase{
 		{
 			setup:   []fileCreation{},
-			name:    "no enviornments and manifests",
+			name:    "no environments and manifests",
 			cmdArgs: []string{"--skip_signatures", "--application", "potato"},
 			expectedError: errMatcher{
-				msg: "error while reading command line arguments, error: the args --enviornment and --manifest must be set at least once",
+				msg: "error while reading command line arguments, error: the args --environment and --manifest must be set at least once",
 			},
 		},
 		{
@@ -822,13 +822,13 @@ func TestParseArgs(t *testing.T) {
 			},
 		},
 		{
+			name: "use_dex_auth is passed",
 			setup: []fileCreation{
 				{
 					filename: "development-manifest.yaml",
 					content:  "some development manifest",
 				},
 			},
-			name:    "use_dex_auth is passed",
 			cmdArgs: []string{"--application", "potato", "--environment", "development", "--manifest", "development-manifest.yaml", "--use_dex_auth"},
 			expectedParams: &ReleaseParameters{
 				Application: "potato",
@@ -839,6 +839,7 @@ func TestParseArgs(t *testing.T) {
 			},
 		},
 		{
+			name: "signatures are not allowed when use_dex_auth is enabled",
 			setup: []fileCreation{
 				{
 					filename: "development-manifest.yaml",
@@ -849,7 +850,6 @@ func TestParseArgs(t *testing.T) {
 					content:  "some development signature",
 				},
 			},
-			name:           "signatures are not allowed when use_dex_auth is enabled",
 			cmdArgs:        []string{"--use_dex_auth", "--application", "potato", "--environment", "development", "--manifest", "development-manifest.yaml", "--signature", "development-signature.gpg"},
 			expectedParams: nil,
 			expectedError: errMatcher{
@@ -857,13 +857,13 @@ func TestParseArgs(t *testing.T) {
 			},
 		},
 		{
+			name: "with environment, manifest and ci link",
 			setup: []fileCreation{
 				{
 					filename: "production-manifest.yaml",
 					content:  "some production manifest",
 				},
 			},
-			name:    "with environment, manifest and ci link",
 			cmdArgs: []string{"--skip_signatures", "--application", "potato", "--environment", "production", "--manifest", "production-manifest.yaml", "--ci_link", "https://localhost:8000"},
 			expectedParams: &ReleaseParameters{
 				Application: "potato",
@@ -871,6 +871,25 @@ func TestParseArgs(t *testing.T) {
 					"production": []byte("some production manifest"),
 				},
 				CiLink: strPtr("https://localhost:8000"),
+				DryRun: false,
+			},
+		},
+		{
+			name: "with dry-run",
+			setup: []fileCreation{
+				{
+					filename: "production-manifest.yaml",
+					content:  "some production manifest",
+				},
+			},
+			cmdArgs: []string{"--dry-run", "--skip_signatures", "--application", "potato", "--environment", "production", "--manifest", "production-manifest.yaml", "--ci_link", "https://localhost:8000"},
+			expectedParams: &ReleaseParameters{
+				Application: "potato",
+				Manifests: map[string][]byte{
+					"production": []byte("some production manifest"),
+				},
+				CiLink: strPtr("https://localhost:8000"),
+				DryRun: true,
 			},
 		},
 	}

--- a/cli/pkg/release/release.go
+++ b/cli/pkg/release/release.go
@@ -39,12 +39,13 @@ type ReleaseParameters struct {
 	CiLink               *string
 	UseDexAuthentication bool
 	IsPrepublish         bool
+	DryRun               bool
 }
 
-// calls the Release endpoint with the specified parameters
+// Release calls the release endpoint with the specified parameters
 // this function might be used in the future for programmatic interaction with Kuberpult, hence its separation
 func Release(requestParams kutil.RequestParameters, authParams kutil.AuthenticationParameters, params ReleaseParameters) error {
-	req, err := prepareHttpRequest(*requestParams.Url, authParams, params)
+	req, err := prepareHttpReleaseRequest(*requestParams.Url, authParams, params)
 	if err != nil {
 		return fmt.Errorf("error while preparing HTTP request, error: %w", err)
 	}
@@ -52,4 +53,17 @@ func Release(requestParams kutil.RequestParameters, authParams kutil.Authenticat
 		return fmt.Errorf("error while issuing HTTP request, error: %v", err)
 	}
 	return nil
+}
+
+// GetManifests calls the API to retrieve current manifests
+func GetManifests(requestParams kutil.RequestParameters, authParams kutil.AuthenticationParameters, params ReleaseParameters) (string, error) {
+	req, err := prepareHttpManifestRequest(*requestParams.Url, authParams, params)
+	if err != nil {
+		return "", fmt.Errorf("error while preparing HTTP request, error: %w", err)
+	}
+	body, err := cli_utils.IssueHttpRequestWithBodyReturn(*req, requestParams.HttpTimeout)
+	if err != nil || body == nil {
+		return "", fmt.Errorf("error while issuing HTTP request, error: %v", err)
+	}
+	return string(body), nil
 }

--- a/cli/pkg/sorting/sorting.go
+++ b/cli/pkg/sorting/sorting.go
@@ -1,0 +1,36 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package sorting
+
+import (
+	"cmp"
+	"sort"
+)
+
+// SortKeys sorts the map by the keys
+// We should always avoid iterating over a map without sorting it first,
+// in order to get a deterministic order of operations.
+func SortKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	keys := make([]K, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	return keys
+}

--- a/cli/pkg/sorting/sorting_test.go
+++ b/cli/pkg/sorting/sorting_test.go
@@ -1,0 +1,63 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package sorting
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func TestSortKeys(t *testing.T) {
+	tcs := []struct {
+		Name         string
+		Input        map[string]string
+		ExpectedKeys []string
+	}{
+		{
+			Name:         "empty map",
+			Input:        map[string]string{},
+			ExpectedKeys: []string{},
+		},
+		{
+			Name: "one element",
+			Input: map[string]string{
+				"a": "one",
+			},
+			ExpectedKeys: []string{"a"},
+		},
+		{
+			Name: "many elements",
+			Input: map[string]string{
+				"a": "x",
+				"d": "y",
+				"c": "z",
+				"b": "w",
+			},
+			ExpectedKeys: []string{"a", "b", "c", "d"},
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			actualKeys := SortKeys(tc.Input)
+			if diff := cmp.Diff(tc.ExpectedKeys, actualKeys); diff != "" {
+				t.Errorf("error mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/services/frontend-service/pkg/handler/release.go
+++ b/services/frontend-service/pkg/handler/release.go
@@ -278,7 +278,7 @@ func (s Server) HandleRelease(w http.ResponseWriter, r *http.Request, tail strin
 	}
 
 	writeCorrespondingResponse(ctx, w, r, releaseResponse, err)
-	logger.FromContext(ctx).Warn("warning: /release endoint will be deprecated soon, use /api/release instead. Check https://github.com/freiheit-com/kuberpult/blob/main/docs/endpoint-release.md for more information.\n")
+	logger.FromContext(ctx).Warn("warning: The /release endpoint will be deprecated in the future, use /api/release instead. Check https://github.com/freiheit-com/kuberpult/blob/main/docs/endpoint-release.md for more information.\n")
 }
 
 func (s Server) handleApiRelease(w http.ResponseWriter, r *http.Request, tail string) {


### PR DESCRIPTION
This dry-run parameter toggles the behavior:
With dry-run, we return the diff of the manifests, instead of creating a new release.

Ref: SRX-J7MZFR