### PR TITLE
fix(ui): do not re-render GetProductSummary

### DIFF
--- a/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.tsx
+++ b/services/frontend-service/src/ui/components/ProductVersion/ProductVersion.tsx
@@ -21,6 +21,7 @@ import {
     refreshTags,
     showSnackbarError,
     TagResponse,
+    TagsWithFilter,
     useEnvironmentGroups,
     useEnvironments,
     useFrontendConfig,
@@ -152,9 +153,7 @@ export const ProductVersion: React.FC = () => {
     const teams = (searchParams.get('teams') || '').split(',').filter((val) => val !== '');
     const [selectedTag, setSelectedTag] = React.useState('');
     const envsList = useEnvironments();
-    const tagsResponse = useTags();
-    const filteredTagData = tagsResponse.response.tagData.filter((elem) => !!elem.commitDate);
-
+    const { tagsResponse, filteredTagData }: TagsWithFilter = useTags();
     const onChangeTag = React.useCallback(
         (e: React.ChangeEvent<HTMLSelectElement>) => {
             setSelectedTag(e.target.value);
@@ -172,10 +171,13 @@ export const ProductVersion: React.FC = () => {
                 return;
             }
             tag = filteredTagData[0].commitId;
-            if (tag === null) return;
+            if (tag === null) {
+                return;
+            }
             setSelectedTag(tag);
             searchParams.set('tag', tag);
             setSearchParams(searchParams);
+            return;
         }
         const env = splitCombinedGroupName(environment);
         useApi
@@ -191,7 +193,7 @@ export const ProductVersion: React.FC = () => {
                 setProductSummaries({ summaries: [], error: e.message });
             });
         setSummaryLoading(false);
-    }, [tagsResponse, filteredTagData, envGroupResponse, environment, searchParams, setSearchParams, authHeader]);
+    }, [authHeader, environment, filteredTagData, searchParams, setSearchParams]);
 
     const changeEnv = React.useCallback(
         (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -39,6 +39,7 @@ import {
     Release,
     RolloutStatus,
     StreamStatusResponse,
+    TagData,
     Warning,
 } from '../../api/api';
 import * as React from 'react';
@@ -387,7 +388,21 @@ const randBase36 = (): string => Math.random().toString(36).substring(7);
 export const randomLockId = (): string => 'ui-v2-' + randBase36();
 
 export const useActions = (): BatchAction[] => useAction(({ actions }) => actions);
-export const useTags = (): TagsResponse => useTag((res) => res);
+export type TagsWithFilter = {
+    tagsResponse: TagsResponse;
+    filteredTagData: TagData[];
+};
+
+export const useTags = (): TagsWithFilter => {
+    const tagsResponseLocal = useTag((res) => res);
+    // Only re-run the filter function if tagsResponse.response.tagData changes
+    const filteredTagData = useMemo(
+        () => tagsResponseLocal.response.tagData.filter((elem) => !!elem.commitDate),
+        [tagsResponseLocal.response.tagData]
+    );
+    // Memoize the entire return object
+    return useMemo(() => ({ tagsResponse: tagsResponseLocal, filteredTagData }), [tagsResponseLocal, filteredTagData]);
+};
 
 export enum SnackbarStatus {
     SUCCESS,


### PR DESCRIPTION
The issue here was that '.response.tagData.filter'
always returned a new object, which react counts as "different enough"
to re-render indefinitely.
"useMemo" fixes that.

Ref: SRX-YABX15