### PR TITLE
fix: simplify go mod in Dockerfiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,10 @@ Build a single service Docker image:
 IMAGE_TAG=local make -C services/cd-service docker
 ```
 
+## Docker Concept
+Our "builder" Dockerfile contains the go.mod and runs go mod download.
+Other Dockerfiles that depend on it, should not use go mod download again. They just copy from the builder.
+
 ## Testing
 
 Tests run inside Docker using the builder image and connect to a test PostgreSQL instance.

--- a/infrastructure/docker/builder/Dockerfile
+++ b/infrastructure/docker/builder/Dockerfile
@@ -38,4 +38,5 @@ RUN HELM_SHA256=$(case "$TARGETARCH" in \
 WORKDIR /kp
 
 COPY go.mod go.sum ./
+RUN go mod download
 

--- a/services/cd-service/Dockerfile
+++ b/services/cd-service/Dockerfile
@@ -20,13 +20,14 @@ RUN chown -R kp:kp /kp
 USER kp
 WORKDIR /kp
 
+COPY --from=builder --chown=kp:kp /go/pkg/mod /kp/go/pkg/mod
+
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 RUN go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.5.1
 
 COPY --from=builder /kp/go.mod ./go.mod
 COPY --from=builder /kp/go.sum ./go.sum
-RUN go mod download
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo

--- a/services/frontend-service/Dockerfile
+++ b/services/frontend-service/Dockerfile
@@ -29,8 +29,6 @@ ADD services/frontend-service/.eslintrc /kp/services/frontend-service/
 
 # go:
 WORKDIR /kp/
-COPY go.sum go.mod .
-RUN go mod download
 ADD services/frontend-service/cmd/server/ /kp/services/frontend-service/cmd/server/
 ADD services/frontend-service/pkg /kp/services/frontend-service/pkg
 ADD services/frontend-service/src /kp/services/frontend-service/src

--- a/services/manifest-repo-export-service/Dockerfile
+++ b/services/manifest-repo-export-service/Dockerfile
@@ -30,13 +30,14 @@ RUN chown -R kp:kp /kp
 USER kp
 WORKDIR /kp
 
+COPY --from=builder --chown=kp:kp /go/pkg/mod /kp/go/pkg/mod
+
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 RUN go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.5.1
 
 COPY --from=builder /kp/go.mod ./go.mod
 COPY --from=builder /kp/go.sum ./go.sum
-RUN go mod download
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo


### PR DESCRIPTION
We now run go mod download only in one place: the builder.

Ref: SRX-O9UH81