### PR TITLE
fix: disable github concurrency limitations

### DIFF
--- a/.github/workflows/execution-plan-pr.yml
+++ b/.github/workflows/execution-plan-pr.yml
@@ -3,9 +3,6 @@ on:
   pull_request:
     branches:
       - main
-#concurrency:
-#  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-#  cancel-in-progress: true
 jobs:
   execution-plan:
     uses: ./.github/workflows/execution-plan-snippet-earthly.yml

--- a/.github/workflows/execution-plan-pr.yml
+++ b/.github/workflows/execution-plan-pr.yml
@@ -4,7 +4,7 @@ name: "Execution Plan on Pull Request"
     branches:
       - main
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 jobs:
   execution-plan:

--- a/.github/workflows/execution-plan-pr.yml
+++ b/.github/workflows/execution-plan-pr.yml
@@ -1,5 +1,5 @@
 name: "Execution Plan on Pull Request"
-'on':
+on:
   pull_request:
     branches:
       - main

--- a/.github/workflows/execution-plan-pr.yml
+++ b/.github/workflows/execution-plan-pr.yml
@@ -3,9 +3,9 @@ on:
   pull_request:
     branches:
       - main
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+#  cancel-in-progress: true
 jobs:
   execution-plan:
     uses: ./.github/workflows/execution-plan-snippet-earthly.yml

--- a/README.md
+++ b/README.md
@@ -109,3 +109,9 @@ See [Remove Service Entirely](./docs/remove-service.md)
 
 
 
+
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -103,3 +103,9 @@ See [Remove Service Entirely](./docs/remove-service.md)
 
 
 
+
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -97,3 +97,9 @@ See [Remove Env From Service](./docs/remove-env-from-service.md)
 
 ### Remove a service entirely
 See [Remove Service Entirely](./docs/remove-service.md)
+
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -97,21 +97,3 @@ See [Remove Env From Service](./docs/remove-env-from-service.md)
 
 ### Remove a service entirely
 See [Remove Service Entirely](./docs/remove-service.md)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This changes the github workflow to not run only one action per PR at a time.
Reasoning is that the cancellation via "cancel-in-progress: true" does not work (it does not seem to cancel anything), so this just slows us down. Note that also clicking on "cancel" in the workflow also does not work properly at the moment.

Ref: SRX-JEU54H