### PR TITLE
fix: show request uri in top level span "ServeHTTP"

### DIFF
--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -569,6 +569,7 @@ func (p *Auth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := logger.Wrap(r.Context(), func(ctx context.Context) error {
 		span, ctx := tracer.StartSpanFromContext(ctx, "ServeHTTP")
 		defer span.Finish()
+		span.SetTag("uri", r.URL)
 		var user *auth.User = nil
 		var err error
 		var source string


### PR DESCRIPTION
Ref: SRX-3U98Y2