### PR TITLE
feat(export-service): avoid empty commits with release trains and create release

### DIFF
--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -901,6 +901,10 @@ func (c *CreateApplicationVersion) Transform(
 		}
 	}
 
+	if tCtx.ShouldMinimizeGitData() && len(deploymentsMap) == 0 {
+		return GetNoOpMessage(c)
+	}
+
 	return fmt.Sprintf("created version %d of %q", version, c.Application), nil
 }
 
@@ -1499,6 +1503,12 @@ func (u *ReleaseTrain) Transform(
 			return "", err
 		}
 	}
+
+	if len(deployments) == 0 {
+		// if t.ChangedAppsCount() == prevChangedApps {
+		return GetNoOpMessage(u)
+	}
+
 	commitMessage := fmt.Sprintf("Release Train to environment/environment group '%s':\n", targetGroupName)
 	for _, skipped := range skippedDeployments {
 		eventData, err := event.UnMarshallEvent("lock-prevented-deployment", skipped.EventJson)

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -1505,7 +1505,6 @@ func (u *ReleaseTrain) Transform(
 	}
 
 	if len(deployments) == 0 {
-		// if t.ChangedAppsCount() == prevChangedApps {
 		return GetNoOpMessage(u)
 	}
 


### PR DESCRIPTION
The endpoints for release trains and new releases now only create a commit, if a deployment happened. 

Ref: SRX-YSWDSA