### PR TITLE
fix: build ui in CI

### DIFF
--- a/infrastructure/docker/ui/Makefile
+++ b/infrastructure/docker/ui/Makefile
@@ -1,0 +1,29 @@
+# This file is part of kuberpult.
+
+# Kuberpult is free software: you can redistribute it and/or modify
+# it under the terms of the Expat(MIT) License as published by
+# the Free Software Foundation.
+
+# Kuberpult is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MIT License for more details.
+
+# You should have received a copy of the MIT License
+# along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+# Copyright freiheit.com
+
+
+# The "ui" image is only used for local development.
+# Nowhere in the CI is it referenced.
+# We do not need to push it necessarily,
+# but we want to build it in the CI if something changed.
+
+retag-main:
+	echo "nothing to do"
+
+build-pr:
+	docker build . -t ui:local
+
+build-main: build-pr

--- a/infrastructure/scripts/execution-plan/create-matrix.sh
+++ b/infrastructure/scripts/execution-plan/create-matrix.sh
@@ -7,7 +7,7 @@
 set -uo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 
-STAGE_A_BUILDS="infrastructure/docker/builder"
+STAGE_A_BUILDS="infrastructure/docker/builder infrastructure/docker/ui"
 STAGE_B_BUILDS="pkg cli services/cd-service services/frontend-service services/manifest-repo-export-service services/rollout-service services/reposerver-service"
 
 function debug() {


### PR DESCRIPTION
The "ui" image is only used for local development.
Nowhere in the CI is it referenced.
We do not need to push it necessarily,
but with this change, it will be build it in the CI if something changed.

Ref: SRX-O4HMIP