### PR TITLE
fix(rollout): preserve SyncPolicy on argo app updates

### DIFF
--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -26,7 +26,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -290,6 +289,8 @@ func (a *ArgoAppProcessor) CreateArgoApp(ctx context.Context, overview *api.GetO
 
 func (a *ArgoAppProcessor) UpdateArgoApp(ctx context.Context, overview *api.GetOverviewResponse, appInfo *AppInfo, existingApp *v1alpha1.Application) {
 	appToUpdate := CreateArgoApplication(overview, appInfo)
+	// Preserve whatever SyncPolicy the operator has set on the live app (e.g. nil when auto-sync was disabled manually).
+	appToUpdate.Spec.SyncPolicy = existingApp.Spec.SyncPolicy
 	appUpdateRequest := &application.ApplicationUpdateRequest{
 		XXX_NoUnkeyedLiteral: struct{}{},
 		XXX_unrecognized:     nil,
@@ -299,12 +300,15 @@ func (a *ArgoAppProcessor) UpdateArgoApp(ctx context.Context, overview *api.GetO
 		Project:              conversion.FromString(appToUpdate.Spec.Project),
 	}
 
-	//We have to exclude the unexported type destination and the syncPolicy
 	//exhaustruct:ignore
 	diff := cmp.Diff(appUpdateRequest.Application.Spec, existingApp.Spec,
-		cmp.AllowUnexported(v1alpha1.ApplicationDestination{}),
-		cmpopts.IgnoreTypes(v1alpha1.SyncPolicy{}))
+		cmp.AllowUnexported(v1alpha1.ApplicationDestination{}))
 	if diff != "" {
+		logger.FromContext(ctx).Info("UpdateArgoApp",
+			zap.String("diff", diff),
+			zap.Any("newSpec", appUpdateRequest.Application.Spec),
+			zap.Any("existingSpec", existingApp.Spec),
+		)
 		updateSpan, ctx := tracer.StartSpanFromContext(ctx, "UpdateApplications")
 		updateSpan.SetTag("application", appInfo.ApplicationName)
 		updateSpan.SetTag("environment", appInfo.EnvironmentName)

--- a/services/rollout-service/pkg/argo/argo_test.go
+++ b/services/rollout-service/pkg/argo/argo_test.go
@@ -74,12 +74,13 @@ func (m *mockApplicationServiceClient) Recv() (*v1alpha1.ApplicationWatchEvent, 
 }
 
 type mockApplicationServiceClient struct {
-	Steps     []step
-	Apps      []*ArgoApp
-	current   int
-	t         *testing.T
-	lastEvent chan *ArgoEvent
-	cancel    context.CancelFunc
+	Steps             []step
+	Apps              []*ArgoApp
+	current           int
+	t                 *testing.T
+	lastEvent         chan *ArgoEvent
+	cancel            context.CancelFunc
+	lastUpdateRequest *application.ApplicationUpdateRequest
 	grpc.ClientStream
 }
 
@@ -240,6 +241,7 @@ func (m *mockApplicationServiceClient) Delete(ctx context.Context, req *applicat
 }
 
 func (m *mockApplicationServiceClient) Update(ctx context.Context, req *application.ApplicationUpdateRequest, opts ...grpc.CallOption) (*v1alpha1.Application, error) {
+	m.lastUpdateRequest = req
 	for _, a := range m.Apps {
 		if a.App.Name == req.Application.Name {
 			updateApp := &ArgoApp{App: a.App, LastEvent: "MODIFIED"}
@@ -1564,6 +1566,82 @@ func (a *mockApplicationServiceClient) PopulateApps(appInfo []ArgoAppMetadata) {
 				},
 			},
 			LastEvent: "ADDED",
+		})
+	}
+}
+
+func TestUpdateArgoAppPreservesSyncPolicy(t *testing.T) {
+	tcs := []struct {
+		Name               string
+		ExistingSyncPolicy *v1alpha1.SyncPolicy
+	}{
+		{
+			Name:               "preserves nil SyncPolicy when operator removed auto-sync",
+			ExistingSyncPolicy: nil,
+		},
+		{
+			Name: "preserves custom SyncPolicy set by operator",
+			ExistingSyncPolicy: &v1alpha1.SyncPolicy{
+				Automated: &v1alpha1.SyncPolicyAutomated{
+					Prune:    false,
+					SelfHeal: false,
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			testutil.WrapTestRoutine(t, context.Background(), "INFO", func(ctx context.Context) {
+				mockClient := &mockApplicationServiceClient{
+					t:         t,
+					lastEvent: make(chan *ArgoEvent, 10),
+					cancel:    func() {},
+				}
+				argoProcessor := &ArgoAppProcessor{
+					ApplicationClient:     mockClient,
+					ManageArgoAppsEnabled: true,
+					ManageArgoAppsFilter:  []string{"*"},
+					KnownApps:             map[string]map[string]*v1alpha1.Application{},
+				}
+
+				overview := &api.GetOverviewResponse{
+					ManifestRepoUrl: "https://git.example.com/repo",
+					Branch:          "new-branch",
+				}
+				appInfo := &AppInfo{
+					ApplicationName:       "myapp",
+					TeamName:              "myteam",
+					EnvironmentName:       "staging",
+					ParentEnvironmentName: "staging",
+					ArgoEnvironmentConfiguration: &api.ArgoCDEnvironmentConfiguration{
+						Destination: &api.ArgoCDEnvironmentConfiguration_Destination{
+							Server: "https://kubernetes.default.svc",
+						},
+					},
+				}
+				// existingApp has a different TargetRevision to trigger an update,
+				// and whatever SyncPolicy the operator set.
+				//exhaustruct:ignore
+				existingApp := &v1alpha1.Application{
+					//exhaustruct:ignore
+					Spec: v1alpha1.ApplicationSpec{
+						//exhaustruct:ignore
+						Source: &v1alpha1.ApplicationSource{
+							TargetRevision: "old-branch",
+						},
+						SyncPolicy: tc.ExistingSyncPolicy,
+					},
+				}
+
+				argoProcessor.UpdateArgoApp(ctx, overview, appInfo, existingApp)
+
+				if mockClient.lastUpdateRequest == nil {
+					t.Fatal("expected Update to be called but it was not")
+				}
+				if diff := cmp.Diff(tc.ExistingSyncPolicy, mockClient.lastUpdateRequest.Application.Spec.SyncPolicy); diff != "" {
+					t.Errorf("SyncPolicy mismatch (-want, +got):\n%s", diff)
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
This fixes the issue where the rollout-service overwrites changes in the syncpolicy of Argo apps that were made manually in the Argo CD UI by an operator.

## Summary

- `UpdateArgoApp` now copies the existing app's `SyncPolicy` into the update request before diffing and sending, so operators can remove auto-sync in the ArgoCD UI without it being restored on the next reconciliation.
- Fixed `cmpopts.IgnoreTypes(v1alpha1.SyncPolicy{})` which only suppressed diffs between two non-nil values, not nil-vs-non-nil pointer comparisons.
- Added a `logger.Info` line to log the diff and both specs on every call for observability.

Ref: SRX-VRKPNL
