### PR TITLE
fix: do not write manifest in bracket mode

### DIFF
--- a/services/manifest-repo-export-service/pkg/repository/repository_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository_test.go
@@ -2969,10 +2969,10 @@ func TestCombineTransformerResult(t *testing.T) {
 func TestManifestLockPreventsDeployment(t *testing.T) {
 	const manifestFile = "environments/production/applications/test/manifests/manifests.yaml"
 	tcs := []struct {
-		Name             string
-		WriteLock        bool
-		DeleteLock       bool
-		ExpectManifest   bool
+		Name           string
+		WriteLock      bool
+		DeleteLock     bool
+		ExpectManifest bool
 	}{
 		{
 			Name:           "no lock - manifest is written",
@@ -3012,9 +3012,9 @@ func TestManifestLockPreventsDeployment(t *testing.T) {
 					TransformerMetadata: TransformerMetadata{AuthorName: "test", AuthorEmail: "test@example.com"},
 				},
 				&CreateApplicationVersion{
-					Application: "test",
-					Manifests:   map[types.EnvName]string{"production": "manifest-content"},
-					Version:     1,
+					Application:         "test",
+					Manifests:           map[types.EnvName]string{"production": "manifest-content"},
+					Version:             1,
 					TransformerMetadata: TransformerMetadata{AuthorName: "test", AuthorEmail: "test@example.com"},
 				},
 			}
@@ -3073,6 +3073,122 @@ func TestManifestLockPreventsDeployment(t *testing.T) {
 			manifestExists := !errors.Is(statErr, os.ErrNotExist)
 			if diff := testutil.CmpDiff(tc.ExpectManifest, manifestExists); diff != "" {
 				t.Errorf("manifest existence mismatch (-want, +got):\n%s\nFiles present:\n%s", diff, strings.Join(listFiles(state.Filesystem), "\n"))
+			}
+		})
+	}
+}
+
+func TestManifestLockPreventsDeploymentInBracketMode(t *testing.T) {
+	const bracketManifestFile = "environments/production/brackets/test/test.yaml"
+	tcs := []struct {
+		Name           string
+		WriteLock      bool
+		DeleteLock     bool
+		ExpectManifest bool
+	}{
+		{
+			Name:           "no lock - bracket manifest is written",
+			WriteLock:      false,
+			DeleteLock:     false,
+			ExpectManifest: true,
+		},
+		{
+			Name:           "active lock - bracket manifest is not written",
+			WriteLock:      true,
+			DeleteLock:     false,
+			ExpectManifest: false,
+		},
+		{
+			Name:           "deleted lock - bracket manifest is written",
+			WriteLock:      true,
+			DeleteLock:     true,
+			ExpectManifest: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutilauth.MakeTestContext()
+			repo, _ := setupRepositoryTestWithPath(t, func(opts *argocd.RenderOptions) {
+				opts.RenderApps = false
+				opts.RenderBrackets = true
+				opts.PointToBrackets = true
+			})
+			repoInternal := repo.(*repository)
+			dbHandler := repo.State().DBHandler
+
+			setupTransformers := []Transformer{
+				&CreateEnvironment{
+					Environment: "production",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{Latest: true},
+						ArgoCd:   &config.EnvironmentConfigArgoCd{Destination: config.ArgoCdDestination{Server: "production"}},
+					},
+					TransformerMetadata: TransformerMetadata{AuthorName: "test", AuthorEmail: "test@example.com"},
+				},
+				&CreateApplicationVersion{
+					Application:         "test",
+					Manifests:           map[types.EnvName]string{"production": "manifest-content"},
+					Version:             1,
+					TransformerMetadata: TransformerMetadata{AuthorName: "test", AuthorEmail: "test@example.com"},
+				},
+			}
+
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				for _, tr := range setupTransformers {
+					prepareDatabaseLikeCdService(ctx, transaction, tr, dbHandler, t, "test@example.com", "test")
+				}
+				return nil
+			})
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				for _, tr := range setupTransformers {
+					_, applyErr := repoInternal.ApplyTransformer(ctx, transaction, tr)
+					if applyErr != nil {
+						t.Fatalf("setup transformer failed: %v", applyErr)
+					}
+				}
+				return nil
+			})
+
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				if tc.WriteLock {
+					//exhaustruct:ignore
+					if err := dbHandler.DBWriteManifestLock(ctx, transaction, "test", "production", db.LockMetadata{}); err != nil {
+						t.Fatalf("DBWriteManifestLock: %v", err)
+					}
+				}
+				if tc.DeleteLock {
+					if err := dbHandler.DBDeleteManifestLock(ctx, transaction, "test", "production"); err != nil {
+						t.Fatalf("DBDeleteManifestLock: %v", err)
+					}
+				}
+				return nil
+			})
+
+			deployTransformer := &DeployApplicationVersion{
+				Application:         "test",
+				Environment:         "production",
+				Version:             1,
+				TransformerMetadata: TransformerMetadata{AuthorName: "test", AuthorEmail: "test@example.com"},
+			}
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				prepareDatabaseLikeCdService(ctx, transaction, deployTransformer, dbHandler, t, "test@example.com", "test")
+				return nil
+			})
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				_, applyErr := repoInternal.ApplyTransformer(ctx, transaction, deployTransformer)
+				if applyErr != nil {
+					t.Fatalf("deploy transformer failed: %v", applyErr)
+				}
+				return nil
+			})
+
+			state := repo.State()
+			_, statErr := state.Filesystem.Stat(bracketManifestFile)
+			manifestExists := !errors.Is(statErr, os.ErrNotExist)
+			if diff := testutil.CmpDiff(tc.ExpectManifest, manifestExists); diff != "" {
+				t.Errorf("manifest existence mismatch (-want, +got):\n%s\nFiles present:\n%s\nActual err=%v", diff, strings.Join(listFiles(state.Filesystem), "\n"), statErr)
 			}
 		})
 	}

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -96,20 +96,20 @@ func environmentApplicationDirectory(fs billy.Filesystem, environment types.EnvN
 }
 
 // writeManifests writes the manifests.yaml file to the given parent path
