### PR TITLE
feat: Render Manifest-Locks on service lane

### DIFF
--- a/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
+++ b/services/frontend-service/src/ui/components/ServiceLane/ServiceLane.tsx
@@ -22,12 +22,13 @@ import {
     updateAppDetails,
     useAppDetailsForApp,
     useEnvironments,
+    useManifestsLockForApp,
     useMinorsForApp,
     useNavigateWithSearchParams,
 } from '../../utils/store';
 import { ReleaseCard } from '../ReleaseCard/ReleaseCard';
 import { DeleteWhite, HistoryWhite } from '../../../images';
-import { OverviewApplication } from '../../../api/api';
+import { ManifestLockInfo, OverviewApplication } from '../../../api/api';
 import * as React from 'react';
 import { useCallback, useState } from 'react';
 import { AppLockSummary } from '../chip/EnvironmentGroupChip';
@@ -438,6 +439,7 @@ export const ReadyServiceLane: React.FC<{
     const dotsMenu = <DotsMenu buttons={buttons} />;
     const appLocks = Object.values(appDetails?.appLocks ? appDetails.appLocks : []);
     const teamLocks = Object.values(appDetails?.teamLocks ? appDetails.teamLocks : []);
+    const manifestLocks: ManifestLockInfo[] = useManifestsLockForApp(application.name);
     const app = appDetails?.application ? appDetails?.application?.name : '';
     const dialog = (
         <EnvDelDialog
@@ -465,7 +467,20 @@ export const ReadyServiceLane: React.FC<{
                 <div className="service-lane-wrapper">
                     {appLocks.length + teamLocks.length >= 1 && (
                         <div className={'test-app-lock-summary'}>
-                            <AppLockSummary app={application.name} numLocks={appLocks.length + teamLocks.length} />
+                            <AppLockSummary
+                                app={application.name}
+                                numLocks={appLocks.length + teamLocks.length}
+                                isManifestLock={false}
+                            />
+                        </div>
+                    )}
+                    {manifestLocks.length >= 1 && (
+                        <div className={'test-app-lock-summary'}>
+                            <AppLockSummary
+                                app={application.name}
+                                numLocks={manifestLocks.length}
+                                isManifestLock={true}
+                            />
                         </div>
                     )}
                     <ServiceLaneHeaderData application={props.application}></ServiceLaneHeaderData>

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
@@ -31,18 +31,30 @@ import { ArgoAppEnvLink, ArgoAppMultiEnvLink } from '../../utils/Links';
 export const AppLockSummary: React.FC<{
     app: string;
     numLocks: number;
-}> = ({ app, numLocks }) => {
-    const plural = numLocks === 1 ? 'lock' : 'locks';
+    isManifestLock: boolean;
+}> = ({ app, numLocks, isManifestLock }) => {
+    const plural = isManifestLock
+        ? numLocks === 1
+            ? 'manifest-lock'
+            : 'manifest-locks'
+        : numLocks === 1
+          ? 'lock'
+          : 'locks';
+    const cssClass: string = isManifestLock ? 'app-lock-summary-manifest-lock' : '';
+    const message: string = isManifestLock ? 'M-Locked' : 'Locked';
+    const title: string = isManifestLock
+        ? 'Go to the locks page on /ui/locks to see details.'
+        : 'Click on a tile to see details.';
     return (
         <div
-            className={'app-lock-summary'}
+            className={'app-lock-summary ' + cssClass}
             key={'app-lock-hint-' + app}
-            title={'"' + app + '" has ' + numLocks + ' ' + plural + '. Click on a tile to see details.'}>
+            title={'"' + app + '" has ' + numLocks + ' ' + plural + '. ' + title}>
             <div className={'app-lock-summary-wrapper'}>
                 <div className={'app-lock-summary-lock'}>
                     <LocksWhite className="env-card-env-lock-icon" width="20px" height="20px" />
                 </div>
-                <div className={'app-lock-summary-text'}>Locked</div>
+                <div className={'app-lock-summary-text'}>{message}</div>
             </div>
         </div>
     );

--- a/services/frontend-service/src/ui/components/chip/chip.scss
+++ b/services/frontend-service/src/ui/components/chip/chip.scss
@@ -113,3 +113,7 @@ Copyright freiheit.com*/
         margin-top: 8px;
     }
 }
+
+.app-lock-summary.app-lock-summary-manifest-lock {
+    background-color: var(--mdc-theme-error);
+}

--- a/services/frontend-service/src/ui/utils/store.tsx
+++ b/services/frontend-service/src/ui/utils/store.tsx
@@ -42,6 +42,7 @@ import {
     StreamStatusResponse,
     TagData,
     Warning,
+    ManifestLockInfo,
 } from '../../api/api';
 import * as React from 'react';
 import { useCallback, useMemo } from 'react';
@@ -118,6 +119,9 @@ type ManifestLocksResponse = {
 
 export const emptyManifestLocks: ManifestLocksResponse = { response: { manifestLocks: [] } };
 export const [useAllManifestLocks, UpdateAllManifestLocks] = createStore<ManifestLocksResponse>(emptyManifestLocks);
+
+export const useManifestsLockForApp = (appName: string): ManifestLockInfo[] =>
+    useAllManifestLocks(({ response }) => response.manifestLocks.filter((lock) => lock.app === appName));
 
 type TagsResponse = {
     response: GetGitTagsResponse;


### PR DESCRIPTION
The Service Lane now renders the new Manifest-Locks like this:
<img width="643" height="256" alt="Screenshot from 2026-05-11 13-11-05" src="https://github.com/user-attachments/assets/47b85ab9-5980-4261-bd9d-f617c9f93eb5" />

Just the normal app lock:
<img width="643" height="256" alt="Screenshot from 2026-05-11 13-11-44" src="https://github.com/user-attachments/assets/974e7bb4-ae7b-4279-950e-6e2115035a04" />

Both combined:
<img width="643" height="256" alt="Screenshot from 2026-05-11 13-11-24" src="https://github.com/user-attachments/assets/eaf82fb3-2513-4913-8721-dd9685650207" />

No locks:
<img width="643" height="256" alt="Screenshot from 2026-05-11 13-11-57" src="https://github.com/user-attachments/assets/339a5b4b-56c4-4685-83aa-9464cb7468d0" />


Ref: SRX-1V3OAY