### PR TITLE
fix(cd): remove ProcessQueue from main

### DIFF
--- a/services/cd-service/pkg/cmd/server.go
+++ b/services/cd-service/pkg/cmd/server.go
@@ -310,7 +310,7 @@ func RunServer() {
 			DBHandler:             dbHandler,
 		}
 
-		repo, repoQueue, err := repository.New2(ctx, cfg)
+		repo, _, err := repository.New2(ctx, cfg)
 		if err != nil {
 			logger.FromContext(ctx).Fatal("repository.new.error", zap.Error(err), zap.String("git.url", c.GitUrl), zap.String("git.branch", c.GitBranch))
 		}
@@ -456,11 +456,6 @@ func RunServer() {
 						})
 						return nil
 					},
-				},
-				{
-					Shutdown: nil,
-					Name:     "push queue",
-					Run:      repoQueue,
 				},
 			},
 			Shutdown: func(ctx context.Context) error {

--- a/services/cd-service/pkg/repository/repository.go
+++ b/services/cd-service/pkg/repository/repository.go
@@ -270,6 +270,8 @@ func New2(ctx context.Context, cfg RepositoryConfig) (Repository, setup.Backgrou
 	return result, result.ProcessQueue, nil
 }
 
+// ProcessQueue is deprecated!
+// We only keep it for now because of tests
 func (r *repository) ProcessQueue(ctx context.Context, health *setup.HealthReporter) error {
 	defer func() {
 		close(r.queue.transformerBatches)


### PR DESCRIPTION
This stops the cd-service from starting
the function ProcessQueue because it is effectively a no-op.

We keep the function around, because it simplifies testing, but we do not want to use when starting the cd-services "main".

Ref: SRX-NSIUVB