### PR TITLE
fix: remove sqlite leftovers

### DIFF
--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -276,21 +276,6 @@ func RunServer() {
 					MaxIdleConnections: c.DbMaxIdleConnections,
 					MaxOpenConnections: c.DbMaxOpenConnections,
 				}
-			} else if c.DbOption == "sqlite" {
-				dbCfg = db.DBConfig{
-					DbHost:         c.DbLocation,
-					DbPort:         c.DbAuthProxyPort,
-					DriverName:     "sqlite3",
-					DbName:         c.DbName,
-					DbPassword:     c.DbUserPassword,
-					DbUser:         c.DbUserName,
-					MigrationsPath: c.DbMigrationsLocation,
-					WriteEslOnly:   c.DbWriteEslTableOnly,
-					SSLMode:        c.DbSslMode,
-
-					MaxIdleConnections: c.DbMaxIdleConnections,
-					MaxOpenConnections: c.DbMaxOpenConnections,
-				}
 			} else {
 				logger.FromContext(ctx).Fatal("Database was enabled but no valid DB option was provided.")
 			}
@@ -327,7 +312,7 @@ func RunServer() {
 			AllowLongAppNames:         c.AllowLongAppNames,
 			ArgoCdGenerateFiles:       c.ArgoCdGenerateFiles,
 			DBHandler:                 dbHandler,
-			
+
 			DisableQueue: c.DisableQueue,
 		}
 

--- a/services/cd-service/pkg/repository/transformer_test.go
+++ b/services/cd-service/pkg/repository/transformer_test.go
@@ -4610,7 +4610,7 @@ func TestReleaseTrainsWithCommitHash(t *testing.T) {
 					t.Fatalf("Error applying transformers step %d: %v", idx, err)
 				}
 
-				time.Sleep(1000 * time.Millisecond) //This is here so that timestamps on sqlite do not collide when multiple stages are involved.
+				time.Sleep(1000 * time.Millisecond) //This is here so that timestamps on the db do not collide when multiple stages are involved.
 			}
 
 			// Run the Release Train

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -222,21 +222,6 @@ func Run(ctx context.Context) error {
 			MaxIdleConnections: dbMaxIdle,
 			MaxOpenConnections: dbMaxOpen,
 		}
-	} else if dbOption == "sqlite" {
-		dbCfg = db.DBConfig{
-			DbHost:         dbLocation,
-			DbPort:         dbAuthProxyPort,
-			DriverName:     "sqlite3",
-			DbName:         dbName,
-			DbPassword:     dbPassword,
-			DbUser:         dbUserName,
-			MigrationsPath: dbMigrationLocation,
-			WriteEslOnly:   false,
-			SSLMode:        sslMode,
-
-			MaxIdleConnections: dbMaxIdle,
-			MaxOpenConnections: dbMaxOpen,
-		}
 	} else {
 		logger.FromContext(ctx).Fatal("Cannot start without DB configuration was provided.")
 	}

--- a/services/rollout-service/pkg/cmd/server.go
+++ b/services/rollout-service/pkg/cmd/server.go
@@ -249,21 +249,6 @@ func runServer(ctx context.Context, config Config) error {
 				MaxIdleConnections: config.DbMaxIdleConnections,
 				MaxOpenConnections: config.DbMaxOpenConnections,
 			}
-		} else if config.DbOption == "sqlite" {
-			dbCfg = db.DBConfig{
-				DbHost:         config.DbLocation,
-				DbPort:         config.DbAuthProxyPort,
-				DriverName:     "sqlite3",
-				DbName:         config.DbName,
-				DbPassword:     config.DbUserPassword,
-				DbUser:         config.DbUserName,
-				MigrationsPath: config.DbMigrationsLocation,
-				WriteEslOnly:   false,
-				SSLMode:        "disable",
-
-				MaxIdleConnections: config.DbMaxIdleConnections,
-				MaxOpenConnections: config.DbMaxOpenConnections,
-			}
 		}
 		dbHandler, err = db.Connect(ctx, dbCfg)
 		if err != nil {


### PR DESCRIPTION
Kuberpult did not support sqlite already,
this just gets rid of some effectively dead code.

Ref: SRX-LQWK6B