### PR TITLE
feat(db): release error handling, db lock type, removed read-before-write

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -269,6 +269,8 @@ spec:
           value: "{{ .Values.db.connections.cd.maxIdle }}"
         - name: KUBERPULT_CHECK_CUSTOM_MIGRATIONS
           value: "{{ .Values.db.checkCustomMigrations }}"
+        - name: KUBERPULT_LOCK_TYPE
+          value: "{{ .Values.cd.lockType }}"
 {{- end }}
         - name: KUBERPULT_ALLOW_LONG_APP_NAMES
           value: "{{ .Values.cd.allowLongAppNames }}"

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -96,6 +96,15 @@ cd:
   allowedDomains: ""
   cacheTtlHours: 24
   maxNumberOfThreads: 3
+
+  # The lockType option is EXPERIMENTAL and may be removed or changed without a breaking change.
+  # By default, (lockType: "go") the cd-service uses in-memory go-locks to make sure that
+  # destructive actions like deleting an app are only run by one transaction at a time.
+  # With database locks (lockType: "db") kuberpult will not use go-locks, but instead postgres-locks.
+  # These have the advantage that they are not limited to one cd-service pod.
+  # LockType: "none" means there is no locking at all, increasing the risk of an inconsistent database state.
+  # This lock type should only be used for testing purposes.
+  lockType: "go"
   service:
     annotations: {}
   pod:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
   cd-service:
     image: europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult/kuberpult-cd-service:local
     environment:
+      - KUBERPULT_LOCK_TYPE=db
       - LOG_LEVEL=INFO
       - KUBERPULT_DISABLE_QUEUE=true
       - KUBERPULT_GIT_URL=/kp/kuberpult/repository_remote

--- a/infrastructure/scripts/create-testdata/create-many-releases.sh
+++ b/infrastructure/scripts/create-testdata/create-many-releases.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# create-many-releases.sh MIN MAX
+# Where MIN is the first release number used, and MAX is the last. Make sure that MAX>=MIN and MIN>=0.
+# This script creates a few releases, while in parallel we call undeploy.
+# This is useful to test the lock feature (db.lockType).
+# To check if the test is successful or not:
+# select applications from environments where name='development'; select appname from releases where appname='echo-???'
+# The test is successful if EACH application either appear in both tables, or in neither. See query.sql for the test.
+
+cd "$(dirname "$0")" || exit 1
+
+set -u
+
+MIN=${1}
+MAX=${2}
+
+./create-environments.sh
+
+# Setup: ensure the app exists:
+for appId in $(seq -w "${MIN}" "${MAX}" ); do
+  RELEASE_VERSION=99999 ./create-release.sh "echo-${appId}";
+done
+
+echo "Done with setup, starting test..."
+
+# Test:
+for appId in $(seq -w "${MIN}" "${MAX}" ); do
+  app="echo-${appId}"
+  RELEASE_VERSION=1 ./create-release.sh "${app}" &
+  (
+    echo '{
+"actions": [
+  {
+    "prepare_undeploy": {
+      "application": "'"${app}"'"
+    }
+  },
+  {
+    "undeploy": {
+      "application": "'"${app}"'"
+    }
+  }
+]
+}' | \
+    evans --header author-name=YXV0aG9y --header author-email=YXV0aG9yQGF1dGhvcg== --host localhost --port 8443 -r cli call api.v1.BatchService.ProcessBatch \
+    && echo "app ${appId} deletion success" \
+    || echo "app ${appId} deletion failed"
+  ) &
+done
+
+echo "waiting for all calls to finish..."
+wait
+echo "ALL DONE."

