### PR TITLE
fix: Re-render root-app after deleteEnvFromApp

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1497,7 +1497,11 @@ func (h *DBHandler) RunCustomMigrationCleanOutdatedDeployments(ctx context.Conte
 	for deploymentBatch := range slices.Chunk(orphanDeployments, MaxDeleteBatchSize) {
 		err = h.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
 			for _, deployment := range deploymentBatch {
-				err = h.DBDeleteDeployment(ctx, transaction, deployment.App, deployment.Env)
+				err = h.DBDeleteDeploymentWithHistory(ctx, transaction, deployment.App, deployment.Env, deployment.TransformerID, DeploymentMetadata{
+					DeployedByName:  "",
+					DeployedByEmail: "",
+					CiLink:          "",
+				})
 			}
 			return nil
 		})
@@ -1524,12 +1528,20 @@ func (h *DBHandler) RunCustomMigrationCleanOutdatedDeployments(ctx context.Conte
 					return fmt.Errorf("could not fetch release %v for app %s: %w", deployment.ReleaseNumbers, deployment.App, err)
 				}
 				if release == nil { // release does not exist
-					err = h.DBDeleteDeployment(ctx, transaction, deployment.App, deployment.Env)
+					err = h.DBDeleteDeploymentWithHistory(ctx, transaction, deployment.App, deployment.Env, deployment.TransformerID, DeploymentMetadata{
+						DeployedByName:  "",
+						DeployedByEmail: "",
+						CiLink:          "",
+					})
 					if err != nil {
 						return fmt.Errorf("could not delete deployment for app %s in env %s: %w", deployment.App, deployment.Env, err)
 					}
 				} else if _, ok := release.Manifests.Manifests[deployment.Env]; !ok {
-					err = h.DBDeleteDeployment(ctx, transaction, deployment.App, deployment.Env)
+					err = h.DBDeleteDeploymentWithHistory(ctx, transaction, deployment.App, deployment.Env, deployment.TransformerID, DeploymentMetadata{
+						DeployedByName:  "",
+						DeployedByEmail: "",
+						CiLink:          "",
+					})
 					if err != nil {
 						return fmt.Errorf("could not delete deployment for app %s in env %s: %w", deployment.App, deployment.Env, err)
 					}

--- a/pkg/db/db_deployments.go
+++ b/pkg/db/db_deployments.go
@@ -745,6 +745,32 @@ func (h *DBHandler) DBDeleteDeployment(ctx context.Context, tx *sql.Tx, appName 
 	return nil
 }
 
+// DBDeleteDeploymentWithHistory removes the current deployment for the given app/env and records
+// the un-deployment in the append-only deployments_history table (a row with a nil release
+// version). Callers that delete a deployment should use this instead of DBDeleteDeployment, so
+// timestamped history queries (e.g. DBSelectAppsWithDeploymentInEnvAtTimestamp) reflect the
+// deletion at the transformer's timestamp. The metadata records who performed the deletion.
+func (h *DBHandler) DBDeleteDeploymentWithHistory(ctx context.Context, tx *sql.Tx, appName types.AppName, envName types.EnvName, transformerID TransformerID, metadata DeploymentMetadata) (err error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBDeleteDeploymentWithHistory")
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
+	if err = h.DBDeleteDeployment(ctx, tx, appName, envName); err != nil {
+		return err
+	}
+	return h.insertDeploymentHistoryRow(ctx, tx, Deployment{
+		Created: time.Time{},
+		App:     appName,
+		Env:     envName,
+		ReleaseNumbers: types.ReleaseNumbers{
+			Version:  nil,
+			Revision: 0,
+		},
+		Metadata:      metadata,
+		TransformerID: transformerID,
+	})
+}
+
 func (h *DBHandler) DBMigrationUpdateDeploymentsTimestamp(ctx context.Context, transaction *sql.Tx, application types.AppName, releaseversion uint64, env types.EnvName, createdAt time.Time, revision uint64) (err error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "DBMigrationUpdateDeploymentsTimestamp")
 	defer func() {

--- a/services/cd-service/pkg/repository/transformer.go
+++ b/services/cd-service/pkg/repository/transformer.go
@@ -1187,8 +1187,16 @@ func (u *UndeployApplication) Transform(
 		}
 
 		if deployment != nil && deployment.ReleaseNumbers.Version != nil {
+			user, err := auth.ReadUserFromContext(ctx)
+			if err != nil {
+				return "", err
+			}
 			// delete deployment
-			err := state.DBHandler.DBDeleteDeployment(ctx, transaction, deployment.App, env)
+			err = state.DBHandler.DBDeleteDeploymentWithHistory(ctx, transaction, deployment.App, env, u.TransformerEslVersion, db.DeploymentMetadata{
+				DeployedByName:  user.Name,
+				DeployedByEmail: user.Email,
+				CiLink:          "",
+			})
 			if err != nil {
 				return "", err
 			}
@@ -1358,7 +1366,7 @@ func (u *DeleteEnvFromApp) Transform(
 				Created:      *now,
 				Manifests:    db.DBReleaseManifests{Manifests: newManifests},
 				Metadata:     dbReleaseWithMetadata.Metadata,
-				Environments: []types.EnvName{},
+				Environments: []types.EnvName{}, // filled by DBUpdateOrCreateRelease
 			}
 			err = state.DBHandler.DBUpdateOrCreateRelease(ctx, transaction, newRelease)
 			if err != nil {
@@ -1366,7 +1374,15 @@ func (u *DeleteEnvFromApp) Transform(
 			}
 		}
 	}
-	if err := state.DBHandler.DBDeleteDeployment(ctx, transaction, u.Application, envName); err != nil {
+	user, err := auth.ReadUserFromContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	if err := state.DBHandler.DBDeleteDeploymentWithHistory(ctx, transaction, u.Application, envName, u.TransformerEslVersion, db.DeploymentMetadata{
+		DeployedByName:  user.Name,
+		DeployedByEmail: user.Email,
+		CiLink:          "",
+	}); err != nil {
 		return "", fmt.Errorf("DeleteEnvFromApp: could not delete deployment for app '%s' env '%s': %w", u.Application, envName, err)
 	}
 	// Signal the rollout-service to cascade-delete the Argo Application that
@@ -1504,7 +1520,11 @@ func (c *CleanupOldApplicationVersions) Transform(
 	for envName, releaseNums := range allDeployments {
 		// clean up deployments of old environments:
 		if _, envExists := activeEnvs[envName]; !envExists {
-			if err := state.DBHandler.DBDeleteDeployment(ctx, transaction, c.Application, envName); err != nil {
+			if err := state.DBHandler.DBDeleteDeploymentWithHistory(ctx, transaction, c.Application, envName, c.TransformerEslVersion, db.DeploymentMetadata{
+				DeployedByName:  "",
+				DeployedByEmail: "",
+				CiLink:          "",
+			}); err != nil {
 				return "", err
 			}
 			msg = fmt.Sprintf("%sremoved zombie deployment of app %v on deleted env %v\n", msg, c.Application, envName)
@@ -1517,7 +1537,11 @@ func (c *CleanupOldApplicationVersions) Transform(
 			return "", fmt.Errorf("cleanup: could not get release %v for app '%s': %w", releaseNums, c.Application, err)
 		}
 		if release == nil {
-			if err := state.DBHandler.DBDeleteDeployment(ctx, transaction, c.Application, envName); err != nil {
+			if err := state.DBHandler.DBDeleteDeploymentWithHistory(ctx, transaction, c.Application, envName, c.TransformerEslVersion, db.DeploymentMetadata{
+				DeployedByName:  "",
+				DeployedByEmail: "",
+				CiLink:          "",
+			}); err != nil {
 				return "", err
 			}
 			msg = fmt.Sprintf("%sremoved dangling deployment of app %v on env %v (release %v does not exist)\n", msg, c.Application, envName, releaseNums)

--- a/services/cd-service/pkg/repository/transformer_db_test.go
+++ b/services/cd-service/pkg/repository/transformer_db_test.go
@@ -5308,6 +5308,21 @@ func TestUndeployDBState(t *testing.T) {
 			expectedAllReleases: []types.ReleaseNumbers{},
 			expectedDeployments: []db.Deployment{
 				{
+					// UndeployApplication deletes the deployment and records the un-deployment
+					// in history as a row with a nil release version.
+					App: appName,
+					Env: envProduction,
+					ReleaseNumbers: types.ReleaseNumbers{
+						Revision: 0,
+						Version:  nil,
+					},
+					Metadata: db.DeploymentMetadata{
+						DeployedByEmail: "testmail@example.com",
+						DeployedByName:  "test tester",
+					},
+					TransformerID: 4,
+				},
+				{
 					App: appName,
 					Env: envProduction,
 					ReleaseNumbers: types.ReleaseNumbers{

--- a/services/manifest-repo-export-service/pkg/db_history/db_history_test.go
+++ b/services/manifest-repo-export-service/pkg/db_history/db_history_test.go
@@ -277,6 +277,102 @@ func TestDBSelectAppsWithDeploymentInEnvAtTimestamp(t *testing.T) {
 	}
 }
 
+// TestDBDeleteDeploymentWithHistoryReflectsInTimestampQuery ensures that deleting a deployment via
+// the history-aware wrapper makes the timestamped history query stop reporting the app as deployed.
+// A plain DBDeleteDeployment (current table only) would leave the history showing the old version,
+// which is the bug that kept deleted apps in the env's argocd root app.
+func TestDBDeleteDeploymentWithHistoryReflectsInTimestampQuery(t *testing.T) {
+	const app = types.AppName("foo")
+	const dev = types.EnvName("dev")
+	tcs := []struct {
+		Name          string
+		DeployVersion uint64
+	}{
+		{
+			Name:          "deleting a deployment marks it un-deployed in history",
+			DeployVersion: 1,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutilauth.MakeTestContext()
+			dbHandler := setupDB(t)
+
+			// GIVEN: an app deployed to dev
+			err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				if err := dbHandler.DBWriteEnvironment(ctx, transaction, dev, config.EnvironmentConfig{}); err != nil {
+					return err
+				}
+				if err := dbHandler.DBUpdateOrCreateRelease(ctx, transaction, db.DBReleaseWithMetaData{
+					ReleaseNumbers: types.MakeReleaseNumberVersion(tc.DeployVersion),
+					App:            app,
+					Manifests:      db.DBReleaseManifests{Manifests: map[types.EnvName]string{dev: "manifest"}},
+				}); err != nil {
+					return err
+				}
+				return dbHandler.DBUpdateOrCreateDeployment(ctx, transaction, db.Deployment{
+					Created:        time.Time{},
+					App:            app,
+					Env:            dev,
+					ReleaseNumbers: types.MakeReleaseNumbers(tc.DeployVersion, 0),
+					Metadata:       db.DeploymentMetadata{},
+					TransformerID:  0,
+				})
+			})
+			if err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+
+			// sanity check: the app is reported as deployed before deletion
+			err = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				ts, err := dbHandler.DBReadTransactionTimestamp(ctx, transaction)
+				if err != nil {
+					return err
+				}
+				res, err := DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx, dbHandler, transaction, dev, *ts)
+				if err != nil {
+					return err
+				}
+				if dep, ok := res[app]; !ok || dep.ReleaseNumbers.Version == nil {
+					t.Fatalf("expected app %q to be deployed before deletion, got: %v", app, res)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("sanity: %v", err)
+			}
+
+			// WHEN: the deployment is deleted via the history-aware wrapper
+			err = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				return dbHandler.DBDeleteDeploymentWithHistory(ctx, transaction, app, dev, 0, db.DeploymentMetadata{})
+			})
+			if err != nil {
+				t.Fatalf("delete: %v", err)
+			}
+
+			// THEN: the timestamped history query no longer reports the app as deployed
+			err = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				ts, err := dbHandler.DBReadTransactionTimestamp(ctx, transaction)
+				if err != nil {
+					return err
+				}
+				res, err := DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx, dbHandler, transaction, dev, *ts)
+				if err != nil {
+					return err
+				}
+				if dep, ok := res[app]; ok && dep.ReleaseNumbers.Version != nil {
+					t.Errorf("expected app %q to be un-deployed after deletion, but it still has version %d", app, *dep.ReleaseNumbers.Version)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("verify: %v", err)
+			}
+		})
+	}
+}
+
 // setupDB returns a new DBHandler with a tmp directory every time, so tests are completely independent
 func setupDB(t *testing.T) *db.DBHandler {
 	ctx := context.Background()

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -959,6 +959,7 @@ func (r *repository) afterTransform(ctx context.Context, transaction *sql.Tx, st
 	logging.Info(ctx, "rendering of environments",
 		zap.Strings("skippedEnvs", types.EnvNamesToStrings(skippedEnvs)),
 		zap.Strings("renderedEnvs", types.EnvNamesToStrings(renderedEnvs)),
+		zap.Any("changedEnvs", changedEnvironments),
 	)
 	return errorGroup.Wait()
 }
@@ -1133,7 +1134,7 @@ func CalculateAppDataWithBrackets(
 	appToTeamMap := appTeamsToMap(appTeams)
 	for bracketName, appNames := range bracketMap {
 		bracketsTeamNames := []string{}
-		//appsInBracket := []argocd.AppTeam{}
+		hasDeployedApp := false
 		for _, appName := range appNames {
 			appsTeamName, ok := appToTeamMap[appName]
 			if !ok {
@@ -1149,7 +1150,14 @@ func CalculateAppDataWithBrackets(
 				// There was a deployment here previously, but at the timestamp, nothing is deployed, skip:
 				continue
 			}
+			hasDeployedApp = true
 			bracketsTeamNames = append(bracketsTeamNames, appsTeamName)
+		}
+
+		if !hasDeployedApp {
+			// no app in this bracket has a live deployment in this env at the timestamp,
+			// so the bracket must not appear in the env's root app, so we skip:
+			continue
 		}
 
 		appData = append(appData, argocd.AppData{

--- a/services/manifest-repo-export-service/pkg/repository/repository_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository_test.go
@@ -234,6 +234,54 @@ func TestCalculateAppDatWithBrackets(t *testing.T) {
 				},
 			},
 		},
+		{
+			// an app that has no (live) deployment in this env must not be rendered into
+			// the env's root app, even if it still has a team/release.
+			Name:          "app without a deployment is not rendered",
+			InputBrackets: makeBracketMap(map[types.ArgoBracketName]db.AppNames{}),
+			InputTeams: []db.AppWithTeam{
+				{
+					AppName:  "deployed",
+					TeamName: "t1",
+				},
+				{
+					AppName:  "undeployed",
+					TeamName: "t1",
+				},
+			},
+			InputDeploymentMap: makeDeploymentMap([]types.AppName{"deployed"}),
+			ExpectedAppData: []argocd.AppData{
+				{
+					ArgoAppName:        "deployed",
+					ReferencedAppTeams: []string{"t1"},
+				},
+			},
+		},
+		{
+			// a bracket in which no contained app has a live deployment must not be rendered.
+			Name: "bracket without any deployed app is not rendered",
+			InputBrackets: makeBracketMap(map[types.ArgoBracketName]db.AppNames{
+				"f1": {"foo1"},
+				"p1": {"pow1"},
+			}),
+			InputTeams: []db.AppWithTeam{
+				{
+					AppName:  "foo1",
+					TeamName: "t1",
+				},
+				{
+					AppName:  "pow1",
+					TeamName: "t2",
+				},
+			},
+			InputDeploymentMap: makeDeploymentMap([]types.AppName{"foo1"}),
+			ExpectedAppData: []argocd.AppData{
+				{
+					ArgoAppName:        "f1",
+					ReferencedAppTeams: []string{"t1"},
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -1077,6 +1125,8 @@ spec:
 					},
 				},
 				{
+					// The app is released but not yet deployed. Since the env's root app only
+					// references apps with a live deployment, only the AppProject is rendered here.
 					Transformers: []Transformer{
 						&CreateApplicationVersion{
 							Application: "test",
@@ -1100,30 +1150,6 @@ spec:
   - server: development
   sourceRepos:
   - '*'
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  annotations:
-    argocd.argoproj.io/manifest-generate-paths: ""
-    com.freiheit.kuberpult/aa-parent-environment: production
-    com.freiheit.kuberpult/application: test
-    com.freiheit.kuberpult/environment: production
-    com.freiheit.kuberpult/teams: ""
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  labels:
-    com.freiheit.kuberpult/teams: ""
-  name: production-test
-spec:
-  destination:
-    server: development
-  project: production
-  syncPolicy:
-    automated:
-      allowEmpty: true
-      prune: true
-      selfHeal: true
 `),
 						},
 					},
@@ -1226,6 +1252,8 @@ spec:
 					},
 				},
 				{
+					// The app is released but not yet deployed; only the AppProject is rendered
+					// because the root app references apps with a live deployment.
 					Transformers: []Transformer{
 						&CreateApplicationVersion{
 							Application: "test",
@@ -1257,30 +1285,6 @@ spec:
   - server: development
   sourceRepos:
   - '*'
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  annotations:
-    argocd.argoproj.io/manifest-generate-paths: ""
-    com.freiheit.kuberpult/aa-parent-environment: production
-    com.freiheit.kuberpult/application: test
-    com.freiheit.kuberpult/environment: production
-    com.freiheit.kuberpult/teams: ""
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  labels:
-    com.freiheit.kuberpult/teams: ""
-  name: production-test
-spec:
-  destination:
-    server: development
-  project: production
-  syncPolicy:
-    automated:
-      allowEmpty: true
-      prune: true
-      selfHeal: true
 `),
 						},
 					},

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -1579,16 +1579,24 @@ func (c *DeleteEnvFromApp) Transform(
 	if entries, err := fs.ReadDir(envAppDir); err != nil {
 		return "", wrapFileError(err, envAppDir, thisSprintf("Could not open application directory"))
 	} else if entries == nil {
-		return thisSprintf("environment does not exist."), nil
-	}
+		// environment does not exist, we do not need to delete any dirs
+	} else {
+		appLocksDir := fs.Join(envAppDir, "locks")
 
-	appLocksDir := fs.Join(envAppDir, "locks")
-	if err := fs.Remove(appLocksDir); err != nil {
-		return "", thisErrorf("cannot delete app locks '%v'", appLocksDir)
-	}
+		if _, err := fs.Stat(appLocksDir); err != nil {
+			if !errors.Is(err, os.ErrNotExist) { // only errors other that "not exist" are unexpected => propagate
+				return "", wrapFileError(err, appLocksDir, thisSprintf("Could not open lock directory"))
+			}
+		} else {
+			if err := fs.Remove(appLocksDir); err != nil {
+				return "", thisErrorf("cannot delete app locks '%v'", appLocksDir)
+			}
+		}
 
-	if err := fs.Remove(envAppDir); err != nil {
-		return "", wrapFileError(err, envAppDir, thisSprintf("Cannot delete app."))
+		// we already know envAppDir exists, now just delete it:
+		if err := fs.Remove(envAppDir); err != nil {
+			return "", wrapFileError(err, envAppDir, thisSprintf("Cannot delete app."))
+		}
 	}
 
 	tCtx.DeleteEnvFromApp(c.Application, c.Environment)


### PR DESCRIPTION
This fixes 3 issues related to rendering after deleting an app from an env:

1) Render only brackets that have at least one app with deployment in it.
2) The deployment-history was not appended when deleting an env from app (db_deployments).
3) The DeleteEnvFromApp Transformer falsly exited with an error when a specific directory did not exist.

Ref: SRX-PI9NJN