### PR TITLE
fix: do not load the team for permission checks

### DIFF
--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -903,10 +903,6 @@ func (s *State) GetEnvironmentApplicationVersion(ctx context.Context, transactio
 	return &v, nil
 }
 
-func (s *State) GetTeamName(ctx context.Context, transaction *sql.Tx, application string) (string, error) {
-	return s.GetApplicationTeamOwner(ctx, transaction, application)
-}
-
 var InvalidJson = errors.New("JSON file is not valid")
 
 func envExists(envConfigs map[string]config.EnvironmentConfig, envNameToSearchFor string) bool {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1364,13 +1364,6 @@ func (s *State) checkUserPermissionsFromConfig(ctx context.Context, transaction 
 		return err
 	}
 	if checkTeam {
-		if team == "" && application != "*" {
-			team, err = s.GetTeamName(ctx, transaction, application)
-
-			if err != nil {
-				return err
-			}
-		}
 		err = auth.CheckUserTeamPermissions(RBACConfig, user, team, action)
 	}
 	return err
@@ -3430,7 +3423,7 @@ func (c *envReleaseTrain) renderApplicationSkipCause(
 		if latestDeploymentVersion, found := allLatestDeployments[appName]; found && latestDeploymentVersion != nil {
 			currentlyDeployedVersion = uint64(*latestDeploymentVersion)
 		}
-		teamName, _ := state.GetTeamName(ctx, transaction, appName)
+		teamName, _ := state.GetApplicationTeamOwner(ctx, transaction, appName)
 		switch SkipCause.SkipCause {
 		case api.ReleaseTrainAppSkipCause_APP_HAS_NO_VERSION_IN_UPSTREAM_ENV:
 			return fmt.Sprintf("skipping because there is no version for application %q in env %q \n", appName, upstreamEnvName)

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -127,7 +127,7 @@ func (o *OverviewServiceServer) GetAppDetails(
 			return result.Releases[j].Version < result.Releases[i].Version
 		})
 
-		appTeamName, err := o.Repository.State().GetTeamName(ctx, transaction, appName)
+		appTeamName, err := o.Repository.State().GetApplicationTeamOwner(ctx, transaction, appName)
 		if err != nil {
 			return nil, fmt.Errorf("app team not found: %s", appName)
 		}


### PR DESCRIPTION
This also removes a redundant function.

Ref: SRX-GSWFC7