### PR TITLE
feat: Store new manifest-lock in DB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,16 +104,17 @@ for _, tc := range tcs {
 }
 ```
 
-**Assertions with `cmp.Diff`:**
+**Assertions with `cmpDiff`:**
 ```go
-if diff := cmp.Diff(expected, actual); diff != "" {
+if diff := cmpDiff(expected, actual); diff != "" {
     t.Errorf("mismatch (-want, +got):\n%s", diff)
 }
 ```
+Always use cmpDiff, never use cmp.Diff, as it is not type-safe.
 
 **Proto message comparison:**
 ```go
-if diff := cmp.Diff(expected, actual, protocmp.Transform()); diff != "" {
+if diff := cmpDiff(expected, actual, protocmp.Transform()); diff != "" {
     t.Errorf("mismatch (-want, +got):\n%s", diff)
 }
 ```
@@ -181,3 +182,9 @@ The only exceptions are early calls that happen before the Authentication happen
 api.configService()
     .GetConfig({}) // the config service does not require authorisation
 ```
+
+## Nil Checks in DB code
+Do not add nil checks for DBHandler (h) or sql.Tx (tx/transaction) in DB package functions.
+**Why:** They are bloating the code too much. In the unlikely case that one is nil, we can deal with the panic.
+**How to apply:** When writing any new function in `pkg/db/`,
+skip the `if h == nil { return nil }` and `if tx == nil { return fmt.Errorf(...) }` guard clauses entirely.

--- a/database/migrations/postgres/1778169290527246_manifest_locks_history.up.sql
+++ b/database/migrations/postgres/1778169290527246_manifest_locks_history.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS manifest_locks_history
+(
+    lockid      SERIAL,
+    recorded_at TIMESTAMP,
+    app         VARCHAR,
+    env         VARCHAR,
+    metadata    VARCHAR,
+    active      BOOLEAN,
+    event_type  VARCHAR,
+    PRIMARY KEY (lockid)
+);
+
+CREATE INDEX IF NOT EXISTS manifest_locks_history_active_idx
+    ON manifest_locks_history (active);
+
+CREATE INDEX IF NOT EXISTS manifest_locks_history_app_env_active_idx
+    ON manifest_locks_history (app, env, active);

--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -447,6 +447,7 @@ service OverviewService {
   rpc GetAppDetails (GetAppDetailsRequest) returns (GetAppDetailsResponse) {}
   rpc GetAllAppLocks (GetAllAppLocksRequest) returns (GetAllAppLocksResponse) {}
   rpc GetAllEnvTeamLocks (GetAllEnvTeamLocksRequest) returns (GetAllEnvTeamLocksResponse) {}
+  rpc GetAllManifestLocks (GetAllManifestLocksRequest) returns (GetAllManifestLocksResponse) {}
 
   rpc StreamDeploymentHistory (DeploymentHistoryRequest) returns (stream DeploymentHistoryResponse) {}
 }
@@ -487,6 +488,18 @@ message GetAllEnvTeamLocksRequest {}
 message GetAllEnvTeamLocksResponse {
   map<string, Locks> all_env_locks = 1; //EnvName -> All env locks for that env
   map<string, AllTeamLocks> all_team_locks = 2; //EnvName -> All team locks for that env
+}
+
+message GetAllManifestLocksRequest {}
+
+message GetAllManifestLocksResponse {
+  repeated ManifestLockInfo manifest_locks = 1;
+}
+
+message ManifestLockInfo {
+  string app = 1;
+  string env = 2;
+  Lock   lock = 3;
 }
 
 message DeploymentHistoryRequest {

--- a/pkg/db/db_manifest_locks.go
+++ b/pkg/db/db_manifest_locks.go
@@ -1,0 +1,167 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	"github.com/freiheit-com/kuberpult/pkg/types"
+)
+
+type ManifestLockEventType string
+
+const (
+	ManifestLockEventTypeCreated ManifestLockEventType = "created"
+	ManifestLockEventTypeDeleted ManifestLockEventType = "deleted"
+)
+
+type ManifestLock struct {
+	LockID     types.ManifestLockID
+	RecordedAt time.Time
+	App        types.AppName
+	Env        types.EnvName
+	Metadata   LockMetadata
+	Active     bool
+	EventType  ManifestLockEventType
+}
+
+// SELECTS
+
+func (h *DBHandler) DBSelectAllActiveManifestLocks(ctx context.Context, tx *sql.Tx) (_ []ManifestLock, err error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBSelectAllActiveManifestLocks")
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
+
+	selectQuery := h.AdaptQuery(`
+		SELECT lockid, recorded_at, app, env, metadata, active, event_type
+		FROM manifest_locks_history
+		WHERE active = true
+		ORDER BY env, app;`)
+
+	rows, err := tx.QueryContext(ctx, selectQuery)
+	if err != nil {
+		return nil, fmt.Errorf("could not query manifest_locks_history table from DB. Error: %w", err)
+	}
+	defer closeRowsAndLog(rows, ctx, "DBSelectAllActiveManifestLocks")
+	return h.processManifestLockRows(ctx, rows)
+}
+
+func (h *DBHandler) DBSelectAllActiveManifestLocksForApp(ctx context.Context, tx *sql.Tx, appName types.AppName) (_ []ManifestLock, err error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBSelectAllActiveManifestLocksForApp")
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
+
+	selectQuery := h.AdaptQuery(`
+		SELECT lockid, recorded_at, app, env, metadata, active, event_type
+		FROM manifest_locks_history
+		WHERE active = true AND app = ?
+		ORDER BY env;`)
+
+	rows, err := tx.QueryContext(ctx, selectQuery, appName)
+	if err != nil {
+		return nil, fmt.Errorf("could not query manifest_locks_history table from DB. Error: %w", err)
+	}
+	defer closeRowsAndLog(rows, ctx, "DBSelectAllActiveManifestLocksForApp")
+	return h.processManifestLockRows(ctx, rows)
+}
+
+// INSERT, UPDATE
+
+func (h *DBHandler) DBWriteManifestLock(ctx context.Context, tx *sql.Tx, app types.AppName, env types.EnvName, metadata LockMetadata) (err error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBWriteManifestLock")
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
+
+	now, err := h.DBReadTransactionTimestamp(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("DBWriteManifestLock unable to get transaction timestamp: %w", err)
+	}
+
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("DBWriteManifestLock could not marshal metadata: %w", err)
+	}
+
+	insertQuery := h.AdaptQuery(`
+		INSERT INTO manifest_locks_history (recorded_at, app, env, metadata, active, event_type)
+		VALUES (?, ?, ?, ?, true, ?);`)
+
+	_, err = tx.ExecContext(ctx, insertQuery, *now, app, env, metadataJSON, ManifestLockEventTypeCreated)
+	if err != nil {
+		return fmt.Errorf("could not insert manifest lock for app '%s' env '%s' into DB. Error: %w", app, env, err)
+	}
+	return nil
+}
+
+func (h *DBHandler) DBDeleteManifestLock(ctx context.Context, tx *sql.Tx, app types.AppName, env types.EnvName) (err error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBDeleteManifestLock")
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
+
+	updateQuery := h.AdaptQuery(`
+		UPDATE manifest_locks_history
+		SET active = false, event_type = ?
+		WHERE app = ? AND env = ? AND active = true;`)
+
+	_, err = tx.ExecContext(ctx, updateQuery, ManifestLockEventTypeDeleted, app, env)
+	if err != nil {
+		return fmt.Errorf("could not delete manifest lock for app '%s' env '%s' from DB. Error: %w", app, env, err)
+	}
+	return nil
+}
+
+// process rows
+
+func (h *DBHandler) processManifestLockRows(ctx context.Context, rows *sql.Rows) ([]ManifestLock, error) {
+	var locks []ManifestLock
+	for rows.Next() {
+		var row ManifestLock
+		var metadataJSON string
+		var eventType string
+		err := rows.Scan(&row.LockID, &row.RecordedAt, &row.App, &row.Env, &metadataJSON, &row.Active, &eventType)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("error scanning manifest_locks_history row from DB. Error: %w", err)
+		}
+		row.EventType = ManifestLockEventType(eventType)
+
+		//exhaustruct:ignore
+		err = json.Unmarshal([]byte(metadataJSON), &row.Metadata)
+		if err != nil {
+			return nil, fmt.Errorf("error during json unmarshal of manifest lock metadata. Error: %w", err)
+		}
+		locks = append(locks, row)
+	}
+	err := closeRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	return locks, nil
+}