--- a/infrastructure/scripts/create-testdata/create-release.sh
+++ b/infrastructure/scripts/create-testdata/create-release.sh
@@ -22,7 +22,6 @@ authors[6]="João"
 authors[7]="Leandro"
 sizeAuthors=${#authors[@]}
 index=$((RANDOM % sizeAuthors))
-echo "${authors[$index]}"
 author="${authors[$index]}"
 commit_message_file="$(mktemp "${TMPDIR:-/tmp}/publish.XXXXXX")"
 trap "rm -f ""$commit_message_file" INT TERM HUP EXIT
@@ -44,12 +43,10 @@ msgs[9]="Fix bug in distanceToUpstream calculation"
 msgs[10]="Allow deleting locks on locks page"
 sizeMsgs=${#msgs[@]}
 index=$((RANDOM % sizeMsgs))
-echo $index
 echo -e "${msgs[$index]}\n" > "${commit_message_file}"
 echo "1: ${msgs[$index]}" >> "${commit_message_file}"
 echo "2: ${msgs[$index]}" >> "${commit_message_file}"
 
-ls "${commit_message_file}"
 
 release_version=()
 case "${RELEASE_VERSION:-}" in
@@ -57,7 +54,6 @@ case "${RELEASE_VERSION:-}" in
 	*) release_version+=('--form-string' "version=${RELEASE_VERSION:-}");;
 esac
 
-echo "release version:" "${release_version[@]}"
 
 configuration=()
 configuration+=("--form" "team=${applicationOwnerTeam}")
@@ -80,10 +76,8 @@ data:
   releaseVersion: "${release_version[@]}"
 ---
 EOF
-  echo "wrote file ${file}"
   manifests+=("--form" "manifests[${env}]=@${file}")
 done
-echo commit id: "${commit_id}"
 
 FRONTEND_PORT=8081 # see docker-compose.yml
 

--- a/infrastructure/scripts/create-testdata/grpc/Readme.md
+++ b/infrastructure/scripts/create-testdata/grpc/Readme.md
@@ -1,0 +1,7 @@
+This directory contains files that can be used with `evans` to make grpc calls on the command line (non-interactive).
+
+Example to call "delete env from app" via evans:
+```shell
+cat batch-delete-app-env.json | \
+evans --header author-name=YXV0aG9y --header author-email=YXV0aG9yQGF1dGhvcg== --host localhost --port 8443 -r cli call api.v1.BatchService.ProcessBatch
+```

--- a/infrastructure/scripts/create-testdata/grpc/batch-delete-app-env.json
+++ b/infrastructure/scripts/create-testdata/grpc/batch-delete-app-env.json
@@ -1,0 +1,10 @@
+{
+  "actions": [
+    {
+      "delete_env_from_app": {
+        "application": "echo-10",
+        "environment": "development"
+      }
+    }
+  ]
+}

--- a/infrastructure/scripts/create-testdata/grpc/batch-delete-app.json
+++ b/infrastructure/scripts/create-testdata/grpc/batch-delete-app.json
@@ -1,0 +1,14 @@
+{
+  "actions": [
+    {
+      "prepare_undeploy": {
+        "application": "echo-143"
+      }
+    },
+    {
+      "undeploy": {
+        "application": "echo-143"
+      }
+    }
+  ]
+}

--- a/infrastructure/scripts/create-testdata/grpc/batch-delete-env.json
+++ b/infrastructure/scripts/create-testdata/grpc/batch-delete-env.json
@@ -1,0 +1,9 @@
+{
+  "actions": [
+    {
+      "delete_environment": {
+        "environment": "development"
+      }
+    }
+  ]
+}

--- a/infrastructure/scripts/create-testdata/query.sql
+++ b/infrastructure/scripts/create-testdata/query.sql
@@ -30,4 +30,4 @@ SELECT
     (SELECT result FROM app_was_created) AS "App created in apps table",
     (SELECT result FROM env_has_app) AS "Environment has App",
     (SELECT result FROM app_has_release) AS "App has Release(s)",
-    ((SELECT result FROM env_has_app) = (SELECT result FROM app_has_release)) AS "All consistent";
+    ((SELECT result FROM env_has_app) = (SELECT result FROM app_has_release) AND (SELECT result FROM app_has_release) = (SELECT result FROM app_was_created)) AS "All consistent";

--- a/infrastructure/scripts/create-testdata/query.sql
+++ b/infrastructure/scripts/create-testdata/query.sql
@@ -1,0 +1,33 @@
+
+-- checks if an app's state in the DB is consistent:
+-- apps table, releases table, and environments table
+
+WITH env_has_app AS (
+    SELECT EXISTS (
+        SELECT 1
+        FROM environments
+        WHERE name = 'development'
+          AND applications::jsonb @> json_build_array(:'app'::text)::jsonb
+    ) AS result
+),
+     app_has_release AS (
+         SELECT EXISTS (
+             SELECT 1
+             FROM releases
+             WHERE appname = :'app'
+             ORDER BY releaseVersion DESC
+         ) AS result
+     ),
+    app_was_created AS (
+        SELECT EXISTS (
+            select appname, statechange
+            from apps
+            WHERE appname = :'app'
+            AND statechange='AppStateChangeCreate'
+       ) AS result
+)
+SELECT
+    (SELECT result FROM app_was_created) AS "App created in apps table",
+    (SELECT result FROM env_has_app) AS "Environment has App",
+    (SELECT result FROM app_has_release) AS "App has Release(s)",
+    ((SELECT result FROM env_has_app) = (SELECT result FROM app_has_release)) AS "All consistent";

--- a/pkg/db/db_advisory_locks.go
+++ b/pkg/db/db_advisory_locks.go
@@ -1,0 +1,125 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	_ "github.com/lib/pq"
+)
+
+type AdvisoryLockId int
+
+type DBFunctionNoTx func(ctx context.Context) error
+
+const (
+	// LockIsolateTransformers is for transformer exclusivity:
+	LockIsolateTransformers AdvisoryLockId = 666
+)
+
+func (h *DBHandler) WithAdvisoryLock(ctx context.Context, isShared bool, lockId AdvisoryLockId, f DBFunctionNoTx) error {
+	span, ctx := tracer.StartSpanFromContext(ctx, "WithAdvisoryLock")
+	defer span.Finish()
+
+	err := h.DBAcquireAdvisoryLock(ctx, isShared, lockId)
+	if err != nil {
+		return err
+	}
+	err = f(ctx)
+	if err != nil {
+		unlockErr := h.DBReleaseAdvisoryLock(ctx, isShared, lockId)
+		if unlockErr != nil {
+			return fmt.Errorf("could not release advisory lock %v/%d and inner function failed: %w", isShared, lockId, errors.Join(err, unlockErr))
+		} else {
+			return fmt.Errorf("lock %v/%d was released, but the inner function failed with: %w", isShared, lockId, err)
+		}
+	} else {
+		unlockErr := h.DBReleaseAdvisoryLock(ctx, isShared, lockId)
+		if unlockErr != nil {
+			return fmt.Errorf("could not release advisory lock %v/%d: %w", isShared, lockId, unlockErr)
+		} else {
+			return nil
+		}
+	}
+}
+
+// DBAcquireAdvisoryLock waits until the advisory lock is available
+func (h *DBHandler) DBAcquireAdvisoryLock(ctx context.Context, isShared bool, lockID AdvisoryLockId) error {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBAcquireAdvisoryLock")
+	defer span.Finish()
+	span.SetTag("lockId", lockID)
+	if h == nil {
+		return fmt.Errorf("DBAcquireAdvisoryLock: no db handler provided")
+	}
+
+	err := h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+		var selectQuery string
+		if isShared {
+			selectQuery = h.AdaptQuery("SELECT pg_advisory_lock_shared(?)")
+		} else {
+			selectQuery = h.AdaptQuery("SELECT pg_advisory_lock(?)")
+		}
+		span.SetTag("query", selectQuery)
+		row, err := transaction.QueryContext(
+			ctx,
+			selectQuery,
+			lockID,
+		)
+		if err != nil {
+			return fmt.Errorf("could not query %s. Error: %w", selectQuery, err)
+		}
+		if !row.Next() {
+			return fmt.Errorf("could not call Next on row: %w", err)
+		}
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("DBAcquireAdvisoryLock: could not run transaction. Error: %w", err)
+	}
+	return nil
+}
+
+// DBReleaseAdvisoryLock releases the advisory lock immediately (not waiting for end of transaction)
+func (h *DBHandler) DBReleaseAdvisoryLock(ctx context.Context, isShared bool, lockID AdvisoryLockId) error {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBReleaseAdvisoryLock")
+	defer span.Finish()
+	span.SetTag("lockId", lockID)
+
+	var selectQuery string
+	if isShared {
+		selectQuery = h.AdaptQuery("SELECT pg_advisory_unlock_shared(?)")
+	} else {
+		selectQuery = h.AdaptQuery("SELECT pg_advisory_unlock(?)")
+	}
+
+	span.SetTag("query", selectQuery)
+	_, err := h.DB.ExecContext(
+		ctx,
+		selectQuery,
+		lockID,
+	)
+	if err != nil {
+		return fmt.Errorf("DBReleaseAdvisoryLock: error releasing lock with id=%d and shared=%v. Error: %w\n", lockID, isShared, err)
+	}
+
+	return nil
+}

