### PR TITLE
fix: exclude the deployment without a release version when re-rendering environment

### DIFF
--- a/pkg/db/db_deployments.go
+++ b/pkg/db/db_deployments.go
@@ -148,7 +148,7 @@ func (h *DBHandler) DBSelectLatestDeploymentAtTimestamp(ctx context.Context, tx 
 	selectQuery := h.AdaptQuery(`
 		SELECT created, releaseVersion, appName, envName, metadata, transformereslVersion, revision
 		FROM deployments_history
-		WHERE appName=? AND envName=? AND created <=?
+		WHERE appName=? AND envName=? AND created <=? AND releaseVersion IS NOT NULL
 		ORDER BY version DESC
 		LIMIT 1;
 	`)

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -2232,18 +2232,6 @@ func (s *State) GetEnvironmentApplicationVersion(ctx context.Context, transactio
 	return depl.ReleaseNumbers, nil
 }
 
-func (s *State) GetEnvironmentApplicationVersionAtTimestamp(ctx context.Context, transaction *sql.Tx, environment types.EnvName, application string, ts time.Time) (types.ReleaseNumbers, error) {
-	depl, err := s.DBHandler.DBSelectLatestDeploymentAtTimestamp(ctx, transaction, types.AppName(application), environment, ts)
-	if err != nil {
-		return types.MakeEmptyReleaseNumbers(), err
-	}
-	if depl == nil || depl.ReleaseNumbers.Version == nil {
-		return types.MakeEmptyReleaseNumbers(), nil
-	}
-
-	return depl.ReleaseNumbers, nil
-}
-
 func (s *State) GetEnvironmentApplicationVersionFromManifest(environment types.EnvName, application string) (types.ReleaseNumbers, error) {
 	return s.readSymlink(environment, application, "version")
 }

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -1450,13 +1450,14 @@ func (c *RenderEnvironment) Transform(
 		}
 
 		if release == nil {
-			logging.Warn(ctx, "release not found or is deleted for app", zap.Any("appName", appName), zap.Any("releaseNumbers", releaseNumbers), zap.Any("releaseIsNil", release == nil))
+			logging.Warn(ctx, "release not found for app", zap.Any("appName", appName), zap.Any("releaseNumbers", releaseNumbers))
 			// skip if there is no release found matching the version numbers for this app
 			// or if the release has been undeployed
 			continue
 		}
 
 		if release.Deleted {
+			// we do not care the deleted releases as they were undeployed from the environment, therefore, no need to render manifests.
 			continue
 		}
 

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -1448,16 +1448,21 @@ func (c *RenderEnvironment) Transform(
 		if err != nil {
 			return "", err
 		}
-		if release == nil || release.Deleted {
-			logging.Info(ctx, "release not found or is deleted for app", zap.Any("appName", appName), zap.Any("releaseNumbers", releaseNumbers), zap.Any("releaseIsNil", release == nil))
+
+		if release == nil {
+			logging.Warn(ctx, "release not found or is deleted for app", zap.Any("appName", appName), zap.Any("releaseNumbers", releaseNumbers), zap.Any("releaseIsNil", release == nil))
 			// skip if there is no release found matching the version numbers for this app
 			// or if the release has been undeployed
 			continue
 		}
 
+		if release.Deleted {
+			continue
+		}
+
 		envManifest, ok := release.Manifests.Manifests[c.Environment]
 		if !ok {
-			logging.Info(ctx, "app doesn't have any manifests on this environment", zap.Any("appName", appName), zap.Any("releaseNumbers", releaseNumbers), zap.Any("env", c.Environment))
+			logging.Warn(ctx, "app doesn't have any manifests on this environment", zap.Any("appName", appName), zap.Any("releaseNumbers", releaseNumbers), zap.Any("env", c.Environment))
 			// skip an app if it doesn't have any manifests on this environment
 			// this might happen if the app was already undeployed from the environment at the given timestamp
 			continue


### PR DESCRIPTION
Ref: SRX-UGP7S2
