### PR TITLE
fix(cd-service): revert: remove earthly from cd-service (#2451)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,6 @@ compose-down:
 	docker compose down
 
 kuberpult: compose-down
-	IMAGE_TAG=local make -C services/cd-service docker
 	earthly +all-services --UID=$(USER_UID)
 	docker compose -f docker-compose.yml -f docker-compose.persist.yml up
 
@@ -90,7 +89,6 @@ kuberpult-freshdb: compose-down
 	docker compose up 
 
 all-services:
-	IMAGE_TAG=$(VERSION) make -C services/cd-service docker
 	earthly +all-services --tag=$(VERSION)
 
 integration-test:

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -18,6 +18,7 @@ ROOT_DIR=..
 CGO_ENABLED=0
 MAIN_PATH=cmd/kuberpult-client
 SERVICE=client
+GOARCH=amd64
 MIN_COVERAGE=67.1
 
 include ../infrastructure/make/go/include.mk

--- a/infrastructure/make/go/include.mk
+++ b/infrastructure/make/go/include.mk
@@ -1,7 +1,7 @@
 ROOT_DIR?=../..
 include $(ROOT_DIR)/Makefile.variables
 
-GOARCH?=amd64
+GOARCH?=arm64
 MAIN_PATH?=cmd/server
 export CGO_ENABLED?=1
 GO_TEST_ARGS?=
@@ -30,7 +30,7 @@ unit-test: deps
 bench-test: deps
 	docker compose -f $(ROOT_DIR)/docker-compose-unittest.yml up -d
 	docker run --rm -w $(SERVICE_DIR) --network host -v ".:$(SERVICE_DIR)" $(DEPS_IMAGE) sh -c "go test $(GO_TEST_ARGS) -bench=. ./..."
-	docker compose -f $(ROOT_DIR)/docker-compose-unittest.yml down
+	docker-compose -f $(ROOT_DIR)/docker-compose-unittest.yml down
 
 .PHONY: lint
 lint: deps

--- a/services/cd-service/Dockerfile
+++ b/services/cd-service/Dockerfile
@@ -1,11 +1,32 @@
-ARG BUILDER_IMAGE=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult/infrastructure/docker/deps:latest
-FROM ${BUILDER_IMAGE}
+ARG PARENT_CONTAINER
+FROM europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult/infrastructure/docker/builder:${PARENT_CONTAINER} as builder
 
-COPY gitconfig /etc/gitconfig
-COPY policy.csv /etc/policy.csv
-COPY team.csv /etc/team.csv
+WORKDIR /kp/
 
-RUN mv /kp/database/migrations /migrations
-COPY ./cmd/server/bin/main /main
+# cd-service
+ADD services/cd-service/cmd/server/ /kp/services/cd-service/cmd/server/
+ADD services/cd-service/pkg /kp/services/cd-service/pkg
 
-CMD /main
+# global:
+ADD pkg /kp/pkg
+ADD Makefile.variables .
+COPY go.sum go.mod /kp/
+
+RUN make -C /kp/pkg proto
+RUN go build -o /kp/main /kp/services/cd-service/cmd/server/
+
+FROM alpine:3.21
+ARG UID=1000
+ARG DIR
+LABEL org.opencontainers.image.source https://github.com/freiheit-com/kuberpult
+RUN apk --update add ca-certificates tzdata git sqlite-libs
+RUN adduser --disabled-password --gecos "" --home "/kp" --uid ${UID} kp
+RUN chown -R kp:kp /kp
+ENV TZ=Europe/Berlin
+COPY ${DIR}/gitconfig /etc/gitconfig
+COPY --from=builder /kp/main /kuberpult/main
+USER kp
+
+# Kuberpult expects to be able to write to "./repository", so we need to define the workdir:
+WORKDIR "/kp/"
+CMD ["/kuberpult/main"]

--- a/services/cd-service/Earthfile
+++ b/services/cd-service/Earthfile
@@ -1,0 +1,91 @@
+VERSION 0.8
+IMPORT ../../infrastructure/earthly/go AS go-build
+
+LOCALLY
+ARG --global service=$(basename $PWD)
+ARG --global src_files=$(find pkg -type f ! -name "*_test.go")
+ARG --global cgo_enabled=1
+
+deps:
+    FROM ../../+deps
+    DO go-build+DEPS --service=$service --src_files=$src_files
+    WORKDIR services/$service
+
+artifacts:
+    FROM +deps
+    SAVE ARTIFACT /etc/ssl/certs/ca-certificates.crt
+    SAVE ARTIFACT /usr/share/zoneinfo
+    SAVE ARTIFACT pkg
+
+bench-test:
+    FROM +compile
+    ARG GO_TEST_ARGS
+    DO go-build+BENCH_TEST --GO_TEST_ARGS=$GO_TEST_ARGS
+
+compile:
+    FROM +deps
+    ARG USERARCH
+    
+    DO go-build+COMPILE --cgo_enabled=$cgo_enabled
+
+unit-test:
+    FROM +compile
+    ARG GO_TEST_ARGS
+    DO go-build+UNIT_TEST --GO_TEST_ARGS=$GO_TEST_ARGS --COVERAGE_MIN=63.4
+
+lint:
+    FROM +deps
+    DO go-build+LINT --skip_lint_errors=false
+
+docker:
+    FROM alpine:3.21
+    ARG UID=1000
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
+    ARG tag="local"
+    ARG use_datadog=false
+    COPY gitconfig /etc/gitconfig
+    COPY policy.csv /etc/policy.csv
+    COPY team.csv /etc/team.csv
+    DO go-build+DOCKER --UID=$UID --image_tag=$registry/kuberpult-$service:$tag --cgo_enabled=$cgo_enabled --entry_point=/main --service=$service --use_datadog=$use_datadog
+
+release:
+    FROM +docker
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
+    ARG --required tag
+    DO go-build+RELEASE --image_tag=$registry/kuberpult-$service:$tag
+
+build-pr:
+    ARG --required tag
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
+    ARG mirror="false"
+    ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
+
+    DO +BUILD_ALL --tag=$tag --registry=$registry --mirror=$mirror  --mirror_registry=$mirror_registry
+
+build-main:
+    ARG --required tag
+    ARG registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
+    ARG mirror="false"
+    ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
+
+    DO +BUILD_ALL --tag=$tag --registry=$registry --mirror=$mirror  --mirror_registry=$mirror_registry --dd_release=true
+
+BUILD_ALL:
+    FUNCTION
+    ARG --required tag
+    ARG --required registry
+    ARG mirror_registry="europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult"
+    ARG mirror=""
+    ARG dd_release=false
+
+    FROM +deps
+    BUILD +lint 
+    BUILD +unit-test
+    BUILD +bench-test
+    BUILD +release --registry=$registry --tag=$tag
+    IF [ "$mirror" = "true" ]
+        BUILD +release --registry=$mirror_registry --tag=$tag
+    END
+    IF [ "$dd_release" = "true" ]
+        BUILD +release --registry=$mirror_registry --tag="${tag}-datadog" --use_datadog=true
+    END

--- a/services/cd-service/Makefile
+++ b/services/cd-service/Makefile
@@ -14,15 +14,103 @@
 
 # Copyright freiheit.com
 
-MIN_COVERAGE=63.4
+# NOTE: this will be replaced with the etf-golang makefile
+
+include ../../Makefile.variables
+
 MAKEFLAGS += --no-builtin-rules
 
-include ../../infrastructure/make/go/include.mk
+export CGO_ENABLED=1
+IMAGE_REGISTRY?=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
+IMAGENAME?=$(IMAGE_REGISTRY)/kuberpult-cd-service:$(VERSION)
+ARTIFACT_REGISTRY_IMAGE_NAME=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult/kuberpult-cd-service:${VERSION}
 
-test: unit-test
+export KUBERPULT_DEX_MOCK=false
+export KUBERPULT_DEX_ENABLED=false
 
-build-pr: IMAGE_TAG=pr-$(VERSION)
-build-pr: lint unit-test bench-test docker release
+ifeq ($(WITH_DOCKER),)
+COMPILE_WITH_DOCKER := false
+else
+COMPILE_WITH_DOCKER := true
+endif
 
-build-main: IMAGE_TAG=main-$(VERSION)
-build-main: lint unit-test bench-test docker release
+GO := go
+
+GO_FILES := $(shell find . -type f -name '*.go')
+PKG_GO_FILES := $(shell find ../../pkg/ -type f -name '*.go')
+ALL_GO_FILES := $(GO_FILES) $(PKG_GO_FILES)
+
+ifeq ($(patsubst %$(VERSION),,$(IMAGENAME)),)
+else
+$(error "$(IMAGENAME) doesn't end with $(VERSION). Please set the correct version.")
+endif
+
+SERVICE_NAME := $(shell basename $$PWD)
+EARTHLY := earthly
+
+image-name:
+	@echo "$(IMAGENAME)"
+
+version:
+	@echo "$(VERSION)"
+
+proto:
+	make -C../../pkg/api all
+
+bin/:
+	mkdir -p bin
+
+build: bin/main
+
+build-pr:
+	echo "build on pull request"
+	$(EARTHLY) -P --push +build-pr --registry=$(IMAGE_REGISTRY) --tag=pr-$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+
+build-main:
+	echo "build on main"
+	$(EARTHLY) -P --push +build-main --registry=$(IMAGE_REGISTRY) --tag=main-$(VERSION) --mirror=$(ARTIFACT_REGISTRY_MIRROR)
+
+.PHONY: cleanup-pr
+cleanup-pr:
+	echo "Nothing to clean"
+
+.PHONY: cleanup-main
+cleanup-main:
+	echo "Nothing to clean"
+
+bin/main: bin/ $(ALL_GO_FILES) | proto
+	@echo "building without docker, just plain go"
+	$(GO) build -o bin/main ./cmd/server/
+
+clean:
+	rm -rf pkg/api/api.gen.go
+	rm -rf bin
+	docker rmi $(IMAGENAME) || true
+
+.PHONY: test-dependancies
+test-dependancies:
+	make -C ../../pkg test
+	make -C ../../pkg/api test
+
+test:
+	$(EARTHLY) -P +unit-test "--GO_TEST_ARGS=$(GO_TEST_ARGS)"
+
+docker:
+	$(EARTHLY) +docker --registry=$(IMAGE_REGISTRY) --tag=$(VERSION)
+
+all: test docker
+
+.PHONY: publish
+publish: release
+
+.PHONY: all release test docker clean
+
+.PHONY: get-builder-image
+get-builder-image:
+	@echo "$(KUBERPULT_BUILDER)"
+
+kind-load: docker
+	kind load docker-image "$(IMAGENAME)"
+
+patch-kind: kind-load
+	kubectl set image deployment/kuberpult-cd-service service=$(IMAGENAME)


### PR DESCRIPTION
This reverts commit afa372cb871584311175cc911b1521f17fe1095a.

There's a problem where the new makefile does not push the `-datadog` version of the image.

Ref: SRX-6W0QPU