### PR TITLE
fix: allow /api for specific configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ repository_remote
 services/cd-service/client
 services/cd-service/host
 services/cd-service/known_hosts
+services/cd-service/test_pgp_keyring.asc
 services/cd-service/repository_checked_out/
 CHANGELOG.tmp.md
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,15 @@ cleanup-git:
 	rm -rf services/cd-service/repository_remote
 	rm -rf services/cd-service/repository_checkedout
 
+prepare-pgp:
+	@if [ ! -f "services/cd-service/test_pgp_keyring.asc" ]; then \
+		echo "Generating test PGP key ring for local development..."; \
+		GNUPGHOME=$$(mktemp -d); \
+		printf "Key-Type: RSA\nKey-Length: 2048\nName-Real: Local Dev\nName-Email: dev@example.com\nExpire-Date: 0\n%%no-protection\n%%commit\n" | gpg --batch --gen-key --homedir "$$GNUPGHOME"; \
+		gpg --homedir "$$GNUPGHOME" --armor --export dev@example.com > services/cd-service/test_pgp_keyring.asc; \
+		rm -rf "$$GNUPGHOME"; \
+	fi
+
 prepare-compose: builder
 	BUILDER_IMAGE=$(DOCKER_REGISTRY_URI)/infrastructure/docker/builder:local make -C pkg gen
 	IMAGE_TAG=local make -C services/cd-service docker
@@ -96,21 +105,21 @@ prepare-compose: builder
 	IMAGE_TAG=local make -C services/frontend-service docker gen-api
 	make -C infrastructure/docker/ui build-pr
 
-kuberpult-datadog: prepare-compose prepare-git compose-down
+kuberpult-datadog: prepare-compose prepare-git prepare-pgp compose-down
 ifndef DD_ENV
 	$(error "DD_ENV should be set to execute this target. E.g., DD_ENV=example-local-nov7-a make kuberpult-datadog")
 else
 	DD_ENV=$(DD_ENV) docker compose -f docker-compose.datadog.yml -f docker-compose.yml -f docker-compose.persist.yml up
 endif
 
-kuberpult: prepare-compose prepare-git compose-down
+kuberpult: prepare-compose prepare-git prepare-pgp compose-down
 	docker compose -f docker-compose.yml -f docker-compose.persist.yml up
 
 reset-db: compose-down
 	# This deletes the volume of the default db location:
 	docker volume rm kuberpult_pgdata
 
-kuberpult-freshdb: prepare-compose cleanup-git prepare-git compose-down
+kuberpult-freshdb: prepare-compose cleanup-git prepare-git prepare-pgp compose-down
 	docker compose up
 
 # Run this before starting the unit tests in your IDE:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - KUBERPULT_GRPC_MAX_RECV_MSG_SIZE=4
       - KUBERPULT_MIGRATION_SERVER_SECURE=false
       - KUBERPULT_VERSION=v0.1.2
+      - KUBERPULT_AZURE_ENABLE_AUTH=false
     ports:
       - "8080:8080"
       - "8443:8443"
@@ -129,11 +130,14 @@ services:
       - KUBERPULT_SOURCE_REPO_URL=https://github.com/freiheit-com/kuberpult/commit/{commit}
       - KUBERPULT_MANIFEST_REPO_URL=https://github.com/freiheit-com/fdc-standard-setup-dev-env-manifest/tree/{branch}/{dir}
       - KUBERPULT_GIT_BRANCH=master
-      - KUBERPULT_API_ENABLE_DESPITE_NO_AUTH=true
       - KUBERPULT_BATCH_CLIENT_TIMEOUT=2m
       - KUBERPULT_DEX_RBAC_POLICY_PATH=/etc/policy.csv
       - KUBERPULT_GRPC_MAX_RECV_MSG_SIZE=8
       - KUBERPULT_REVISIONS_ENABLED=true
+      - KUBERPULT_AZURE_ENABLE_AUTH=false
+      - KUBERPULT_API_ENABLE_DESPITE_NO_AUTH=true
+# keyring is only needed for azure auth
+#      - KUBERPULT_PGP_KEY_RING_PATH=/kp/kuberpult/services/cd-service/test_pgp_keyring.asc
     ports:
       - "8081:8081"
       - "5555:5555"

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
           # frontend
           pkgs.nodejs_24
           pkgs.pnpm_8
