### PR TITLE
fix: Run release trains with only one writing transaction

### DIFF
--- a/charts/kuberpult/templates/cd-service.yaml
+++ b/charts/kuberpult/templates/cd-service.yaml
@@ -238,6 +238,8 @@ spec:
           value: "{{ .Values.cd.backendConfig.queueSize }}"
         - name: KUBERPULT_MAX_NUMBER_OF_THREADS
           value: "{{ .Values.cd.maxNumberOfThreads }}"
+        - name: KUBERPULT_EXPERIMENTAL_PARALLELISM_ONE_TRANSACTION
+          value: "{{ .Values.cd.experimentalParallelismOneTransaction }}"
         - name: KUBERPULT_DB_OPTION # { postgreSQL}
           value: {{ .Values.db.dbOption }}
         - name: KUBERPULT_DB_WRITE_ESL_TABLE_ONLY

--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -96,6 +96,7 @@ cd:
   allowedDomains: ""
   cacheTtlHours: 24
   maxNumberOfThreads: 3
+  experimentalParallelismOneTransaction: false
 
   # The lockType option is EXPERIMENTAL and may be removed or changed without a breaking change.
   # By default, (lockType: "go") the cd-service uses in-memory go-locks to make sure that

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
   cd-service:
     image: europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult/kuberpult-cd-service:local
     environment:
+      - KUBERPULT_EXPERIMENTAL_PARALLELISM_ONE_TRANSACTION=true
       - KUBERPULT_LOCK_TYPE=db
       - LOG_LEVEL=INFO
       - KUBERPULT_DISABLE_QUEUE=true

