### PR TITLE
fix: 3 digits for go.mod

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,5 +1,5 @@
 module github.com/freiheit-com/kuberpult/cli
 
-go 1.24
+go 1.24.0
 
 require github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
This is required for go tools to work

Ref: SRX-UGK40K