### PR TITLE
fix: kind test script improvements

### DIFF
--- a/charts/kuberpult/Makefile
+++ b/charts/kuberpult/Makefile
@@ -63,6 +63,10 @@ test-helm: $(TGZ_FILE) Chart.yaml
 test: ct-test test-helm
 
 kind-test:
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "Error: working tree has uncommitted changes. Run charts/kuberpult/run-kind.sh instead (it rebuilds images from your local source)."; \
+		exit 1; \
+	fi
 	cd ../../ && go test -v ./tests/kind-brackets/ -timeout 20m
 
 clean:

--- a/charts/kuberpult/install-kuberpult-helm.sh
+++ b/charts/kuberpult/install-kuberpult-helm.sh
@@ -10,7 +10,7 @@ function print() {
 
 print 'installing kuberpult helm chart...'
 
-token=$(argocd account generate-token --server localhost:8080 --account kuberpult --insecure)
+token=$(argocd account generate-token --server localhost:5001 --account kuberpult --insecure)
 
 echo "argocd token: $token" # this is only ok because this script is only used locally for a temporary cluster. Never do this on production.
 
@@ -141,9 +141,9 @@ kubectl get pods
 
 print "port forwarding to cd service..."
 waitForDeployment "default" "app=kuberpult-cd-service"
-portForwardAndWait "default" deployment/kuberpult-cd-service 8082 8080
-portForwardAndWait "default" deployment/kuberpult-cd-service 8083 8443
+portForwardAndWait "default" deployment/kuberpult-cd-service 5003 8080
+portForwardAndWait "default" deployment/kuberpult-cd-service 5004 8443
 
 waitForDeployment "default" "app=kuberpult-frontend-service"
-portForwardAndWait "default" "deployment/kuberpult-frontend-service" "8081" "8081"
+portForwardAndWait "default" "deployment/kuberpult-frontend-service" "5002" "8081"
 print "connection to frontend service successful"

--- a/charts/kuberpult/install-kuberpult-helm.sh
+++ b/charts/kuberpult/install-kuberpult-helm.sh
@@ -10,6 +10,7 @@ function print() {
 
 print 'installing kuberpult helm chart...'
 
+portForwardAndWait "default" service/argocd-server 5001 443
 token=$(argocd account generate-token --server localhost:5001 --account kuberpult --insecure)
 
 echo "argocd token: $token" # this is only ok because this script is only used locally for a temporary cluster. Never do this on production.

--- a/charts/kuberpult/lib.sh
+++ b/charts/kuberpult/lib.sh
@@ -31,7 +31,7 @@ function portForwardAndWait() {
   # Loop so the forward auto-restarts whenever the target pod is replaced (e.g. after helm upgrade).
   while kubectl cluster-info &>/dev/null 2>&1; do kubectl -n "$ns" port-forward "$deployment" "$ports" 2>/dev/null || true; sleep 2; done &
   print "portForwardAndWait: waiting until the port forward works..."
-  sleep 10
+  sleep 1
   until nc -vz localhost "$portHere"
   do
     sleep 3

--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -5,7 +5,9 @@ source "$(dirname "$0")/lib.sh"
 
 set -eu
 set -o pipefail
-trap 'kill 0' EXIT SIGINT SIGTERM
+
+# avoid infinite trap invocations in shell by resetting trap handler on trap:
+trap 'trap - EXIT SIGINT SIGTERM; kill 0' EXIT SIGINT SIGTERM
 
 # This script assumes that the docker images have already been built.
 # To run/debug/develop this locally, you probably want to run like this:
@@ -209,6 +211,9 @@ portForwardAndWait "default" service/argocd-server 8080 443
 
 # For now, we are only creating development here
 # This means argo cd will only handle development, including the rollout-status
+
+# when testing on our gke environment, note that the namespace is different:
+#export ARGO_NAMESPACE=tools
 kubectl apply -f - <<EOF
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
@@ -330,6 +335,7 @@ kubectl get pods
 START=30
 NUM_RELEASES=2
 END=$((START + NUM_RELEASES))
+
 for v in $(seq "$START" "$END")
 do
    RELEASE_VERSION=$v ../../infrastructure/scripts/create-testdata/create-release-allparams.sh echo-1 sreteam e
@@ -357,6 +363,7 @@ fi
 
 print "running bracket stability integration tests..."
 make kind-test
+
 
 if "$LOCAL_EXECUTION"
 then

--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -71,12 +71,12 @@ $GPG --armor --export kuberpult-kind@example.com > kuberpult-keyring.gpg
 
 print "setting up manifest repo"
 waitForDeployment "git" "app.kubernetes.io/name=server"
-portForwardAndWait "git" "deployment/server" "2222" "22"
+portForwardAndWait "git" "deployment/server" "5000" "22"
 
 rm -f emptyfile
 rm -rf manifests
 print "cloning..."
-GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=emptyfile -o StrictHostKeyChecking=no -i ../../services/cd-service/client' git clone ssh://git@localhost:2222/git/repos/manifests
+GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=emptyfile -o StrictHostKeyChecking=no -i ../../services/cd-service/client' git clone ssh://git@localhost:5000/git/repos/manifests
 
 cd manifests
 pwd
@@ -207,7 +207,7 @@ print applying app...
 
 #waitForDeployment "default" "app.kubernetes.io/name=argocd-repo-server"
 waitForDeployment "default" "app.kubernetes.io/name=argocd-server"
-portForwardAndWait "default" service/argocd-server 8080 443
+portForwardAndWait "default" service/argocd-server 5001 443
 
 # For now, we are only creating development here
 # This means argo cd will only handle development, including the rollout-status
@@ -309,7 +309,7 @@ argocd_adminpw=$(kubectl -n default get secret argocd-initial-admin-secret -o js
 echo "$argocd_adminpw"
 echo "$argocd_adminpw" > argocd_adminpw.txt
 
-argocd login localhost:8080 --username admin --password "$argocd_adminpw" --insecure
+argocd login localhost:5001 --username admin --password "$argocd_adminpw" --insecure
 
 
 
@@ -330,6 +330,8 @@ print 'checking for pods and waiting for portforwarding to be ready...'
 kubectl get deployment
 kubectl get pods
 
+export FRONTEND_PORT=5002
+export CD_GRPC_PORT=5004
 (cd ../../infrastructure/scripts/create-testdata/ ; sh create-environments.sh)
 
 START=30
@@ -363,7 +365,6 @@ fi
 
 print "running bracket stability integration tests..."
 make kind-test
-
 
 if "$LOCAL_EXECUTION"
 then

--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -350,19 +350,6 @@ RELEASE_VERSION=$v ../../infrastructure/scripts/create-testdata/create-release-a
 RELEASE_VERSION=$v ../../infrastructure/scripts/create-testdata/create-release-allparams.sh echo-2 sreteam e
 RELEASE_VERSION=$v ../../infrastructure/scripts/create-testdata/create-release-allparams.sh foo-1 sreteam f
 
-
-
-if false;
-then
-  for v in $(seq 1 3)
-  do
-     RELEASE_VERSION=$v ../../infrastructure/scripts/create-testdata/create-release-allparams.sh echo-3 sreteam e
-     RELEASE_VERSION=$v ../../infrastructure/scripts/create-testdata/create-release-allparams.sh foo-1 sreteam f
-
-     #RELEASE_VERSION=$v ../../infrastructure/scripts/create-testdata/create-release-allparams.sh foo-1 sreteam f
-  done
-fi
-
 print "running bracket stability integration tests..."
 make kind-test
 

--- a/infrastructure/scripts/create-testdata/create-app-lock.sh
+++ b/infrastructure/scripts/create-testdata/create-app-lock.sh
@@ -8,7 +8,7 @@ source "$(dirname "$0")/ports.sh"
 env=staging
 lockId=test${RANDOM}
 app=${1}
-url="http://localhost:${FRONTEND_PORT}/environments/${env}/applications/${app}/locks/${lockId}"
+url="${URL}:${FRONTEND_PORT}/environments/${env}/applications/${app}/locks/${lockId}"
 
 curl -X PUT "$url" -d '{"message": "test app lock"}' -H 'Content-Type: application/json'
 

--- a/infrastructure/scripts/create-testdata/create-env-group-lock.sh
+++ b/infrastructure/scripts/create-testdata/create-env-group-lock.sh
@@ -8,7 +8,7 @@ source "$(dirname "$0")/ports.sh"
 envGroup=prod
 lockId=lockIdTest${RANDOM}
 lockId=lockIdIntegration0
-url="http://localhost:${FRONTEND_PORT}/environment-groups/${envGroup}/locks/${lockId}"
+url="${URL}${FRONTEND_PORT}/environment-groups/${envGroup}/locks/${lockId}"
 echo "$url"
 useSignature=false
 if ${useSignature}

--- a/infrastructure/scripts/create-testdata/create-env-lock.sh
+++ b/infrastructure/scripts/create-testdata/create-env-lock.sh
@@ -7,7 +7,7 @@ set -x
 source "$(dirname "$0")/ports.sh"
 env=staging
 lockId=lockIdTest${RANDOM}
-url="http://localhost:${FRONTEND_PORT}/environments/${env}/locks/${lockId}"
+url="${URL}${FRONTEND_PORT}/environments/${env}/locks/${lockId}"
 
 curl -X PUT "$url" -d '{"message": "test env lock"}' -H 'Content-Type: application/json'
 

--- a/infrastructure/scripts/create-testdata/create-environments.sh
+++ b/infrastructure/scripts/create-testdata/create-environments.sh
@@ -20,11 +20,11 @@ for filename in "$testData"/*; do
   if $useOldApi; then
     curl  -f -X POST -H "multipart/form-data" \
           --form-string "config=${DATA}" \
-           http://localhost:"${FRONTEND_PORT}"/environments/"${env}"
+           ${URL}:"${FRONTEND_PORT}"/environments/"${env}"
   else
     curl  -w "%{http_code}\n" -X POST -H "multipart/form-data" \
           --form-string "config=${DATA}" \
-           http://localhost:"${FRONTEND_PORT}"/api/environments/"${env}"
+           ${URL}:"${FRONTEND_PORT}"/api/environments/"${env}"
   fi
   echo # curl sometimes does not print a trailing \n
 done

--- a/infrastructure/scripts/create-testdata/create-release-allparams.sh
+++ b/infrastructure/scripts/create-testdata/create-release-allparams.sh
@@ -160,7 +160,7 @@ inputs+=(--form-string "source_commit_id=$commit_id")
 inputs+=(--form-string "source_author=$author")
 inputs+=(--form-string "previous_commit_id=${prev_commit_id}")
 
-curl http://localhost:"${FRONTEND_PORT}"/api/release \
+curl ${URL}:"${FRONTEND_PORT}"/api/release \
   -H "author-email:${EMAIL}" \
   -H "author-name:${AUTHOR}=" \
   "${inputs[@]}" \

--- a/infrastructure/scripts/create-testdata/create-release.sh
+++ b/infrastructure/scripts/create-testdata/create-release.sh
@@ -116,7 +116,7 @@ fi
 
 debug "useOldApi=$useOldApi"
 if $useOldApi; then
-  curl http://localhost:"${FRONTEND_PORT}"/release \
+  curl ${URL}:"${FRONTEND_PORT}"/release \
     -H "author-email:${EMAIL}" \
     -H "author-name:${AUTHOR}=" \
     "${inputs[@]}" \
@@ -127,7 +127,7 @@ if $useOldApi; then
     "${configuration[@]}" \
     "${manifests[@]}"
 else
-  curl http://localhost:"${FRONTEND_PORT}"/api/release \
+  curl ${URL}:"${FRONTEND_PORT}"/api/release \
     -H "author-email:${EMAIL}" \
     -H "author-name:${AUTHOR}=" \
     -H "client-uuid:${clientUUID}" \

--- a/infrastructure/scripts/create-testdata/create-team-lock.sh
+++ b/infrastructure/scripts/create-testdata/create-team-lock.sh
@@ -10,7 +10,7 @@ team=${1}
 env=${2:-development}
 lockId=test${RANDOM}
 
-url="http://localhost:${FRONTEND_PORT}/api/environments/${env}/lock/team/${team}/${lockId}"
+url="${URL}${FRONTEND_PORT}/api/environments/${env}/lock/team/${team}/${lockId}"
 
 curl -X PUT "$url" -d '{"message": "test team lock"}' -H 'Content-Type: application/json'
 

--- a/infrastructure/scripts/create-testdata/delete-app-lock.sh
+++ b/infrastructure/scripts/create-testdata/delete-app-lock.sh
@@ -9,7 +9,7 @@ env=staging
 
 lockId=${2}
 app=${1}
-url="http://localhost:${FRONTEND_PORT}/environments/${env}/applications/${app}/locks/${lockId}"
+url="${URL}${FRONTEND_PORT}/environments/${env}/applications/${app}/locks/${lockId}"
 
 curl -X DELETE "$url" -H 'Content-Type: application/json'
 

--- a/infrastructure/scripts/create-testdata/delete-env-group-lock.sh
+++ b/infrastructure/scripts/create-testdata/delete-env-group-lock.sh
@@ -8,7 +8,7 @@ source "$(dirname "$0")/ports.sh"
 envGroup=prod
 
 lockId=${1}
-url="http://localhost:${FRONTEND_PORT}/environment-groups/${envGroup}/locks/${lockId}"
+url="${URL}${FRONTEND_PORT}/environment-groups/${envGroup}/locks/${lockId}"
 
 curl -X DELETE "$url" -H 'Content-Type: application/json'
 

--- a/infrastructure/scripts/create-testdata/delete-env-lock.sh
+++ b/infrastructure/scripts/create-testdata/delete-env-lock.sh
@@ -8,7 +8,7 @@ source "$(dirname "$0")/ports.sh"
 env=staging
 
 lockId=${1}
-url="http://localhost:${FRONTEND_PORT}/environments/${env}/locks/${lockId}"
+url="${URL}${FRONTEND_PORT}/environments/${env}/locks/${lockId}"
 
 curl -X DELETE "$url" -H 'Content-Type: application/json'
 

--- a/infrastructure/scripts/create-testdata/delete-environments-with-signature.sh
+++ b/infrastructure/scripts/create-testdata/delete-environments-with-signature.sh
@@ -13,6 +13,6 @@ source "$(dirname "$0")/ports.sh"
 env=${1}
 curl  -f -X DELETE  \
     --form signature=@"$env".yaml.sig \
-    http://localhost:"${FRONTEND_PORT}"/api/environments/"${env}" -v
+    ${URL}"${FRONTEND_PORT}"/api/environments/"${env}" -v
 
 echo # curl sometimes does not print a trailing \n

--- a/infrastructure/scripts/create-testdata/delete-environments.sh
+++ b/infrastructure/scripts/create-testdata/delete-environments.sh
@@ -12,6 +12,6 @@ source "$(dirname "$0")/ports.sh"
 env=${1}
 
 curl  -f -X DELETE  \
-    http://localhost:"${FRONTEND_PORT}"/api/environments/"${env}"
+    ${URL}"${FRONTEND_PORT}"/api/environments/"${env}"
 
 echo # curl sometimes does not print a trailing \n

--- a/infrastructure/scripts/create-testdata/delete-team-lock.sh
+++ b/infrastructure/scripts/create-testdata/delete-team-lock.sh
@@ -9,7 +9,7 @@ env=development
 team=${1}
 lockId=${2}
 
-url="http://localhost:${FRONTEND_PORT}/api/environments/${env}/lock/team/${team}/${lockId}"
+url="${URL}${FRONTEND_PORT}/api/environments/${env}/lock/team/${team}/${lockId}"
 
 curl -X DELETE "$url" -H 'Content-Type: application/json'
 

--- a/infrastructure/scripts/create-testdata/env-group-status.sh
+++ b/infrastructure/scripts/create-testdata/env-group-status.sh
@@ -6,7 +6,7 @@ set -x
 # shellcheck source=ports.sh
 source "$(dirname "$0")/ports.sh"
 envGroup="${1:-development}"
-url="http://localhost:${FRONTEND_PORT}/environment-groups/${envGroup}/rollout-status"
+url="${URL}${FRONTEND_PORT}/environment-groups/${envGroup}/rollout-status"
 useSignature=false
 if ${useSignature}
 then

--- a/infrastructure/scripts/create-testdata/get-process-delay.sh
+++ b/infrastructure/scripts/create-testdata/get-process-delay.sh
@@ -10,4 +10,4 @@ set -o pipefail
 source "$(dirname "$0")/ports.sh"
 
 curl  -f -X GET  \
-    "http://localhost:${FRONTEND_PORT}/api/process-delay/" | jq .
+    "${URL}${FRONTEND_PORT}/api/process-delay/" | jq .

--- a/infrastructure/scripts/create-testdata/ports.sh
+++ b/infrastructure/scripts/create-testdata/ports.sh
@@ -15,12 +15,14 @@ if [ -f "${_REPO_ROOT}/.env.local" ]; then
     set +a
 fi
 
+if [ -z "$FRONTEND_PORT" ] || [ -z "$CD_GRPC_PORT" ]; then
 if [ -n "$_REPO_ROOT" ] && command -v docker &>/dev/null && command -v jq &>/dev/null; then
     _DC_JSON=$(docker compose -f "${_REPO_ROOT}/docker-compose.yml" config --format json 2>/dev/null || true)
     if [ -n "$_DC_JSON" ]; then
-        FRONTEND_PORT=$(printf '%s' "$_DC_JSON" | jq -r '.services["frontend-service"].ports[] | select(.target == 8081) | .published // empty' 2>/dev/null || true)
-        CD_GRPC_PORT=$(printf '%s' "$_DC_JSON" | jq -r '.services["cd-service"].ports[] | select(.target == 8443) | .published // empty' 2>/dev/null || true)
+        [ -z "$FRONTEND_PORT" ] && FRONTEND_PORT=$(printf '%s' "$_DC_JSON" | jq -r '.services["frontend-service"].ports[] | select(.target == 8081) | .published // empty' 2>/dev/null || true)
+        [ -z "$CD_GRPC_PORT" ] && CD_GRPC_PORT=$(printf '%s' "$_DC_JSON" | jq -r '.services["cd-service"].ports[] | select(.target == 8443) | .published // empty' 2>/dev/null || true)
     fi
+fi
 fi
 
 if [ -z "$FRONTEND_PORT" ]; then
@@ -35,3 +37,7 @@ CD_GRPC_PORT=${CD_GRPC_PORT:-8443}
 
 export FRONTEND_PORT CD_GRPC_PORT
 unset _REPO_ROOT _DC_JSON
+
+export URL=http://localhost
+
+echo "using url: ${URL}" > /dev/stderr

--- a/infrastructure/scripts/create-testdata/run-releasetrain-prognosis.sh
+++ b/infrastructure/scripts/create-testdata/run-releasetrain-prognosis.sh
@@ -6,7 +6,7 @@ set -o pipefail
 # shellcheck source=ports.sh
 source "$(dirname "$0")/ports.sh"
 env=${1:-fakeprod-ca}
-url="http://localhost:${FRONTEND_PORT}/api/environments/${env}/releasetrain/prognosis"
+url="${URL}${FRONTEND_PORT}/api/environments/${env}/releasetrain/prognosis"
 
 
 curl -X GET "$url"

--- a/infrastructure/scripts/create-testdata/run-releasetrain.sh
+++ b/infrastructure/scripts/create-testdata/run-releasetrain.sh
@@ -10,9 +10,9 @@ clientUUID="12345678-1234-1234-1234-123456789012"
 source "$(dirname "$0")/ports.sh"
 env=${1:-fakeprod-ca}
 if test "$#" -eq 2; then
-  url="http://localhost:${FRONTEND_PORT}/api/environments/${env}/releasetrain?""$2"
+  url="${URL}:${FRONTEND_PORT}/api/environments/${env}/releasetrain?""$2"
 else
-  url="http://localhost:${FRONTEND_PORT}/api/environments/${env}/releasetrain"
+  url="${URL}:${FRONTEND_PORT}/api/environments/${env}/releasetrain"
 fi
 
 

--- a/infrastructure/scripts/create-testdata/stress_testing/create-releases.sh
+++ b/infrastructure/scripts/create-testdata/stress_testing/create-releases.sh
@@ -150,7 +150,7 @@ EOF
     fi
     index=$((RANDOM % sizeAuthors))
     author="${authors[$index]}"
-      time curl http://localhost:"${FRONTEND_PORT}"/release \
+      time curl ${URL}"${FRONTEND_PORT}"/release \
         -H "author-email:${EMAIL}" \
         -H "author-name:${AUTHOR}=" \
         "${inputs[@]}" \


### PR DESCRIPTION
- Improved trap handler
- allow overwriting base URL in testdata scripts
- use different ports in run-kind as opposed to docker-compose
-  ensure argocd is up before getting a token
- in make, force user to commit before running tests

Ref: SRX-VRKPNL