### PR TITLE
fix: improve kind-brackets tests

### DIFF
--- a/tests/kind-brackets/bracket_migration_test.go
+++ b/tests/kind-brackets/bracket_migration_test.go
@@ -701,13 +701,7 @@ func TestBracketMoveBetweenBrackets(t *testing.T) {
 
 // TestBracketMoveAndBack is the regression test for the scenario where an app
 // moves from bracket1 to bracket2 and then back to bracket1.
-//
-// The first move (b1→b2) may work due to lucky ArgoCD finalizer timing.
-// The second move (b2→b1) is more likely to fail because bracket1 must be
-// RECREATED (it was deleted after move 1), and bracket2's cascade-delete
-// finalizer may race against bracket1's re-creation and prune the pod.
-//
-// Both moves are checked independently so it is clear which transition fails.
+// Previously this had lead to deployment deletions.
 func TestBracketMoveAndBack(t *testing.T) {
 	cleanupCluster(t)
 	tLogf(t, "runSuffix: %s", runSuffix)

--- a/tests/kind-brackets/bracket_migration_test.go
+++ b/tests/kind-brackets/bracket_migration_test.go
@@ -18,26 +18,26 @@ package kindbracketstest
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
-	auth "github.com/freiheit-com/kuberpult/pkg/auth"
 	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
+	auth "github.com/freiheit-com/kuberpult/pkg/auth"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
-const cdServiceGrpcAddr = "localhost:8083"
+const cdServiceGrpcAddr = "localhost:5004"
+const argoNamespace = "default"
 
-// helmUpgrade calls helm upgrade with the bracket staging cluster override and waits
-// for the rollout-service deployment to finish rolling out.
-// It calls helm directly (not install-kuberpult-helm.sh) to avoid port-forward side
-// effects and dependency rebuild overhead.
-func helmUpgrade(t *testing.T, stagingEnabled bool) {
+// helmUpgrade calls helm upgrade with the given bracket configuration and waits
+// for all services to finish rolling out.
+func helmUpgrade(t *testing.T, bracketsEnabled, developmentEnabled, stagingEnabled bool, channelSize int) {
 	t.Helper()
 	out, err := exec.Command("git", "describe", "--always", "--long", "--tags").Output()
 	if err != nil {
@@ -52,18 +52,25 @@ func helmUpgrade(t *testing.T, stagingEnabled bool) {
 	chartPath := root + "/charts/kuberpult/kuberpult-" + version + ".tgz"
 	valsPath := root + "/charts/kuberpult/vals.yaml"
 
-	stagingVal := "false"
-	if stagingEnabled {
-		stagingVal = "true"
+	boolStr := func(b bool) string {
+		if b {
+			return "true"
+		}
+		return "false"
 	}
-	t.Logf("helmUpgrade: staging=%s, chart=%s", stagingVal, chartPath)
+	tLogf(t, "helmUpgrade: enabled=%s development=%s staging=%s channelSize=%d chart=%s",
+		boolStr(bracketsEnabled), boolStr(developmentEnabled), boolStr(stagingEnabled), channelSize, chartPath)
 
 	cmd := exec.Command("helm", "upgrade", "--install",
 		"--values", valsPath,
-		"--set", "rollout.experimentalBrackets.clusters.staging="+stagingVal,
+		"--set", "rollout.experimentalBrackets.enabled="+boolStr(bracketsEnabled),
+		"--set", "rollout.experimentalBrackets.clusters.development="+boolStr(developmentEnabled),
+		"--set", "rollout.experimentalBrackets.clusters.staging="+boolStr(stagingEnabled),
+		"--set", fmt.Sprintf("rollout.kuberpultEventsChannelSize=%d", channelSize),
 		"kuberpult-local", chartPath)
 	if out2, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("helm upgrade (staging=%s): %v\n%s", stagingVal, err, out2)
+		t.Fatalf("helm upgrade (enabled=%s dev=%s staging=%s): %v\n%s",
+			boolStr(bracketsEnabled), boolStr(developmentEnabled), boolStr(stagingEnabled), err, out2)
 	}
 
 	for _, dep := range []string{
@@ -76,8 +83,15 @@ func helmUpgrade(t *testing.T, stagingEnabled bool) {
 		if err != nil {
 			t.Fatalf("kubectl rollout status %s: %v\n%s", dep, err, out3)
 		}
-		t.Logf("%s rolled out: %s", dep, strings.TrimSpace(string(out3)))
+		tLogf(t, "%s rolled out: %s", dep, strings.TrimSpace(string(out3)))
 	}
+	globalPFM.restart()
+	waitForFrontendHTTPReady(t)
+	scriptPath := root + "/infrastructure/scripts/create-testdata/create-environments.sh"
+	if out4, err := exec.Command("bash", scriptPath).CombinedOutput(); err != nil {
+		t.Fatalf("create-environments: %v\n%s", err, out4)
+	}
+	tLog(t, "create-environments: done")
 }
 
 // waitForArgoApp polls until the named Argo Application exists in the default namespace.
@@ -85,9 +99,9 @@ func waitForArgoApp(t *testing.T, name string) {
 	t.Helper()
 	deadline := time.Now().Add(argoAppWaitTimeout)
 	for time.Now().Before(deadline) {
-		out, err := exec.Command("kubectl", "get", "application", name, "-n", "default").Output()
+		out, err := exec.Command("kubectl", "get", "application", name, "-n", argoNamespace).Output()
 		if err == nil && strings.Contains(string(out), name) {
-			t.Logf("  Argo app present: %s", name)
+			tLogf(t, "  Argo app present: %s", name)
 			return
 		}
 		time.Sleep(argoAppPollInterval)
@@ -100,9 +114,9 @@ func waitForArgoAppGone(t *testing.T, name string) {
 	t.Helper()
 	deadline := time.Now().Add(argoAppGoneTimeout)
 	for time.Now().Before(deadline) {
-		_, err := exec.Command("kubectl", "get", "application", name, "-n", "default").Output()
+		_, err := exec.Command("kubectl", "get", "application", name, "-n", argoNamespace).Output()
 		if err != nil {
-			t.Logf("  Argo app gone: %s", name)
+			tLogf(t, "  Argo app gone: %s", name)
 			return
 		}
 		time.Sleep(argoAppPollInterval)
@@ -124,7 +138,8 @@ func waitForArgoAppGone(t *testing.T, name string) {
 // individual Argo Application objects are removed without pruning the K8s resources,
 // so the bracket app can take over ownership without a downtime gap.
 func TestBracketMigration(t *testing.T) {
-	t.Logf("runSuffix: %s", runSuffix)
+	cleanupCluster(t)
+	tLogf(t, "runSuffix: %s", runSuffix)
 	app1 := "bmt-app1-" + runSuffix
 	app2 := "bmt-app2-" + runSuffix
 	apps := []string{app1, app2}
@@ -134,69 +149,53 @@ func TestBracketMigration(t *testing.T) {
 	//   individual: "{env}-{appName}"   e.g. "staging-bmt-app1-XXXXX"
 	//   bracket:    "{env}-{bracketName}" e.g. "staging-bmt-bracket-XXXXX"
 
-	t.Log("step 1: upgrade to staging=false (individual Argo apps mode for staging)")
-	helmUpgrade(t, false)
+	tLog(t, "step 1: upgrade to staging=false (individual Argo apps mode for staging)")
+	helmUpgrade(t, true, false, false, 50)
 
-	t.Log("step 2: create v1 releases (dev + dev2 + staging manifests)")
+	tLog(t, "step 2: create v1 releases (dev + staging manifests)")
 	for _, app := range apps {
 		createRelease(t, app, "sreteam", migrationBracket, "1", map[string]string{
 			devNamespace:     stableManifest(app, devNamespace, "1"),
-			dev2Namespace:    stableManifest(app, dev2Namespace, "1"),
 			stagingNamespace: stableManifest(app, stagingNamespace, "1"),
 		})
 	}
 
-	t.Log("step 3: run staging release train (deploys v1 from development2 to staging)")
+	tLog(t, "step 3: run staging release train (deploys v1 from development to staging)")
 	releaseTrain(t, stagingNamespace)
 
-	t.Log("step 4: wait for v1 synced in staging (ArgoCD applied the deployment)")
+	tLog(t, "step 4: wait for v1 synced in staging (ArgoCD applied the deployment)")
 	for _, app := range apps {
 		waitForDeploymentAnnotation(t, stagingNamespace, app+"-bracket-dep", "1")
 	}
 
-	t.Log("step 5: verify individual Argo apps exist on staging")
+	tLog(t, "step 5: verify individual Argo apps exist on staging")
 	for _, app := range apps {
 		waitForArgoApp(t, "staging-"+app)
 	}
 
-	t.Log("step 6: record pod start times")
-	type podKey struct{ ns, app string }
-	startTimes := map[podKey]string{}
+	tLog(t, "step 6: record deployment creation times")
+	creationTimes := map[deploymentKey]string{}
 	for _, app := range apps {
 		for _, ns := range []string{devNamespace, stagingNamespace} {
-			k := podKey{ns, app}
-			startTimes[k] = podStartTime(t, ns, app)
-			t.Logf("  %s/%s: %s", ns, app, startTimes[k])
+			k := deploymentKey{ns, app + "-bracket-dep"}
+			creationTimes[k] = deploymentCreationTime(t, ns, app+"-bracket-dep")
+			tLogf(t, "  %s/%s: %s", ns, app+"-bracket-dep", creationTimes[k])
 		}
 	}
 
-	t.Log("step 7: upgrade to staging=true (migrate to bracket Argo app)")
-	helmUpgrade(t, true)
+	tLog(t, "step 7: upgrade to staging=true (migrate to bracket Argo app)")
+	helmUpgrade(t, true, false, true, 50)
 
-	t.Log("step 8: wait for bracket Argo app to appear on staging")
+	tLog(t, "step 8: wait for bracket Argo app to appear on staging")
 	waitForArgoApp(t, "staging-"+migrationBracket)
 
-	t.Log("step 9: wait for individual Argo apps to be deleted from staging")
+	tLog(t, "step 9: wait for individual Argo apps to be deleted from staging")
 	for _, app := range apps {
 		waitForArgoAppGone(t, "staging-"+app)
 	}
 
-	t.Log("step 10: 20s buffer to let any accidental pod churn complete")
-	time.Sleep(podChurnBuffer)
-
-	t.Log("step 11: verify pod start times have not changed (all environments)")
-	for _, app := range apps {
-		for _, ns := range []string{devNamespace, stagingNamespace} {
-			k := podKey{ns, app}
-			got := podStartTime(t, ns, app)
-			if got != startTimes[k] {
-				t.Errorf("REGRESSION: pod %s/%s was restarted during bracket migration\n  before: %s\n  after:  %s",
-					ns, app, startTimes[k], got)
-			} else {
-				t.Logf("  OK %s/%s start time stable at %s", ns, app, got)
-			}
-		}
-	}
+	tLog(t, "step 10: assert deployment creation times stable (bracket migration)")
+	assertDeploymentCreationTimesStable(t, creationTimes, "bracket migration")
 }
 
 // processBatch sends a BatchRequest to the cd-service, retrying on Unavailable
@@ -217,7 +216,9 @@ func processBatch(t *testing.T, req *api.BatchRequest) {
 			continue
 		}
 		_, lastErr = api.NewBatchServiceClient(conn).ProcessBatch(ctx, req)
-		conn.Close()
+		if err := conn.Close(); err != nil {
+			tLogf(t, "grpc conn.Close: %v", err)
+		}
 		if lastErr == nil {
 			return
 		}
@@ -246,36 +247,36 @@ func deleteEnvFromApp(t *testing.T, env, app string) {
 // (via deleteEnvFromApp) does not cause the bracket Argo Application to be deleted.
 // The bracket should persist as long as the brackets_history table has an entry.
 func TestBracketDeleteEnvFromApp(t *testing.T) {
-	t.Logf("runSuffix: %s", runSuffix)
+	cleanupCluster(t)
+	tLogf(t, "runSuffix: %s", runSuffix)
 	app := "bde-app1-" + runSuffix
 	bracket := "bde-bracket-" + runSuffix
 
-	t.Log("step 1: upgrade to staging=true (bracket mode)")
-	helmUpgrade(t, true)
+	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
+	helmUpgrade(t, true, false, true, 50)
 
-	t.Log("step 2: create v1 release (dev + dev2 + staging manifests)")
+	tLog(t, "step 2: create v1 release (dev + staging manifests)")
 	createRelease(t, app, "sreteam", bracket, "1", map[string]string{
 		devNamespace:     stableManifest(app, devNamespace, "1"),
-		dev2Namespace:    stableManifest(app, dev2Namespace, "1"),
 		stagingNamespace: stableManifest(app, stagingNamespace, "1"),
 	})
 
-	t.Log("step 3: run staging release train")
+	tLog(t, "step 3: run staging release train")
 	releaseTrain(t, stagingNamespace)
 
-	t.Log("step 4: wait for v1 synced in staging")
+	tLog(t, "step 4: wait for v1 synced in staging")
 	waitForDeploymentAnnotation(t, stagingNamespace, app+"-bracket-dep", "1")
 
-	t.Log("step 5: wait for bracket Argo app to appear on staging")
+	tLog(t, "step 5: wait for bracket Argo app to appear on staging")
 	waitForArgoApp(t, "staging-"+bracket)
 
-	t.Log("step 6: delete env from app")
+	tLog(t, "step 6: delete env from app")
 	deleteEnvFromApp(t, stagingNamespace, app)
 
-	t.Log("step 7: 30s buffer for rollout-service to reconcile")
+	tLogf(t, "step 7: %s buffer for rollout-service to reconcile", reconcileBuffer)
 	time.Sleep(reconcileBuffer)
 
-	t.Log("step 8: verify bracket Argo app still exists (must not be deleted)")
+	tLog(t, "step 8: verify bracket Argo app still exists (must not be deleted)")
 	waitForArgoApp(t, "staging-"+bracket)
 }
 
@@ -289,72 +290,59 @@ func TestBracketDeleteEnvFromApp(t *testing.T) {
 //     (apps are still members of the bracket in brackets_history), and the K8s
 //     Deployment pods are UNTOUCHED (pod start times unchanged).
 func TestBracketReverseMigration(t *testing.T) {
-	t.Logf("runSuffix: %s", runSuffix)
+	cleanupCluster(t)
+	tLogf(t, "runSuffix: %s", runSuffix)
 	app1 := "brm-app1-" + runSuffix
 	app2 := "brm-app2-" + runSuffix
 	apps := []string{app1, app2}
 	bracket := "brm-bracket-" + runSuffix
 
-	t.Log("step 1: upgrade to staging=true (bracket mode)")
-	helmUpgrade(t, true)
+	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
+	helmUpgrade(t, true, false, true, 50)
 
-	t.Log("step 2: create v1 releases (dev + dev2 + staging manifests)")
+	tLog(t, "step 2: create v1 releases (dev + staging manifests)")
 	for _, app := range apps {
 		createRelease(t, app, "sreteam", bracket, "1", map[string]string{
 			devNamespace:     stableManifest(app, devNamespace, "1"),
-			dev2Namespace:    stableManifest(app, dev2Namespace, "1"),
 			stagingNamespace: stableManifest(app, stagingNamespace, "1"),
 		})
 	}
 
-	t.Log("step 3: run staging release train (deploys v1 from development2 to staging)")
+	tLog(t, "step 3: run staging release train (deploys v1 from development to staging)")
 	releaseTrain(t, stagingNamespace)
 
-	t.Log("step 4: wait for v1 synced in staging")
+	tLog(t, "step 4: wait for v1 synced in staging")
 	for _, app := range apps {
 		waitForDeploymentAnnotation(t, stagingNamespace, app+"-bracket-dep", "1")
 	}
 
-	t.Log("step 5: wait for bracket Argo app to appear on staging")
+	tLog(t, "step 5: wait for bracket Argo app to appear on staging")
 	waitForArgoApp(t, "staging-"+bracket)
 
-	t.Log("step 6: record pod start times")
-	type podKey struct{ ns, app string }
-	startTimes := map[podKey]string{}
+	tLog(t, "step 6: record deployment creation times")
+	creationTimes := map[deploymentKey]string{}
 	for _, app := range apps {
-		k := podKey{stagingNamespace, app}
-		startTimes[k] = podStartTime(t, stagingNamespace, app)
-		t.Logf("  %s/%s: %s", stagingNamespace, app, startTimes[k])
+		k := deploymentKey{stagingNamespace, app + "-bracket-dep"}
+		creationTimes[k] = deploymentCreationTime(t, stagingNamespace, app+"-bracket-dep")
+		tLogf(t, "  %s/%s: %s", stagingNamespace, app+"-bracket-dep", creationTimes[k])
 	}
 
-	t.Log("step 7: upgrade to staging=false (revert to individual Argo apps)")
-	helmUpgrade(t, false)
+	tLog(t, "step 7: upgrade to staging=false (revert to individual Argo apps)")
+	helmUpgrade(t, true, false, false, 50)
 
-	t.Log("step 8: wait for individual Argo apps to appear on staging")
+	tLog(t, "step 8: wait for individual Argo apps to appear on staging")
 	for _, app := range apps {
 		waitForArgoApp(t, "staging-"+app)
 	}
 
-	t.Log("step 9: 30s buffer for rollout-service to reconcile")
+	tLogf(t, "step 9: %s buffer for rollout-service to reconcile", reconcileBuffer)
 	time.Sleep(reconcileBuffer)
 
-	t.Log("step 10: verify bracket Argo app is still present (apps still in brackets_history)")
+	tLog(t, "step 10: verify bracket Argo app is still present (apps still in brackets_history)")
 	waitForArgoApp(t, "staging-"+bracket)
 
-	t.Log("step 11: 20s buffer to let any accidental pod churn complete")
-	time.Sleep(podChurnBuffer)
-
-	t.Log("step 12: verify pod start times have not changed")
-	for _, app := range apps {
-		k := podKey{stagingNamespace, app}
-		got := podStartTime(t, stagingNamespace, app)
-		if got != startTimes[k] {
-			t.Errorf("REGRESSION: pod %s/%s was restarted during bracket reverse migration\n  before: %s\n  after:  %s",
-				stagingNamespace, app, startTimes[k], got)
-		} else {
-			t.Logf("  OK %s/%s start time stable at %s", stagingNamespace, app, got)
-		}
-	}
+	tLog(t, "step 11: assert pod start times stable (bracket reverse migration)")
+	assertDeploymentCreationTimesStable(t, creationTimes, "bracket reverse migration")
 }
 
 // TestBracketAddAppToExistingBracket verifies that adding a second app to an already-running
@@ -366,61 +354,53 @@ func TestBracketReverseMigration(t *testing.T) {
 //   - Expected: bracket Argo app persists, bracket version string updates to include
 //     both apps (colon-separated), and app1 pods are UNTOUCHED.
 func TestBracketAddAppToExistingBracket(t *testing.T) {
-	t.Logf("runSuffix: %s", runSuffix)
+	cleanupCluster(t)
+	tLogf(t, "runSuffix: %s", runSuffix)
 	app1 := "bae-app1-" + runSuffix
 	app2 := "bae-app2-" + runSuffix
 	bracket := "bae-bracket-" + runSuffix
 
-	t.Log("step 1: upgrade to staging=true (bracket mode)")
-	helmUpgrade(t, true)
+	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
+	helmUpgrade(t, true, false, true, 50)
 
-	t.Log("step 2: create v1 release for app1 only")
+	tLog(t, "step 2: create v1 release for app1 only")
 	createRelease(t, app1, "sreteam", bracket, "1", map[string]string{
 		devNamespace:     stableManifest(app1, devNamespace, "1"),
-		dev2Namespace:    stableManifest(app1, dev2Namespace, "1"),
 		stagingNamespace: stableManifest(app1, stagingNamespace, "1"),
 	})
 
-	t.Log("step 3: run staging release train (deploys app1 v1 to staging)")
+	tLog(t, "step 3: run staging release train (deploys app1 v1 to staging)")
 	releaseTrain(t, stagingNamespace)
 
-	t.Log("step 4: wait for app1 v1 synced in staging")
+	tLog(t, "step 4: wait for app1 v1 synced in staging")
 	waitForDeploymentAnnotation(t, stagingNamespace, app1+"-bracket-dep", "1")
 
-	t.Log("step 5: wait for bracket Argo app to appear on staging")
+	tLog(t, "step 5: wait for bracket Argo app to appear on staging")
 	waitForArgoApp(t, "staging-"+bracket)
 
-	t.Log("step 6: record app1 pod start time")
-	app1StartTime := podStartTime(t, stagingNamespace, app1)
-	t.Logf("  %s/%s: %s", stagingNamespace, app1, app1StartTime)
+	tLog(t, "step 6: record app1 deployment creation time")
+	creationTimes := map[deploymentKey]string{
+		{stagingNamespace, app1 + "-bracket-dep"}: deploymentCreationTime(t, stagingNamespace, app1+"-bracket-dep"),
+	}
+	tLogf(t, "  %s/%s: %s", stagingNamespace, app1+"-bracket-dep", creationTimes[deploymentKey{stagingNamespace, app1 + "-bracket-dep"}])
 
-	t.Log("step 7: create v1 release for app2 (same bracket, new member)")
+	tLog(t, "step 7: create v1 release for app2 (same bracket, new member)")
 	createRelease(t, app2, "sreteam", bracket, "1", map[string]string{
 		devNamespace:     stableManifest(app2, devNamespace, "1"),
-		dev2Namespace:    stableManifest(app2, dev2Namespace, "1"),
 		stagingNamespace: stableManifest(app2, stagingNamespace, "1"),
 	})
 
-	t.Log("step 8: run staging release train (deploys app2 v1 to staging)")
+	tLog(t, "step 8: run staging release train (deploys app2 v1 to staging)")
 	releaseTrain(t, stagingNamespace)
 
-	t.Log("step 9: wait for app2 v1 synced in staging (bracket version string updated to include both apps)")
+	tLog(t, "step 9: wait for app2 v1 synced in staging (bracket version string updated to include both apps)")
 	waitForDeploymentAnnotation(t, stagingNamespace, app2+"-bracket-dep", "1")
 
-	t.Log("step 10: 20s buffer to let any accidental pod churn complete")
-	time.Sleep(podChurnBuffer)
-
-	t.Log("step 11: verify bracket Argo app still exists (must not be deleted)")
+	tLog(t, "step 10: verify bracket Argo app still exists (must not be deleted)")
 	waitForArgoApp(t, "staging-"+bracket)
 
-	t.Log("step 12: verify app1 pod start time has not changed")
-	got := podStartTime(t, stagingNamespace, app1)
-	if got != app1StartTime {
-		t.Errorf("REGRESSION: pod %s/%s was restarted when app2 was added to the bracket\n  before: %s\n  after:  %s",
-			stagingNamespace, app1, app1StartTime, got)
-	} else {
-		t.Logf("  OK %s/%s start time stable at %s", stagingNamespace, app1, got)
-	}
+	tLog(t, "step 11: assert app1 pod start time stable (adding app2 to bracket)")
+	assertDeploymentCreationTimesStable(t, creationTimes, "add app to existing bracket")
 }
 
 // TestBracketPartialUpdate verifies that a release train updating only one of two apps
@@ -435,59 +415,51 @@ func TestBracketAddAppToExistingBracket(t *testing.T) {
 // This differs from TestBracketPodStability, where development changes and staging is
 // skipped entirely.  Here staging itself receives a partial update.
 func TestBracketPartialUpdate(t *testing.T) {
-	t.Logf("runSuffix: %s", runSuffix)
+	cleanupCluster(t)
+	tLogf(t, "runSuffix: %s", runSuffix)
 	app1 := "bpu-app1-" + runSuffix
 	app2 := "bpu-app2-" + runSuffix
 	bracket := "bpu-bracket-" + runSuffix
 
-	t.Log("step 1: upgrade to staging=true (bracket mode)")
-	helmUpgrade(t, true)
+	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
+	helmUpgrade(t, true, false, true, 50)
 
-	t.Log("step 2: create v1 releases for both apps")
+	tLog(t, "step 2: create v1 releases for both apps")
 	for _, app := range []string{app1, app2} {
 		createRelease(t, app, "sreteam", bracket, "1", map[string]string{
 			devNamespace:     stableManifest(app, devNamespace, "1"),
-			dev2Namespace:    stableManifest(app, dev2Namespace, "1"),
 			stagingNamespace: stableManifest(app, stagingNamespace, "1"),
 		})
 	}
 
-	t.Log("step 3: run staging release train (deploys both apps v1)")
+	tLog(t, "step 3: run staging release train (deploys both apps v1)")
 	releaseTrain(t, stagingNamespace)
 
-	t.Log("step 4: wait for v1 synced in staging for both apps")
+	tLog(t, "step 4: wait for v1 synced in staging for both apps")
 	for _, app := range []string{app1, app2} {
 		waitForDeploymentAnnotation(t, stagingNamespace, app+"-bracket-dep", "1")
 	}
 
-	t.Log("step 5: record app2 pod start time")
-	app2StartTime := podStartTime(t, stagingNamespace, app2)
-	t.Logf("  %s/%s: %s", stagingNamespace, app2, app2StartTime)
+	tLog(t, "step 5: record app2 deployment creation time")
+	creationTimes := map[deploymentKey]string{
+		{stagingNamespace, app2 + "-bracket-dep"}: deploymentCreationTime(t, stagingNamespace, app2+"-bracket-dep"),
+	}
+	tLogf(t, "  %s/%s: %s", stagingNamespace, app2+"-bracket-dep", creationTimes[deploymentKey{stagingNamespace, app2 + "-bracket-dep"}])
 
-	t.Log("step 6: create v2 release for app1 only (app2 stays at v1)")
+	tLog(t, "step 6: create v2 release for app1 only (app2 stays at v1)")
 	createRelease(t, app1, "sreteam", bracket, "2", map[string]string{
 		devNamespace:     stableManifest(app1, devNamespace, "2"),
-		dev2Namespace:    stableManifest(app1, dev2Namespace, "2"),
 		stagingNamespace: stableManifest(app1, stagingNamespace, "2"),
 	})
 
-	t.Log("step 7: run staging release train (promotes app1 v2, app2 stays at v1)")
+	tLog(t, "step 7: run staging release train (promotes app1 v2, app2 stays at v1)")
 	releaseTrain(t, stagingNamespace)
 
-	t.Log("step 8: wait for app1 v2 synced in staging (bracket version advances to mixed state)")
+	tLog(t, "step 8: wait for app1 v2 synced in staging (bracket version advances to mixed state)")
 	waitForDeploymentAnnotation(t, stagingNamespace, app1+"-bracket-dep", "2")
 
-	t.Log("step 9: 20s buffer to let any accidental pod churn complete")
-	time.Sleep(podChurnBuffer)
-
-	t.Log("step 10: verify app2 pod start time has not changed")
-	got := podStartTime(t, stagingNamespace, app2)
-	if got != app2StartTime {
-		t.Errorf("REGRESSION: pod %s/%s was restarted during partial bracket version update\n  before: %s\n  after:  %s",
-			stagingNamespace, app2, app2StartTime, got)
-	} else {
-		t.Logf("  OK %s/%s start time stable at %s", stagingNamespace, app2, got)
-	}
+	tLog(t, "step 9: assert app2 pod start time stable (partial bracket version update)")
+	assertDeploymentCreationTimesStable(t, creationTimes, "partial bracket version update")
 }
 
 func undeployApp(t *testing.T, app string) {
@@ -499,121 +471,59 @@ func undeployApp(t *testing.T, app string) {
 	}})
 }
 
-// TestBracketUndeploy verifies that undeploying the only app in bracket1 does not:
-// (a) delete the bracket1 Argo Application, and
-// (b) restart pods belonging to a separate bracket2.
+// TestBracketUndeploy verifies that undeploying the only app in bracket1:
+// (a) deletes the bracket1 Argo Application, and
+// (b) does not restart pods belonging to a separate bracket2.
 func TestBracketUndeploy(t *testing.T) {
-	t.Logf("runSuffix: %s", runSuffix)
+	cleanupCluster(t)
+	tLogf(t, "runSuffix: %s", runSuffix)
 	app1 := "bu-app1-" + runSuffix
 	bracket1 := "bu-bracket1-" + runSuffix
 	app2 := "bu-app2-" + runSuffix
 	bracket2 := "bu-bracket2-" + runSuffix
 
-	t.Log("step 1: upgrade to staging=true (bracket mode)")
-	helmUpgrade(t, true)
+	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
+	helmUpgrade(t, true, false, true, 50)
 
-	t.Log("step 2: create v1 releases for both apps")
+	tLog(t, "step 2: create v1 releases for both apps")
 	createRelease(t, app1, "sreteam", bracket1, "1", map[string]string{
 		devNamespace:     stableManifest(app1, devNamespace, "1"),
-		dev2Namespace:    stableManifest(app1, dev2Namespace, "1"),
 		stagingNamespace: stableManifest(app1, stagingNamespace, "1"),
 	})
 	createRelease(t, app2, "sreteam", bracket2, "1", map[string]string{
 		devNamespace:     stableManifest(app2, devNamespace, "1"),
-		dev2Namespace:    stableManifest(app2, dev2Namespace, "1"),
 		stagingNamespace: stableManifest(app2, stagingNamespace, "1"),
 	})
 
-	t.Log("step 3: run staging release train (deploys both apps)")
+	tLog(t, "step 3: run staging release train (deploys both apps)")
 	releaseTrain(t, stagingNamespace)
 
-	t.Log("step 4: wait for both apps synced in staging")
-	waitForDeploymentAnnotation(t, stagingNamespace, app1+"-bracket-dep", "1")
-	waitForDeploymentAnnotation(t, stagingNamespace, app2+"-bracket-dep", "1")
-
-	t.Log("step 5: wait for both bracket Argo apps to appear on staging")
+	tLog(t, "step 4: wait for both bracket Argo apps to appear on staging")
 	waitForArgoApp(t, "staging-"+bracket1)
 	waitForArgoApp(t, "staging-"+bracket2)
 
-	t.Log("step 6: record app2 pod start time")
-	app2StartTime := podStartTime(t, stagingNamespace, app2)
-	t.Logf("  %s/%s: %s", stagingNamespace, app2, app2StartTime)
+	waitForDeploymentAnnotation(t, stagingNamespace, app2+"-bracket-dep", "1")
+	waitForDeploymentAnnotation(t, devNamespace, app2+"-bracket-dep", "1")
 
-	t.Log("step 7: undeploy app1 entirely")
+	tLog(t, "step 5: record deployment creation times for app2")
+	creationTimes := map[deploymentKey]string{
+		{stagingNamespace, app2 + "-bracket-dep"}: deploymentCreationTime(t, stagingNamespace, app2+"-bracket-dep"),
+		{devNamespace, app2 + "-bracket-dep"}:     deploymentCreationTime(t, devNamespace, app2+"-bracket-dep"),
+	}
+	tLogf(t, "  %s/%s: %s", stagingNamespace, app2+"-bracket-dep", creationTimes[deploymentKey{stagingNamespace, app2 + "-bracket-dep"}])
+	tLogf(t, "  %s/%s: %s", devNamespace, app2+"-bracket-dep", creationTimes[deploymentKey{devNamespace, app2 + "-bracket-dep"}])
+
+	tLog(t, "step 6: undeploy app1 entirely")
 	undeployApp(t, app1)
 
-	t.Log("step 8: 30s buffer for rollout-service to reconcile")
+	tLogf(t, "step 7: %s buffer for rollout-service to reconcile", reconcileBuffer)
 	time.Sleep(reconcileBuffer)
 
-	t.Log("step 9: verify bracket1 Argo app still exists (must not be deleted)")
-	waitForArgoApp(t, "staging-"+bracket1)
+	tLog(t, "step 8: verify bracket1 Argo app is deleted on staging (no apps remain)")
+	waitForArgoAppGone(t, "staging-"+bracket1)
 
-	t.Log("step 10: verify app2 pod start time has not changed (no accidental restart)")
-	got := podStartTime(t, stagingNamespace, app2)
-	if got != app2StartTime {
-		t.Errorf("REGRESSION: pod %s/%s was restarted during undeploy of %s\n  before: %s\n  after:  %s",
-			stagingNamespace, app2, app1, app2StartTime, got)
-	} else {
-		t.Logf("  OK %s/%s start time stable at %s", stagingNamespace, app2, got)
-	}
-}
-
-// helmUpgradeWithBracketsConfig is like helmUpgrade but controls the master
-// experimentalBrackets.enabled switch as well as both the development and
-// staging cluster flags simultaneously.  This lets tests start from a state
-// where brackets are fully disabled (enabled=false) and then flip everything
-// on at once — the exact scenario the user reported.
-func helmUpgradeWithBracketsConfig(t *testing.T, bracketsEnabled, developmentEnabled, stagingEnabled bool) {
-	t.Helper()
-	out, err := exec.Command("git", "describe", "--always", "--long", "--tags").Output()
-	if err != nil {
-		t.Fatalf("git describe: %v", err)
-	}
-	version := strings.TrimSpace(string(out))
-	repoRoot, err2 := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err2 != nil {
-		t.Fatalf("git rev-parse: %v", err2)
-	}
-	root := strings.TrimSpace(string(repoRoot))
-	chartPath := root + "/charts/kuberpult/kuberpult-" + version + ".tgz"
-	valsPath := root + "/charts/kuberpult/vals.yaml"
-
-	boolStr := func(b bool) string {
-		if b {
-			return "true"
-		}
-		return "false"
-	}
-	t.Logf("helmUpgradeWithBracketsConfig: enabled=%s development=%s staging=%s chart=%s",
-		boolStr(bracketsEnabled), boolStr(developmentEnabled), boolStr(stagingEnabled), chartPath)
-
-	// Use a trigger channel of size 1 so that rapid back-to-back cd-service
-	// events reliably overflow it when Push is non-blocking — reproducing the
-	// exact condition that caused the original cascade-deletion bug.
-	cmd := exec.Command("helm", "upgrade", "--install",
-		"--values", valsPath,
-		"--set", "rollout.experimentalBrackets.enabled="+boolStr(bracketsEnabled),
-		"--set", "rollout.experimentalBrackets.clusters.development="+boolStr(developmentEnabled),
-		"--set", "rollout.experimentalBrackets.clusters.staging="+boolStr(stagingEnabled),
-		"--set", "rollout.kuberpultEventsChannelSize=1",
-		"kuberpult-local", chartPath)
-	if out2, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("helm upgrade (enabled=%s dev=%s staging=%s): %v\n%s",
-			boolStr(bracketsEnabled), boolStr(developmentEnabled), boolStr(stagingEnabled), err, out2)
-	}
-
-	for _, dep := range []string{
-		"deployment/kuberpult-rollout-service",
-		"deployment/kuberpult-cd-service",
-		"deployment/kuberpult-frontend-service",
-		"deployment/kuberpult-reposerver-service",
-	} {
-		out3, err := exec.Command("kubectl", "rollout", "status", dep, "--timeout=3m").CombinedOutput()
-		if err != nil {
-			t.Fatalf("kubectl rollout status %s: %v\n%s", dep, err, out3)
-		}
-		t.Logf("%s rolled out: %s", dep, strings.TrimSpace(string(out3)))
-	}
+	tLog(t, "step 9: assert pod start times stable after undeploy of app1")
+	assertDeploymentCreationTimesStable(t, creationTimes, "undeploy app1 should not bother app2")
 }
 
 // TestBracketEnableAllClusters is the regression test for the bug where enabling
@@ -630,91 +540,231 @@ func helmUpgradeWithBracketsConfig(t *testing.T, bracketsEnabled, developmentEna
 //   - Expected: bracket Argo apps appear on both envs, individual Argo apps are
 //     deleted, and all K8s Deployments are UNTOUCHED (pod start times unchanged).
 func TestBracketEnableAllClusters(t *testing.T) {
-	t.Logf("runSuffix: %s", runSuffix)
-	app1 := "beac-app1-" + runSuffix
-	app2 := "beac-app2-" + runSuffix
-	apps := []string{app1, app2}
+	cleanupCluster(t)
+	tLogf(t, "runSuffix: %s", runSuffix)
+	apps := make([]string, numTestApps)
+	for i := range apps {
+		apps[i] = fmt.Sprintf("beac-app%d-%s", i+1, runSuffix)
+	}
 	bracket := "beac-bracket-" + runSuffix
 
-	t.Log("step 1: upgrade to experimentalBrackets.enabled=false (fully disabled brackets)")
-	helmUpgradeWithBracketsConfig(t, false, false, false)
+	tLog(t, "step 1: upgrade to experimentalBrackets.enabled=false (fully disabled brackets)")
+	helmUpgrade(t, false, false, false, 1)
 
-	t.Log("step 2: create v1 releases (dev + dev2 + staging manifests)")
+	tLog(t, "step 2: create v1 releases (dev + dev2 + staging manifests)")
 	for _, app := range apps {
 		createRelease(t, app, "sreteam", bracket, "1", map[string]string{
 			devNamespace:     stableManifest(app, devNamespace, "1"),
-			dev2Namespace:    stableManifest(app, dev2Namespace, "1"),
 			stagingNamespace: stableManifest(app, stagingNamespace, "1"),
 		})
 	}
 
-	t.Log("step 3: run staging release train (deploys v1 from development2 to staging)")
+	tLog(t, "step 3: run staging release train (deploys v1 from development2 to staging)")
 	releaseTrain(t, stagingNamespace)
 
 	// diagnostic: show what ArgoCD apps and staging deployments exist after release train
-	if out, err := exec.Command("kubectl", "get", "applications", "-n", "default", "--no-headers").CombinedOutput(); err == nil {
-		t.Logf("ArgoCD apps after releaseTrain:\n%s", out)
+	if out, err := exec.Command("kubectl", "get", "applications", "-n", argoNamespace, "--no-headers").CombinedOutput(); err == nil {
+		tLogf(t, "ArgoCD apps after releaseTrain:\n%s", out)
 	}
 	if out, err := exec.Command("kubectl", "get", "deployments", "-n", stagingNamespace, "--no-headers").CombinedOutput(); err == nil {
-		t.Logf("Deployments in staging after releaseTrain:\n%s", out)
+		tLogf(t, "Deployments in staging after releaseTrain:\n%s", out)
 	}
-	if out, err := exec.Command("kubectl", "logs", "-n", "default", "deployment/kuberpult-rollout-service", "--tail=40").CombinedOutput(); err == nil {
-		t.Logf("rollout-service tail after releaseTrain:\n%s", out)
+	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "deployment/kuberpult-rollout-service", "--tail=40").CombinedOutput(); err == nil {
+		tLogf(t, "rollout-service tail after releaseTrain:\n%s", out)
 	}
 
-	t.Log("step 4: wait for v1 synced in both development and staging")
+	tLog(t, "step 4: wait for v1 synced in both development and staging")
 	for _, app := range apps {
 		for _, ns := range []string{devNamespace, stagingNamespace} {
 			waitForDeploymentAnnotation(t, ns, app+"-bracket-dep", "1")
 		}
 	}
 
-	t.Log("step 5: verify individual Argo apps exist on both development and staging")
+	tLog(t, "step 5: verify individual Argo apps exist on both development and staging")
 	for _, app := range apps {
 		waitForArgoApp(t, devNamespace+"-"+app)
 		waitForArgoApp(t, stagingNamespace+"-"+app)
 	}
 
-	t.Log("step 6: record pod start times in both envs")
-	type podKey struct{ ns, app string }
-	startTimes := map[podKey]string{}
+	tLog(t, "step 6: record deployment creation times in both envs")
+	creationTimes := map[deploymentKey]string{}
 	for _, app := range apps {
 		for _, ns := range []string{devNamespace, stagingNamespace} {
-			k := podKey{ns, app}
-			startTimes[k] = podStartTime(t, ns, app)
-			t.Logf("  %s/%s: %s", ns, app, startTimes[k])
+			k := deploymentKey{ns, app + "-bracket-dep"}
+			creationTimes[k] = deploymentCreationTime(t, ns, app+"-bracket-dep")
+			tLogf(t, "  %s/%s: %s", ns, app+"-bracket-dep", creationTimes[k])
 		}
 	}
 
-	t.Log("step 7: upgrade to experimentalBrackets.enabled=true, development=true, staging=true")
-	helmUpgradeWithBracketsConfig(t, true, true, true)
+	tLog(t, "step 7: upgrade to experimentalBrackets.enabled=true, development=true, staging=true")
+	helmUpgrade(t, true, true, true, 1)
 
-	t.Log("step 8: wait for bracket Argo apps to appear on both envs")
+	var individualArgoApps []string
+	for _, app := range apps {
+		individualArgoApps = append(individualArgoApps, devNamespace+"-"+app, stagingNamespace+"-"+app)
+	}
+
+	tLog(t, "step 7.5: dump state immediately after helmUpgrade (capture drain activity)")
+	dumpBracketDiagnosticsExpanded(t,
+		[]string{devNamespace + "-" + bracket, stagingNamespace + "-" + bracket},
+		individualArgoApps,
+		[]string{devNamespace, stagingNamespace},
+	)
+
+	tLog(t, "step 8: wait for bracket Argo apps to appear on both envs")
 	waitForArgoApp(t, devNamespace+"-"+bracket)
 	waitForArgoApp(t, stagingNamespace+"-"+bracket)
 
-	t.Log("step 9: wait for individual Argo apps to be deleted from both envs")
+	tLog(t, "step 9: wait for individual Argo apps to be deleted from both envs")
 	for _, app := range apps {
 		waitForArgoAppGone(t, devNamespace+"-"+app)
 		waitForArgoAppGone(t, stagingNamespace+"-"+app)
 	}
 
-	t.Log("step 10: 20s buffer to let any accidental pod churn complete")
-	time.Sleep(podChurnBuffer)
+	tLog(t, "step 9.5: dump diagnostics after transition (ArgoCD state, events, service logs)")
+	dumpBracketDiagnosticsExpanded(t,
+		[]string{devNamespace + "-" + bracket, stagingNamespace + "-" + bracket},
+		individualArgoApps,
+		[]string{devNamespace, stagingNamespace},
+	)
 
-	t.Log("step 11: verify pod start times have not changed in either env")
-	for _, app := range apps {
-		for _, ns := range []string{devNamespace, stagingNamespace} {
-			k := podKey{ns, app}
-			got := podStartTime(t, ns, app)
-			if got != startTimes[k] {
-				t.Errorf("REGRESSION: pod %s/%s was restarted when brackets were enabled\n  before: %s\n  after:  %s",
-					ns, app, startTimes[k], got)
-			} else {
-				t.Logf("  OK %s/%s start time stable at %s", ns, app, got)
-			}
-		}
+	tLog(t, "step 10: assert pod start times stable (enable all clusters)")
+	assertDeploymentCreationTimesStable(t, creationTimes, "enable all clusters")
+}
+
+// TestBracketMoveBetweenBrackets is the regression test for the bug where moving
+// an app from one bracket to another causes the deployment to be briefly deleted.
+//
+// Scenario:
+//   - An app is deployed to staging inside bracket1.
+//   - A new release is created for the same app, now assigned to bracket2.
+//   - The staging release train is run.
+//   - Expected: the bracket2 Argo app appears, and the app's pods are UNTOUCHED
+//     (pod start time unchanged) — the old bracket1 Argo app must NOT cascade-delete
+//     the K8s resources before bracket2 takes ownership.
+func TestBracketMoveBetweenBrackets(t *testing.T) {
+	cleanupCluster(t)
+	tLogf(t, "runSuffix: %s", runSuffix)
+	app := "bmb-app1-" + runSuffix
+	bracket1 := "bmb-bracket1-" + runSuffix
+	bracket2 := "bmb-bracket2-" + runSuffix
+
+	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
+	helmUpgrade(t, true, false, true, 50)
+
+	tLog(t, "step 2: create v1 release for app in bracket1")
+	createRelease(t, app, "sreteam", bracket1, "1", map[string]string{
+		devNamespace:     stableManifest(app, devNamespace, "1"),
+		stagingNamespace: stableManifest(app, stagingNamespace, "1"),
+	})
+
+	tLog(t, "step 3: run staging release train (deploys v1 from development2 to staging)")
+	releaseTrain(t, stagingNamespace)
+
+	tLog(t, "step 4: wait for v1 synced in staging")
+	waitForDeploymentAnnotation(t, stagingNamespace, app+"-bracket-dep", "1")
+
+	tLog(t, "step 5: wait for bracket1 Argo app to appear on staging")
+	waitForArgoApp(t, "staging-"+bracket1)
+
+	tLog(t, "step 6: record deployment creation time")
+	creationTimes := map[deploymentKey]string{
+		{stagingNamespace, app + "-bracket-dep"}: deploymentCreationTime(t, stagingNamespace, app+"-bracket-dep"),
 	}
+	tLogf(t, "  %s/%s: %s", stagingNamespace, app+"-bracket-dep", creationTimes[deploymentKey{stagingNamespace, app + "-bracket-dep"}])
+
+	tLog(t, "step 7: create v2 release for same app, now assigned to bracket2")
+	createRelease(t, app, "sreteam", bracket2, "2", map[string]string{
+		devNamespace:     stableManifest(app, devNamespace, "2"),
+		stagingNamespace: stableManifest(app, stagingNamespace, "2"),
+	})
+
+	tLog(t, "step 8: run staging release train (promotes v2, now in bracket2)")
+	releaseTrain(t, stagingNamespace)
+
+	tLog(t, "step 9: wait for bracket2 Argo app to appear on staging")
+	waitForArgoApp(t, "staging-"+bracket2)
+
+	tLog(t, "step 10: wait for v2 synced in staging")
+	waitForDeploymentAnnotation(t, stagingNamespace, app+"-bracket-dep", "2")
+
+	tLog(t, "step 11: assert pod start time stable (app moved bracket1→bracket2)")
+	assertDeploymentCreationTimesStable(t, creationTimes, "move bracket1→bracket2")
+}
+
+// TestBracketMoveAndBack is the regression test for the scenario where an app
+// moves from bracket1 to bracket2 and then back to bracket1.
+//
+// The first move (b1→b2) may work due to lucky ArgoCD finalizer timing.
+// The second move (b2→b1) is more likely to fail because bracket1 must be
+// RECREATED (it was deleted after move 1), and bracket2's cascade-delete
+// finalizer may race against bracket1's re-creation and prune the pod.
+//
+// Both moves are checked independently so it is clear which transition fails.
+func TestBracketMoveAndBack(t *testing.T) {
+	cleanupCluster(t)
+	tLogf(t, "runSuffix: %s", runSuffix)
+	app := "bmab-app1-" + runSuffix
+	bracket1 := "bmab-bracket1-" + runSuffix
+	bracket2 := "bmab-bracket2-" + runSuffix
+
+	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
+	helmUpgrade(t, true, false, true, 50)
+
+	tLog(t, "step 2: create v1 release for app in bracket1")
+	createRelease(t, app, "sreteam", bracket1, "1", map[string]string{
+		devNamespace:     stableManifest(app, devNamespace, "1"),
+		stagingNamespace: stableManifest(app, stagingNamespace, "1"),
+	})
+
+	tLog(t, "step 3: run staging release train (deploys v1 from development2 to staging)")
+	releaseTrain(t, stagingNamespace)
+
+	tLog(t, "step 4: wait for v1 synced in staging and bracket1 Argo app present")
+	waitForDeploymentAnnotation(t, stagingNamespace, app+"-bracket-dep", "1")
+	waitForArgoApp(t, "staging-"+bracket1)
+
+	tLog(t, "step 5: record initial deployment creation time")
+	creationTimes := map[deploymentKey]string{
+		{stagingNamespace, app + "-bracket-dep"}: deploymentCreationTime(t, stagingNamespace, app+"-bracket-dep"),
+	}
+	tLogf(t, "  initial: %s", creationTimes[deploymentKey{stagingNamespace, app + "-bracket-dep"}])
+
+	// ---------- Move 1: bracket1 → bracket2 ----------
+
+	tLog(t, "step 6: create v2 release for app now in bracket2")
+	createRelease(t, app, "sreteam", bracket2, "2", map[string]string{
+		devNamespace:     stableManifest(app, devNamespace, "2"),
+		stagingNamespace: stableManifest(app, stagingNamespace, "2"),
+	})
+
+	tLog(t, "step 7: run staging release train (promotes v2 in bracket2)")
+	releaseTrain(t, stagingNamespace)
+
+	tLog(t, "step 8: wait for bracket2 Argo app to appear and v2 synced")
+	waitForArgoApp(t, "staging-"+bracket2)
+	waitForDeploymentAnnotation(t, stagingNamespace, app+"-bracket-dep", "2")
+
+	tLog(t, "step 9: assert pod start time stable after move 1 (b1→b2)")
+	assertDeploymentCreationTimesStable(t, creationTimes, "move 1 (b1→b2)")
+
+	// ---------- Move 2: bracket2 → bracket1 ----------
+
+	tLog(t, "step 10: create v3 release for app back in bracket1")
+	createRelease(t, app, "sreteam", bracket1, "3", map[string]string{
+		devNamespace:     stableManifest(app, devNamespace, "3"),
+		stagingNamespace: stableManifest(app, stagingNamespace, "3"),
+	})
+
+	tLog(t, "step 11: run staging release train (promotes v3 back in bracket1)")
+	releaseTrain(t, stagingNamespace)
+
+	tLog(t, "step 12: wait for bracket1 Argo app to reappear and v3 synced")
+	waitForArgoApp(t, "staging-"+bracket1)
+	waitForDeploymentAnnotation(t, stagingNamespace, app+"-bracket-dep", "3")
+
+	tLog(t, "step 13: assert pod start time stable after move 2 (b2→b1)")
+	assertDeploymentCreationTimesStable(t, creationTimes, "move 2 (b2→b1)")
 }
 
 // TestBracketMigrateDevelopment is the regression test for the bug where enabling
@@ -729,62 +779,116 @@ func TestBracketEnableAllClusters(t *testing.T) {
 //   - Expected: bracket Argo app appears on development, individual Argo apps are
 //     deleted, and all K8s Deployments are UNTOUCHED (pod start times unchanged).
 func TestBracketMigrateDevelopment(t *testing.T) {
-	t.Logf("runSuffix: %s", runSuffix)
+	cleanupCluster(t)
+	tLogf(t, "runSuffix: %s", runSuffix)
 	app1 := "bmd-app1-" + runSuffix
 	app2 := "bmd-app2-" + runSuffix
 	apps := []string{app1, app2}
 	bracket := "bmd-bracket-" + runSuffix
 
-	t.Log("step 1: upgrade to brackets enabled, development=false (individual-app mode)")
-	helmUpgradeWithBracketsConfig(t, true, false, false)
+	tLog(t, "step 1: upgrade to brackets enabled, development=false (individual-app mode)")
+	helmUpgrade(t, true, false, false, 1)
 
-	t.Log("step 2: create v1 releases (dev + dev2 manifests)")
+	tLog(t, "step 2: create v1 releases (dev + dev2 manifests)")
 	for _, app := range apps {
 		createRelease(t, app, "sreteam", bracket, "1", map[string]string{
-			devNamespace:  stableManifest(app, devNamespace, "1"),
-			dev2Namespace: stableManifest(app, dev2Namespace, "1"),
+			devNamespace: stableManifest(app, devNamespace, "1"),
 		})
 	}
 
-	t.Log("step 3: wait for v1 synced in development")
+	tLog(t, "step 3: wait for v1 synced in development")
 	for _, app := range apps {
 		waitForDeploymentAnnotation(t, devNamespace, app+"-bracket-dep", "1")
 	}
 
-	t.Log("step 4: verify individual Argo apps exist on development")
+	tLog(t, "step 4: verify individual Argo apps exist on development")
 	for _, app := range apps {
 		waitForArgoApp(t, devNamespace+"-"+app)
 	}
 
-	t.Log("step 5: record pod start times in development")
-	startTimes := map[string]string{}
+	tLog(t, "step 5: record deployment creation times in development")
+	creationTimes := map[deploymentKey]string{}
 	for _, app := range apps {
-		startTimes[app] = podStartTime(t, devNamespace, app)
-		t.Logf("  %s/%s: %s", devNamespace, app, startTimes[app])
+		creationTimes[deploymentKey{devNamespace, app + "-bracket-dep"}] = deploymentCreationTime(t, devNamespace, app+"-bracket-dep")
+		tLogf(t, "  %s/%s: %s", devNamespace, app+"-bracket-dep", creationTimes[deploymentKey{devNamespace, app + "-bracket-dep"}])
 	}
 
-	t.Log("step 6: upgrade to development=true (the bug-triggering upgrade)")
-	helmUpgradeWithBracketsConfig(t, true, true, false)
+	tLog(t, "step 6: upgrade to development=true (the bug-triggering upgrade)")
+	helmUpgrade(t, true, true, false, 1)
 
-	t.Log("step 7: wait for bracket Argo app to appear on development")
+	tLog(t, "step 7: wait for bracket Argo app to appear on development")
 	waitForArgoApp(t, devNamespace+"-"+bracket)
 
-	t.Log("step 8: wait for individual Argo apps to be deleted from development")
+	tLog(t, "step 8: wait for individual Argo apps to be deleted from development")
 	for _, app := range apps {
 		waitForArgoAppGone(t, devNamespace+"-"+app)
 	}
 
-	t.Log("step 9: 20s buffer to let any accidental pod churn complete")
-	time.Sleep(podChurnBuffer)
+	tLog(t, "step 9: assert pod start times stable (enable development brackets)")
+	assertDeploymentCreationTimesStable(t, creationTimes, "enable development brackets")
+}
 
-	t.Log("step 10: verify pod start times have not changed")
-	for _, app := range apps {
-		got := podStartTime(t, devNamespace, app)
-		if got != startTimes[app] {
-			t.Errorf("REGRESSION: pod %s/%s was restarted when development brackets were enabled\n  before: %s\n  after:  %s",
-				devNamespace, app, startTimes[app], got)
-		} else {
-			t.Logf("  OK %s/%s start time stable at %s", devNamespace, app, got)
+// dumpBracketDiagnostics dumps ArgoCD app status, namespace events, and service logs
+// to help diagnose unexpected pod restarts during bracket transitions.
+func dumpBracketDiagnostics(t *testing.T, argoApps []string, namespaces []string) {
+	t.Helper()
+	for _, app := range argoApps {
+		if out, err := exec.Command("kubectl", "describe", "application", app, "-n", argoNamespace).CombinedOutput(); err == nil {
+			tLogf(t, "ArgoCD app describe %s:\n%s", app, out)
 		}
+	}
+	for _, ns := range namespaces {
+		if out, err := exec.Command("kubectl", "get", "events", "-n", ns, "--sort-by=.lastTimestamp").CombinedOutput(); err == nil {
+			tLogf(t, "events in %s:\n%s", ns, out)
+		}
+	}
+	for _, svc := range []string{"rollout-service", "manifest-repo-export-service"} {
+		dep := "deployment/kuberpult-" + svc
+		if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, dep, "--tail=100").CombinedOutput(); err == nil {
+			tLogf(t, "%s logs (tail 100):\n%s", svc, out)
+		}
+	}
+	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "statefulset/argocd-application-controller", "--tail=100").CombinedOutput(); err == nil {
+		tLogf(t, "argocd-application-controller logs (tail 100):\n%s", out)
+	}
+}
+
+// dumpBracketDiagnosticsExpanded is like dumpBracketDiagnostics but also describes
+// individual (non-bracket) ArgoCD apps and uses --since=5m for logs so the full
+// bracket-migration window is captured regardless of log volume.
+func dumpBracketDiagnosticsExpanded(t *testing.T, bracketApps []string, individualApps []string, namespaces []string) {
+	t.Helper()
+	for _, app := range bracketApps {
+		if out, err := exec.Command("kubectl", "describe", "application", app, "-n", argoNamespace).CombinedOutput(); err == nil {
+			tLogf(t, "ArgoCD app describe %s:\n%s", app, out)
+		}
+	}
+	for _, app := range individualApps {
+		if out, err := exec.Command("kubectl", "describe", "application", app, "-n", argoNamespace).CombinedOutput(); err == nil {
+			tLogf(t, "ArgoCD app describe (individual) %s:\n%s", app, out)
+		}
+	}
+	for _, ns := range namespaces {
+		if out, err := exec.Command("kubectl", "get", "events", "-n", ns, "--sort-by=.lastTimestamp").CombinedOutput(); err == nil {
+			tLogf(t, "events in %s:\n%s", ns, out)
+		}
+	}
+	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "deployment/kuberpult-rollout-service", "--since=5m").CombinedOutput(); err == nil {
+		tLogf(t, "rollout-service logs (since 5m):\n%s", out)
+	}
+	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "statefulset/argocd-application-controller", "--since=5m").CombinedOutput(); err == nil {
+		tLogf(t, "argocd-application-controller logs (since 5m):\n%s", out)
+	}
+	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "deployment/argocd-server", "--since=5m").CombinedOutput(); err == nil {
+		tLogf(t, "argocd-server logs (since 5m):\n%s", out)
+	}
+	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "deployment/kuberpult-reposerver-service", "--since=5m").CombinedOutput(); err == nil {
+		tLogf(t, "kuberpult-reposerver-service logs (since 5m):\n%s", out)
+	}
+	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "deployment/kuberpult-rollout-service", "--since=5m", "--previous").CombinedOutput(); err == nil {
+		tLogf(t, "rollout-service logs (previous container, since 5m):\n%s", out)
+	}
+	if out, err := exec.Command("kubectl", "get", "appprojects", "-n", argoNamespace, "-o", "yaml").CombinedOutput(); err == nil {
+		tLogf(t, "AppProjects in %s:\n%s", argoNamespace, out)
 	}
 }

--- a/tests/kind-brackets/bracket_migration_test.go
+++ b/tests/kind-brackets/bracket_migration_test.go
@@ -35,9 +35,16 @@ import (
 const cdServiceGrpcAddr = "localhost:5004"
 const argoNamespace = "default"
 
+type helmUpgradeParams struct {
+	bracketsEnabled    bool
+	developmentEnabled bool
+	stagingEnabled     bool
+	channelSize        int
+}
+
 // helmUpgrade calls helm upgrade with the given bracket configuration and waits
 // for all services to finish rolling out.
-func helmUpgrade(t *testing.T, bracketsEnabled, developmentEnabled, stagingEnabled bool, channelSize int) {
+func helmUpgrade(t *testing.T, p helmUpgradeParams) {
 	t.Helper()
 	out, err := exec.Command("git", "describe", "--always", "--long", "--tags").Output()
 	if err != nil {
@@ -59,18 +66,18 @@ func helmUpgrade(t *testing.T, bracketsEnabled, developmentEnabled, stagingEnabl
 		return "false"
 	}
 	tLogf(t, "helmUpgrade: enabled=%s development=%s staging=%s channelSize=%d chart=%s",
-		boolStr(bracketsEnabled), boolStr(developmentEnabled), boolStr(stagingEnabled), channelSize, chartPath)
+		boolStr(p.bracketsEnabled), boolStr(p.developmentEnabled), boolStr(p.stagingEnabled), p.channelSize, chartPath)
 
 	cmd := exec.Command("helm", "upgrade", "--install",
 		"--values", valsPath,
-		"--set", "rollout.experimentalBrackets.enabled="+boolStr(bracketsEnabled),
-		"--set", "rollout.experimentalBrackets.clusters.development="+boolStr(developmentEnabled),
-		"--set", "rollout.experimentalBrackets.clusters.staging="+boolStr(stagingEnabled),
-		"--set", fmt.Sprintf("rollout.kuberpultEventsChannelSize=%d", channelSize),
+		"--set", "rollout.experimentalBrackets.enabled="+boolStr(p.bracketsEnabled),
+		"--set", "rollout.experimentalBrackets.clusters.development="+boolStr(p.developmentEnabled),
+		"--set", "rollout.experimentalBrackets.clusters.staging="+boolStr(p.stagingEnabled),
+		"--set", fmt.Sprintf("rollout.kuberpultEventsChannelSize=%d", p.channelSize),
 		"kuberpult-local", chartPath)
 	if out2, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("helm upgrade (enabled=%s dev=%s staging=%s): %v\n%s",
-			boolStr(bracketsEnabled), boolStr(developmentEnabled), boolStr(stagingEnabled), err, out2)
+			boolStr(p.bracketsEnabled), boolStr(p.developmentEnabled), boolStr(p.stagingEnabled), err, out2)
 	}
 
 	for _, dep := range []string{
@@ -150,7 +157,7 @@ func TestBracketMigration(t *testing.T) {
 	//   bracket:    "{env}-{bracketName}" e.g. "staging-bmt-bracket-XXXXX"
 
 	tLog(t, "step 1: upgrade to staging=false (individual Argo apps mode for staging)")
-	helmUpgrade(t, true, false, false, 50)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: false, stagingEnabled: false, channelSize: 50})
 
 	tLog(t, "step 2: create v1 releases (dev + staging manifests)")
 	for _, app := range apps {
@@ -184,7 +191,7 @@ func TestBracketMigration(t *testing.T) {
 	}
 
 	tLog(t, "step 7: upgrade to staging=true (migrate to bracket Argo app)")
-	helmUpgrade(t, true, false, true, 50)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: false, stagingEnabled: true, channelSize: 50})
 
 	tLog(t, "step 8: wait for bracket Argo app to appear on staging")
 	waitForArgoApp(t, "staging-"+migrationBracket)
@@ -253,7 +260,7 @@ func TestBracketDeleteEnvFromApp(t *testing.T) {
 	bracket := "bde-bracket-" + runSuffix
 
 	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
-	helmUpgrade(t, true, false, true, 50)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: false, stagingEnabled: true, channelSize: 50})
 
 	tLog(t, "step 2: create v1 release (dev + staging manifests)")
 	createRelease(t, app, "sreteam", bracket, "1", map[string]string{
@@ -298,7 +305,7 @@ func TestBracketReverseMigration(t *testing.T) {
 	bracket := "brm-bracket-" + runSuffix
 
 	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
-	helmUpgrade(t, true, false, true, 50)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: false, stagingEnabled: true, channelSize: 50})
 
 	tLog(t, "step 2: create v1 releases (dev + staging manifests)")
 	for _, app := range apps {
@@ -328,7 +335,7 @@ func TestBracketReverseMigration(t *testing.T) {
 	}
 
 	tLog(t, "step 7: upgrade to staging=false (revert to individual Argo apps)")
-	helmUpgrade(t, true, false, false, 50)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: false, stagingEnabled: false, channelSize: 50})
 
 	tLog(t, "step 8: wait for individual Argo apps to appear on staging")
 	for _, app := range apps {
@@ -361,7 +368,7 @@ func TestBracketAddAppToExistingBracket(t *testing.T) {
 	bracket := "bae-bracket-" + runSuffix
 
 	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
-	helmUpgrade(t, true, false, true, 50)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: false, stagingEnabled: true, channelSize: 50})
 
 	tLog(t, "step 2: create v1 release for app1 only")
 	createRelease(t, app1, "sreteam", bracket, "1", map[string]string{
@@ -422,7 +429,7 @@ func TestBracketPartialUpdate(t *testing.T) {
 	bracket := "bpu-bracket-" + runSuffix
 
 	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
-	helmUpgrade(t, true, false, true, 50)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: false, stagingEnabled: true, channelSize: 50})
 
 	tLog(t, "step 2: create v1 releases for both apps")
 	for _, app := range []string{app1, app2} {
@@ -483,7 +490,7 @@ func TestBracketUndeploy(t *testing.T) {
 	bracket2 := "bu-bracket2-" + runSuffix
 
 	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
-	helmUpgrade(t, true, false, true, 50)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: false, stagingEnabled: true, channelSize: 50})
 
 	tLog(t, "step 2: create v1 releases for both apps")
 	createRelease(t, app1, "sreteam", bracket1, "1", map[string]string{
@@ -549,7 +556,7 @@ func TestBracketEnableAllClusters(t *testing.T) {
 	bracket := "beac-bracket-" + runSuffix
 
 	tLog(t, "step 1: upgrade to experimentalBrackets.enabled=false (fully disabled brackets)")
-	helmUpgrade(t, false, false, false, 1)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: false, developmentEnabled: false, stagingEnabled: false, channelSize: 1})
 
 	tLog(t, "step 2: create v1 releases (dev + dev2 + staging manifests)")
 	for _, app := range apps {
@@ -597,7 +604,7 @@ func TestBracketEnableAllClusters(t *testing.T) {
 	}
 
 	tLog(t, "step 7: upgrade to experimentalBrackets.enabled=true, development=true, staging=true")
-	helmUpgrade(t, true, true, true, 1)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: true, stagingEnabled: true, channelSize: 1})
 
 	var individualArgoApps []string
 	for _, app := range apps {
@@ -650,7 +657,7 @@ func TestBracketMoveBetweenBrackets(t *testing.T) {
 	bracket2 := "bmb-bracket2-" + runSuffix
 
 	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
-	helmUpgrade(t, true, false, true, 50)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: false, stagingEnabled: true, channelSize: 50})
 
 	tLog(t, "step 2: create v1 release for app in bracket1")
 	createRelease(t, app, "sreteam", bracket1, "1", map[string]string{
@@ -709,7 +716,7 @@ func TestBracketMoveAndBack(t *testing.T) {
 	bracket2 := "bmab-bracket2-" + runSuffix
 
 	tLog(t, "step 1: upgrade to staging=true (bracket mode)")
-	helmUpgrade(t, true, false, true, 50)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: false, stagingEnabled: true, channelSize: 50})
 
 	tLog(t, "step 2: create v1 release for app in bracket1")
 	createRelease(t, app, "sreteam", bracket1, "1", map[string]string{
@@ -787,7 +794,7 @@ func TestBracketMigrateDevelopment(t *testing.T) {
 	bracket := "bmd-bracket-" + runSuffix
 
 	tLog(t, "step 1: upgrade to brackets enabled, development=false (individual-app mode)")
-	helmUpgrade(t, true, false, false, 1)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: false, stagingEnabled: false, channelSize: 1})
 
 	tLog(t, "step 2: create v1 releases (dev + dev2 manifests)")
 	for _, app := range apps {
@@ -814,7 +821,7 @@ func TestBracketMigrateDevelopment(t *testing.T) {
 	}
 
 	tLog(t, "step 6: upgrade to development=true (the bug-triggering upgrade)")
-	helmUpgrade(t, true, true, false, 1)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: true, stagingEnabled: false, channelSize: 1})
 
 	tLog(t, "step 7: wait for bracket Argo app to appear on development")
 	waitForArgoApp(t, devNamespace+"-"+bracket)

--- a/tests/kind-brackets/bracket_stability_test.go
+++ b/tests/kind-brackets/bracket_stability_test.go
@@ -431,7 +431,7 @@ func resetDB(t *testing.T) {
 // pod startTime means the Deployment was deleted — the bug.
 func TestBracketPodStability(t *testing.T) {
 	cleanupCluster(t)
-	helmUpgrade(t, true, false, true, 50)
+	helmUpgrade(t, helmUpgradeParams{bracketsEnabled: true, developmentEnabled: false, stagingEnabled: true, channelSize: 50})
 	tLogf(t, "runSuffix: %s", runSuffix)
 	app1 := "bst-app1-" + runSuffix
 	app2 := "bst-app2-" + runSuffix

--- a/tests/kind-brackets/bracket_stability_test.go
+++ b/tests/kind-brackets/bracket_stability_test.go
@@ -28,7 +28,9 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -39,23 +41,49 @@ import (
 var runSuffix = fmt.Sprintf("%d", time.Now().Unix()%100000)
 
 const (
-	kuberpultFrontendPort = "8081"
+	kuberpultFrontendPort = "5002"
 	devNamespace          = "development"
-	dev2Namespace         = "development2"
 	stagingNamespace      = "staging"
 	// Bracket name used for the two test apps.
 	testBracket = "bracket-stability-test"
+
+	// numTestApps is the number of apps used in load-test scenarios.
+	// Increase this to stress-test bracket operations at scale.
+	// 2 is "the default"
+	numTestApps = 2
 
 	// Polling intervals and deadlines.
 	argoAppWaitTimeout  = 2 * time.Minute
 	argoAppGoneTimeout  = 3 * time.Minute
 	argoAppPollInterval = 5 * time.Second
 	podPollInterval     = 3 * time.Second
-	podChurnBuffer      = 20 * time.Second
-	reconcileBuffer     = 30 * time.Second
+	reconcileBuffer     = 10 * time.Second
 	grpcRetryTimeout    = 30 * time.Second
 	grpcRetryInterval   = 2 * time.Second
 )
+
+// deploymentKey identifies a Deployment by namespace and name.
+type deploymentKey struct{ namespace, name string }
+
+// waitForFrontendHTTPReady polls the frontend /health endpoint until it returns
+// a valid HTTP response, covering the race where the port-forward reconnects
+// after pods are replaced. Mirrors the processBatch retry logic.
+func waitForFrontendHTTPReady(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(grpcRetryTimeout)
+	url := "http://localhost:" + kuberpultFrontendPort + "/health"
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			if err := resp.Body.Close(); err != nil {
+				tLogf(t, "close health response body: %v", err)
+			}
+			return
+		}
+		time.Sleep(grpcRetryInterval)
+	}
+	t.Fatalf("frontend service at %s not reachable after 30s", url)
+}
 
 // stableManifest returns a Deployment + ConfigMap for app/namespace/version.
 //
@@ -93,9 +121,10 @@ spec:
       labels:
         app: %s-bracket
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: sleep
-        image: alpine:latest
+        image: busybox:latest
         command: ["/bin/sh", "-c", "trap 'exit 0' SIGTERM; while true; do sleep 1000; done"]
         readinessProbe:
           exec:
@@ -140,10 +169,17 @@ func createRelease(t *testing.T, app, team, bracketName, version string, manifes
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Fatalf("POST /api/release for %s v%s: %v", app, version, err)
+		fatalWithServiceLogs(t, "POST /api/release for %s v%s: %v", app, version, err)
 	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("close response body: %v", err)
+		}
+	}()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body for %s v%s: %v", app, version, err)
+	}
 	if resp.StatusCode > 299 {
 		t.Fatalf("POST /api/release for %s v%s: HTTP %d: %s", app, version, resp.StatusCode, body)
 	}
@@ -156,6 +192,50 @@ func mustWriteField(t *testing.T, w *multipart.Writer, key, value string) {
 	}
 }
 
+// dumpKuberpultLogs prints the last 300 log lines (current + previous container)
+// of every pod belonging to the frontend and cd services to stderr.
+// Uses per-pod kubectl calls so all replicas are covered (kubectl logs deployment/X
+// silently picks just one pod when multiple exist).
+func dumpKuberpultLogs(t *testing.T) {
+	t.Helper()
+	fmt.Fprintln(os.Stderr, "=== CRITICAL: dumping kuberpult service logs ===")
+	podsOut, err := exec.Command("kubectl", "get", "pods", "-n", "default", "-o", "name").CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "kubectl get pods: %v\n", err)
+	}
+	for _, dep := range []string{"kuberpult-frontend-service", "kuberpult-cd-service"} {
+		for _, line := range strings.Fields(string(podsOut)) {
+			podName := strings.TrimPrefix(line, "pod/")
+			if !strings.HasPrefix(podName, dep+"-") {
+				continue
+			}
+			for _, prev := range []bool{false, true} {
+				args := []string{"logs", "-n", "default", podName, "--tail=300"}
+				label := podName
+				if prev {
+					args = append(args, "--previous")
+					label = podName + " (previous)"
+				}
+				out, err := exec.Command("kubectl", args...).CombinedOutput()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "kubectl logs %s: %v\n", label, err)
+				} else {
+					fmt.Fprintf(os.Stderr, "=== logs: %s ===\n%s\n", label, out)
+				}
+			}
+		}
+	}
+}
+
+// fatalWithServiceLogs dumps service logs then exits the entire test binary so
+// no further tests run and the cluster stays in its failed state for inspection.
+func fatalWithServiceLogs(t *testing.T, format string, args ...any) {
+	t.Helper()
+	dumpKuberpultLogs(t)
+	fmt.Fprintf(os.Stderr, "FATAL: "+format+"\n", args...)
+	os.Exit(1)
+}
+
 func releaseTrain(t *testing.T, env string) {
 	t.Helper()
 	url := "http://localhost:" + kuberpultFrontendPort + "/api/environments/" + env + "/releasetrain"
@@ -165,37 +245,51 @@ func releaseTrain(t *testing.T, env string) {
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Fatalf("PUT release train %s: %v", env, err)
+		fatalWithServiceLogs(t, "PUT release train %s: %v", env, err)
 	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("close response body: %v", err)
+		}
+	}()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read release-train response body for %s: %v", env, err)
+	}
 	if resp.StatusCode > 299 {
 		t.Fatalf("PUT release train %s: HTTP %d: %s", env, resp.StatusCode, body)
 	}
 }
 
-// podStartTime returns the RFC3339 startTime of the first Running pod in
-// namespace matching label app=<app>-bracket. Retries for up to 2 minutes.
-func podStartTime(t *testing.T, namespace, app string) string {
+// deploymentCreationTime returns the creationTimestamp of the named Deployment.
+// Fails the test if the Deployment does not exist.
+func deploymentCreationTime(t *testing.T, namespace, name string) string {
 	t.Helper()
-	label := "app=" + app + "-bracket"
-	deadline := time.Now().Add(argoAppWaitTimeout)
-	for time.Now().Before(deadline) {
-		out, err := exec.Command(
-			"kubectl", "get", "pods",
-			"-n", namespace,
-			"-l", label,
-			"--field-selector=status.phase=Running",
-			"-o", "jsonpath={.items[0].status.startTime}",
-		).Output()
-		s := strings.TrimSpace(string(out))
-		if err == nil && s != "" {
-			return s
-		}
-		time.Sleep(podPollInterval)
+	out, err := exec.Command(
+		"kubectl", "get", "deployment", name,
+		"-n", namespace,
+		"-o", "jsonpath={.metadata.creationTimestamp}",
+	).Output()
+	if err != nil {
+		t.Fatalf("get deployment %s/%s creationTimestamp: %v", namespace, name, err)
 	}
-	t.Fatalf("no Running pod with label %s in namespace %s after 2 minutes", label, namespace)
-	return ""
+	return strings.TrimSpace(string(out))
+}
+
+// assertDeploymentCreationTimesStable checks that no Deployment was deleted+recreated
+// (which would cause downtime) by verifying that creationTimestamps are unchanged.
+func assertDeploymentCreationTimesStable(t *testing.T, times map[deploymentKey]string, context string) {
+	t.Helper()
+	for k, want := range times {
+		got := deploymentCreationTime(t, k.namespace, k.name)
+		if got != want {
+			t.Fatalf("REGRESSION (%s): deployment %s/%s was deleted and recreated\n  before: %s\n  after:  %s",
+				context, k.namespace, k.name, want, got)
+		}
+	}
+	for k, want := range times {
+		tLogf(t, "  OK %s/%s creation time stable at %s", k.namespace, k.name, want)
+	}
 }
 
 // waitForDeploymentAnnotation polls until the named Deployment's annotation
@@ -215,8 +309,108 @@ func waitForDeploymentAnnotation(t *testing.T, namespace, deploymentName, wantVe
 		}
 		time.Sleep(podPollInterval)
 	}
+	if out2, _ := exec.Command("kubectl", "describe", "deployment", deploymentName, "-n", namespace).CombinedOutput(); len(out2) > 0 {
+		tLogf(t, "deployment describe:\n%s", out2)
+	}
+	if out3, _ := exec.Command("kubectl", "get", "pods", "-n", namespace, "-o", "wide").CombinedOutput(); len(out3) > 0 {
+		tLogf(t, "pods in %s:\n%s", namespace, out3)
+	}
 	t.Fatalf("deployment %s/%s annotation release-version never reached %q after 3 minutes",
 		namespace, deploymentName, wantVersion)
+}
+
+// cleanupCluster deletes all ArgoCD applications and all pods/deployments in
+// the three test namespaces, then waits for each deletion to complete.
+// Call this at the start of every test to ensure a clean cluster state.
+func removeAllArgoAppFinalizers(t *testing.T) {
+	names, _ := exec.Command("kubectl", "get", "applications", "-n", "default", "-o", "name").CombinedOutput()
+	for _, name := range strings.Fields(string(names)) {
+		err := exec.Command("kubectl", "patch", "-n", "default", name,
+			"--type=merge", "-p", `{"metadata":{"finalizers":[]}}`).Run()
+		if err != nil {
+			tLog(t, "kubectl patch finalizers failed (continuing)[%s]: %v", name, err)
+		} else {
+			tLog(t, "deleted finalizer for application %s", name)
+		}
+	}
+}
+
+func cleanupCluster(t *testing.T) {
+	t.Helper()
+	tLog(t, "cleanupCluster: deleting all ArgoCD applications")
+	removeAllArgoAppFinalizers(t)
+	out, err := exec.Command("kubectl", "delete", "applications", "--all", "-n", "default", "--wait=true").CombinedOutput()
+	if err != nil {
+		t.Fatalf("kubectl delete applications failed: %v: %s", err, out)
+	}
+	tLogf(t, "  %s", strings.TrimSpace(string(out)))
+	for _, ns := range []string{devNamespace, stagingNamespace} {
+		out2, err := exec.Command("kubectl", "delete", "deployments,pods", "--all", "-n", ns, "--wait=true").CombinedOutput()
+		if err != nil {
+			t.Fatalf("kubectl delete deployment/etc failed: %v: %s", err, out2)
+		}
+		tLogf(t, "  %s: %s", ns, strings.TrimSpace(string(out2)))
+	}
+
+	resetDB(t)
+}
+
+func resetDB(t *testing.T) {
+	t.Helper()
+
+	// Step 1: query all table names in the public schema
+	tLog(t, "resetDB: querying tables")
+	out, err := exec.Command("kubectl", "exec", "deployment/postgres", "-n", "default", "--",
+		"psql", "-U", "postgres", "-d", "kuberpult", "-At",
+		"-c", "SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename;",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("resetDB: list tables: %v: %s", err, out)
+	}
+	var tables []string
+	for _, line := range strings.Fields(string(out)) {
+		if line != "" && line != "schema_migrations" {
+			tables = append(tables, line)
+		}
+	}
+
+	// Step 2: log which tables will be truncated
+	if len(tables) == 0 {
+		tLog(t, "resetDB: no tables found, db is already empty")
+	} else {
+		tLogf(t, "resetDB: will truncate tables: %s", strings.Join(tables, ", "))
+
+		// Step 3: truncate tables in batches of 5 to reduce kubectl exec calls (~1 sec per call)
+		for batch := range slices.Chunk(tables, 5) {
+			var parts []string
+			for _, table := range batch {
+				parts = append(parts, fmt.Sprintf(`"%s"`, table))
+			}
+			tLogf(t, "resetDB: truncating tables %s", strings.Join(parts, ", "))
+			out2, err2 := exec.Command("kubectl", "exec", "deployment/postgres", "-n", "default", "--",
+				"psql", "-U", "postgres", "-d", "kuberpult", "-c",
+				fmt.Sprintf(`TRUNCATE TABLE %s CASCADE;`, strings.Join(parts, ", ")),
+			).CombinedOutput()
+			if err2 != nil {
+				t.Fatalf("resetDB: truncate %s: %v: %s", strings.Join(parts, ", "), err2, out2)
+			}
+		}
+	}
+
+	// Scale kuberpult services to 0 to clear in-memory state and db connection.
+	// Scale-up is handled by helmUpgrade in each test.
+	tLog(t, "resetDB: scaling kuberpult services to 0")
+	kuberpultDeployments := []string{
+		"deployment/kuberpult-cd-service",
+		"deployment/kuberpult-frontend-service",
+		"deployment/kuberpult-reposerver-service",
+		"deployment/kuberpult-rollout-service",
+	}
+	for _, dep := range kuberpultDeployments {
+		if out3, err3 := exec.Command("kubectl", "scale", dep, "--replicas=0").CombinedOutput(); err3 != nil {
+			t.Fatalf("resetDB: scale %s: %v\n%s", dep, err3, out3)
+		}
+	}
 }
 
 // TestBracketPodStability is the regression test for the seenVersions cascade-
@@ -236,61 +430,48 @@ func waitForDeploymentAnnotation(t *testing.T, namespace, deploymentName, wantVe
 // versions, Kubernetes does NOT roll pods on a version update.  Any change in
 // pod startTime means the Deployment was deleted — the bug.
 func TestBracketPodStability(t *testing.T) {
-	t.Logf("runSuffix: %s", runSuffix)
+	cleanupCluster(t)
+	helmUpgrade(t, true, false, true, 50)
+	tLogf(t, "runSuffix: %s", runSuffix)
 	app1 := "bst-app1-" + runSuffix
 	app2 := "bst-app2-" + runSuffix
 	apps := []string{app1, app2}
 
-	// staging's upstream is development2; development2's upstream is "latest".
-	// We must provide a development2 manifest so that Kuberpult records a
-	// deployment there, enabling the staging release train to pick it up.
-	manifestsV := func(version string) map[string]string {
-		m := map[string]string{}
-		for _, ns := range []string{devNamespace, dev2Namespace, stagingNamespace} {
-			m[ns] = stableManifest("", ns, version) // app filled in by caller
-		}
-		return m
-	}
-
-	t.Log("step 1: create initial releases (version 1)")
+	tLog(t, "step 1: create initial releases (version 1)")
 	for _, app := range apps {
 		manifests := map[string]string{
 			devNamespace:     stableManifest(app, devNamespace, "1"),
-			dev2Namespace:    stableManifest(app, dev2Namespace, "1"),
 			stagingNamespace: stableManifest(app, stagingNamespace, "1"),
 		}
 		createRelease(t, app, "sreteam", testBracket, "1", manifests)
 	}
-	_ = manifestsV // suppress unused warning from the helper above
 
-	// development and development2 both have upstream=latest → auto-deploy v1.
-	// staging needs an explicit release train that reads from development2.
-	t.Log("step 2: run release train for staging (deploys v1 from development2)")
+	// development has upstream=latest → auto-deploy v1.
+	// staging needs an explicit release train that reads from development.
+	tLog(t, "step 2: run release train for staging (deploys v1 from development)")
 	releaseTrain(t, stagingNamespace)
 
-	t.Log("step 3: wait for v1 to be synced in development and staging")
+	tLog(t, "step 3: wait for v1 to be synced in development and staging")
 	for _, app := range apps {
 		for _, ns := range []string{devNamespace, stagingNamespace} {
 			waitForDeploymentAnnotation(t, ns, app+"-bracket-dep", "1")
 		}
 	}
 
-	t.Log("step 4: record pod start times")
-	type podKey struct{ ns, app string }
-	startTimes := map[podKey]string{}
+	tLog(t, "step 4: record deployment creation times")
+	creationTimes := map[deploymentKey]string{}
 	for _, app := range apps {
 		for _, ns := range []string{devNamespace, stagingNamespace} {
-			k := podKey{ns, app}
-			startTimes[k] = podStartTime(t, ns, app)
-			t.Logf("  %s/%s: %s", ns, app, startTimes[k])
+			k := deploymentKey{ns, app + "-bracket-dep"}
+			creationTimes[k] = deploymentCreationTime(t, ns, app+"-bracket-dep")
+			tLogf(t, "  %s/%s: %s", ns, app+"-bracket-dep", creationTimes[k])
 		}
 	}
 
-	t.Log("step 5: create version 2 (annotation changes, pod spec identical)")
+	tLog(t, "step 5: create version 2 (annotation changes, pod spec identical)")
 	for _, app := range apps {
 		createRelease(t, app, "sreteam", testBracket, "2", map[string]string{
 			devNamespace:     stableManifest(app, devNamespace, "2"),
-			dev2Namespace:    stableManifest(app, dev2Namespace, "2"),
 			stagingNamespace: stableManifest(app, stagingNamespace, "2"),
 		})
 	}
@@ -298,25 +479,11 @@ func TestBracketPodStability(t *testing.T) {
 	// Intentionally do NOT run the staging release train: staging stays at v1.
 	// development auto-deploys v2 (upstream=latest).
 	// This is the seenVersions scenario: development changes, staging is stable.
-	t.Log("step 6: wait for development to sync v2 (staging intentionally stays at v1)")
+	tLog(t, "step 6: wait for development to sync v2 (staging intentionally stays at v1)")
 	for _, app := range apps {
 		waitForDeploymentAnnotation(t, devNamespace, app+"-bracket-dep", "2")
 	}
 
-	// Extra buffer: if a pod was deleted give it time to come back, so a
-	// transient absence is reliably caught by the startTime diff.
-	t.Log("step 7: 20s buffer to let any accidental pod churn complete")
-	time.Sleep(podChurnBuffer)
-
-	t.Log("step 8: verify staging pod start times have not changed")
-	for _, app := range apps {
-		k := podKey{stagingNamespace, app}
-		got := podStartTime(t, stagingNamespace, app)
-		if got != startTimes[k] {
-			t.Errorf("REGRESSION: pod %s/%s was restarted unexpectedly\n  before: %s\n  after:  %s",
-				stagingNamespace, app, startTimes[k], got)
-		} else {
-			t.Logf("  OK %s/%s start time stable at %s", stagingNamespace, app, got)
-		}
-	}
+	tLog(t, "step 7: assert staging pod start times stable")
+	assertDeploymentCreationTimesStable(t, creationTimes, "pod stability")
 }

--- a/tests/kind-brackets/log_test.go
+++ b/tests/kind-brackets/log_test.go
@@ -1,0 +1,32 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package kindbracketstest
+
+import (
+	"testing"
+	"time"
+)
+
+func tLog(t *testing.T, args ...any) {
+	t.Helper()
+	t.Log(append([]any{"[" + time.Now().Format("15:04:05") + "]"}, args...)...)
+}
+
+func tLogf(t *testing.T, format string, args ...any) {
+	t.Helper()
+	t.Logf("[%s] "+format, append([]any{time.Now().Format("15:04:05")}, args...)...)
+}

--- a/tests/kind-brackets/main_test.go
+++ b/tests/kind-brackets/main_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-var globalPFM *pfManager
+var globalPFM *portForwardManager
 
 func TestMain(m *testing.M) {
 	globalPFM = startPFManager()

--- a/tests/kind-brackets/main_test.go
+++ b/tests/kind-brackets/main_test.go
@@ -1,0 +1,31 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package kindbracketstest
+
+import (
+	"os"
+	"testing"
+)
+
+var globalPFM *pfManager
+
+func TestMain(m *testing.M) {
+	globalPFM = startPFManager()
+	code := m.Run()
+	globalPFM.stop()
+	os.Exit(code)
+}

--- a/tests/kind-brackets/portforward_test.go
+++ b/tests/kind-brackets/portforward_test.go
@@ -1,0 +1,85 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package kindbracketstest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// pfManager keeps a kubectl port-forward process alive. When the process exits
+// (pod replaced, network blip) the goroutine restarts it after a short guard
+// delay. Calling restart() kills the current process so the loop immediately
+// connects to the newly rolled-out pod.
+type pfManager struct {
+	mu     sync.Mutex
+	cmd    *exec.Cmd
+	cancel context.CancelFunc
+}
+
+// startPFManager kills any shell-managed port-forward for kuberpult-frontend-service
+// and starts a self-healing manager that owns port 5002 for the test run.
+func startPFManager() *pfManager {
+	// Take ownership from any shell background loop; ignore exit code.
+	_ = exec.Command("pkill", "-f", "port-forward.*kuberpult-frontend-service").Run()
+	ctx, cancel := context.WithCancel(context.Background())
+	m := &pfManager{cancel: cancel}
+	go m.loop(ctx)
+	return m
+}
+
+func (m *pfManager) loop(ctx context.Context) {
+	for ctx.Err() == nil {
+		cmd := exec.CommandContext(ctx, "kubectl", "port-forward",
+			"-n", "default",
+			"deployment/kuberpult-frontend-service",
+			"5002:8081")
+		m.mu.Lock()
+		m.cmd = cmd
+		m.mu.Unlock()
+		if err := cmd.Run(); err != nil && ctx.Err() == nil {
+			fmt.Fprintf(os.Stderr, "port-forward exited: %v — restarting\n", err)
+		}
+		// Brief guard to avoid a tight spin when kubectl fails immediately
+		// (e.g. port still releasing). The concrete readiness signal is
+		// waitForFrontendHTTPReady at the call site.
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(300 * time.Millisecond):
+		}
+	}
+}
+
+// restart kills the running port-forward process so the loop reconnects to the
+// freshly rolled-out pod. The caller should then call waitForFrontendHTTPReady.
+func (m *pfManager) restart() {
+	m.mu.Lock()
+	cmd := m.cmd
+	m.mu.Unlock()
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}
+
+func (m *pfManager) stop() {
+	m.cancel()
+}

--- a/tests/kind-brackets/portforward_test.go
+++ b/tests/kind-brackets/portforward_test.go
@@ -25,11 +25,11 @@ import (
 	"time"
 )
 
-// pfManager keeps a kubectl port-forward process alive. When the process exits
+// portForwardManager keeps a kubectl port-forward process alive. When the process exits
 // (pod replaced, network blip) the goroutine restarts it after a short guard
 // delay. Calling restart() kills the current process so the loop immediately
 // connects to the newly rolled-out pod.
-type pfManager struct {
+type portForwardManager struct {
 	mu     sync.Mutex
 	cmd    *exec.Cmd
 	cancel context.CancelFunc
@@ -37,16 +37,16 @@ type pfManager struct {
 
 // startPFManager kills any shell-managed port-forward for kuberpult-frontend-service
 // and starts a self-healing manager that owns port 5002 for the test run.
-func startPFManager() *pfManager {
+func startPFManager() *portForwardManager {
 	// Take ownership from any shell background loop; ignore exit code.
 	_ = exec.Command("pkill", "-f", "port-forward.*kuberpult-frontend-service").Run()
 	ctx, cancel := context.WithCancel(context.Background())
-	m := &pfManager{cancel: cancel}
+	m := &portForwardManager{cancel: cancel}
 	go m.loop(ctx)
 	return m
 }
 
-func (m *pfManager) loop(ctx context.Context) {
+func (m *portForwardManager) loop(ctx context.Context) {
 	for ctx.Err() == nil {
 		cmd := exec.CommandContext(ctx, "kubectl", "port-forward",
 			"-n", "default",
@@ -71,7 +71,7 @@ func (m *pfManager) loop(ctx context.Context) {
 
 // restart kills the running port-forward process so the loop reconnects to the
 // freshly rolled-out pod. The caller should then call waitForFrontendHTTPReady.
-func (m *pfManager) restart() {
+func (m *portForwardManager) restart() {
 	m.mu.Lock()
 	cmd := m.cmd
 	m.mu.Unlock()
@@ -80,6 +80,6 @@ func (m *pfManager) restart() {
 	}
 }
 
-func (m *pfManager) stop() {
+func (m *portForwardManager) stop() {
 	m.cancel()
 }


### PR DESCRIPTION
These are integration-level tests, that focus on the bracket migration.

The tests mostly work like this:

0) assume kind cluster is set up with kuberpult and argocd.
1) clean up cluster by truncating all tables, and scaling kuberpult to 0
2) install kuberpult helm chart with specific values (e.g. brackets disabled on dev)
3) deploy something and record deployment creation times
4) install kuberpult helm chart with other values (e.g. brackets enabled on dev)
5) wait for argo to reconcile
6) check that the recording deployment times (step 3) are still correct (deployment was not interrupted)

All tests come with a log setup, e.g. the test logger always prints the timestamp, and we dump a lot of pod logs (kuberpult/argocd) when a test fails.
portforward_test.go takes care that dropped port-forwards are quickly re-established.


Ref: SRX-VRKPNL