### PR TITLE
fix(docs): display only main pipeline in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ![Main Pipeline](https://github.com/freiheit-com/kuberpult/actions/workflows/execution-plan-main.yml/badge.svg)
-![Release Pipeline](https://github.com/freiheit-com/kuberpult/actions/workflows/release.yml/badge.svg)
 
 
 # Kuberpult Readme for users


### PR DESCRIPTION
The old "release" pipeline is now integrated in the main pipeline.

Ref: SRX-VRKPNL