--- a/pkg/db/db_environments.go
+++ b/pkg/db/db_environments.go
@@ -266,11 +266,12 @@ func (h *DBHandler) DBRemoveAppFromEnvironment(ctx context.Context, tx *sql.Tx, 
 	if err != nil {
 		return err
 	}
-	if dbEnv != nil { // if this is nil, then there was no change made in `addAppToEnvironment`
-		err = h.insertEnvironmentHistoryRow(ctx, tx, environmentName, dbEnv.Config, dbEnv.Applications, false)
-		if err != nil {
-			return err
-		}
+	if dbEnv == nil {
+		return fmt.Errorf("environment does not exist: '%s'", environmentName)
+	}
+	err = h.insertEnvironmentHistoryRow(ctx, tx, environmentName, dbEnv.Config, dbEnv.Applications, false)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -4632,7 +4632,7 @@ func setupDB(t *testing.T) *DBHandler {
 	t.Logf("directory for DB migrations: %s", dir)
 	t.Logf("tmp dir for DB data: %s", tmpDir)
 
-	dbConfig, err := SetupPostgresContainer(ctx, t, dir, false, t.Name())
+	dbConfig, err := ConnectToPostgresContainer(ctx, t, dir, false, t.Name())
 	if err != nil {
 		t.Fatalf("SetupPostgres: %v", err)
 	}
@@ -4660,7 +4660,7 @@ func SetupRepositoryTestWithDB(t *testing.T, runMigrations bool) (*DBHandler, *D
 
 func SetupRepositoryTestWithDBMigrationPath(t *testing.T, migrationsPath string, runMigrations bool) (*DBHandler, *DBConfig) {
 	ctx := context.Background()
-	dbConfig, err := SetupPostgresContainer(ctx, t, migrationsPath, false, t.Name())
+	dbConfig, err := ConnectToPostgresContainer(ctx, t, migrationsPath, false, t.Name())
 	dir := t.TempDir()
 	remoteDir := path.Join(dir, "remote")
 	localDir := path.Join(dir, "local")

--- a/pkg/db/db_testutil.go
+++ b/pkg/db/db_testutil.go
@@ -17,16 +17,13 @@ Copyright freiheit.com*/
 package db
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"github.com/freiheit-com/kuberpult/pkg/logger"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
-	"time"
 )
 
 // simpleHash is a basic hash function for strings
@@ -56,79 +53,7 @@ func CreateMigrationsPath(numDirs int) (string, error) {
 	return "/kp" + subDir, nil
 }
 
-// GetGitRootDirectory runs `git rev-parse --show-toplevel` and returns the top-level directory of the git repository
-func GetGitRootDirectory() (string, error) {
-	// Create the command for "git rev-parse --show-toplevel"
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-
-	// Capture the output
-	var out bytes.Buffer
-	cmd.Stdout = &out
-
-	// Run the command
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to run 'git rev-parse --show-toplevel': %w", err)
-	}
-
-	// Return the output as a string, trimming any extra whitespace
-	return strings.TrimSpace(out.String()), nil
-}
-
-// waitForHealthyContainers checks the health status of all services
-// and waits until they are all marked as healthy.
-func waitForHealthyContainers(directory string) error {
-	const maxRetries = 5
-	const retryInterval = 5 * time.Second
-
-	for i := 0; i < maxRetries; i++ {
-		// Run "docker compose ps" to check the health status
-		cmd := exec.Command("docker", "compose", "ps")
-		cmd.Dir = directory
-
-		var out bytes.Buffer
-		cmd.Stdout = &out
-
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to run 'docker compose ps': %w", err)
-		}
-
-		// Parse the output to check if all services are healthy
-		output := out.String()
-		if allServicesHealthy(output) {
-			fmt.Println("All services are up and healthy")
-			return nil
-		}
-		fmt.Println(output) // Print the current status for debugging
-
-		// Wait before retrying
-		time.Sleep(retryInterval)
-	}
-
-	return fmt.Errorf("timed out waiting for services to become healthy")
-}
-
-// allServicesHealthy parses the output of "docker compose ps" and checks if all services are healthy.
-func allServicesHealthy(output string) bool {
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		if strings.Contains(line, "unhealthy") || strings.Contains(line, "starting") {
-			return false
-		}
-	}
-	return true
-}
-
 func ConnectToPostgresContainer(ctx context.Context, t *testing.T, migrationsPath string, writeEslOnly bool, rawNewDbName string) (*DBConfig, error) {
-	// we expect the postgres container to be up already:
-	gitRootDir, err := GetGitRootDirectory()
-	if err != nil {
-		return nil, err
-	}
-	err = waitForHealthyContainers(gitRootDir)
-	if err != nil {
-		return nil, err
-	}
-
 	dbConfig := &DBConfig{
 		// the options here must be the same as provided by docker-compose-unittest.yml
 		DbHost:     "localhost",

--- a/pkg/db/db_testutil.go
+++ b/pkg/db/db_testutil.go
@@ -121,6 +121,9 @@ func allServicesHealthy(output string) bool {
 func ConnectToPostgresContainer(ctx context.Context, t *testing.T, migrationsPath string, writeEslOnly bool, rawNewDbName string) (*DBConfig, error) {
 	// we expect the postgres container to be up already:
 	gitRootDir, err := GetGitRootDirectory()
+	if err != nil {
+		return nil, err
+	}
 	err = waitForHealthyContainers(gitRootDir)
 	if err != nil {
 		return nil, err

--- a/pkg/db/db_testutil.go
+++ b/pkg/db/db_testutil.go
@@ -117,26 +117,8 @@ func allServicesHealthy(output string) bool {
 	}
 	return true
 }
-func RunDockerComposeUp(workdir string) error {
-	// Create the command for "docker compose up -d"
-	cmd := exec.Command("docker", "compose", "-f", "docker-compose-unittest.yml", "up", "-d")
-	cmd.Dir = workdir
 
-	// Run the command and capture the output
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to run 'docker compose up -d': %w\nOutput: %s", err, string(output))
-	}
-
-	err = waitForHealthyContainers(workdir)
-	if err != nil {
-		return fmt.Errorf("failed to wait or all docker services to be up: %w", err)
-	}
-
-	return nil
-}
-
-func SetupPostgresContainer(ctx context.Context, _ *testing.T, migrationsPath string, writeEslOnly bool, rawNewDbName string) (*DBConfig, error) {
+func SetupPostgresContainer(ctx context.Context, t *testing.T, migrationsPath string, writeEslOnly bool, rawNewDbName string) (*DBConfig, error) {
 	dbConfig := &DBConfig{
 		// the options here must be the same as provided by docker-compose-unittest.yml
 		DbHost:     "localhost",
@@ -178,6 +160,7 @@ func SetupPostgresContainer(ctx context.Context, _ *testing.T, migrationsPath st
 	if err != nil {
 		return nil, fmt.Errorf("failed to create database %s: %w", newDbName, err)
 	}
+	t.Logf("Database %s created successfully", newDbName)
 	logger.FromContext(ctx).Sugar().Infof("Database %s created successfully", newDbName)
 
 	dbConfig.DbName = newDbName

--- a/pkg/db/db_testutil.go
+++ b/pkg/db/db_testutil.go
@@ -77,7 +77,7 @@ func GetGitRootDirectory() (string, error) {
 // waitForHealthyContainers checks the health status of all services
 // and waits until they are all marked as healthy.
 func waitForHealthyContainers(directory string) error {
-	const maxRetries = 30
+	const maxRetries = 5
 	const retryInterval = 5 * time.Second
 
 	for i := 0; i < maxRetries; i++ {
@@ -118,7 +118,14 @@ func allServicesHealthy(output string) bool {
 	return true
 }
 
-func SetupPostgresContainer(ctx context.Context, t *testing.T, migrationsPath string, writeEslOnly bool, rawNewDbName string) (*DBConfig, error) {
+func ConnectToPostgresContainer(ctx context.Context, t *testing.T, migrationsPath string, writeEslOnly bool, rawNewDbName string) (*DBConfig, error) {
+	// we expect the postgres container to be up already:
+	gitRootDir, err := GetGitRootDirectory()
+	err = waitForHealthyContainers(gitRootDir)
+	if err != nil {
+		return nil, err
+	}
+
 	dbConfig := &DBConfig{
 		// the options here must be the same as provided by docker-compose-unittest.yml
 		DbHost:     "localhost",

--- a/pkg/db/db_testutil.go
+++ b/pkg/db/db_testutil.go
@@ -94,11 +94,11 @@ func waitForHealthyContainers(directory string) error {
 
 		// Parse the output to check if all services are healthy
 		output := out.String()
-		fmt.Println(output) // Print the current status for debugging
 		if allServicesHealthy(output) {
 			fmt.Println("All services are up and healthy")
 			return nil
 		}
+		fmt.Println(output) // Print the current status for debugging
 
 		// Wait before retrying
 		time.Sleep(retryInterval)

--- a/services/cd-service/pkg/argocd/reposerver/reposerver_test.go
+++ b/services/cd-service/pkg/argocd/reposerver/reposerver_test.go
@@ -311,7 +311,7 @@ func SetupRepositoryTestWithDBOptions(t *testing.T, writeEslOnly bool) (reposito
 	if err != nil {
 		t.Fatalf("CreateMigrationsPath error: %v", err)
 	}
-	dbConfig, err := db.SetupPostgresContainer(ctx, t, migrationsPath, writeEslOnly, t.Name())
+	dbConfig, err := db.ConnectToPostgresContainer(ctx, t, migrationsPath, writeEslOnly, t.Name())
 	if err != nil {
 		t.Fatalf("SetupPostgres: %v", err)
 	}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -1057,6 +1057,7 @@ func (s *State) GetEnvironmentConfigsForGroup(ctx context.Context, transaction *
 	return groupEnvNames, nil
 }
 
+// returns all apps of this environment
 func (s *State) GetEnvironmentApplications(ctx context.Context, transaction *sql.Tx, environment string) ([]string, error) {
 	return s.GetEnvironmentApplicationsFromDB(ctx, transaction, environment)
 }

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -216,7 +216,7 @@ func TestApplyQueuePanic(t *testing.T) {
 			if err != nil {
 				t.Fatalf("CreateMigrationsPath error: %v", err)
 			}
-			dbConfig, err := db.SetupPostgresContainer(ctx, t, migrationsPath, false, t.Name())
+			dbConfig, err := db.ConnectToPostgresContainer(ctx, t, migrationsPath, false, t.Name())
 			if err != nil {
 				t.Fatalf("SetupPostgres: %v", err)
 			}
@@ -307,7 +307,7 @@ func TestApplyQueueTtlForHealth(t *testing.T) {
 			if err != nil {
 				t.Fatalf("CreateMigrationsPath error: %v", err)
 			}
-			dbConfig, err := db.SetupPostgresContainer(ctx, t, migrationsPath, false, t.Name())
+			dbConfig, err := db.ConnectToPostgresContainer(ctx, t, migrationsPath, false, t.Name())
 			if err != nil {
 				t.Fatalf("SetupPostgres: %v", err)
 			}

--- a/services/cd-service/pkg/repository/repository_test.go
+++ b/services/cd-service/pkg/repository/repository_test.go
@@ -571,14 +571,15 @@ func TestApplyQueue(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			repo := SetupRepositoryTestWithDB(t)
+			repo, _ := SetupRepositoryTestWithAllOptions(t, false, 100, true)
 			ctx := testutil.MakeTestContext()
 			repoInternal := repo.(*repository)
 			// Block the worker so that we have multiple items in the queue
 			finished := make(chan struct{})
 			started := make(chan struct{}, 1)
+			var applyErr error = nil
 			go func() {
-				repo.Apply(testutil.MakeTestContext(), &SlowTransformer{finished: finished, started: started})
+				applyErr = repo.Apply(testutil.MakeTestContext(), &SlowTransformer{finished: finished, started: started})
 			}()
 			<-started
 			// The worker go routine is now blocked. We can move some items into the queue now.
@@ -591,6 +592,9 @@ func TestApplyQueue(t *testing.T) {
 				if action.Transformer != nil {
 					results[i] = repoInternal.applyDeferred(ctx, action.Transformer)
 				} else {
+					_ = repoInternal.applyDeferred(ctx, &CreateEnvironment{
+						Environment: "development",
+					})
 					tf := &CreateApplicationVersion{
 						Application: "foo",
 						Manifests: map[string]string{
@@ -608,8 +612,13 @@ func TestApplyQueue(t *testing.T) {
 			finished <- struct{}{}
 			// Check for the correct errors
 			for i, action := range tc.Actions {
-				if err := <-results[i]; err != nil && err.Error() != action.ExpectedError.Error() {
-					t.Errorf("result[%d] error is not \"%v\" but got \"%v\"", i, action.ExpectedError, err)
+				err := <-results[i]
+				expErrStr := ""
+				if action.ExpectedError != nil {
+					expErrStr = action.ExpectedError.Error()
+				}
+				if err != nil && err.Error() != expErrStr {
+					t.Errorf("result[%d] error is not \"%s\" but got \"%v\"", i, expErrStr, err)
 				}
 			}
 			_ = repo.State().DBHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
@@ -619,7 +628,9 @@ func TestApplyQueue(t *testing.T) {
 				}
 				return nil
 			})
-
+			if applyErr != nil {
+				t.Fatalf("could not run slow transformer: %v", applyErr)
+			}
 		})
 	}
 }

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -612,7 +612,7 @@ func (c *CreateApplicationVersion) Transform(
 		env := sortedKeys[i]
 		err = state.DBHandler.DBAppendAppToEnvironment(ctx, transaction, env, c.Application)
 		if err != nil {
-			return "", GetCreateReleaseGeneralFailure(err)
+			return "", grpc.PublicError(ctx, err)
 		}
 
 		err = state.checkUserPermissions(ctx, transaction, env, c.Application, auth.PermissionCreateRelease, c.Team, c.RBACConfig, true)

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1225,7 +1225,7 @@ func (u *DeleteEnvFromApp) Transform(
 
 	err = state.DBHandler.DBRemoveAppFromEnvironment(ctx, transaction, u.Environment, u.Application)
 	if err != nil {
-		return "", fmt.Errorf("Couldn't write environment: %s into environments table, error: %w", u.Environment, err)
+		return "", fmt.Errorf("Couldn't write environment '%s' into environments table, error: %w", u.Environment, err)
 	}
 	t.DeleteEnvFromApp(u.Application, u.Environment)
 	return fmt.Sprintf("Environment '%v' was removed from application '%v' successfully.", u.Environment, u.Application), nil

--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -3276,6 +3276,16 @@ func TestUndeployTransformerDB(t *testing.T) {
 			ctx := testutil.MakeTestContext()
 			r := repo.(*repository)
 			err := r.State().DBHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				_, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), transaction, &CreateEnvironment{Environment: "production"})
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("Did no expect error but got):\n%+v", err)
+			}
+			err = r.State().DBHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
 				_, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), transaction, tc.Transformers...)
 				if err != nil {
 					return err

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -3321,7 +3321,7 @@ func SetupRepositoryTestWithAllOptions(t *testing.T, writeEslOnly bool, queueSiz
 	if err != nil {
 		t.Fatalf("CreateMigrationsPath error: %v", err)
 	}
-	dbConfig, err := db.SetupPostgresContainer(ctx, t, migrationsPath, writeEslOnly, t.Name())
+	dbConfig, err := db.ConnectToPostgresContainer(ctx, t, migrationsPath, writeEslOnly, t.Name())
 	if err != nil {
 		t.Fatalf("SetupPostgres: %v", err)
 	}

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -3627,7 +3627,7 @@ func TestDeleteEnvFromApp(t *testing.T) {
 			},
 			expectedError: &TransformerBatchApplyError{
 				Index:            3,
-				TransformerError: errMatcher{"Couldn't write environment '' into environments table, error: environment does not exist: ''"},
+				TransformerError: errMatcher{"Couldn't write environment '' into environments table, error: remove from env with environment does not exist: ''"},
 			},
 			shouldSucceed: false,
 		},

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -1047,11 +1047,17 @@ func TestUndeployErrors(t *testing.T) {
 			ctx := testutil.MakeTestContext()
 			r := repo.(*repository)
 			_ = r.State().DBHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				_, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), transaction, &CreateEnvironment{Environment: "production"})
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return nil
+			})
+			_ = r.State().DBHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
 				_, _, _, err := repo.ApplyTransformersInternal(testutil.MakeTestContext(), transaction, tc.Transformers...)
 				if diff := cmp.Diff(tc.expectedError, err, cmpopts.EquateErrors()); diff != "" {
 					t.Fatalf("error mismatch (-want, +got):\n%s", diff)
 				}
-
 				return nil
 			})
 

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -3628,7 +3628,7 @@ func TestDeleteEnvFromApp(t *testing.T) {
 			},
 			expectedError: &TransformerBatchApplyError{
 				Index:            3,
-				TransformerError: errMatcher{"Attempting to delete an environment that doesn't exist in the environments table"},
+				TransformerError: errMatcher{"Couldn't write environment '' into environments table, error: environment does not exist: ''"},
 			},
 			shouldSucceed: false,
 		},

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -3329,7 +3329,6 @@ func SetupRepositoryTestWithAllOptions(t *testing.T, writeEslOnly bool, queueSiz
 	repoCfg := RepositoryConfig{
 		ArgoCdGenerateFiles: true,
 		MaximumQueueSize:    queueSize,
-		//MaximumQueueSize: 100,
 	}
 
 	migErr := db.RunDBMigrations(ctx, *dbConfig)

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -278,6 +278,10 @@ func TestUndeployApplicationErrors(t *testing.T) {
 		{
 			Name: "Undeploy application where the last release is not Undeploy shouldn't work",
 			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "production",
+					Config:      config.EnvironmentConfig{Upstream: &config.EnvironmentConfigUpstream{Environment: "", Latest: false}},
+				},
 				&CreateApplicationVersion{
 					Application: "app1",
 					Manifests: map[string]string{
@@ -303,7 +307,7 @@ func TestUndeployApplicationErrors(t *testing.T) {
 				},
 			},
 			expectedError: &TransformerBatchApplyError{
-				Index:            3,
+				Index:            4,
 				TransformerError: errMatcher{"UndeployApplication: error last release is not un-deployed application version of 'app1'"},
 			},
 		},

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -52,9 +52,8 @@ import (
 )
 
 const (
-	envAcceptance      = "acceptance"
-	envProduction      = "production"
-	additionalVersions = 7
+	envAcceptance = "acceptance"
+	envProduction = "production"
 )
 
 var timeNowOld = time.Date(1999, 01, 02, 03, 04, 05, 0, time.UTC)

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -479,6 +479,15 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 			Name: "Create a single application version without deploying it",
 			// no need to bother with environments here
 			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "staging",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Environment: "staging",
+							Latest:      true,
+						},
+					},
+				},
 				&CreateApplicationVersion{
 					Application:    "app",
 					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -495,7 +504,14 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					EventType:     "new-release",
 					EventJson:     "{}",
-					TransformerID: 1,
+					TransformerID: 2,
+				},
+				{
+					Uuid:          "00000000-0000-0000-0000-000000000002",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					EventType:     "deployment",
+					EventJson:     "{}",
+					TransformerID: 2,
 				},
 			},
 		},
@@ -503,6 +519,15 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 			Name: "Create a single application version and deploy it",
 			// no need to bother with environments here
 			Transformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "staging",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Environment: "staging",
+							Latest:      true,
+						},
+					},
+				},
 				&CreateApplicationVersion{
 					Application:    "app",
 					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -521,11 +546,18 @@ func TestApplicationDeploymentEvent(t *testing.T) {
 			},
 			expectedDBEvents: []db.EventRow{
 				{
-					Uuid:          "00000000-0000-0000-0000-000000000002",
+					Uuid:          "00000000-0000-0000-0000-000000000003",
 					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					EventType:     "deployment",
 					EventJson:     "{}",
-					TransformerID: 2,
+					TransformerID: 3,
+				},
+				{
+					Uuid:          "00000000-0000-0000-0000-000000000004",
+					CommitHash:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					EventType:     "replaced-by",
+					EventJson:     "{}",
+					TransformerID: 3,
 				},
 			},
 		},

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -644,6 +644,10 @@ func TestBatchServiceLimit(t *testing.T) {
 }
 
 func setupRepositoryTestWithDB(t *testing.T) (repository.Repository, error) {
+	return setupRepositoryTestWithAllOptions(t, true)
+}
+
+func setupRepositoryTestWithAllOptions(t *testing.T, withBackgroundJob bool) (repository.Repository, error) {
 	ctx := context.Background()
 	migrationsPath, err := db.CreateMigrationsPath(4)
 	if err != nil {
@@ -681,15 +685,25 @@ func setupRepositoryTestWithDB(t *testing.T) (repository.Repository, error) {
 		repoCfg.DBHandler = db
 	}
 
-	repo, err := repository.New(
-		testutil.MakeTestContext(),
-		repoCfg,
-	)
-	if err != nil {
-		t.Fatal(err)
+	if withBackgroundJob {
+		repo, err := repository.New(
+			testutil.MakeTestContext(),
+			repoCfg,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return repo, nil
+	} else {
+		repo, _, err := repository.New2(
+			testutil.MakeTestContext(),
+			repoCfg,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return repo, nil
 	}
-
-	return repo, nil
 }
 
 func setupRepositoryTest(t *testing.T) (repository.Repository, error) {

--- a/services/cd-service/pkg/service/batch_test.go
+++ b/services/cd-service/pkg/service/batch_test.go
@@ -661,7 +661,7 @@ func setupRepositoryTestWithAllOptions(t *testing.T, withBackgroundJob bool) (re
 	cmd.Wait()
 	t.Logf("test created dir: %s", localDir)
 
-	dbConfig, err := db.SetupPostgresContainer(ctx, t, migrationsPath, false, t.Name())
+	dbConfig, err := db.ConnectToPostgresContainer(ctx, t, migrationsPath, false, t.Name())
 	if err != nil {
 		t.Fatalf("SetupPostgres: %v", err)
 	}

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -2085,6 +2085,7 @@ func TestDeploymentHistory(t *testing.T) {
 	versionOne := int64(1)
 	versionTwo := int64(2)
 	dev := "dev"
+	staging := "staging"
 
 	tcs := []struct {
 		Name             string
@@ -2427,6 +2428,13 @@ func TestDeploymentHistory(t *testing.T) {
 					Config: config.EnvironmentConfig{
 						ArgoCd:           nil,
 						EnvironmentGroup: &dev,
+					},
+				},
+				&repository.CreateEnvironment{
+					Environment: "staging",
+					Config: config.EnvironmentConfig{
+						ArgoCd:           nil,
+						EnvironmentGroup: &staging,
 					},
 				},
 				&repository.CreateApplicationVersion{

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -560,7 +560,7 @@ func TestOverviewService(t *testing.T) {
 			DB:   true,
 			Setup: []repository.Transformer{
 				&repository.CreateEnvironment{
-					Environment: "development",
+					Environment: dev,
 					Config: config.EnvironmentConfig{
 						Upstream: &config.EnvironmentConfigUpstream{
 							Latest: true,
@@ -582,7 +582,7 @@ func TestOverviewService(t *testing.T) {
 					TransformerEslVersion: 1,
 					Application:           "test",
 					Manifests: map[string]string{
-						"dev": "v1",
+						dev: "v1",
 					},
 				},
 				&repository.CreateApplicationVersion{
@@ -598,7 +598,7 @@ func TestOverviewService(t *testing.T) {
 					TransformerEslVersion: 2,
 					Application:           "test",
 					Manifests: map[string]string{
-						"dev": "v2",
+						dev: "v2",
 					},
 				},
 			},
@@ -624,7 +624,7 @@ func TestOverviewService(t *testing.T) {
 					t.Errorf("dev environmentGroup has wrong name: %q", devGroup.EnvironmentGroupName)
 				}
 				dev := devGroup.Environments[0]
-				if dev.Name != "development" {
+				if dev.Name != "dev" {
 					t.Errorf("development environment has wrong name: %q", dev.Name)
 				}
 				if dev.Config.Upstream == nil {
@@ -707,7 +707,7 @@ func TestOverviewService(t *testing.T) {
 }
 
 func TestGetApplicationDetails(t *testing.T) {
-	var dev = "dev"
+	//var dev = "dev"
 	var env = "development"
 	var secondEnv = "development2"
 	var stagingGroup = "stagingGroup"
@@ -785,7 +785,17 @@ func TestGetApplicationDetails(t *testing.T) {
 							Latest: true,
 						},
 						ArgoCd:           nil,
-						EnvironmentGroup: &dev,
+						EnvironmentGroup: &env,
+					},
+				},
+				&repository.CreateEnvironment{
+					Environment: secondEnv,
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Latest: true,
+						},
+						ArgoCd:           nil,
+						EnvironmentGroup: &secondEnv,
 					},
 				},
 				&repository.CreateApplicationVersion{
@@ -841,7 +851,17 @@ func TestGetApplicationDetails(t *testing.T) {
 							Latest: true,
 						},
 						ArgoCd:           nil,
-						EnvironmentGroup: &dev,
+						EnvironmentGroup: &env,
+					},
+				},
+				&repository.CreateEnvironment{
+					Environment: secondEnv,
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Latest: true,
+						},
+						ArgoCd:           nil,
+						EnvironmentGroup: &secondEnv,
 					},
 				},
 				&repository.CreateApplicationVersion{
@@ -933,7 +953,7 @@ func TestGetApplicationDetails(t *testing.T) {
 							Latest: true,
 						},
 						ArgoCd:           nil,
-						EnvironmentGroup: &dev,
+						EnvironmentGroup: &env,
 					},
 				},
 				&repository.CreateEnvironment{

--- a/services/cloudrun-service/pkg/db/db_test.go
+++ b/services/cloudrun-service/pkg/db/db_test.go
@@ -177,7 +177,7 @@ func setupDB(t *testing.T) *db.DBHandler {
 	ctx := context.Background()
 	migrationsPath, _ := db.CreateMigrationsPath(4)
 
-	dbConfig, err := db.SetupPostgresContainer(ctx, t, migrationsPath, false, t.Name())
+	dbConfig, err := db.ConnectToPostgresContainer(ctx, t, migrationsPath, false, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/services/manifest-repo-export-service/pkg/migrations/migration_test.go
+++ b/services/manifest-repo-export-service/pkg/migrations/migration_test.go
@@ -102,7 +102,7 @@ func setupRepositoryTestWithPath(t *testing.T) (repository.Repository, string) {
 	if err != nil {
 		t.Fatalf("CreateMigrationsPath error: %v", err)
 	}
-	dbConfig, err := db.SetupPostgresContainer(ctx, t, migrationsPath, false, t.Name())
+	dbConfig, err := db.ConnectToPostgresContainer(ctx, t, migrationsPath, false, t.Name())
 	if err != nil {
 		t.Fatalf("SetupPostgres: %v", err)
 	}

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -881,7 +881,7 @@ func (r *repository) processArgoAppForEnv(ctx context.Context, transaction *sql.
 				return fmt.Errorf("updateArgoCdApps: could not select app '%s' in db %v", appName, err)
 			}
 			if oneAppData == nil {
-				return fmt.Errorf("skipping app %s because it was not found in the database", appName)
+				return fmt.Errorf("skipping app '%s' because it was not found in the apps table", appName)
 			}
 			version, err := state.GetEnvironmentApplicationVersion(ctx, transaction, info.ParentEnvironmentName, appName)
 			if err != nil {

--- a/services/manifest-repo-export-service/pkg/repository/repository_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository_test.go
@@ -221,7 +221,7 @@ func SetupRepositoryTestWithDB(t *testing.T) (Repository, *db.DBHandler, *Reposi
 	if err != nil {
 		t.Fatalf("CreateMigrationsPath error: %v", err)
 	}
-	dbConfig, err := db.SetupPostgresContainer(ctx, t, migrationsPath, false, t.Name())
+	dbConfig, err := db.ConnectToPostgresContainer(ctx, t, migrationsPath, false, t.Name())
 	if err != nil {
 		t.Fatalf("SetupPostgres: %v", err)
 	}
@@ -1521,7 +1521,7 @@ func setupRepositoryBenchmarkWithPath(t *testing.B) (Repository, string) {
 	if err != nil {
 		t.Fatalf("CreateMigrationsPath error: %v", err)
 	}
-	dbConfig, err := db.SetupPostgresContainer(ctx, nil, migrationsPath, false, t.Name())
+	dbConfig, err := db.ConnectToPostgresContainer(ctx, nil, migrationsPath, false, t.Name())
 	if err != nil {
 		t.Fatalf("CreateMigrationsPath error: %v", err)
 	}

--- a/services/manifest-repo-export-service/pkg/repository/transformer_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer_test.go
@@ -69,7 +69,7 @@ func setupRepositoryTestWithPath(t *testing.T) (Repository, string) {
 	if err != nil {
 		t.Fatalf("CreateMigrationsPath error: %v", err)
 	}
-	dbConfig, err := db.SetupPostgresContainer(ctx, t, migrationsPath, false, t.Name())
+	dbConfig, err := db.ConnectToPostgresContainer(ctx, t, migrationsPath, false, t.Name())
 	if err != nil {
 		t.Fatalf("SetupPostgres: %v", err)
 	}

--- a/services/manifest-repo-export-service/pkg/service/version_test.go
+++ b/services/manifest-repo-export-service/pkg/service/version_test.go
@@ -47,7 +47,7 @@ func setupRepositoryTestWithPath(t *testing.T) (repository.Repository, string) {
 	if err != nil {
 		t.Fatalf("CreateMigrationsPath error: %v", err)
 	}
-	dbConfig, err := db.SetupPostgresContainer(ctx, t, migrationsPath, false, t.Name())
+	dbConfig, err := db.ConnectToPostgresContainer(ctx, t, migrationsPath, false, t.Name())
 	if err != nil {
 		t.Fatalf("SetupPostgres: %v", err)
 	}

--- a/services/rollout-service/pkg/service/service_test.go
+++ b/services/rollout-service/pkg/service/service_test.go
@@ -844,7 +844,7 @@ func SetupDB(t *testing.T) *db.DBHandler {
 	tmpDir := t.TempDir()
 	t.Logf("directory for DB migrations: %s", migrationsPath)
 	t.Logf("tmp dir for DB data: %s", tmpDir)
-	dbConfig, err := db.SetupPostgresContainer(ctx, t, migrationsPath, false, t.Name())
+	dbConfig, err := db.ConnectToPostgresContainer(ctx, t, migrationsPath, false, t.Name())
 	if err != nil {
 		t.Fatalf("SetupPostgres: %v", err)
 	}

--- a/services/rollout-service/pkg/versions/versions_test.go
+++ b/services/rollout-service/pkg/versions/versions_test.go
@@ -952,7 +952,7 @@ func assertExpectedVersions(t *testing.T, expectedVersions []expectedVersion, vc
 func setupDB(t *testing.T) *db.DBHandler {
 	ctx := context.Background()
 	migrationsPath, err := db.CreateMigrationsPath(4)
-	dbConfig, err := db.SetupPostgresContainer(ctx, t, migrationsPath, false, t.Name())
+	dbConfig, err := db.ConnectToPostgresContainer(ctx, t, migrationsPath, false, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/integration-tests/release_test.go
+++ b/tests/integration-tests/release_test.go
@@ -37,23 +37,10 @@ import (
 )
 
 const (
-	devEnv       = "dev"
+	devEnv       = "development"
 	stageEnv     = "staging"
 	frontendPort = "8081"
 )
-
-// Used to compare two error message strings, needed because errors.Is(fmt.Errorf(text),fmt.Errorf(text)) == false
-type errMatcher struct {
-	msg string
-}
-
-func (e errMatcher) Error() string {
-	return e.msg
-}
-
-func (e errMatcher) Is(err error) bool {
-	return e.Error() == err.Error()
-}
 
 func postWithForm(client *http.Client, url string, values map[string]io.Reader, files map[string]io.Reader) (*http.Response, error) {
 	// Prepare a form that you will submit to that URL.
@@ -528,7 +515,7 @@ func TestAppParameter(t *testing.T) {
 			values["version"] = strings.NewReader(strconv.Itoa(tc.inputVersion))
 
 			files := map[string]io.Reader{}
-			files["manifests[dev]"] = strings.NewReader("manifest")
+			files["manifests[development]"] = strings.NewReader("manifest")
 
 			actualStatusCode, actualBody, err := callRelease(values, files, "/api/release")
 			if diff := cmp.Diff(tc.expectedError, err, cmpopts.EquateErrors()); diff != "" {


### PR DESCRIPTION
0) With this change, the endpoint to create new releases (/release and /api/release) will now return an error (status 400) when a manifest for a non-existing environment was supplied.

1) Replaced in-memory locks with db locks

Note that this feature is considered experimental.

With this change, we have three options in the helm chart ("cd.lockType") to lock:
* "go": with an in-memory (golang) lock (default)
* "db": with a postgres advisory lock
* "none": without any locks

The first option was already implemented, the other two options are new. The postgres locks are an improvement over the go-locks, because they are not limited to the current pod/process. Apart from that they work the same.

Both lock types ensure that only one destructive action (undeploy, delete env from app, delete env) is running at a time.


2) Removed "Read-before-Writes"

There were 2 points where the cd-service read from the DB before writing:
When adding an app to an environment, and when removing an app from an environment.
Both have been simplified to one sql statement.


Ref: SRX-8JRR7Q