### PR TITLE
fix: null pointer deref in DBSelectReleaseByVersion

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -573,10 +573,14 @@ func (h *DBHandler) DBWriteNewReleaseEvent(ctx context.Context, transaction *sql
 	span, ctx := tracer.StartSpanFromContext(ctx, "DBWriteDeploymentEvent")
 	defer span.Finish()
 
+	version := uint64(0)
+	if releaseVersion.Version != nil {
+		version = *releaseVersion.Version
+	}
 	metadata := event.Metadata{
 		Uuid:           uuid,
 		EventType:      string(event.EventTypeNewRelease),
-		ReleaseVersion: *releaseVersion.Version,
+		ReleaseVersion: version,
 	}
 	jsonToInsert, err := json.Marshal(event.DBEventGo{
 		EventData:     newReleaseEvent,

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -815,7 +815,7 @@ func (c *CreateApplicationVersion) calculateVersion(ctx context.Context, transac
 	if c.Version == 0 {
 		return types.MakeEmptyReleaseNumbers(), fmt.Errorf("version is required when using the database")
 	} else {
-		metaData, err := state.DBHandler.DBSelectReleaseByReleaseNumbers(ctx, transaction, c.Application, types.ReleaseNumbers{Version: &c.Version, Revision: c.Revision}, true)
+		metaData, err := state.DBHandler.DBSelectReleaseByVersion(ctx, transaction, c.Application, types.ReleaseNumbers{Version: &c.Version, Revision: c.Revision}, true)
 		if err != nil {
 			return types.MakeEmptyReleaseNumbers(), fmt.Errorf("could not calculate version, error: %v", err)
 		}


### PR DESCRIPTION
- also merge DBSelectReleaseBy{Version,ReleaseNumbers} as they both would suffer from the same issue
- make DBWriteNewReleaseEvent robust against the same null pointer

Ref: SRX-M6Z1XN