### PR TITLE
fix: increase max team length to 63

### DIFF
--- a/pkg/valid/validations.go
+++ b/pkg/valid/validations.go
@@ -67,7 +67,8 @@ func ApplicationName(name string) bool {
 }
 
 func TeamName(name string) bool {
-	return len(name) < 21 && teamNameRx.MatchString(name)
+	// we use the team name in render.go as label and annotations which both have a limit of 63 characters:
+	return len(name) < 63 && teamNameRx.MatchString(name)
 }
 
 func UserEmail(email string) bool {


### PR DESCRIPTION
Apart from the UI, we only use the team name
when rendering a label and annotation
in the argo cd manifests.
Those have a maximum of 63 characters in kubernetes.

Ref: SRX-YWG553