--- a/pkg/db/db_manifest_locks.go
+++ b/pkg/db/db_manifest_locks.go
@@ -48,6 +48,33 @@ type ManifestLock struct {
 
 // SELECTS
 
+func (h *DBHandler) DBHasActiveManifestLock(ctx context.Context, tx *sql.Tx, app types.AppName, env types.EnvName) (_ bool, err error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBHasActiveManifestLock")
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
+
+	selectQuery := h.AdaptQuery(`
+		SELECT EXISTS(
+			SELECT 1 FROM manifest_locks_history
+			WHERE app = ? AND env = ? AND active = true
+		);`)
+
+	rows, err := tx.QueryContext(ctx, selectQuery, app, env)
+	if err != nil {
+		return false, fmt.Errorf("could not query manifest_locks_history: %w", err)
+	}
+	defer closeRowsAndLog(rows, ctx, "DBHasActiveManifestLock")
+	if !rows.Next() {
+		return false, nil
+	}
+	var exists bool
+	if err := rows.Scan(&exists); err != nil {
+		return false, fmt.Errorf("error scanning DBHasActiveManifestLock result: %w", err)
+	}
+	return exists, nil
+}
+
 func (h *DBHandler) DBSelectAllActiveManifestLocks(ctx context.Context, tx *sql.Tx) (_ []ManifestLock, err error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "DBSelectAllActiveManifestLocks")
 	defer func() {

--- a/pkg/db/db_manifest_locks_test.go
+++ b/pkg/db/db_manifest_locks_test.go
@@ -200,3 +200,84 @@ func TestDBDeleteManifestLock(t *testing.T) {
 		})
 	}
 }
