### PR TITLE
fix(ci): tag as main

### DIFF
--- a/infrastructure/make/go/include.mk
+++ b/infrastructure/make/go/include.mk
@@ -65,7 +65,7 @@ ifeq ($(SKIP_RETAG_MAIN_AS_PR),1)
 	@echo "Skipping retag-main"
 else
 	@echo "Starting retag-main: Tagging the main image as PR image"
-	test -n "$(MAIN_PATH)" || exit 0; docker tag $(MAIN_IMAGE_NAME) $(IMAGE_NAME); docker push $(MAIN_IMAGE_NAME)
+	test -n "$(MAIN_PATH)" || exit 0; docker pull $(MAIN_IMAGE_NAME) && docker tag $(MAIN_IMAGE_NAME) $(IMAGE_NAME) && docker push $(IMAGE_NAME)
 endif
 
 

--- a/infrastructure/make/go/include.mk
+++ b/infrastructure/make/go/include.mk
@@ -61,6 +61,7 @@ release-main:
 	test -n "$(MAIN_PATH)" || exit 0; docker tag $(IMAGE_NAME) $(MAIN_IMAGE_NAME); docker push $(MAIN_IMAGE_NAME)
 
 retag-main: IMAGE_TAG=pr-$(VERSION)
+retag-main:
 ifeq ($(SKIP_RETAG_MAIN_AS_PR),1)
 	@echo "Skipping retag-main"
 else

--- a/infrastructure/make/go/include.mk
+++ b/infrastructure/make/go/include.mk
@@ -60,7 +60,7 @@ release-main:
 	@echo "Tagging the PR image as main image"
 	test -n "$(MAIN_PATH)" || exit 0; docker tag $(IMAGE_NAME) $(MAIN_IMAGE_NAME); docker push $(MAIN_IMAGE_NAME)
 
-retag-main:
+retag-main: IMAGE_TAG=pr-$(VERSION)
 ifeq ($(SKIP_RETAG_MAIN_AS_PR),1)
 	@echo "Skipping retag-main"
 else

--- a/infrastructure/scripts/execution-plan/create-matrix.sh
+++ b/infrastructure/scripts/execution-plan/create-matrix.sh
@@ -110,12 +110,6 @@ function createMatrix() {
                     --arg artifactName "Artifact_$(sanitizeArtifactName "${stageBDirectory}")" \
                     '$ARGS.named'
       )
-      if [ -z "${stageArray}" ]
-      then
-        stageArray="${inner}"
-      else
-        stageArray="${stageArray},${inner}"
-      fi
     else
       debug "adding ${stageBDirectory} to the list, despite no change, in order to tag the main image."
       inner=$(jq -n --arg directory "${stageBDirectory}" \
@@ -126,6 +120,12 @@ function createMatrix() {
       )
     fi
     debug "grep stage b: ${grepOutput}"
+    if [ -z "${stageArray}" ]
+    then
+      stageArray="${inner}"
+    else
+      stageArray="${stageArray},${inner}"
+    fi
   done
   stageB=$(jq -n --argjson steps "[$stageArray]" \
                 '$ARGS.named'

--- a/infrastructure/scripts/execution-plan/create-matrix.sh
+++ b/infrastructure/scripts/execution-plan/create-matrix.sh
@@ -53,7 +53,7 @@ function createMatrix() {
   stageArrayFullBuild=false
   for stageADirectory in $STAGE_A_BUILDS
   do
-    grepOutput=$(echo "${ALL_FILES}" | grep "infrastructure/docker/${stageADirectory}")
+    grepOutput=$(echo "${ALL_FILES}" | grep "^infrastructure/docker/${stageADirectory}")
   # shellcheck disable=SC2181
     if [ $? -eq 0 ]
     then
@@ -99,7 +99,7 @@ function createMatrix() {
   stageArray=""
   for stageBDirectory in $STAGE_B_BUILDS
   do
-    grepOutput=$(echo "${ALL_FILES}" | grep "${stageBDirectory}")
+    grepOutput=$(echo "${ALL_FILES}" | grep "^${stageBDirectory}")
   # shellcheck disable=SC2181
     if [ $? -eq 0 ]
     then


### PR DESCRIPTION
This fixes some details about which service needs to be build,
and tags all `main` images as `pr` image, if they are not build in the current CI job.
Ref: SRX-3FH1FA