### PR TITLE
fix: use same logic for combining bracket versions

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -48,6 +48,14 @@ func RolloutAppBracketVersionFromUint64(v uint64) RolloutAppBracketVersion {
 	return RolloutAppBracketVersion(fmt.Sprintf("%d", v))
 }
 
+// JoinBracketVersionFromParts joins sorted per-app version numbers into the canonical
+// bracket version wire format (colon-separated with a trailing colon).
+// The trailing colon makes single-app brackets ("42:") distinguishable from plain
+// app versions ("42") wherever the string is used as a revision.
+func JoinBracketVersionFromParts(deployedVersions []string) RolloutAppBracketVersion {
+	return RolloutAppBracketVersion(strings.Join(deployedVersions, ":") + ":")
+}
+
 // ToUint64 returns the numeric value and true for single-app versions.
 // Returns 0, false for bracket versions.
 func (v RolloutAppBracketVersion) ToUint64() (uint64, bool) {

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"slices"
 	"sort"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -756,7 +755,7 @@ func combineBracketDeployments(appDetails []*api.GetAppDetailsResponse, bracketE
 			}
 		}
 
-		version := strings.Join(versionParts, ":")
+		version := string(types.JoinBracketVersionFromParts(versionParts))
 		if len(versionParts) == 0 {
 			version = string(types.BracketVersionDelete)
 		}

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -3142,7 +3142,7 @@ func TestCombineBracketDeployments(t *testing.T) {
 			Apps:        []*api.GetAppDetailsResponse{app1, app2, app3},
 			BracketEnvs: []string{"dev"},
 			WantVersions: map[string]string{
-				"dev": "1:3:0", // aaa→1, bbb→3, ccc→0 (not deployed)
+				"dev": "1:3:0:", // aaa→1, bbb→3, ccc→0 (not deployed)
 			},
 			WantCommit: map[string]string{
 				"dev": "commit-bbb-3", // bbb has latest deploy_time
@@ -3154,7 +3154,7 @@ func TestCombineBracketDeployments(t *testing.T) {
 			Apps:        []*api.GetAppDetailsResponse{app3, app2, app1}, // ccc, bbb, aaa — reversed
 			BracketEnvs: []string{"dev"},
 			WantVersions: map[string]string{
-				"dev": "1:3:0", // sorted: aaa→1, bbb→3, ccc→0
+				"dev": "1:3:0:", // sorted: aaa→1, bbb→3, ccc→0
 			},
 			WantCommit: map[string]string{
 				"dev": "commit-bbb-3",
@@ -3166,7 +3166,7 @@ func TestCombineBracketDeployments(t *testing.T) {
 			Apps:        []*api.GetAppDetailsResponse{app1, app2},
 			BracketEnvs: []string{"dev"},
 			WantVersions: map[string]string{
-				"dev": "1:3",
+				"dev": "1:3:",
 			},
 			WantCommit: map[string]string{
 				"dev": "commit-bbb-3",
@@ -3186,7 +3186,7 @@ func TestCombineBracketDeployments(t *testing.T) {
 			Apps:        []*api.GetAppDetailsResponse{app3}, // ccc has no dev deployment
 			BracketEnvs: []string{"dev"},
 			WantVersions: map[string]string{
-				"dev": "0",
+				"dev": "0:",
 			},
 			WantCommit:       map[string]string{"dev": ""},
 			WantDeployedEnvs: []string{"dev"},
@@ -3196,7 +3196,7 @@ func TestCombineBracketDeployments(t *testing.T) {
 			Apps:        []*api.GetAppDetailsResponse{app3, app3}, // both have no dev deployment
 			BracketEnvs: []string{"dev"},
 			WantVersions: map[string]string{
-				"dev": "0:0",
+				"dev": "0:0:",
 			},
 			WantCommit:       map[string]string{"dev": ""},
 			WantDeployedEnvs: []string{"dev"},

--- a/services/reposerver-service/pkg/reposerver/reposerver.go
+++ b/services/reposerver-service/pkg/reposerver/reposerver.go
@@ -173,7 +173,7 @@ func (r *reposerver) generateBracketManifest(ctx context.Context, split []string
 
 		return &bracketResult{
 			manifests: mn,
-			revision:  strings.Join(versionParts, ":") + ":",
+			revision:  string(types.JoinBracketVersionFromParts(versionParts)),
 		}, nil
 	})
 	if err != nil {

--- a/services/rollout-service/pkg/notifier/notifier.go
+++ b/services/rollout-service/pkg/notifier/notifier.go
@@ -68,8 +68,8 @@ func (n *notifier) NotifyArgoCd(ctx context.Context, environment, application st
 			Refresh: conversion.FromString(string(argoappv1.RefreshTypeNormal)),
 		})
 		if err != nil {
-			if !strings.Contains(err.Error(), "DeadlineExceeded") ||
-				!strings.Contains(err.Error(), "deadline exceeded") ||
+			if !strings.Contains(err.Error(), "DeadlineExceeded") &&
+				!strings.Contains(err.Error(), "deadline exceeded") &&
 				!strings.Contains(err.Error(), "context canceled") {
 				l.Error("argocd.refresh", zap.Error(err))
 			}


### PR DESCRIPTION
The slightly misaligned formats of the cd-service `v1:v2` vs reposerver `v1:v2:` had lead to argo cd needing to sync, even though the versions are semantically the same. This fixes the issue and improves logging.


Ref: SRX-VRKPNL