+
+func TestDBHasActiveManifestLock(t *testing.T) {
+	tcs := []struct {
+		Name        string
+		Locks       []lockInput
+		DeleteLocks []lockInput
+		QueryApp    types.AppName
+		QueryEnv    types.EnvName
+		Expected    bool
+	}{
+		{
+			Name:     "no locks - returns false",
+			QueryApp: "app-a",
+			QueryEnv: "dev",
+			Expected: false,
+		},
+		{
+			Name: "active lock for queried app+env - returns true",
+			Locks: []lockInput{
+				{App: "app-a", Env: "dev"},
+			},
+			QueryApp: "app-a",
+			QueryEnv: "dev",
+			Expected: true,
+		},
+		{
+			Name: "lock for different env - returns false",
+			Locks: []lockInput{
+				{App: "app-a", Env: "staging"},
+			},
+			QueryApp: "app-a",
+			QueryEnv: "dev",
+			Expected: false,
+		},
+		{
+			Name: "deleted lock - returns false",
+			Locks: []lockInput{
+				{App: "app-a", Env: "dev"},
+			},
+			DeleteLocks: []lockInput{
+				{App: "app-a", Env: "dev"},
+			},
+			QueryApp: "app-a",
+			QueryEnv: "dev",
+			Expected: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			dbHandler := setupDB(t)
+
+			err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, tx *sql.Tx) error {
+				for _, l := range tc.Locks {
+					//exhaustruct:ignore
+					if err := dbHandler.DBWriteManifestLock(ctx, tx, l.App, l.Env, l.Metadata); err != nil {
+						return err
+					}
+				}
+				for _, l := range tc.DeleteLocks {
+					if err := dbHandler.DBDeleteManifestLock(ctx, tx, l.App, l.Env); err != nil {
+						return err
+					}
+				}
+				got, err := dbHandler.DBHasActiveManifestLock(ctx, tx, tc.QueryApp, tc.QueryEnv)
+				if err != nil {
+					return err
+				}
+				if diff := testutil.CmpDiff(tc.Expected, got); diff != "" {
+					t.Errorf("has-active-lock mismatch (-want, +got):\n%s", diff)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("transaction error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/db/db_manifest_locks_test.go
+++ b/pkg/db/db_manifest_locks_test.go
@@ -1,0 +1,202 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
+	"github.com/freiheit-com/kuberpult/pkg/types"
+)
+
+type lockInput struct {
+	App      types.AppName
+	Env      types.EnvName
+	Metadata LockMetadata
+}
+
+func TestDBManifestLocks(t *testing.T) {
+	tcs := []struct {
+		Name           string
+		Locks          []lockInput
+		QueryApp       types.AppName
+		ExpectedAll    []ManifestLock
+		ExpectedForApp []ManifestLock
+	}{
+		{
+			Name: "write one lock - appears in all and for-app queries",
+			Locks: []lockInput{
+				{App: "app-a", Env: "dev", Metadata: LockMetadata{CreatedByName: "user", CreatedByEmail: "u@example.com", Message: "lock"}},
+			},
+			QueryApp: "app-a",
+			ExpectedAll: []ManifestLock{
+				{App: "app-a", Env: "dev", Active: true, EventType: ManifestLockEventTypeCreated,
+					Metadata: LockMetadata{CreatedByName: "user", CreatedByEmail: "u@example.com", Message: "lock"}},
+			},
+			ExpectedForApp: []ManifestLock{
+				{App: "app-a", Env: "dev", Active: true, EventType: ManifestLockEventTypeCreated,
+					Metadata: LockMetadata{CreatedByName: "user", CreatedByEmail: "u@example.com", Message: "lock"}},
+			},
+		},
+		{
+			Name: "locks for different apps - for-app filters correctly",
+			Locks: []lockInput{
+				{App: "app-a", Env: "dev"},
+				{App: "app-b", Env: "dev"},
+			},
+			QueryApp: "app-a",
+			ExpectedAll: []ManifestLock{
+				{App: "app-a", Env: "dev", Active: true, EventType: ManifestLockEventTypeCreated},
+				{App: "app-b", Env: "dev", Active: true, EventType: ManifestLockEventTypeCreated},
+			},
+			ExpectedForApp: []ManifestLock{
+				{App: "app-a", Env: "dev", Active: true, EventType: ManifestLockEventTypeCreated},
+			},
+		},
+		{
+			Name: "two locks for same app on different envs",
+			Locks: []lockInput{
+				{App: "app-a", Env: "dev"},
+				{App: "app-a", Env: "staging"},
+			},
+			QueryApp: "app-a",
+			ExpectedAll: []ManifestLock{
+				{App: "app-a", Env: "dev", Active: true, EventType: ManifestLockEventTypeCreated},
+				{App: "app-a", Env: "staging", Active: true, EventType: ManifestLockEventTypeCreated},
+			},
+			ExpectedForApp: []ManifestLock{
+				{App: "app-a", Env: "dev", Active: true, EventType: ManifestLockEventTypeCreated},
+				{App: "app-a", Env: "staging", Active: true, EventType: ManifestLockEventTypeCreated},
+			},
+		},
+		{
+			Name: "no locks for queried app",
+			Locks: []lockInput{
+				{App: "app-b", Env: "dev"},
+			},
+			QueryApp: "app-a",
+			ExpectedAll: []ManifestLock{
+				{App: "app-b", Env: "dev", Active: true, EventType: ManifestLockEventTypeCreated},
+			},
+			ExpectedForApp: nil,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			dbHandler := setupDB(t)
+
+			err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, tx *sql.Tx) error {
+				for _, l := range tc.Locks {
+					//exhaustruct:ignore
+					if err := dbHandler.DBWriteManifestLock(ctx, tx, l.App, l.Env, l.Metadata); err != nil {
+						return err
+					}
+				}
+
+				all, err := dbHandler.DBSelectAllActiveManifestLocks(ctx, tx)
+				if err != nil {
+					return err
+				}
+				if diff := testutil.CmpDiff(tc.ExpectedAll, all, cmpopts.IgnoreFields(ManifestLock{}, "LockID", "RecordedAt")); diff != "" {
+					t.Errorf("all-locks mismatch (-want, +got):\n%s", diff)
+				}
+
+				forApp, err := dbHandler.DBSelectAllActiveManifestLocksForApp(ctx, tx, tc.QueryApp)
+				if err != nil {
+					return err
+				}
+				if diff := testutil.CmpDiff(tc.ExpectedForApp, forApp, cmpopts.IgnoreFields(ManifestLock{}, "LockID", "RecordedAt"), cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("for-app locks mismatch (-want, +got):\n%s", diff)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("transaction error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDBDeleteManifestLock(t *testing.T) {
+	tcs := []struct {
+		Name      string
+		Locks     []lockInput
+		DeleteApp types.AppName
+		DeleteEnv types.EnvName
+		Expected  []ManifestLock
+	}{
+		{
+			Name: "write then delete leaves no active locks",
+			Locks: []lockInput{
+				{App: "app-a", Env: "dev"},
+			},
+			DeleteApp: "app-a",
+			DeleteEnv: "dev",
+			Expected:  nil,
+		},
+		{
+			Name: "delete one of two locks - other remains",
+			Locks: []lockInput{
+				{App: "app-a", Env: "dev"},
+				{App: "app-a", Env: "staging"},
+			},
+			DeleteApp: "app-a",
+			DeleteEnv: "dev",
+			Expected: []ManifestLock{
+				{App: "app-a", Env: "staging", Active: true, EventType: ManifestLockEventTypeCreated},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			dbHandler := setupDB(t)
+
+			err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, tx *sql.Tx) error {
+				for _, l := range tc.Locks {
+					//exhaustruct:ignore
+					if err := dbHandler.DBWriteManifestLock(ctx, tx, l.App, l.Env, l.Metadata); err != nil {
+						return err
+					}
+				}
+				if err := dbHandler.DBDeleteManifestLock(ctx, tx, tc.DeleteApp, tc.DeleteEnv); err != nil {
+					return err
+				}
+				locks, err := dbHandler.DBSelectAllActiveManifestLocks(ctx, tx)
+				if err != nil {
+					return err
+				}
+				if diff := testutil.CmpDiff(tc.Expected, locks, cmpopts.IgnoreFields(ManifestLock{}, "LockID", "RecordedAt"), cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("active locks after delete (-want, +got):\n%s", diff)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("transaction error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -33,6 +33,8 @@ type AppName string
 
 type ArgoBracketName string
 
+type ManifestLockID int64
+
 type ArgoProjectName string
 
 func EnvNamesToStrings(a []EnvName) []string {

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -413,6 +413,41 @@ func (o *OverviewServiceServer) GetAllEnvTeamLocks(ctx context.Context,
 	})
 }
 
+func (o *OverviewServiceServer) GetAllManifestLocks(ctx context.Context,
+	in *api.GetAllManifestLocksRequest) (*api.GetAllManifestLocksResponse, error) {
+
+	span, ctx := tracer.StartSpanFromContext(ctx, "GetAllManifestLocks")
+	defer span.Finish()
+
+	return db.WithTransactionT(o.DBHandler, ctx, 2, true, func(ctx context.Context, transaction *sql.Tx) (*api.GetAllManifestLocksResponse, error) {
+		locks, err := o.DBHandler.DBSelectAllActiveManifestLocks(ctx, transaction)
+		if err != nil {
+			return nil, err
+		}
+		response := api.GetAllManifestLocksResponse{
+			ManifestLocks: make([]*api.ManifestLockInfo, 0, len(locks)),
+		}
+		for _, l := range locks {
+			response.ManifestLocks = append(response.ManifestLocks, &api.ManifestLockInfo{
+				App: string(l.App),
+				Env: string(l.Env),
+				Lock: &api.Lock{
+					LockId:    fmt.Sprintf("%d", l.LockID),
+					Message:   l.Metadata.Message,
+					CreatedAt: timestamppb.New(l.Metadata.CreatedAt),
+					CreatedBy: &api.Actor{
+						Name:  l.Metadata.CreatedByName,
+						Email: l.Metadata.CreatedByEmail,
+					},
+					CiLink:            l.Metadata.CiLink,
+					SuggestedLifetime: l.Metadata.SuggestedLifeTime,
+				},
+			})
+		}
+		return &response, nil
+	})
+}
+
 func (o *OverviewServiceServer) getOverviewDB(
 	ctx context.Context,
 	s *repository.State) (*api.GetOverviewResponse, error) {

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -427,6 +427,9 @@ func (o *OverviewServiceServer) GetAllManifestLocks(ctx context.Context,
 		response := api.GetAllManifestLocksResponse{
 			ManifestLocks: make([]*api.ManifestLockInfo, 0, len(locks)),
 		}
+		if locks == nil {
+			return &response, nil
+		}
 		for _, l := range locks {
 			response.ManifestLocks = append(response.ManifestLocks, &api.ManifestLockInfo{
 				App: string(l.App),

--- a/services/frontend-service/pkg/cmd/server.go
+++ b/services/frontend-service/pkg/cmd/server.go
@@ -819,6 +819,12 @@ func (p *GrpcProxy) GetAllEnvTeamLocks(
 	return p.OverviewClient.GetAllEnvTeamLocks(ctx, in)
 }
 
+func (p *GrpcProxy) GetAllManifestLocks(
+	ctx context.Context,
+	in *api.GetAllManifestLocksRequest) (*api.GetAllManifestLocksResponse, error) {
+	return p.OverviewClient.GetAllManifestLocks(ctx, in)
+}
+
 func (p *GrpcProxy) GetGitTags(
 	ctx context.Context,
 	in *api.GetGitTagsRequest) (*api.GetGitTagsResponse, error) {

--- a/services/frontend-service/src/ui/App/index.test.tsx
+++ b/services/frontend-service/src/ui/App/index.test.tsx
@@ -32,6 +32,7 @@ const mock_GetConfig = Spy('Config');
 const mock_StreamOverview = Spy('Overview');
 const mock_GetAllAppLocks = Spy('AllAppLocks');
 const mock_GetAllEnvTeamLocks = Spy('AllEnvLocks');
+const mock_GetAllManifestLocks = Spy('AllManifestLocks');
 const mock_StreamStatus = Spy('Status');
 const mock_StreamGitSyncStatus = Spy('GitSyncStatus');
 
@@ -46,6 +47,7 @@ jest.mock('../utils/GrpcApi', () => ({
                 StreamOverview: () => mock_StreamOverview(),
                 GetAllAppLocks: () => mock_GetAllAppLocks(),
                 GetAllEnvTeamLocks: () => mock_GetAllEnvTeamLocks(),
+                GetAllManifestLocks: () => mock_GetAllManifestLocks(),
             }),
             rolloutService: () => ({
                 StreamStatus: () => mock_StreamStatus(),
@@ -84,6 +86,7 @@ describe('App uses the API', () => {
         mock_StreamGitSyncStatus.returns(new Observable(() => {}));
         mock_GetAllAppLocks.returns(Promise.resolve('test'));
         mock_GetAllEnvTeamLocks.returns(Promise.resolve('test'));
+        mock_GetAllManifestLocks.returns(Promise.resolve({ manifestLocks: [] }));
         mock_GetConfig.returns(Promise.resolve('test-config'));
         AzureAuthSub.set({ authReady: true });
         mock_StreamStatus.returns(
@@ -120,6 +123,7 @@ describe('App uses the API', () => {
         );
         mock_GetAllAppLocks.returns(Promise.resolve('test'));
         mock_GetAllEnvTeamLocks.returns(Promise.resolve('test'));
+        mock_GetAllManifestLocks.returns(Promise.resolve({ manifestLocks: [] }));
         mock_GetConfig.returns(Promise.resolve('test-config'));
         AzureAuthSub.set({ authReady: true });
 

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -28,6 +28,7 @@ import {
     showSnackbarWarn,
     UpdateAllApplicationLocks,
     updateAllEnvLocks,
+    UpdateAllManifestLocks,
     updateAppDetails,
     UpdateFrontendConfig,
     UpdateGitSyncStatus,
@@ -165,6 +166,15 @@ export const App: React.FC = () => {
                             })
                             .catch((e) => {
                                 PanicOverview.set({ error: JSON.stringify({ msg: 'error in GetAllEnvTeamLocks', e }) });
+                            });
+                        // Get Manifest Locks
+                        api.overviewService()
+                            .GetAllManifestLocks({}, authHeader)
+                            .then((res) => {
+                                UpdateAllManifestLocks.set(res);
+                            })
+                            .catch((e) => {
+                                PanicOverview.set({ error: JSON.stringify({ msg: 'error in GetAllManifestLocks', e }) });
                             });
                     },
                     (error) => {

--- a/services/frontend-service/src/ui/App/index.tsx
+++ b/services/frontend-service/src/ui/App/index.tsx
@@ -171,10 +171,12 @@ export const App: React.FC = () => {
                         api.overviewService()
                             .GetAllManifestLocks({}, authHeader)
                             .then((res) => {
-                                UpdateAllManifestLocks.set(res);
+                                UpdateAllManifestLocks.set({ response: res });
                             })
                             .catch((e) => {
-                                PanicOverview.set({ error: JSON.stringify({ msg: 'error in GetAllManifestLocks', e }) });
+                                PanicOverview.set({
+                                    error: JSON.stringify({ msg: 'error in GetAllManifestLocks', e }),
+                                });
                             });
                     },
                     (error) => {

--- a/services/frontend-service/src/ui/Pages/Locks/LocksPage.test.tsx
+++ b/services/frontend-service/src/ui/Pages/Locks/LocksPage.test.tsx
@@ -18,6 +18,7 @@ import { LocksPage } from './LocksPage';
 import {
     DisplayLock,
     UpdateAllApplicationLocks,
+    UpdateAllManifestLocks,
     UpdateOverview,
     updateAllEnvLocks,
     useAllLocks,
@@ -28,6 +29,7 @@ import { MemoryRouter } from 'react-router-dom';
 import {
     AllAppLocks,
     Environment,
+    ManifestLockInfo,
     OverviewApplication,
     Priority,
     Locks,
@@ -799,4 +801,68 @@ describe('Test Team locks', () => {
             expect(obtained.map((lock) => lock.lockId)).toStrictEqual(testcase.expectedLockIDs);
         });
     });
+});
+
+describe('Test manifest locks filter', () => {
+    const twoManifestLocks: ManifestLockInfo[] = [
+        {
+            app: 'app-alpha',
+            env: 'dev',
+            lock: { lockId: 'manifest-lock-1', message: 'lock alpha', ciLink: '', suggestedLifetime: '', createdAt: new Date(2024, 0, 1), createdBy: undefined },
+        },
+        {
+            app: 'app-beta',
+            env: 'dev',
+            lock: { lockId: 'manifest-lock-2', message: 'lock beta', ciLink: '', suggestedLifetime: '', createdAt: new Date(2024, 0, 2), createdBy: undefined },
+        },
+    ];
+
+    interface dataT {
+        name: string;
+        urlPath: string;
+        expectedLockIDs: string[];
+    }
+
+    const tcs: dataT[] = [
+        {
+            name: 'no filter shows all manifest locks',
+            urlPath: '/',
+            expectedLockIDs: ['manifest-lock-1', 'manifest-lock-2'],
+        },
+        {
+            name: 'filter matching one app shows only that lock',
+            urlPath: '/?application=app-alpha',
+            expectedLockIDs: ['manifest-lock-1'],
+        },
+        {
+            name: 'filter matching no app shows no manifest locks',
+            urlPath: '/?application=no-match',
+            expectedLockIDs: [],
+        },
+    ];
+
+    for (const tc of tcs) {
+        it(tc.name, () => {
+            // given
+            fakeLoadEverything(true);
+            UpdateAllManifestLocks.set({ response: { manifestLocks: twoManifestLocks } });
+            const { container } = render(
+                <MemoryRouter initialEntries={[tc.urlPath]}>
+                    <LocksPage />
+                </MemoryRouter>
+            );
+            // when
+            const manifestTable = Array.from(container.getElementsByClassName('mdc-data-table')).find((el) =>
+                el.textContent?.includes('Manifest Locks')
+            );
+            // then
+            const shownLockIDs = tc.expectedLockIDs.every((id) => manifestTable?.textContent?.includes(id));
+            const hiddenLockIDs = twoManifestLocks
+                .map((l) => l.lock?.lockId ?? '')
+                .filter((id) => !tc.expectedLockIDs.includes(id))
+                .every((id) => !manifestTable?.textContent?.includes(id));
+            expect(shownLockIDs).toBe(true);
+            expect(hiddenLockIDs).toBe(true);
+        });
+    }
 });

--- a/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
@@ -132,20 +132,22 @@ export const LocksPage: React.FC = () => {
     }, [allAppLocks, appNameParam]);
 
     const manifestLocks = useMemo(() => {
-        const display: DisplayLock[] = (manifestLocksResponse.manifestLocks ?? []).map((info) => ({
-            date: info.lock?.createdAt,
-            environment: info.env,
-            application: info.app,
-            lockId: info.lock?.lockId ?? '',
-            message: info.lock?.message ?? '',
-            authorName: info.lock?.createdBy?.name,
-            authorEmail: info.lock?.createdBy?.email,
-            ciLink: info.lock?.ciLink ?? '',
-            suggestedLifetime: info.lock?.suggestedLifetime ?? '',
-            isManifestLock: true,
-        }));
+        const display: DisplayLock[] = (manifestLocksResponse.response.manifestLocks ?? [])
+            .map((info) => ({
+                date: info.lock?.createdAt,
+                environment: info.env,
+                application: info.app,
+                lockId: info.lock?.lockId ?? '',
+                message: info.lock?.message ?? '',
+                authorName: info.lock?.createdBy?.name,
+                authorEmail: info.lock?.createdBy?.email,
+                ciLink: info.lock?.ciLink ?? '',
+                suggestedLifetime: info.lock?.suggestedLifetime ?? '',
+                isManifestLock: true,
+            }))
+            .filter((lock) => searchCustomFilter(appNameParam, lock.application));
         return sortLocks(display, 'oldestToNewest');
-    }, [manifestLocksResponse]);
+    }, [manifestLocksResponse, appNameParam]);
 
     const element = useGlobalLoadingState();
     if (element) {
@@ -163,7 +165,11 @@ export const LocksPage: React.FC = () => {
                 <LocksTable headerTitle="Environment Locks" columnHeaders={environmentFieldHeaders} locks={envLocks} />
                 <LocksTable headerTitle="Application Locks" columnHeaders={applicationFieldHeaders} locks={appLocks} />
                 <LocksTable headerTitle="Team Locks" columnHeaders={teamFieldHeaders} locks={teamLocks} />
-                <LocksTable headerTitle="Manifest Locks" columnHeaders={manifestLockFieldHeaders} locks={manifestLocks} />
+                <LocksTable
+                    headerTitle="Manifest Locks"
+                    columnHeaders={manifestLockFieldHeaders}
+                    locks={manifestLocks}
+                />
             </main>
         </div>
     );

--- a/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
+++ b/services/frontend-service/src/ui/Pages/Locks/LocksPage.tsx
@@ -21,6 +21,7 @@ import {
     sortLocks,
     useAllApplicationLocks,
     useAllEnvLocks,
+    useAllManifestLocks,
     useApplications,
     useGlobalLoadingState,
     useTeamLocks,
@@ -63,6 +64,19 @@ const environmentFieldHeaders = [
     'Suggested Lifetime',
     '',
 ];
+
+const manifestLockFieldHeaders = [
+    'Date',
+    'Environment',
+    'Application',
+    'Lock Id',
+    'Message',
+    'Author Name',
+    'Author Email',
+    'Suggested Lifetime',
+    '',
+];
+
 export const LocksPage: React.FC = () => {
     const [params] = useSearchParams();
     const appNameParam = params.get('application');
@@ -70,6 +84,7 @@ export const LocksPage: React.FC = () => {
     const allAppLocks = useAllApplicationLocks((map) => map);
     const allEnvLocks = useAllEnvLocks((map) => map.allEnvLocks);
     let teamLocks = useTeamLocks(allApps);
+    const manifestLocksResponse = useAllManifestLocks((r) => r);
     const envLocks = useMemo(() => {
         const allEnvLocksDisplay: DisplayLock[] = [];
         Object.entries(allEnvLocks).forEach(([env, envLocks]): void => {
@@ -116,6 +131,22 @@ export const LocksPage: React.FC = () => {
         );
     }, [allAppLocks, appNameParam]);
 
+    const manifestLocks = useMemo(() => {
+        const display: DisplayLock[] = (manifestLocksResponse.manifestLocks ?? []).map((info) => ({
+            date: info.lock?.createdAt,
+            environment: info.env,
+            application: info.app,
+            lockId: info.lock?.lockId ?? '',
+            message: info.lock?.message ?? '',
+            authorName: info.lock?.createdBy?.name,
+            authorEmail: info.lock?.createdBy?.email,
+            ciLink: info.lock?.ciLink ?? '',
+            suggestedLifetime: info.lock?.suggestedLifetime ?? '',
+            isManifestLock: true,
+        }));
+        return sortLocks(display, 'oldestToNewest');
+    }, [manifestLocksResponse]);
+
     const element = useGlobalLoadingState();
     if (element) {
         return element;
@@ -132,6 +163,7 @@ export const LocksPage: React.FC = () => {
                 <LocksTable headerTitle="Environment Locks" columnHeaders={environmentFieldHeaders} locks={envLocks} />
                 <LocksTable headerTitle="Application Locks" columnHeaders={applicationFieldHeaders} locks={appLocks} />
                 <LocksTable headerTitle="Team Locks" columnHeaders={teamFieldHeaders} locks={teamLocks} />
+                <LocksTable headerTitle="Manifest Locks" columnHeaders={manifestLockFieldHeaders} locks={manifestLocks} />
             </main>
         </div>
     );

--- a/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.tsx
+++ b/services/frontend-service/src/ui/components/LockDisplay/LockDisplay.tsx
@@ -110,7 +110,8 @@ export const LockDisplay: React.FC<{ lock: DisplayLock }> = (props) => {
                     )}
                     <Button
                         className="lock-display-info lock-action service-action--delete"
-                        onClick={deleteLock}
+                        onClick={lock.isManifestLock ? undefined : deleteLock}
+                        disabled={lock.isManifestLock}
                         icon={<Delete />}
                         highlightEffect={false}
                     />

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -112,8 +112,12 @@ export const [useAllEnvLocks, updateAllEnvLocks] = createStore<{
     allTeamLocks: emptyTeamLocks,
 });
 
-export const emptyManifestLocks: GetAllManifestLocksResponse = { manifestLocks: [] };
-export const [useAllManifestLocks, UpdateAllManifestLocks] = createStore<GetAllManifestLocksResponse>(emptyManifestLocks);
+type ManifestLocksResponse = {
+    response: GetAllManifestLocksResponse;
+};
+
+export const emptyManifestLocks: ManifestLocksResponse = { response: { manifestLocks: [] } };
+export const [useAllManifestLocks, UpdateAllManifestLocks] = createStore<ManifestLocksResponse>(emptyManifestLocks);
 
 type TagsResponse = {
     response: GetGitTagsResponse;

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -28,6 +28,7 @@ import {
     GetFailedEslsResponse,
     GetFrontendConfigResponse,
     GetGitSyncStatusResponse,
+    GetAllManifestLocksResponse,
     GetGitTagsResponse,
     GetManifestsResponse,
     GetOverviewResponse,
@@ -65,6 +66,7 @@ export interface DisplayLock {
     authorEmail?: string;
     ciLink: string;
     suggestedLifetime: string;
+    isManifestLock?: boolean;
 }
 
 export interface ReleaseNumbers {
@@ -109,6 +111,9 @@ export const [useAllEnvLocks, updateAllEnvLocks] = createStore<{
     allEnvLocks: emptyEnvLocks,
     allTeamLocks: emptyTeamLocks,
 });
+
+export const emptyManifestLocks: GetAllManifestLocksResponse = { manifestLocks: [] };
+export const [useAllManifestLocks, UpdateAllManifestLocks] = createStore<GetAllManifestLocksResponse>(emptyManifestLocks);
 
 type TagsResponse = {
     response: GetGitTagsResponse;

--- a/services/manifest-repo-export-service/pkg/repository/repository_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository_test.go
@@ -2965,3 +2965,115 @@ func TestCombineTransformerResult(t *testing.T) {
 		})
 	}
 }
+
+func TestManifestLockPreventsDeployment(t *testing.T) {
+	const manifestFile = "environments/production/applications/test/manifests/manifests.yaml"
+	tcs := []struct {
+		Name             string
+		WriteLock        bool
+		DeleteLock       bool
+		ExpectManifest   bool
+	}{
+		{
+			Name:           "no lock - manifest is written",
+			WriteLock:      false,
+			DeleteLock:     false,
+			ExpectManifest: true,
+		},
+		{
+			Name:           "active lock - manifest is not written",
+			WriteLock:      true,
+			DeleteLock:     false,
+			ExpectManifest: false,
+		},
+		{
+			Name:           "deleted lock - manifest is written",
+			WriteLock:      true,
+			DeleteLock:     true,
+			ExpectManifest: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutilauth.MakeTestContext()
+			repo, dbHandler, _ := SetupRepositoryTestWithDB(t)
+			repoInternal := repo.(*repository)
+
+			setupTransformers := []Transformer{
+				&CreateEnvironment{
+					Environment: "production",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{Latest: true},
+						ArgoCd:   &config.EnvironmentConfigArgoCd{Destination: config.ArgoCdDestination{Server: "production"}},
+					},
+					TransformerMetadata: TransformerMetadata{AuthorName: "test", AuthorEmail: "test@example.com"},
+				},
+				&CreateApplicationVersion{
+					Application: "test",
+					Manifests:   map[types.EnvName]string{"production": "manifest-content"},
+					Version:     1,
+					TransformerMetadata: TransformerMetadata{AuthorName: "test", AuthorEmail: "test@example.com"},
+				},
+			}
+
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				for _, tr := range setupTransformers {
+					prepareDatabaseLikeCdService(ctx, transaction, tr, dbHandler, t, "test@example.com", "test")
+				}
+				return nil
+			})
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				for _, tr := range setupTransformers {
+					_, applyErr := repoInternal.ApplyTransformer(ctx, transaction, tr)
+					if applyErr != nil {
+						t.Fatalf("setup transformer failed: %v", applyErr)
+					}
+				}
+				return nil
+			})
+
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				if tc.WriteLock {
+					//exhaustruct:ignore
+					if err := dbHandler.DBWriteManifestLock(ctx, transaction, "test", "production", db.LockMetadata{}); err != nil {
+						t.Fatalf("DBWriteManifestLock: %v", err)
+					}
+				}
+				if tc.DeleteLock {
+					if err := dbHandler.DBDeleteManifestLock(ctx, transaction, "test", "production"); err != nil {
+						t.Fatalf("DBDeleteManifestLock: %v", err)
+					}
+				}
+				return nil
+			})
+
+			deployTransformer := &DeployApplicationVersion{
+				Application:         "test",
+				Environment:         "production",
+				Version:             1,
+				TransformerMetadata: TransformerMetadata{AuthorName: "test", AuthorEmail: "test@example.com"},
+			}
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				prepareDatabaseLikeCdService(ctx, transaction, deployTransformer, dbHandler, t, "test@example.com", "test")
+				return nil
+			})
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				_, applyErr := repoInternal.ApplyTransformer(ctx, transaction, deployTransformer)
+				if applyErr != nil {
+					t.Fatalf("deploy transformer failed: %v", applyErr)
+				}
+				return nil
+			})
+
+			state := repo.State()
+			_, statErr := state.Filesystem.Stat(manifestFile)
+			manifestExists := !errors.Is(statErr, os.ErrNotExist)
+			if diff := testutil.CmpDiff(tc.ExpectManifest, manifestExists); diff != "" {
+				t.Errorf("manifest existence mismatch (-want, +got):\n%s\nFiles present:\n%s", diff, strings.Join(listFiles(state.Filesystem), "\n"))
+			}
+		})
+	}
+}

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -109,6 +109,17 @@ func writeManifests(fs billy.Filesystem, parentPath string, envManifest string) 
 	return nil
 }
 
+func writeManifestsIfNoManifestLock(ctx context.Context, dbHandler *db.DBHandler, transaction *sql.Tx, fs billy.Filesystem, parentPath string, envManifest string, app types.AppName, env types.EnvName) error {
+	hasLock, err := dbHandler.DBHasActiveManifestLock(ctx, transaction, app, env)
+	if err != nil {
+		return err
+	}
+	if hasLock {
+		return nil
+	}
+	return writeManifests(fs, parentPath, envManifest)
+}
+
 // releasesDirectoryWithVersion returns applications/<app>/releases/<version>
 func releasesDirectoryWithVersion(fs billy.Filesystem, application string, version types.ReleaseNumbers) string {
 	return fs.Join(releasesDirectory(fs, application), versionToString(version))
@@ -417,7 +428,7 @@ func (c *DeployApplicationVersion) Transform(
 	}
 
 	if state.ArgoRenderOptions.RenderApps {
-		if err := writeManifests(fsys, manifestsDir, manifestContent); err != nil {
+		if err := writeManifestsIfNoManifestLock(ctx, state.DBHandler, transaction, fsys, manifestsDir, manifestContent, types.AppName(c.Application), c.Environment); err != nil {
 			return "", err
 		}
 	}

--- a/services/rollout-service/pkg/versions/versions_test.go
+++ b/services/rollout-service/pkg/versions/versions_test.go
@@ -140,6 +140,10 @@ func (m *mockOverviewClient) Recv() (*api.GetChangedAppsResponse, error) {
 	return reply.ChangedApps, reply.RecvErr
 }
 
+func (m *mockOverviewClient) GetAllManifestLocks(ctx context.Context, in *api.GetAllManifestLocksRequest, opts ...grpc.CallOption) (*api.GetAllManifestLocksResponse, error) {
+	return nil, nil
+}
+
 var _ api.OverviewServiceClient = (*mockOverviewClient)(nil)
 
 type mockVersionClient struct {


### PR DESCRIPTION
This creates a new table, and read-only interaction for a new kind of lock: Manifest-locks.
It also displays manifest-locks in the UI.

Manifest-locks are intended to stop the manifest-export from overwriting a specific file in an emergency situation.

Interactions like adding and removing locks in the UI will be added in another PR.

Ref: SRX-1V3OAY