-func writeManifests(fs billy.Filesystem, parentPath string, envManifest string) error {
+func writeManifests(fs billy.Filesystem, completeFilePath string, envManifest string) error {
 	// When we undeploy applications, the manifests will be empty.
 	// The function we are using here is `util.WriteFile`. And that does not allow overwriting files with empty content.
 	// We work around this unusual behavior by writing a space into the file
 	if envManifest == "" {
 		envManifest = " "
 	}
-	if err := util.WriteFile(fs, fs.Join(parentPath, "manifests.yaml"), []byte(envManifest), 0666); err != nil {
+	if err := util.WriteFile(fs, completeFilePath, []byte(envManifest), 0666); err != nil {
 		return err
 	}
 	return nil
 }
 
-func writeManifestsIfNoManifestLock(ctx context.Context, dbHandler *db.DBHandler, transaction *sql.Tx, fs billy.Filesystem, parentPath string, envManifest string, app types.AppName, env types.EnvName) error {
+func writeManifestsIfNoManifestLock(ctx context.Context, dbHandler *db.DBHandler, transaction *sql.Tx, fs billy.Filesystem, completePath string, envManifest string, app types.AppName, env types.EnvName) error {
 	hasLock, err := dbHandler.DBHasActiveManifestLock(ctx, transaction, app, env)
 	if err != nil {
 		return err
@@ -117,7 +117,7 @@ func writeManifestsIfNoManifestLock(ctx context.Context, dbHandler *db.DBHandler
 	if hasLock {
 		return nil
 	}
-	return writeManifests(fs, parentPath, envManifest)
+	return writeManifests(fs, completePath, envManifest)
 }
 
 // releasesDirectoryWithVersion returns applications/<app>/releases/<version>
@@ -428,7 +428,7 @@ func (c *DeployApplicationVersion) Transform(
 	}
 
 	if state.ArgoRenderOptions.RenderApps {
-		if err := writeManifestsIfNoManifestLock(ctx, state.DBHandler, transaction, fsys, manifestsDir, manifestContent, types.AppName(c.Application), c.Environment); err != nil {
+		if err := writeManifestsIfNoManifestLock(ctx, state.DBHandler, transaction, fsys, fsys.Join(manifestsDir, "manifests.yaml"), manifestContent, types.AppName(c.Application), c.Environment); err != nil {
 			return "", err
 		}
 	}
@@ -499,7 +499,8 @@ func (c *DeployApplicationVersion) writeBracketFiles(ctx context.Context, state 
 	if err := fsys.MkdirAll(dir.BracketDirectory, 0777); err != nil {
 		return "", fmt.Errorf("could not create directory %s: %v", dir.BracketDirectory, err)
 	}
-	if err := util.WriteFile(fsys, dir.BracketPath, manifestContent, 0666); err != nil {
+	err = writeManifestsIfNoManifestLock(ctx, state.DBHandler, transaction, fsys, dir.BracketPath, string(manifestContent), types.AppName(c.Application), c.Environment)
+	if err != nil {
 		return "", fmt.Errorf("could not write bracket for deployment of app %s on env %s: %v", c.Application, envName, err)
 	}
 	return "", nil
@@ -872,7 +873,7 @@ func (c *CreateApplicationVersion) Transform(
 			if err = fs.MkdirAll(envDir, 0777); err != nil {
 				return "", GetCreateReleaseGeneralFailure(err)
 			}
-			err = writeManifests(fs, envDir, man)
+			err = writeManifests(fs, fs.Join(envDir, "manifests.yaml"), man)
 			if err != nil {
 				return "", GetCreateReleaseGeneralFailure(err)
 			}
@@ -1230,7 +1231,7 @@ func (c *RenderEnvironment) Transform(
 				return "", fmt.Errorf("could not create directory %s: %v", manifestsDir, err)
 			}
 
-			if err := writeManifests(fs, manifestsDir, envManifest); err != nil {
+			if err := writeManifests(fs, fs.Join(manifestsDir, "manifests.yaml"), envManifest); err != nil {
 				return "", fmt.Errorf("could not write manifests for app '%s' on env '%s': %v", appName, c.Environment, err)
 			}
 

--- a/services/manifest-repo-export-service/pkg/repository/transformer_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer_test.go
@@ -2046,27 +2046,27 @@ spec:
 			err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
 				err := dbHandler.DBWriteMigrationsTransformer(ctx, transaction)
 				if err != nil {
-					return err
+					return fmt.Errorf("migration error: %w", err)
 				}
-				for _, tr := range tc.SetupTransformers {
+				for index, tr := range tc.SetupTransformers {
 					err := dbHandler.DBWriteEslEventInternal(ctx, tr.GetDBEventType(), transaction, t, db.ESLMetadata{AuthorName: tr.GetMetadata().AuthorName, AuthorEmail: tr.GetMetadata().AuthorEmail})
 					if err != nil {
-						return err
+						return fmt.Errorf("setup transformer[%d] failed: %w", index, err)
 					}
 					prepareDatabaseLikeCdService(ctx, transaction, tr, dbHandler, t, authorEmail, authorName)
 				}
 
-				for _, t := range tc.SetupTransformers {
+				for index, t := range tc.SetupTransformers {
 					err := repo.Apply(ctx, transaction, t)
 					if err != nil {
-						return err
+						return fmt.Errorf("apply[%d] failed: %w", index, err)
 					}
 					// just for testing, we push each transformer change separately.
 					// if you need to debug this test, you can git clone the repo
 					// and we will only see anything if we push.
 					err = repo.PushRepo(ctx)
 					if err != nil {
-						return err
+						return fmt.Errorf("push[%d] failed: %w", index, err)
 					}
 				}
 				return nil
@@ -2120,6 +2120,9 @@ spec:
 				}
 				return nil
 			})
+			if err != nil {
+				t.Fatalf("failed to execute transaction: %v", err)
+			}
 
 			updatedState = repo.State()
 			if err := verifyContent(updatedState.Filesystem, tc.ExpectedFiles); err != nil {


### PR DESCRIPTION
When writing a file to the manifest repo in bracket mode, we also do not want to write the file
if there is a manifest-lock.

Ref: SRX-1V3OAY