### PR TITLE
fix: do not load manifests for commits

### DIFF
--- a/pkg/db/db_releases.go
+++ b/pkg/db/db_releases.go
@@ -134,28 +134,6 @@ func (h *DBHandler) DBSelectReleaseByVersion(ctx context.Context, tx *sql.Tx, ap
 	return h.processReleaseRow(ctx, err, rows, ignorePrepublishes, true)
 }
 
-func (h *DBHandler) DBSelectReleaseWithoutManifest(ctx context.Context, tx *sql.Tx, app string, releaseVersion uint64) (*DBReleaseWithMetaData, error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "DBSelectReleaseWithoutManifest")
-	defer span.Finish()
-	selectQuery := h.AdaptQuery(`
-		SELECT created, appName, metadata, releaseVersion, environments, revision
-		FROM releases  
-		WHERE appName=? AND releaseVersion=? 
-		LIMIT 1;
-	`)
-	span.SetTag("query", selectQuery)
-	span.SetTag("app", app)
-	span.SetTag("releaseVersion", releaseVersion)
-
-	rows, err := tx.QueryContext(
-		ctx,
-		selectQuery,
-		app,
-		releaseVersion,
-	)
-	return h.processReleaseRow(ctx, err, rows, true, false)
-}
-
 func (h *DBHandler) DBSelectReleaseByVersionAtTimestamp(ctx context.Context, tx *sql.Tx, app string, releaseVersion uint64, ignorePrepublishes bool, ts time.Time) (*DBReleaseWithMetaData, error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "DBSelectReleaseByVersionAtTimestamp")
 	defer span.Finish()

--- a/services/cd-service/pkg/repository/deployment.go
+++ b/services/cd-service/pkg/repository/deployment.go
@@ -346,13 +346,17 @@ func (c *DeployApplicationVersion) ApplyPrognosis(
 }
 
 func getCommitID(ctx context.Context, transaction *sql.Tx, state *State, release uint64, app string) (string, error) {
-	tmp, err := state.DBHandler.DBSelectReleaseWithoutManifest(ctx, transaction, app, release)
+	tmpList, err := state.DBHandler.DBSelectReleasesByVersions(ctx, transaction, app, []uint64{release}, false)
 	if err != nil {
 		return "", err
 	}
-	if tmp == nil {
+	if len(tmpList) == 0 {
 		return "", fmt.Errorf("getCommitID: release %v not found for app %s", release, app)
 	}
+	if len(tmpList) > 1 {
+		return "", fmt.Errorf("getCommitID: too many releases %v found for app %s", release, app)
+	}
+	tmp := tmpList[0]
 	if tmp.Metadata.SourceCommitId == "" {
 		return "", fmt.Errorf("getCommitID: found release %v for app %s, but commit id was empty", release, app)
 	}


### PR DESCRIPTION
When we are only interested in the commitID,
we will not load the manifest from the DB.

Ref: SRX-TMOBMG