+          pkgs.gnupg
         ];
       in
       {

--- a/pkg/auth/azure_test.go
+++ b/pkg/auth/azure_test.go
@@ -473,6 +473,25 @@ func TestAllowBypassingAzureAuth(t *testing.T) {
 			allowedPrefixes: []string{"bar"},
 			expectedResult:  false,
 		},
+		{
+			// Bug: when ApiEnableDespiteNoAuth=true and AzureEnableAuth=true, /api/release gets
+			// rejected by the Azure middleware because /api is not in the server's allowedPrefixes.
+			Name:            "/api/release does not bypass without /api prefix",
+			allowedPaths:    []string{"/", "/release", "/health", "/favicon.png"},
+			requestUrlPath:  "/api/release",
+			requestMethod:   http.MethodPost,
+			allowedPrefixes: []string{"/static/js", "/static/css", "/ui"},
+			expectedResult:  false,
+		},
+		{
+			// Fix: server.go must add "/api" to allowedPrefixes when ApiEnableDespiteNoAuth=true.
+			Name:            "/api/release bypasses auth when /api is in allowedPrefixes",
+			allowedPaths:    []string{"/", "/release", "/health", "/favicon.png"},
+			requestUrlPath:  "/api/release",
+			requestMethod:   http.MethodPost,
+			allowedPrefixes: []string{"/static/js", "/static/css", "/ui", "/api"},
+			expectedResult:  true,
+		},
 	}
 
 	for _, tc := range tcs {

--- a/services/frontend-service/Makefile
+++ b/services/frontend-service/Makefile
@@ -14,7 +14,7 @@
 
 # Copyright freiheit.com
 
-MIN_COVERAGE=42.0
+MIN_COVERAGE=47.1
 MAKEFLAGS += --no-builtin-rules
 CONTEXT=../..
 # avoid calling docker to run buf:

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -533,8 +533,7 @@ func runServer(ctx context.Context) error {
 				// these are the paths and prefixes that must not have azure authentication, in order to bootstrap the html, js, etc:
 				var allowedPaths = []string{"/", "/release", "/health", "/favicon.png"}
 				var allowedPrefixes = []string{"/static/js", "/static/css", "/ui"}
-				const enableFix = false
-				if c.ApiEnableDespiteNoAuth && enableFix {
+				if c.ApiEnableDespiteNoAuth {
 					// /api/* bypasses Azure auth so that ApiEnableDespiteNoAuth takes effect in restApiHandler.
 					allowedPrefixes = append(allowedPrefixes, "/api")
 				}

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -533,6 +533,11 @@ func runServer(ctx context.Context) error {
 				// these are the paths and prefixes that must not have azure authentication, in order to bootstrap the html, js, etc:
 				var allowedPaths = []string{"/", "/release", "/health", "/favicon.png"}
 				var allowedPrefixes = []string{"/static/js", "/static/css", "/ui"}
+				const enableFix = false
+				if c.ApiEnableDespiteNoAuth && enableFix {
+					// /api/* bypasses Azure auth so that ApiEnableDespiteNoAuth takes effect in restApiHandler.
+					allowedPrefixes = append(allowedPrefixes, "/api")
+				}
 				if err := auth.HttpAuthMiddleWare(resp, req, jwks, c.AzureClientId, c.AzureTenantId, allowedPaths, allowedPrefixes); err != nil {
 					return
 				}

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -61,6 +61,9 @@ import (
 
 const megaBytes int = 1024 * 1024
 
+// jwksInitAzure is a variable so tests can inject a mock JWKS without a real network call.
+var jwksInitAzure = auth.JWKSInitAzure
+
 func getBackendServiceId(c config.ServerConfig, ctx context.Context) string {
 	if c.GKEBackendServiceID == "" && c.GKEBackendServiceName == "" {
 		logging.Warn(ctx, "GKE environment variables are not set up correctly! missing backend_service_id or backend_service_name")
@@ -208,7 +211,7 @@ func runServer(ctx context.Context) error {
 
 	var jwks *keyfunc.JWKS = nil
 	if c.AzureEnableAuth {
-		jwks, err = auth.JWKSInitAzure(ctx)
+		jwks, err = jwksInitAzure(ctx)
 		if err != nil {
 			logging.Fatal(ctx, "Unable to initialize jwks for azure auth")
 			return err

--- a/services/frontend-service/pkg/cmd/server_test.go
+++ b/services/frontend-service/pkg/cmd/server_test.go
@@ -32,6 +32,8 @@ import (
 
 	"github.com/MicahParks/keyfunc/v2"
 	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/proto"
@@ -721,6 +723,156 @@ func TestGetRequestAuthorFromAzure(t *testing.T) {
 			if diff := cmp.Diff(tc.ExpectedUser, got); diff != "" {
 				t.Errorf("user mismatch (-want, +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+// makeTestPgpKeyringFile creates a temporary armored PGP public-key file and returns its path.
+// Required when running the server with AzureEnableAuth=true.
+func makeTestPgpKeyringFile(t *testing.T) string {
+	t.Helper()
+	entity, err := openpgp.NewEntity("Test", "", "test@example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create PGP entity: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "keyring.asc")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("failed to create PGP keyring file: %v", err)
+	}
+	defer f.Close()
+	w, err := armor.Encode(f, openpgp.PublicKeyType, nil)
+	if err != nil {
+		t.Fatalf("failed to create armor encoder: %v", err)
+	}
+	if err := entity.Serialize(w); err != nil {
+		t.Fatalf("failed to serialize PGP entity: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close armor writer: %v", err)
+	}
+	return path
+}
+
+func TestServerApiEnableDespiteNoAuthWithAzure(t *testing.T) {
+	tcs := []struct {
+		Name                   string
+		AzureEnableAuth        bool
+		ApiEnableDespiteNoAuth bool
+		ExpectedUnauthorized   bool
+	}{
+		{
+			// Bug: the Azure middleware rejects /api/release before ApiEnableDespiteNoAuth is checked.
+			// This case should NOT return 401 once the bug is fixed.
+			Name:                   "Azure=true, ApiNoAuth=true - should pass through Azure middleware",
+			AzureEnableAuth:        true,
+			ApiEnableDespiteNoAuth: true,
+			ExpectedUnauthorized:   false,
+		},
+		{
+			Name:                   "Azure=true, ApiNoAuth=false - Azure blocks unauthenticated request",
+			AzureEnableAuth:        true,
+			ApiEnableDespiteNoAuth: false,
+			ExpectedUnauthorized:   true,
+		},
+		{
+			Name:                   "Azure=false, ApiNoAuth=true - request reaches handler",
+			AzureEnableAuth:        false,
+			ApiEnableDespiteNoAuth: true,
+			ExpectedUnauthorized:   false,
+		},
+		{
+			Name:                   "Azure=false, ApiNoAuth=false - /api unavailable without auth method",
+			AzureEnableAuth:        false,
+			ApiEnableDespiteNoAuth: false,
+			ExpectedUnauthorized:   true,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		// NOTE: subtests must NOT run in parallel — they share port 8081 and jwksInitAzure.
+		t.Run(tc.Name, func(t *testing.T) {
+			if tc.AzureEnableAuth {
+				orig := jwksInitAzure
+				jwksInitAzure = func(_ context.Context) (*keyfunc.JWKS, error) {
+					return makeAzureTestJWKS()
+				}
+				defer func() { jwksInitAzure = orig }()
+
+				t.Setenv("KUBERPULT_AZURE_ENABLE_AUTH", "true")
+				t.Setenv("KUBERPULT_AZURE_CLIENT_ID", "testClientId")
+				t.Setenv("KUBERPULT_AZURE_TENANT_ID", "testTenantId")
+				t.Setenv("KUBERPULT_PGP_KEY_RING_PATH", makeTestPgpKeyringFile(t))
+			}
+			if tc.ApiEnableDespiteNoAuth {
+				t.Setenv("KUBERPULT_API_ENABLE_DESPITE_NO_AUTH", "true")
+			}
+
+			var wg sync.WaitGroup
+			ctx, cancel := context.WithCancel(context.Background())
+			wg.Add(1)
+			go func(t *testing.T) {
+				defer wg.Done()
+				defer cancel()
+				for {
+					res, err := http.Get("http://localhost:8081/healthz")
+					if err != nil {
+						t.Logf("unhealthy: %q", err)
+						<-time.After(1 * time.Second)
+						continue
+					}
+					if res.StatusCode != 200 {
+						<-time.After(1 * time.Second)
+						_ = res.Body.Close()
+						continue
+					}
+					_ = res.Body.Close()
+					break
+				}
+
+				req, err := http.NewRequest(http.MethodPost, "http://localhost:8081/api/release", nil)
+				if err != nil {
+					t.Errorf("failed to create request: %v", err)
+					return
+				}
+				res, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Errorf("failed to do request: %v", err)
+					return
+				}
+				defer res.Body.Close()
+				body, _ := io.ReadAll(res.Body)
+				t.Logf("status: %d, body: %q", res.StatusCode, body)
+
+				if tc.ExpectedUnauthorized {
+					if res.StatusCode != http.StatusUnauthorized {
+						t.Errorf("expected 401 Unauthorized but got %d (body: %q)", res.StatusCode, body)
+					}
+				} else {
+					if res.StatusCode == http.StatusUnauthorized {
+						t.Errorf("expected request to pass auth but got 401 Unauthorized (body: %q)", body)
+					}
+				}
+			}(t)
+
+			td := t.TempDir()
+			if err := os.Mkdir(filepath.Join(td, "build"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(td, "build", "index.html"), []byte(`<!doctype html><html lang="en"></html>`), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chdir(td); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("KUBERPULT_GIT_AUTHOR_EMAIL", "mail2")
+			t.Setenv("KUBERPULT_GIT_AUTHOR_NAME", "name1")
+
+			if err := runServer(ctx); err != nil {
+				t.Fatalf("runServer returned unexpected error: %q", err)
+			}
+			wg.Wait()
 		})
 	}
 }

--- a/services/frontend-service/pkg/cmd/server_test.go
+++ b/services/frontend-service/pkg/cmd/server_test.go
@@ -868,6 +868,7 @@ func TestServerApiEnableDespiteNoAuthWithAzure(t *testing.T) {
 			}
 			t.Setenv("KUBERPULT_GIT_AUTHOR_EMAIL", "mail2")
 			t.Setenv("KUBERPULT_GIT_AUTHOR_NAME", "name1")
+			t.Setenv("KUBERPULT_GRPC_MAX_RECV_MSG_SIZE", "4")
 
 			if err := runServer(ctx); err != nil {
 				t.Fatalf("runServer returned unexpected error: %q", err)


### PR DESCRIPTION
The /api endpoints were not working for
API_ENABLE_DESPITE_NO_AUTH=true
KUBERPULT_AZURE_ENABLE_AUTH=true

Ref: SRX-CHXDQM