--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -89,6 +89,8 @@ type Config struct {
 	ArgoCdGenerateFiles      bool          `default:"true" split_words:"true"`
 	MaxNumberOfThreads       uint          `default:"3" split_words:"true"`
 
+	ExperimentalParallelismOneTransaction bool `default:"false" split_words:"true"` // KUBERPULT_EXPERIMENTAL_PARALLELISM_ONE_TRANSACTION
+
 	DbOption             string `default:"NO_DB" split_words:"true"`
 	DbLocation           string `default:"/kp/database" split_words:"true"`
 	DbCloudSqlInstance   string `default:"" split_words:"true"`
@@ -324,22 +326,23 @@ func RunServer() {
 		}
 
 		cfg := repository.RepositoryConfig{
-			WebhookResolver:       nil,
-			URL:                   c.GitUrl,
-			MinorRegexes:          minorRegexes,
-			MaxNumThreads:         c.MaxNumberOfThreads,
-			Branch:                c.GitBranch,
-			ReleaseVersionsLimit:  c.ReleaseVersionsLimit,
-			StorageBackend:        c.storageBackend(),
-			NetworkTimeout:        c.GitNetworkTimeout,
-			DogstatsdEvents:       c.EnableMetrics,
-			WriteCommitData:       c.GitWriteCommitData,
-			MaximumCommitsPerPush: c.GitMaximumCommitsPerPush,
-			MaximumQueueSize:      c.MaximumQueueSize,
-			AllowLongAppNames:     c.AllowLongAppNames,
-			ArgoCdGenerateFiles:   c.ArgoCdGenerateFiles,
-			DBHandler:             dbHandler,
-			CloudRunClient:        cloudRunClient,
+			WebhookResolver:           nil,
+			URL:                       c.GitUrl,
+			MinorRegexes:              minorRegexes,
+			MaxNumThreads:             c.MaxNumberOfThreads,
+			ParallelismOneTransaction: c.ExperimentalParallelismOneTransaction,
+			Branch:                    c.GitBranch,
+			ReleaseVersionsLimit:      c.ReleaseVersionsLimit,
+			StorageBackend:            c.storageBackend(),
+			NetworkTimeout:            c.GitNetworkTimeout,
+			DogstatsdEvents:           c.EnableMetrics,
+			WriteCommitData:           c.GitWriteCommitData,
+			MaximumCommitsPerPush:     c.GitMaximumCommitsPerPush,
+			MaximumQueueSize:          c.MaximumQueueSize,
+			AllowLongAppNames:         c.AllowLongAppNames,
+			ArgoCdGenerateFiles:       c.ArgoCdGenerateFiles,
+			DBHandler:                 dbHandler,
+			CloudRunClient:            cloudRunClient,
 
 			DisableQueue: c.DisableQueue,
 		}

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -184,12 +184,13 @@ type RepositoryConfig struct {
 	ReleaseVersionsLimit uint
 	StorageBackend       StorageBackend
 	// the url to the git repo, like the browser requires it (https protocol)
-	DogstatsdEvents       bool
-	WriteCommitData       bool
-	WebhookResolver       WebhookResolver
-	MaximumCommitsPerPush uint
-	MaximumQueueSize      uint
-	MaxNumThreads         uint
+	DogstatsdEvents           bool
+	WriteCommitData           bool
+	WebhookResolver           WebhookResolver
+	MaximumCommitsPerPush     uint
+	MaximumQueueSize          uint
+	MaxNumThreads             uint
+	ParallelismOneTransaction bool
 	// Extend maximum AppName length
 	AllowLongAppNames bool
 
@@ -658,11 +659,12 @@ func (r *repository) State() *State {
 
 func (r *repository) StateAt() (*State, error) {
 	return &State{
-		ReleaseVersionsLimit: r.config.ReleaseVersionsLimit,
-		MinorRegexes:         r.config.MinorRegexes,
-		MaxNumThreads:        int(r.config.MaxNumThreads),
-		DBHandler:            r.DB,
-		CloudRunClient:       r.config.CloudRunClient,
+		ReleaseVersionsLimit:      r.config.ReleaseVersionsLimit,
+		MinorRegexes:              r.config.MinorRegexes,
+		MaxNumThreads:             int(r.config.MaxNumThreads),
+		DBHandler:                 r.DB,
+		CloudRunClient:            r.config.CloudRunClient,
+		ParallelismOneTransaction: r.config.ParallelismOneTransaction,
 	}, nil
 }
 
@@ -671,9 +673,10 @@ func (r *repository) Notify() *notify.Notify {
 }
 
 type State struct {
-	ReleaseVersionsLimit uint
-	MinorRegexes         []*regexp.Regexp
-	MaxNumThreads        int
+	ReleaseVersionsLimit      uint
+	MinorRegexes              []*regexp.Regexp
+	MaxNumThreads             int
+	ParallelismOneTransaction bool
 	// DbHandler will be nil if the DB is disabled
 	DBHandler      *db.DBHandler
 	CloudRunClient *cloudrun.CloudRunClient

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -2674,16 +2674,18 @@ func (c *ReleaseTrain) Transform(
 
 	if isEnvGroup && state.DBHandler.AllowParallelTransactions() {
 		releaseTrainErrGroup, _ := errgroup.WithContext(ctx)
+		expectedNumPrognoses := len(envNames)
+		var channelSize = expectedNumPrognoses
 		if state.MaxNumThreads > 0 {
 			releaseTrainErrGroup.SetLimit(state.MaxNumThreads)
+			channelSize = state.MaxNumThreads
 		}
 		if state.ParallelismOneTransaction {
 			type ChannelData struct {
 				prognosis *ReleaseTrainEnvironmentPrognosis
 				train     *envReleaseTrain
 			}
-			var prognosisResultChannel = make(chan *ChannelData, 42)
-			expectedNumPrognoses := len(envNames)
+			var prognosisResultChannel = make(chan *ChannelData, channelSize)
 			for _, envName := range envNames {
 				trainGroup := conversion.FromString(targetGroupName)
 				envNameLocal := envName

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -3368,8 +3368,9 @@ func SetupRepositoryTestWithAllOptions(t *testing.T, writeEslOnly bool, queueSiz
 	}
 
 	repoCfg := RepositoryConfig{
-		ArgoCdGenerateFiles: true,
-		MaximumQueueSize:    queueSize,
+		ArgoCdGenerateFiles:       true,
+		MaximumQueueSize:          queueSize,
+		ParallelismOneTransaction: true,
 	}
 
 	migErr := db.RunDBMigrations(ctx, *dbConfig)


### PR DESCRIPTION
The goal here is to avoid that only *parts* of a release train are successful.

This introduce a new experimental helm parameter
"cd.experimentalParallelismOneTransaction".
When set to true the release trains to environment groups are changed:
* The go routines (1 per env) now only produce the prognosis (list of versions to be deployed).
* The go routines use a read only transaction.
* Only the requests go routine is applying the changes with a writing transaction.

Ref: SRX-JEU54H