### PR TITLE
fix: use json for releases column

### DIFF
--- a/database/migrations/postgres/1753879699113996_env_releases_json.up.sql
+++ b/database/migrations/postgres/1753879699113996_env_releases_json.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE releases
+ALTER COLUMN environments TYPE jsonb
+USING environments::jsonb;

--- a/pkg/db/db_environments.go
+++ b/pkg/db/db_environments.go
@@ -211,17 +211,14 @@ func (h *DBHandler) DBSelectEnvironmentApplications(ctx context.Context, transac
 	if transaction == nil {
 		return nil, fmt.Errorf("no transaction provided when selecting environment applications")
 	}
-	acceptableEnvFormats := []any{`["` + envName + `"]`, `["` + envName + `",%`, `%,"` + envName + `"]`, `%,"` + envName + `",%`}
+	acceptableEnvFormat := `["` + envName + `"]`
 
 	selectQuery := h.AdaptQuery(`
-		select DISTINCT appname FROM releases r WHERE 
-			r.environments = ? 
-			OR r.environments LIKE ? 
-			OR r.environments LIKE ?
-			OR r.environments LIKE ?; 
+		select DISTINCT appname FROM releases r WHERE
+			r.environments @> ?;
 	`)
 
-	rows, err := transaction.QueryContext(ctx, selectQuery, acceptableEnvFormats...)
+	rows, err := transaction.QueryContext(ctx, selectQuery, acceptableEnvFormat)
 	if err != nil {
 		return nil, fmt.Errorf("error while executing query to get all environments, error: %w", err)
 	}


### PR DESCRIPTION
The column was already semantically json,
now it's also syntactically json (and more efficient).

Ref: SRX-GVSM9Y