### PR TITLE
fix(export): Improve performance for manifest-export db query

### DIFF
--- a/database/migrations/sqlite/1757329592629060_index_release_history_combined.up.sql
+++ b/database/migrations/sqlite/1757329592629060_index_release_history_combined.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_releases_history_app_release_created_version
+    ON releases_history (appname, releaseversion, created DESC, version DESC);

--- a/database/migrations/sqlite/1757329592629070_index_releases_history_deleted.up.sql
+++ b/database/migrations/sqlite/1757329592629070_index_releases_history_deleted.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX if not exists idx_releases_history_environments_gin
+    ON releases_history USING GIN (environments) WHERE deleted = false;

--- a/database/migrations/sqlite/1757329592629080_index_apps_history_combined.up.sql
+++ b/database/migrations/sqlite/1757329592629080_index_apps_history_combined.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX if not exists idx_apps_history_app_meta_created_version
+    ON apps_history (appname, metadata, created DESC, version DESC);


### PR DESCRIPTION
These indexes are specifically improving performance for the query "DBSelectEnvironmentApplicationsAtTimestamp",
which is required when the manifest export selects relevant apps with teams that need to be written to the manifest-repo.

A quick manual test showed an improvement of ~40% (~1.1s instead of ~2.0s) for that query with a setup with ~30 environments and ~1k apps.

Ref: SRX-TIYKMY