### PR TITLE
fix(ci): improve docker ignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# frontend services needs this:
+!/Makefile
+!/Makefile.variables
+# but generally we do not need Makefiles:
+#**/Makefile
+
+services/frontend-service/node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 # frontend services needs this:
-!/Makefile
-!/Makefile.variables
+!Makefile
+!Makefile.variables
 # but generally we do not need Makefiles:
-#**/Makefile
+services/*/Makefile
 
 services/frontend-service/node_modules

--- a/services/frontend-service/.dockerignore
+++ b/services/frontend-service/.dockerignore
@@ -1,3 +1,0 @@
-node_modules
-Makefile
-cmd


### PR DESCRIPTION
The dockerignore file needs to be in the location of the context, which is the root of this repo.

Ref: SRX-Q21BDN