### PR TITLE
fix: add gke setup for kind-tests

### DIFF
--- a/charts/kuberpult/Makefile
+++ b/charts/kuberpult/Makefile
@@ -14,7 +14,7 @@
 
 # Copyright freiheit.com
 
-.PHONY: build-base-image push-base-image clean release-tag ct-test test-helm test kind-test
+.PHONY: build-base-image push-base-image clean release-tag ct-test test-helm test kind-test kind-test-gke
 include ../../Makefile.variables
 MAKEFILE_PATH := $(abspath $(word 1, $(MAKEFILE_LIST)))
 MAKEFILE_DIR := $(dir $(MAKEFILE_PATH))
@@ -74,6 +74,18 @@ kind-test:
 		echo "kind-test: logging to $$LOG"; \
 		printf "kuberpult commit: $$HASH\n" | tee "$$LOG"; \
 		cd ../../ && go test -count=1 -v $(GO_TEST_ARGS) ./tests/kind-brackets/ -timeout 20m 2>&1 | tee -a "$$LOG"'
+
+kind-test-gke:
+	@if [ -z "$(KUBERPULT_TEST_VERSION)" ]; then \
+		echo "ERROR: KUBERPULT_TEST_VERSION is required for GKE mode (e.g. v13.52.0)"; \
+		exit 1; \
+	fi
+	@bash -euo pipefail -c \
+		'mkdir -p "$(MAKEFILE_DIR)kind-test-logs/$(KUBERPULT_TEST_VERSION)"; \
+		LOG="$(MAKEFILE_DIR)kind-test-logs/$(KUBERPULT_TEST_VERSION)/test-$$(date +%Y%m%d-%H%M%S).log"; \
+		echo "kind-test-gke: logging to $$LOG"; \
+		printf "kuberpult version: $(KUBERPULT_TEST_VERSION)\n" | tee "$$LOG"; \
+		cd ../../ && KUBERPULT_TEST_MODE=gke KUBERPULT_TEST_VERSION="$(KUBERPULT_TEST_VERSION)" go test -count=1 -v $(GO_TEST_ARGS) ./tests/kind-brackets/ -timeout 20m 2>&1 | tee -a "$$LOG"'
 
 clean:
 	rm -rf Chart.yaml

--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -239,6 +239,19 @@ YAML
 
 echo "installing argocd $(cat ./argocd-values.yml)"
 
+# In kind mode, clean up any ArgoCD installation with a different release name/namespace.
+# Helm refuses to adopt CRDs owned by a different release; removing them here lets
+# the install below start clean. On GKE the cluster pre-owns ArgoCD, so skip this.
+if [ "${ARGO_NAMESPACE}" = "default" ] && helm -n tools status argo-cd > /dev/null 2>&1; then
+    print "Found conflicting ArgoCD release 'argo-cd' in namespace 'tools'. Removing it..."
+    helm -n tools uninstall argo-cd || true
+    kubectl delete crd \
+        applications.argoproj.io \
+        applicationsets.argoproj.io \
+        appprojects.argoproj.io \
+        2>/dev/null || true
+fi
+
 helm upgrade --install --history-max 1 argocd argo-cd/argo-cd --values argocd-values.yml --version 5.36.0 || exit 1
 
 print applying app...

--- a/tests/kind-brackets/bracket_migration_test.go
+++ b/tests/kind-brackets/bracket_migration_test.go
@@ -33,8 +33,8 @@ import (
 )
 
 const cdServiceGrpcAddr = "localhost:5004"
-const argoNamespace = "default"
 
+// helmUpgradeParams uses unexported fields so test call sites are unchanged.
 type helmUpgradeParams struct {
 	bracketsEnabled    bool
 	developmentEnabled bool
@@ -42,63 +42,17 @@ type helmUpgradeParams struct {
 	channelSize        int
 }
 
-// helmUpgrade calls helm upgrade with the given bracket configuration and waits
-// for all services to finish rolling out.
+// helmUpgrade restarts the port-forward, then delegates to the shared HelmUpgrade.
 func helmUpgrade(t *testing.T, p helmUpgradeParams) {
 	t.Helper()
-	out, err := exec.Command("git", "describe", "--always", "--long", "--tags").Output()
-	if err != nil {
-		t.Fatalf("git describe: %v", err)
-	}
-	version := strings.TrimSpace(string(out))
-	repoRoot, err2 := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err2 != nil {
-		t.Fatalf("git rev-parse: %v", err2)
-	}
-	root := strings.TrimSpace(string(repoRoot))
-	chartPath := root + "/charts/kuberpult/kuberpult-" + version + ".tgz"
-	valsPath := root + "/charts/kuberpult/vals.yaml"
-
-	boolStr := func(b bool) string {
-		if b {
-			return "true"
-		}
-		return "false"
-	}
-	tLogf(t, "helmUpgrade: enabled=%s development=%s staging=%s channelSize=%d chart=%s",
-		boolStr(p.bracketsEnabled), boolStr(p.developmentEnabled), boolStr(p.stagingEnabled), p.channelSize, chartPath)
-
-	cmd := exec.Command("helm", "upgrade", "--install",
-		"--values", valsPath,
-		"--set", "rollout.experimentalBrackets.enabled="+boolStr(p.bracketsEnabled),
-		"--set", "rollout.experimentalBrackets.clusters.development="+boolStr(p.developmentEnabled),
-		"--set", "rollout.experimentalBrackets.clusters.staging="+boolStr(p.stagingEnabled),
-		"--set", fmt.Sprintf("rollout.kuberpultEventsChannelSize=%d", p.channelSize),
-		"kuberpult-local", chartPath)
-	if out2, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("helm upgrade (enabled=%s dev=%s staging=%s): %v\n%s",
-			boolStr(p.bracketsEnabled), boolStr(p.developmentEnabled), boolStr(p.stagingEnabled), err, out2)
-	}
-
-	for _, dep := range []string{
-		"deployment/kuberpult-rollout-service",
-		"deployment/kuberpult-cd-service",
-		"deployment/kuberpult-frontend-service",
-		"deployment/kuberpult-reposerver-service",
-	} {
-		out3, err := exec.Command("kubectl", "rollout", "status", dep, "--timeout=3m").CombinedOutput()
-		if err != nil {
-			t.Fatalf("kubectl rollout status %s: %v\n%s", dep, err, out3)
-		}
-		tLogf(t, "%s rolled out: %s", dep, strings.TrimSpace(string(out3)))
-	}
 	globalPFM.restart()
-	waitForFrontendHTTPReady(t)
-	scriptPath := root + "/infrastructure/scripts/create-testdata/create-environments.sh"
-	if out4, err := exec.Command("bash", scriptPath).CombinedOutput(); err != nil {
-		t.Fatalf("create-environments: %v\n%s", err, out4)
-	}
-	tLog(t, "create-environments: done")
+	globalCDPFM.restart()
+	HelmUpgrade(t, globalCfg.Config, HelmUpgradeParams{
+		BracketsEnabled:    p.bracketsEnabled,
+		DevelopmentEnabled: p.developmentEnabled,
+		StagingEnabled:     p.stagingEnabled,
+		ChannelSize:        p.channelSize,
+	})
 }
 
 // waitForArgoApp polls until the named Argo Application exists in the default namespace.
@@ -106,7 +60,7 @@ func waitForArgoApp(t *testing.T, name string) {
 	t.Helper()
 	deadline := time.Now().Add(argoAppWaitTimeout)
 	for time.Now().Before(deadline) {
-		out, err := exec.Command("kubectl", "get", "application", name, "-n", argoNamespace).Output()
+		out, err := exec.Command("kubectl", "get", "application", name, "-n", globalCfg.KuberpultNamespace).Output()
 		if err == nil && strings.Contains(string(out), name) {
 			tLogf(t, "  Argo app present: %s", name)
 			return
@@ -121,7 +75,7 @@ func waitForArgoAppGone(t *testing.T, name string) {
 	t.Helper()
 	deadline := time.Now().Add(argoAppGoneTimeout)
 	for time.Now().Before(deadline) {
-		_, err := exec.Command("kubectl", "get", "application", name, "-n", argoNamespace).Output()
+		_, err := exec.Command("kubectl", "get", "application", name, "-n", globalCfg.KuberpultNamespace).Output()
 		if err != nil {
 			tLogf(t, "  Argo app gone: %s", name)
 			return
@@ -571,13 +525,13 @@ func TestBracketEnableAllClusters(t *testing.T) {
 	releaseTrain(t, stagingNamespace)
 
 	// diagnostic: show what ArgoCD apps and staging deployments exist after release train
-	if out, err := exec.Command("kubectl", "get", "applications", "-n", argoNamespace, "--no-headers").CombinedOutput(); err == nil {
+	if out, err := exec.Command("kubectl", "get", "applications", "-n", globalCfg.KuberpultNamespace, "--no-headers").CombinedOutput(); err == nil {
 		tLogf(t, "ArgoCD apps after releaseTrain:\n%s", out)
 	}
 	if out, err := exec.Command("kubectl", "get", "deployments", "-n", stagingNamespace, "--no-headers").CombinedOutput(); err == nil {
 		tLogf(t, "Deployments in staging after releaseTrain:\n%s", out)
 	}
-	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "deployment/kuberpult-rollout-service", "--tail=40").CombinedOutput(); err == nil {
+	if out, err := exec.Command("kubectl", "logs", "-n", globalCfg.KuberpultNamespace, "deployment/kuberpult-rollout-service", "--tail=40").CombinedOutput(); err == nil {
 		tLogf(t, "rollout-service tail after releaseTrain:\n%s", out)
 	}
 
@@ -889,7 +843,7 @@ func TestBracketMigrateDevelopment(t *testing.T) {
 func dumpBracketDiagnostics(t *testing.T, argoApps []string, namespaces []string) {
 	t.Helper()
 	for _, app := range argoApps {
-		if out, err := exec.Command("kubectl", "describe", "application", app, "-n", argoNamespace).CombinedOutput(); err == nil {
+		if out, err := exec.Command("kubectl", "describe", "application", app, "-n", globalCfg.KuberpultNamespace).CombinedOutput(); err == nil {
 			tLogf(t, "ArgoCD app describe %s:\n%s", app, out)
 		}
 	}
@@ -900,11 +854,11 @@ func dumpBracketDiagnostics(t *testing.T, argoApps []string, namespaces []string
 	}
 	for _, svc := range []string{"rollout-service", "manifest-repo-export-service"} {
 		dep := "deployment/kuberpult-" + svc
-		if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, dep, "--tail=100").CombinedOutput(); err == nil {
+		if out, err := exec.Command("kubectl", "logs", "-n", globalCfg.KuberpultNamespace, dep, "--tail=100").CombinedOutput(); err == nil {
 			tLogf(t, "%s logs (tail 100):\n%s", svc, out)
 		}
 	}
-	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "statefulset/argocd-application-controller", "--tail=100").CombinedOutput(); err == nil {
+	if out, err := exec.Command("kubectl", "logs", "-n", globalCfg.KuberpultNamespace, "statefulset/argocd-application-controller", "--tail=100").CombinedOutput(); err == nil {
 		tLogf(t, "argocd-application-controller logs (tail 100):\n%s", out)
 	}
 }
@@ -915,12 +869,12 @@ func dumpBracketDiagnostics(t *testing.T, argoApps []string, namespaces []string
 func dumpBracketDiagnosticsExpanded(t *testing.T, bracketApps []string, individualApps []string, namespaces []string) {
 	t.Helper()
 	for _, app := range bracketApps {
-		if out, err := exec.Command("kubectl", "describe", "application", app, "-n", argoNamespace).CombinedOutput(); err == nil {
+		if out, err := exec.Command("kubectl", "describe", "application", app, "-n", globalCfg.KuberpultNamespace).CombinedOutput(); err == nil {
 			tLogf(t, "ArgoCD app describe %s:\n%s", app, out)
 		}
 	}
 	for _, app := range individualApps {
-		if out, err := exec.Command("kubectl", "describe", "application", app, "-n", argoNamespace).CombinedOutput(); err == nil {
+		if out, err := exec.Command("kubectl", "describe", "application", app, "-n", globalCfg.KuberpultNamespace).CombinedOutput(); err == nil {
 			tLogf(t, "ArgoCD app describe (individual) %s:\n%s", app, out)
 		}
 	}
@@ -929,22 +883,22 @@ func dumpBracketDiagnosticsExpanded(t *testing.T, bracketApps []string, individu
 			tLogf(t, "events in %s:\n%s", ns, out)
 		}
 	}
-	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "deployment/kuberpult-rollout-service", "--since=5m").CombinedOutput(); err == nil {
+	if out, err := exec.Command("kubectl", "logs", "-n", globalCfg.KuberpultNamespace, "deployment/kuberpult-rollout-service", "--since=5m").CombinedOutput(); err == nil {
 		tLogf(t, "rollout-service logs (since 5m):\n%s", out)
 	}
-	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "statefulset/argocd-application-controller", "--since=5m").CombinedOutput(); err == nil {
+	if out, err := exec.Command("kubectl", "logs", "-n", globalCfg.KuberpultNamespace, "statefulset/argocd-application-controller", "--since=5m").CombinedOutput(); err == nil {
 		tLogf(t, "argocd-application-controller logs (since 5m):\n%s", out)
 	}
-	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "deployment/argocd-server", "--since=5m").CombinedOutput(); err == nil {
+	if out, err := exec.Command("kubectl", "logs", "-n", globalCfg.KuberpultNamespace, "deployment/argocd-server", "--since=5m").CombinedOutput(); err == nil {
 		tLogf(t, "argocd-server logs (since 5m):\n%s", out)
 	}
-	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "deployment/kuberpult-reposerver-service", "--since=5m").CombinedOutput(); err == nil {
+	if out, err := exec.Command("kubectl", "logs", "-n", globalCfg.KuberpultNamespace, "deployment/kuberpult-reposerver-service", "--since=5m").CombinedOutput(); err == nil {
 		tLogf(t, "kuberpult-reposerver-service logs (since 5m):\n%s", out)
 	}
-	if out, err := exec.Command("kubectl", "logs", "-n", argoNamespace, "deployment/kuberpult-rollout-service", "--since=5m", "--previous").CombinedOutput(); err == nil {
+	if out, err := exec.Command("kubectl", "logs", "-n", globalCfg.KuberpultNamespace, "deployment/kuberpult-rollout-service", "--since=5m", "--previous").CombinedOutput(); err == nil {
 		tLogf(t, "rollout-service logs (previous container, since 5m):\n%s", out)
 	}
-	if out, err := exec.Command("kubectl", "get", "appprojects", "-n", argoNamespace, "-o", "yaml").CombinedOutput(); err == nil {
-		tLogf(t, "AppProjects in %s:\n%s", argoNamespace, out)
+	if out, err := exec.Command("kubectl", "get", "appprojects", "-n", globalCfg.KuberpultNamespace, "-o", "yaml").CombinedOutput(); err == nil {
+		tLogf(t, "AppProjects in %s:\n%s", globalCfg.KuberpultNamespace, out)
 	}
 }

--- a/tests/kind-brackets/bracket_stability_test.go
+++ b/tests/kind-brackets/bracket_stability_test.go
@@ -23,11 +23,7 @@ Copyright freiheit.com*/
 package kindbracketstest
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"mime/multipart"
-	"net/http"
 	"os"
 	"os/exec"
 	"slices"
@@ -70,19 +66,7 @@ type deploymentKey struct{ namespace, name string }
 // after pods are replaced. Mirrors the processBatch retry logic.
 func waitForFrontendHTTPReady(t *testing.T) {
 	t.Helper()
-	deadline := time.Now().Add(grpcRetryTimeout)
-	url := "http://localhost:" + kuberpultFrontendPort + "/health"
-	for time.Now().Before(deadline) {
-		resp, err := http.Get(url)
-		if err == nil {
-			if err := resp.Body.Close(); err != nil {
-				tLogf(t, "close health response body: %v", err)
-			}
-			return
-		}
-		time.Sleep(grpcRetryInterval)
-	}
-	t.Fatalf("frontend service at %s not reachable after 30s", url)
+	WaitForFrontendReady(t)
 }
 
 // stableManifest returns a Deployment + ConfigMap for app/namespace/version.
@@ -95,101 +79,12 @@ func waitForFrontendHTTPReady(t *testing.T) {
 // This means: if a pod's startTime changes between versions, its Deployment was
 // deleted (i.e. the bracket Argo app was cascade-deleted unexpectedly).
 func stableManifest(app, namespace, version string) string {
-	return fmt.Sprintf(`---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: %s-bracket-cfg
-  namespace: %s
-data:
-  version: "%s"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: %s-bracket-dep
-  namespace: %s
-  annotations:
-    kuberpult.freiheit.com/release-version: "%s"
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: %s-bracket
-  template:
-    metadata:
-      labels:
-        app: %s-bracket
-    spec:
-      terminationGracePeriodSeconds: 0
-      containers:
-      - name: sleep
-        image: busybox:latest
-        command: ["/bin/sh", "-c", "trap 'exit 0' SIGTERM; while true; do sleep 1000; done"]
-        readinessProbe:
-          exec:
-            command: ["ls", "/"]
-          initialDelaySeconds: 3
-          periodSeconds: 5
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-`, app, namespace, version, app, namespace, version, app, app)
+	return StableManifest(app, namespace, version)
 }
 
 func createRelease(t *testing.T, app, team, bracketName, version string, manifests map[string]string) {
 	t.Helper()
-	var b bytes.Buffer
-	w := multipart.NewWriter(&b)
-	mustWriteField(t, w, "application", app)
-	mustWriteField(t, w, "version", version)
-	mustWriteField(t, w, "team", team)
-	if bracketName != "" {
-		mustWriteField(t, w, "experimentalArgoBracket", bracketName)
-	}
-	for env, manifest := range manifests {
-		fw, err := w.CreateFormFile("manifests["+env+"]", "manifests["+env+"]")
-		if err != nil {
-			t.Fatalf("create form file: %v", err)
-		}
-		if _, err := io.WriteString(fw, manifest); err != nil {
-			t.Fatalf("write manifest: %v", err)
-		}
-	}
-	if err := w.Close(); err != nil {
-		t.Fatalf("close multipart writer: %v", err)
-	}
-
-	req, err := http.NewRequest("POST", "http://localhost:"+kuberpultFrontendPort+"/api/release", &b)
-	if err != nil {
-		t.Fatalf("build release request: %v", err)
-	}
-	req.Header.Set("Content-Type", w.FormDataContentType())
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		fatalWithServiceLogs(t, "POST /api/release for %s v%s: %v", app, version, err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			t.Errorf("close response body: %v", err)
-		}
-	}()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("read response body for %s v%s: %v", app, version, err)
-	}
-	if resp.StatusCode > 299 {
-		t.Fatalf("POST /api/release for %s v%s: HTTP %d: %s", app, version, resp.StatusCode, body)
-	}
-}
-
-func mustWriteField(t *testing.T, w *multipart.Writer, key, value string) {
-	t.Helper()
-	if err := w.WriteField(key, value); err != nil {
-		t.Fatalf("write field %s: %v", key, err)
-	}
+	CreateRelease(t, app, team, bracketName, version, manifests)
 }
 
 // dumpKuberpultLogs prints the last 300 log lines (current + previous container)
@@ -199,7 +94,7 @@ func mustWriteField(t *testing.T, w *multipart.Writer, key, value string) {
 func dumpKuberpultLogs(t *testing.T) {
 	t.Helper()
 	fmt.Fprintln(os.Stderr, "=== CRITICAL: dumping kuberpult service logs ===")
-	podsOut, err := exec.Command("kubectl", "get", "pods", "-n", "default", "-o", "name").CombinedOutput()
+	podsOut, err := exec.Command("kubectl", "get", "pods", "-n", globalCfg.KuberpultNamespace, "-o", "name").CombinedOutput()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "kubectl get pods: %v\n", err)
 	}
@@ -210,7 +105,7 @@ func dumpKuberpultLogs(t *testing.T) {
 				continue
 			}
 			for _, prev := range []bool{false, true} {
-				args := []string{"logs", "-n", "default", podName, "--tail=300"}
+				args := []string{"logs", "-n", globalCfg.KuberpultNamespace, podName, "--tail=300"}
 				label := podName
 				if prev {
 					args = append(args, "--previous")
@@ -238,27 +133,7 @@ func fatalWithServiceLogs(t *testing.T, format string, args ...any) {
 
 func releaseTrain(t *testing.T, env string) {
 	t.Helper()
-	url := "http://localhost:" + kuberpultFrontendPort + "/api/environments/" + env + "/releasetrain"
-	req, err := http.NewRequest("PUT", url, nil)
-	if err != nil {
-		t.Fatalf("build release-train request for %s: %v", env, err)
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		fatalWithServiceLogs(t, "PUT release train %s: %v", env, err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			t.Errorf("close response body: %v", err)
-		}
-	}()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("read release-train response body for %s: %v", env, err)
-	}
-	if resp.StatusCode > 299 {
-		t.Fatalf("PUT release train %s: HTTP %d: %s", env, resp.StatusCode, body)
-	}
+	ReleaseTrain(t, env)
 }
 
 // deploymentCreationTime returns the creationTimestamp of the named Deployment.
@@ -324,9 +199,9 @@ func waitForDeploymentAnnotation(t *testing.T, namespace, deploymentName, wantVe
 // Call this at the start of every test to ensure a clean cluster state.
 func removeAllArgoAppFinalizers(t *testing.T) {
 	t.Helper()
-	names, _ := exec.Command("kubectl", "get", "applications", "-n", "default", "-o", "name").CombinedOutput()
+	names, _ := exec.Command("kubectl", "get", "applications", "-n", globalCfg.KuberpultNamespace, "-o", "name").CombinedOutput()
 	for _, name := range strings.Fields(string(names)) {
-		err := exec.Command("kubectl", "patch", "-n", "default", name,
+		err := exec.Command("kubectl", "patch", "-n", globalCfg.KuberpultNamespace, name,
 			"--type=merge", "-p", `{"metadata":{"finalizers":[]}}`).Run()
 		if err != nil {
 			tLog(t, "kubectl patch finalizers failed (continuing)[%s]: %v", name, err)
@@ -340,7 +215,7 @@ func cleanupCluster(t *testing.T) {
 	t.Helper()
 	tLog(t, "cleanupCluster: deleting all ArgoCD applications")
 	removeAllArgoAppFinalizers(t)
-	out, err := exec.Command("kubectl", "delete", "applications", "--all", "-n", "default", "--wait=true").CombinedOutput()
+	out, err := exec.Command("kubectl", "delete", "applications", "--all", "-n", globalCfg.KuberpultNamespace, "--wait=true").CombinedOutput()
 	if err != nil {
 		t.Fatalf("kubectl delete applications failed: %v: %s", err, out)
 	}
@@ -359,12 +234,12 @@ func cleanupCluster(t *testing.T) {
 func resetDB(t *testing.T) {
 	t.Helper()
 
+	stopDBPF := globalCfg.startDBPortForward(t)
+	defer stopDBPF()
+
 	// Step 1: query all table names in the public schema
 	tLog(t, "resetDB: querying tables")
-	out, err := exec.Command("kubectl", "exec", "deployment/postgres", "-n", "default", "--",
-		"psql", "-U", "postgres", "-d", "kuberpult", "-At",
-		"-c", "SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename;",
-	).CombinedOutput()
+	out, err := globalCfg.runPsql("-At", "-c", "SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename;")
 	if err != nil {
 		t.Fatalf("resetDB: list tables: %v: %s", err, out)
 	}
@@ -381,17 +256,14 @@ func resetDB(t *testing.T) {
 	} else {
 		tLogf(t, "resetDB: will truncate tables: %s", strings.Join(tables, ", "))
 
-		// Step 3: truncate tables in batches of 5 to reduce kubectl exec calls (~1 sec per call)
+		// Step 3: truncate tables in batches of 5 to reduce round-trips (~1 sec per call)
 		for batch := range slices.Chunk(tables, 5) {
 			var parts []string
 			for _, table := range batch {
 				parts = append(parts, fmt.Sprintf(`"%s"`, table))
 			}
 			tLogf(t, "resetDB: truncating tables %s", strings.Join(parts, ", "))
-			out2, err2 := exec.Command("kubectl", "exec", "deployment/postgres", "-n", "default", "--",
-				"psql", "-U", "postgres", "-d", "kuberpult", "-c",
-				fmt.Sprintf(`TRUNCATE TABLE %s CASCADE;`, strings.Join(parts, ", ")),
-			).CombinedOutput()
+			out2, err2 := globalCfg.runPsql("-c", fmt.Sprintf(`TRUNCATE TABLE %s CASCADE;`, strings.Join(parts, ", ")))
 			if err2 != nil {
 				t.Fatalf("resetDB: truncate %s: %v: %s", strings.Join(parts, ", "), err2, out2)
 			}
@@ -408,7 +280,7 @@ func resetDB(t *testing.T) {
 		"deployment/kuberpult-rollout-service",
 	}
 	for _, dep := range kuberpultDeployments {
-		if out3, err3 := exec.Command("kubectl", "scale", dep, "--replicas=0").CombinedOutput(); err3 != nil {
+		if out3, err3 := exec.Command("kubectl", "scale", dep, "-n", globalCfg.KuberpultNamespace, "--replicas=0").CombinedOutput(); err3 != nil {
 			t.Fatalf("resetDB: scale %s: %v\n%s", dep, err3, out3)
 		}
 	}

--- a/tests/kind-brackets/cmd/main.go
+++ b/tests/kind-brackets/cmd/main.go
@@ -1,0 +1,111 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+// Manual testing helpers for the kind-brackets test suite.
+//
+// Usage (kind):
+//
+//	go run ./tests/kind-brackets/cmd helm-upgrade [--brackets=true] [--development=false] [--staging=true] [--channel-size=50]
+//	go run ./tests/kind-brackets/cmd release-train [--env=staging]
+//	go run ./tests/kind-brackets/cmd create-release --app=APP --bracket=BRACKET [--team=TEAM] [--version=1] [--envs=development,staging]
+//	go run ./tests/kind-brackets/cmd reset-db
+//
+// Usage (GKE):
+//
+//	KUBERPULT_TEST_MODE=gke KUBERPULT_TEST_VERSION=v13.52.9 go run ./tests/kind-brackets/cmd <subcommand> [flags]
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	kb "github.com/freiheit-com/kuberpult/tests/kind-brackets"
+)
+
+// cliTB implements kb.TB for use outside of a test context.
+type cliTB struct{}
+
+func (c *cliTB) Helper() {}
+func (c *cliTB) Fatalf(format string, args ...any) { log.Fatalf(format, args...) }
+func (c *cliTB) Logf(format string, args ...any)   { log.Printf(format, args...) }
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "Usage:")
+		fmt.Fprintln(os.Stderr, "  main helm-upgrade [--brackets=true] [--development=false] [--staging=true] [--channel-size=50]")
+		fmt.Fprintln(os.Stderr, "  main release-train [--env=staging]")
+		fmt.Fprintln(os.Stderr, "  main create-release --app=APP --bracket=BRACKET [--team=test-team] [--version=1] [--envs=development,staging]")
+		fmt.Fprintln(os.Stderr, "  main reset-db")
+		os.Exit(1)
+	}
+
+	tb := &cliTB{}
+	cfg := kb.MustLoadConfig()
+
+	subcommand := os.Args[1]
+	args := os.Args[2:]
+
+	switch subcommand {
+	case "helm-upgrade":
+		fs := flag.NewFlagSet("helm-upgrade", flag.ExitOnError)
+		brackets := fs.Bool("brackets", true, "enable experimental brackets")
+		development := fs.Bool("development", false, "enable bracket on development cluster")
+		staging := fs.Bool("staging", true, "enable bracket on staging cluster")
+		channelSize := fs.Int("channel-size", 50, "kuberpult events channel size")
+		_ = fs.Parse(args)
+		kb.HelmUpgrade(tb, cfg, kb.HelmUpgradeParams{
+			BracketsEnabled:    *brackets,
+			DevelopmentEnabled: *development,
+			StagingEnabled:     *staging,
+			ChannelSize:        *channelSize,
+		})
+
+	case "release-train":
+		kb.EnsurePortForwards(tb, cfg)
+		fs := flag.NewFlagSet("release-train", flag.ExitOnError)
+		env := fs.String("env", "staging", "target environment")
+		_ = fs.Parse(args)
+		kb.ReleaseTrain(tb, *env)
+
+	case "create-release":
+		kb.EnsurePortForwards(tb, cfg)
+		fs := flag.NewFlagSet("create-release", flag.ExitOnError)
+		app := fs.String("app", "", "application name (required)")
+		team := fs.String("team", "test-team", "team name")
+		bracket := fs.String("bracket", "", "bracket name (required)")
+		version := fs.String("version", "1", "release version number")
+		envsStr := fs.String("envs", "development,staging", "comma-separated target environments")
+		_ = fs.Parse(args)
+		if *app == "" || *bracket == "" {
+			log.Fatal("--app and --bracket are required")
+		}
+		manifests := map[string]string{}
+		for _, env := range strings.Split(*envsStr, ",") {
+			manifests[env] = kb.StableManifest(*app, env, *version)
+		}
+		kb.CreateRelease(tb, *app, *team, *bracket, *version, manifests)
+
+	case "reset-db":
+		db := kb.MustLoadDBCreds(cfg)
+		kb.ResetDB(tb, cfg, db)
+
+	default:
+		log.Fatalf("unknown subcommand %q; valid: helm-upgrade, release-train, create-release, reset-db", subcommand)
+	}
+}

--- a/tests/kind-brackets/config_test.go
+++ b/tests/kind-brackets/config_test.go
@@ -1,0 +1,145 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package kindbracketstest
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// local port used to reach the Cloud SQL proxy sidecar in GKE mode.
+const gkeDBPortForwardPort = "5433"
+
+// port the cloud-sql-proxy sidecar listens on inside the pod.
+const gkeDBProxyPort = "5432"
+
+// testConfig extends Config with DB-access credentials (GKE only).
+// Tests use this; cmd/main.go uses Config directly.
+type testConfig struct {
+	Config
+	dbUser     string
+	dbPassword string
+	dbName     string
+}
+
+// mustLoadConfig calls MustLoadConfig for the shared fields, then adds
+// DB credentials for GKE mode.
+func mustLoadConfig() testConfig {
+	cfg := MustLoadConfig()
+	tc := testConfig{Config: cfg}
+	if cfg.Mode != ModeGKE {
+		return tc
+	}
+
+	tc.dbUser = ReadSecretKey("kuberpult-db", "tools", "username")
+	tc.dbPassword = ReadSecretKey("kuberpult-db", "tools", "password")
+
+	// Range over all containers to find KUBERPULT_DB_NAME (the cloud-sql-proxy
+	// sidecar may appear before the kuberpult-cd-service container).
+	dbNameOut, err := exec.Command("kubectl", "get", "deployment", "kuberpult-cd-service",
+		"-n", "tools", "-o",
+		`jsonpath={range .spec.template.spec.containers[*]}{range .env[*]}{.name}{"="}{.value}{"\n"}{end}{end}`,
+	).Output()
+	if err != nil {
+		log.Fatalf("gke mode: get env vars from kuberpult-cd-service deployment: %v", err)
+	}
+	for _, line := range strings.Split(string(dbNameOut), "\n") {
+		if after, ok := strings.CutPrefix(line, "KUBERPULT_DB_NAME="); ok {
+			tc.dbName = strings.TrimSpace(after)
+			break
+		}
+	}
+	if tc.dbName == "" {
+		log.Fatalf("gke mode: KUBERPULT_DB_NAME not found in kuberpult-cd-service deployment")
+	}
+
+	EnsureArgoAppProjects(cfg.KuberpultNamespace)
+
+	return tc
+}
+
+// runPsql executes psql with the given args against the kuberpult database.
+// Kind: via kubectl exec into the postgres pod.
+// GKE: directly against the Cloud SQL proxy sidecar; the caller must have opened
+// the port-forward first with startDBPortForward.
+func (c testConfig) runPsql(psqlArgs ...string) ([]byte, error) {
+	if c.Mode == ModeKind {
+		base := []string{
+			"exec", "deployment/postgres",
+			"-n", c.KuberpultNamespace, "--",
+			"psql", "-U", "postgres", "-d", "kuberpult",
+		}
+		return exec.Command("kubectl", append(base, psqlArgs...)...).CombinedOutput()
+	}
+	base := []string{"-h", "127.0.0.1", "-p", gkeDBPortForwardPort, "-U", c.dbUser, "-d", c.dbName, "-w"}
+	cmd := exec.Command("psql", append(base, psqlArgs...)...)
+	cmd.Env = append(os.Environ(), "PGPASSWORD="+c.dbPassword)
+	return cmd.CombinedOutput()
+}
+
+// startDBPortForward opens a kubectl port-forward to the Cloud SQL proxy sidecar
+// inside the cd-service pod and waits until psql can connect.
+// In kind mode this is a no-op and returns a no-op stop func.
+func (c testConfig) startDBPortForward(t *testing.T) func() {
+	t.Helper()
+	if c.Mode == ModeKind {
+		return func() {}
+	}
+
+	// If a previous test run left services scaled to 0 (e.g. crashed between resetDB
+	// and helmUpgrade), run a neutral helmUpgrade to bring them back up with the
+	// correct image version before we try to port-forward. Using raw kubectl scale
+	// would start the pod from the last Helm release, which may have a stale image tag.
+	readyOut, _ := exec.Command("kubectl", "get", "deployment", "kuberpult-cd-service",
+		"-n", c.KuberpultNamespace,
+		"-o", "jsonpath={.status.readyReplicas}").Output()
+	if r := strings.TrimSpace(string(readyOut)); r == "" || r == "0" {
+		t.Logf("startDBPortForward: services at 0 replicas, running recovery helmUpgrade")
+		helmUpgrade(t, helmUpgradeParams{bracketsEnabled: false, channelSize: 50})
+	}
+
+	pf := exec.Command("kubectl", "port-forward",
+		"-n", c.KuberpultNamespace,
+		"deployment/kuberpult-cd-service",
+		gkeDBPortForwardPort+":"+gkeDBProxyPort)
+	if err := pf.Start(); err != nil {
+		t.Fatalf("startDBPortForward: %v", err)
+	}
+	stop := func() {
+		if pf.Process != nil {
+			_ = pf.Process.Kill()
+		}
+	}
+	// Probe until the tunnel is ready; retry to avoid depending on a fixed sleep.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		probe := exec.Command("psql", "-h", "127.0.0.1", "-p", gkeDBPortForwardPort,
+			"-U", c.dbUser, "-d", c.dbName, "-w", "-c", "SELECT 1")
+		probe.Env = append(os.Environ(), "PGPASSWORD="+c.dbPassword)
+		if err := probe.Run(); err == nil {
+			return stop
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	stop()
+	t.Fatalf("startDBPortForward: port-forward not ready after 15 seconds")
+	return func() {}
+}

--- a/tests/kind-brackets/main_test.go
+++ b/tests/kind-brackets/main_test.go
@@ -21,11 +21,16 @@ import (
 	"testing"
 )
 
-var globalPFM *portForwardManager
+var globalPFM   *portForwardManager
+var globalCDPFM *portForwardManager
+var globalCfg   testConfig
 
 func TestMain(m *testing.M) {
-	globalPFM = startPFManager()
+	globalCfg = mustLoadConfig()
+	globalPFM = startPFManager(globalCfg, "deployment/kuberpult-frontend-service", "5002:8081")
+	globalCDPFM = startPFManager(globalCfg, "deployment/kuberpult-cd-service", "5004:8443")
 	code := m.Run()
 	globalPFM.stop()
+	globalCDPFM.stop()
 	os.Exit(code)
 }

--- a/tests/kind-brackets/ops.go
+++ b/tests/kind-brackets/ops.go
@@ -185,6 +185,14 @@ func EnsurePortForwards(tb TB, cfg Config) {
 		tb.Logf("EnsurePortForwards: both ports already reachable, skipping restart")
 		return
 	}
+	// Kind mode: portForwardManagers (started in TestMain) handle restart automatically.
+	// pkilling them races with their restart loop — just wait for them to reconnect.
+	if cfg.Mode == ModeKind {
+		tb.Logf("EnsurePortForwards: kind mode — waiting for managers to reconnect")
+		WaitForFrontendReady(tb)
+		waitForTCPPort(tb, "127.0.0.1:5004", 30*time.Second)
+		return
+	}
 	for _, target := range []string{"kuberpult-frontend-service", "kuberpult-cd-service"} {
 		tb.Logf("EnsurePortForwards: pkill port-forward.*%s", target)
 		_ = exec.Command("pkill", "-f", "port-forward.*"+target).Run()

--- a/tests/kind-brackets/ops.go
+++ b/tests/kind-brackets/ops.go
@@ -1,0 +1,667 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package kindbracketstest
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"time"
+)
+
+// TB is the subset of *testing.T used by these helpers, so that the same
+// functions can be called from both test code and CLI tools.
+type TB interface {
+	Helper()
+	Fatalf(format string, args ...any)
+	Logf(format string, args ...any)
+}
+
+// TestMode selects the cluster backend.
+type TestMode string
+
+const (
+	ModeKind TestMode = "kind"
+	ModeGKE  TestMode = "gke"
+)
+
+// FrontendPort is the local port used for the kuberpult frontend port-forward.
+const FrontendPort = "5002"
+
+// GKEContext is the required kubectl context when running in GKE mode.
+const GKEContext = "gke_fdc-standard-setup-dev-env_europe-west1-d_tools-migrationtest"
+
+// Config holds all infrastructure-dependent settings needed by the shared ops.
+// Test code uses this embedded inside testConfig, which adds DB-access fields.
+type Config struct {
+	Mode               TestMode
+	KuberpultNamespace string // "default" (kind) | "tools" (gke)
+	HelmReleaseName    string // "kuberpult-local" (kind) | derived from helm list (gke)
+	TestVersion        string // chart version whose images exist in the registry (GKE only)
+	GKEProjectNumber   string // kept as string; --reuse-values re-introduces it as a number
+}
+
+// HelmUpgradeParams configures bracket settings for a helm upgrade.
+type HelmUpgradeParams struct {
+	BracketsEnabled    bool
+	DevelopmentEnabled bool
+	StagingEnabled     bool
+	ChannelSize        int
+}
+
+// MustLoadConfig reads KUBERPULT_TEST_MODE and derives all cluster settings
+// that do not require database credentials. Suitable for use in cmd/main.go.
+// Uses log.Fatalf because it is typically called outside a test context.
+func MustLoadConfig() Config {
+	mode := TestMode(os.Getenv("KUBERPULT_TEST_MODE"))
+	if mode == "" {
+		mode = ModeKind
+	}
+	if mode != ModeKind && mode != ModeGKE {
+		log.Fatalf("KUBERPULT_TEST_MODE must be 'kind' or 'gke', got %q", mode)
+	}
+	if mode == ModeKind {
+		return Config{
+			Mode:               ModeKind,
+			KuberpultNamespace: "default",
+			HelmReleaseName:    "kuberpult-local",
+		}
+	}
+
+	cfg := Config{Mode: ModeGKE, KuberpultNamespace: "tools"}
+
+	ctxOut, err := exec.Command("kubectl", "config", "current-context").Output()
+	if err != nil {
+		log.Fatalf("gke mode: kubectl config current-context: %v", err)
+	}
+	if got := strings.TrimSpace(string(ctxOut)); got != GKEContext {
+		log.Fatalf("gke mode: wrong kubectl context %q\nExpected: %q\nRun: kubectl config use-context %s",
+			got, GKEContext, GKEContext)
+	}
+
+	relOut, err := exec.Command("helm", "list", "-n", "tools", "--short").Output()
+	if err != nil {
+		log.Fatalf("gke mode: helm list -n tools: %v", err)
+	}
+	var kuberpultReleases []string
+	for _, r := range strings.Fields(string(relOut)) {
+		if strings.Contains(r, "kuberpult") {
+			kuberpultReleases = append(kuberpultReleases, r)
+		}
+	}
+	if len(kuberpultReleases) != 1 {
+		log.Fatalf("gke mode: expected exactly 1 kuberpult helm release in namespace tools, got %d: %v",
+			len(kuberpultReleases), kuberpultReleases)
+	}
+	cfg.HelmReleaseName = kuberpultReleases[0]
+
+	cfg.TestVersion = os.Getenv("KUBERPULT_TEST_VERSION")
+	if cfg.TestVersion == "" {
+		log.Fatalf("gke mode: KUBERPULT_TEST_VERSION is required (e.g. v13.52.0)")
+	}
+
+	cfg.GKEProjectNumber = ReadHelmValue(cfg.HelmReleaseName, "tools", "gke", "project_number")
+
+	return cfg
+}
+
+// ReadHelmValue reads a nested key from a helm release's computed values and
+// returns it as a string. Helm stores large numbers as JSON numbers; this
+// function always returns a string so callers can pass it back via --set-string.
+func ReadHelmValue(release, namespace, topKey, subKey string) string {
+	out, err := exec.Command("helm", "get", "values", release,
+		"-n", namespace, "--all", "-o", "json").Output()
+	if err != nil {
+		log.Fatalf("gke mode: helm get values %s -n %s: %v", release, namespace, err)
+	}
+	var vals map[string]any
+	if err := json.Unmarshal(out, &vals); err != nil {
+		log.Fatalf("gke mode: parse helm values: %v", err)
+	}
+	top, ok := vals[topKey].(map[string]any)
+	if !ok {
+		log.Fatalf("gke mode: helm values: key %q not found or not a map", topKey)
+	}
+	v, ok := top[subKey]
+	if !ok {
+		log.Fatalf("gke mode: helm values: key %q.%q not found", topKey, subKey)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+// ReadSecretKey reads a base64-encoded key from a Kubernetes secret.
+func ReadSecretKey(secret, namespace, key string) string {
+	out, err := exec.Command("kubectl", "get", "secret", secret,
+		"-n", namespace, "-o", "jsonpath={.data."+key+"}").Output()
+	if err != nil {
+		log.Fatalf("gke mode: kubectl get secret %s/%s key %q: %v", namespace, secret, key, err)
+	}
+	dec, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(out)))
+	if err != nil {
+		log.Fatalf("gke mode: base64 decode %s/%s: %v", secret, key, err)
+	}
+	return string(dec)
+}
+
+// EnsurePortForwards ensures kubectl port-forwards for the kuberpult frontend
+// and cd-service are reachable. If both ports are already up it returns
+// immediately; otherwise it kills any stale processes, starts fresh detached
+// ones, and waits until both are reachable. Processes are started detached so
+// they outlive the command and remain available for subsequent runs in the same
+// shell session.
+func EnsurePortForwards(tb TB, cfg Config) {
+	tb.Helper()
+	tb.Logf("EnsurePortForwards: checking 5002 reachability...")
+	reach5002 := isFrontendHTTPReachable()
+	tb.Logf("EnsurePortForwards: 5002 reachable=%v", reach5002)
+	reach5004 := isTCPReachable("127.0.0.1:5004")
+	tb.Logf("EnsurePortForwards: 5004 reachable=%v", reach5004)
+	// If existing port-forwards are already working, reuse them.
+	if reach5002 && reach5004 {
+		tb.Logf("EnsurePortForwards: both ports already reachable, skipping restart")
+		return
+	}
+	for _, target := range []string{"kuberpult-frontend-service", "kuberpult-cd-service"} {
+		tb.Logf("EnsurePortForwards: pkill port-forward.*%s", target)
+		_ = exec.Command("pkill", "-f", "port-forward.*"+target).Run()
+	}
+	startDetached := func(target, portMapping string) {
+		tb.Logf("EnsurePortForwards: starting port-forward for %s %s in namespace %s", target, portMapping, cfg.KuberpultNamespace)
+		cmd := exec.Command("kubectl", "port-forward",
+			"-n", cfg.KuberpultNamespace,
+			"deployment/"+target,
+			portMapping)
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			tb.Fatalf("start port-forward for %s: %v", target, err)
+		}
+		pid := cmd.Process.Pid
+		tb.Logf("EnsurePortForwards: started pid=%d for %s", pid, target)
+		// Watch for immediate exit (e.g. deployment not found) before detaching.
+		exited := make(chan error, 1)
+		go func() { exited <- cmd.Wait() }()
+		select {
+		case err := <-exited:
+			tb.Fatalf("port-forward for %s (pid %d) exited immediately: %v", target, pid, err)
+		case <-time.After(500 * time.Millisecond):
+			// Still running — detach so the process outlives this command.
+			_ = cmd.Process.Release()
+		}
+	}
+	startDetached("kuberpult-frontend-service", "5002:8081")
+	startDetached("kuberpult-cd-service", "5004:8443")
+	tb.Logf("EnsurePortForwards: waiting for frontend at :5002 ...")
+	WaitForFrontendReady(tb)
+	tb.Logf("EnsurePortForwards: waiting for cd-service at :5004 ...")
+	waitForTCPPort(tb, "127.0.0.1:5004", 15*time.Second)
+	tb.Logf("EnsurePortForwards: done")
+}
+
+func isTCPReachable(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// isFrontendHTTPReachable makes a real HTTP request to verify the port-forward
+// tunnel is live end-to-end, not just that the kubectl process is still
+// listening locally (a stale tunnel passes TCP but hangs on HTTP).
+func isFrontendHTTPReachable() bool {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://localhost:" + FrontendPort + "/health") //nolint:gosec
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return true
+}
+
+func waitForTCPPort(tb TB, addr string, timeout time.Duration) {
+	tb.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	tb.Fatalf("port %s not reachable after %s", addr, timeout)
+}
+
+// EnsureArgoAppProjects applies the ArgoCD AppProject resources required by the
+// kind-bracket tests. In kind mode these are created by run-kind.sh; in GKE mode
+// only the "default" project exists, so we apply the missing ones here.
+// The apply is idempotent — safe to call on every test run.
+func EnsureArgoAppProjects(namespace string) {
+	manifest := fmt.Sprintf(`
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: development
+  namespace: %s
+spec:
+  description: test-env
+  destinations:
+  - name: dest1
+    namespace: '*'
+    server: https://kubernetes.default.svc
+  sourceRepos:
+  - '*'
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: staging
+  namespace: %s
+spec:
+  description: staging-normal
+  destinations:
+  - name: dest1
+    namespace: '*'
+    server: https://kubernetes.default.svc
+  sourceRepos:
+  - '*'
+`, namespace, namespace)
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(manifest)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Fatalf("EnsureArgoAppProjects: kubectl apply: %v\n%s", err, out)
+	}
+}
+
+// HelmUpgrade runs helm upgrade with the given bracket parameters, waits for
+// all service rollouts, ensures port-forwards are up, waits for the frontend
+// to be reachable, and runs the create-environments script.
+// Test code should call globalPFM.restart() before this function so the
+// port-forward manager reconnects to the newly rolled-out pod.
+func HelmUpgrade(tb TB, cfg Config, p HelmUpgradeParams) {
+	tb.Helper()
+	repoRoot, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		tb.Fatalf("git rev-parse: %v", err)
+	}
+	root := strings.TrimSpace(string(repoRoot))
+
+	boolStr := func(b bool) string {
+		if b {
+			return "true"
+		}
+		return "false"
+	}
+	tb.Logf("HelmUpgrade: brackets=%s development=%s staging=%s channelSize=%d",
+		boolStr(p.BracketsEnabled), boolStr(p.DevelopmentEnabled), boolStr(p.StagingEnabled), p.ChannelSize)
+
+	var cmd *exec.Cmd
+	switch cfg.Mode {
+	case ModeKind:
+		out, err2 := exec.Command("git", "describe", "--always", "--long", "--tags").Output()
+		if err2 != nil {
+			tb.Fatalf("git describe: %v", err2)
+		}
+		chartPath := root + "/charts/kuberpult/kuberpult-" + strings.TrimSpace(string(out)) + ".tgz"
+		valsPath := root + "/charts/kuberpult/vals.yaml"
+		cmd = exec.Command("helm", "upgrade", "--install",
+			"--values", valsPath,
+			"--set", "rollout.experimentalBrackets.enabled="+boolStr(p.BracketsEnabled),
+			"--set", "rollout.experimentalBrackets.clusters.development="+boolStr(p.DevelopmentEnabled),
+			"--set", "rollout.experimentalBrackets.clusters.staging="+boolStr(p.StagingEnabled),
+			"--set", fmt.Sprintf("rollout.kuberpultEventsChannelSize=%d", p.ChannelSize),
+			cfg.HelmReleaseName, chartPath)
+	case ModeGKE:
+		v := cfg.TestVersion
+		chartPath := "https://github.com/freiheit-com/kuberpult/releases/download/" + v + "/kuberpult-" + v + ".tgz"
+		cmd = exec.Command("helm", "upgrade",
+			"--reuse-values",
+			"-n", cfg.KuberpultNamespace,
+			"--set-string", "gke.project_number="+cfg.GKEProjectNumber,
+			"--set", "rollout.experimentalBrackets.enabled="+boolStr(p.BracketsEnabled),
+			"--set", "rollout.experimentalBrackets.clusters.development="+boolStr(p.DevelopmentEnabled),
+			"--set", "rollout.experimentalBrackets.clusters.staging="+boolStr(p.StagingEnabled),
+			"--set", fmt.Sprintf("rollout.kuberpultEventsChannelSize=%d", p.ChannelSize),
+			cfg.HelmReleaseName, chartPath)
+	}
+	if out2, err2 := cmd.CombinedOutput(); err2 != nil {
+		tb.Fatalf("helm upgrade (brackets=%s dev=%s staging=%s): %v\n%s",
+			boolStr(p.BracketsEnabled), boolStr(p.DevelopmentEnabled), boolStr(p.StagingEnabled), err2, out2)
+	}
+
+	for _, dep := range []string{
+		"deployment/kuberpult-rollout-service",
+		"deployment/kuberpult-cd-service",
+		"deployment/kuberpult-frontend-service",
+		"deployment/kuberpult-reposerver-service",
+	} {
+		out3, err3 := exec.Command("kubectl", "rollout", "status", dep,
+			"-n", cfg.KuberpultNamespace, "--timeout=3m").CombinedOutput()
+		if err3 != nil {
+			tb.Fatalf("kubectl rollout status %s: %v\n%s", dep, err3, out3)
+		}
+		tb.Logf("%s rolled out: %s", dep, strings.TrimSpace(string(out3)))
+	}
+
+	EnsurePortForwards(tb, cfg)
+	WaitForFrontendReady(tb)
+
+	scriptPath := root + "/infrastructure/scripts/create-testdata/create-environments.sh"
+	scriptCmd := exec.Command("bash", scriptPath)
+	scriptCmd.Env = append(os.Environ(), "FRONTEND_PORT="+FrontendPort)
+	if out4, err4 := scriptCmd.CombinedOutput(); err4 != nil {
+		tb.Fatalf("create-environments: %v\n%s", err4, out4)
+	}
+	tb.Logf("create-environments: done")
+}
+
+// DBCreds holds database credentials (GKE mode only; kind uses kubectl exec).
+type DBCreds struct {
+	User     string
+	Password string
+	DBName   string
+}
+
+// MustLoadDBCreds reads DB credentials for the given config.
+// Kind mode returns empty DBCreds (psql runs via kubectl exec).
+func MustLoadDBCreds(cfg Config) DBCreds {
+	if cfg.Mode != ModeGKE {
+		return DBCreds{}
+	}
+	creds := DBCreds{
+		User:     ReadSecretKey("kuberpult-db", "tools", "username"),
+		Password: ReadSecretKey("kuberpult-db", "tools", "password"),
+	}
+	out, err := exec.Command("kubectl", "get", "deployment", "kuberpult-cd-service",
+		"-n", cfg.KuberpultNamespace, "-o",
+		`jsonpath={range .spec.template.spec.containers[*]}{range .env[*]}{.name}{"="}{.value}{"\n"}{end}{end}`,
+	).Output()
+	if err != nil {
+		log.Fatalf("gke mode: get env vars from kuberpult-cd-service deployment: %v", err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if after, ok := strings.CutPrefix(line, "KUBERPULT_DB_NAME="); ok {
+			creds.DBName = strings.TrimSpace(after)
+			break
+		}
+	}
+	if creds.DBName == "" {
+		log.Fatalf("gke mode: KUBERPULT_DB_NAME not found in kuberpult-cd-service deployment")
+	}
+	return creds
+}
+
+func runPsql(cfg Config, db DBCreds, psqlArgs ...string) ([]byte, error) {
+	if cfg.Mode == ModeKind {
+		base := []string{"exec", "deployment/postgres", "-n", cfg.KuberpultNamespace, "--",
+			"psql", "-U", "postgres", "-d", "kuberpult"}
+		return exec.Command("kubectl", append(base, psqlArgs...)...).CombinedOutput()
+	}
+	base := []string{"-h", "127.0.0.1", "-p", "5433", "-U", db.User, "-d", db.DBName, "-w"}
+	cmd := exec.Command("psql", append(base, psqlArgs...)...)
+	cmd.Env = append(os.Environ(), "PGPASSWORD="+db.Password)
+	return cmd.CombinedOutput()
+}
+
+func openDBPortForward(tb TB, cfg Config, db DBCreds) func() {
+	tb.Helper()
+	if cfg.Mode == ModeKind {
+		return func() {}
+	}
+	pf := exec.Command("kubectl", "port-forward",
+		"-n", cfg.KuberpultNamespace,
+		"deployment/kuberpult-cd-service",
+		"5433:5432")
+	if err := pf.Start(); err != nil {
+		tb.Fatalf("openDBPortForward: %v", err)
+	}
+	stop := func() {
+		if pf.Process != nil {
+			_ = pf.Process.Kill()
+		}
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		probe := exec.Command("psql", "-h", "127.0.0.1", "-p", "5433",
+			"-U", db.User, "-d", db.DBName, "-w", "-c", "SELECT 1")
+		probe.Env = append(os.Environ(), "PGPASSWORD="+db.Password)
+		if err := probe.Run(); err == nil {
+			return stop
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	stop()
+	tb.Fatalf("openDBPortForward: not ready after 15 seconds")
+	return func() {}
+}
+
+// ResetDB deletes all ArgoCD applications, drops all DB tables, and scales
+// kuberpult services to 0. After this call, run helm-upgrade to bring
+// services back up.
+func ResetDB(tb TB, cfg Config, db DBCreds) {
+	tb.Helper()
+
+	tb.Logf("ResetDB: removing ArgoCD application finalizers")
+	names, _ := exec.Command("kubectl", "get", "applications",
+		"-n", cfg.KuberpultNamespace, "-o", "name").CombinedOutput()
+	for _, name := range strings.Fields(string(names)) {
+		if err := exec.Command("kubectl", "patch", "-n", cfg.KuberpultNamespace, name,
+			"--type=merge", "-p", `{"metadata":{"finalizers":[]}}`).Run(); err != nil {
+			tb.Logf("ResetDB: patch finalizers for %s failed (continuing): %v", name, err)
+		}
+	}
+	tb.Logf("ResetDB: deleting all ArgoCD applications")
+	out, err := exec.Command("kubectl", "delete", "applications", "--all",
+		"-n", cfg.KuberpultNamespace, "--wait=true").CombinedOutput()
+	if err != nil {
+		tb.Fatalf("ResetDB: delete applications: %v: %s", err, out)
+	}
+	tb.Logf("ResetDB: %s", strings.TrimSpace(string(out)))
+
+	stopDBPF := openDBPortForward(tb, cfg, db)
+	defer stopDBPF()
+
+	tb.Logf("ResetDB: querying tables")
+	out, err = runPsql(cfg, db, "-At", "-c",
+		"SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename;")
+	if err != nil {
+		tb.Fatalf("ResetDB: list tables: %v: %s", err, out)
+	}
+	var tables []string
+	for _, line := range strings.Fields(string(out)) {
+		if line != "" {
+			tables = append(tables, line)
+		}
+	}
+	if len(tables) == 0 {
+		tb.Logf("ResetDB: no tables found, db is already empty")
+	} else {
+		tb.Logf("ResetDB: dropping %d tables: %s", len(tables), strings.Join(tables, ", "))
+		for batch := range slices.Chunk(tables, 5) {
+			var parts []string
+			for _, table := range batch {
+				parts = append(parts, fmt.Sprintf(`"%s"`, table))
+			}
+			out2, err2 := runPsql(cfg, db, "-c",
+				fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE;", strings.Join(parts, ", ")))
+			if err2 != nil {
+				tb.Fatalf("ResetDB: drop %s: %v: %s", strings.Join(parts, ", "), err2, out2)
+			}
+		}
+	}
+
+	// frontend-service is kept running to avoid breaking the ingress.
+	tb.Logf("ResetDB: scaling kuberpult services to 0")
+	for _, dep := range []string{
+		"deployment/kuberpult-cd-service",
+		"deployment/kuberpult-reposerver-service",
+		"deployment/kuberpult-rollout-service",
+	} {
+		if out3, err3 := exec.Command("kubectl", "scale", dep,
+			"-n", cfg.KuberpultNamespace, "--replicas=0").CombinedOutput(); err3 != nil {
+			tb.Fatalf("ResetDB: scale %s: %v\n%s", dep, err3, out3)
+		}
+	}
+}
+
+// WaitForFrontendReady polls the /health endpoint until the frontend responds.
+func WaitForFrontendReady(tb TB) {
+	tb.Helper()
+	url := "http://localhost:" + FrontendPort + "/health"
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url) //nolint:gosec
+		if err == nil {
+			tb.Logf("WaitForFrontendReady: %s responded (status %d)", url, resp.StatusCode)
+			_ = resp.Body.Close()
+			return
+		}
+		if err != lastErr {
+			tb.Logf("WaitForFrontendReady: %s: %v", url, err)
+			lastErr = err
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	tb.Fatalf("frontend not reachable at %s after 30s (last error: %v)", url, lastErr)
+}
+
+// ReleaseTrain triggers a release train for the given environment.
+func ReleaseTrain(tb TB, env string) {
+	tb.Helper()
+	url := "http://localhost:" + FrontendPort + "/api/environments/" + env + "/releasetrain"
+	req, err := http.NewRequest("PUT", url, nil)
+	if err != nil {
+		tb.Fatalf("build release-train request for %s: %v", env, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		tb.Fatalf("PUT release train %s: %v", env, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode > 299 {
+		tb.Fatalf("PUT release train %s: HTTP %d: %s", env, resp.StatusCode, body)
+	}
+}
+
+// CreateRelease posts a new release to kuberpult. manifests maps environment
+// name to the manifest YAML for that environment.
+func CreateRelease(tb TB, app, team, bracket, version string, manifests map[string]string) {
+	tb.Helper()
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	mustWrite := func(key, val string) {
+		if err := w.WriteField(key, val); err != nil {
+			tb.Fatalf("write field %s: %v", key, err)
+		}
+	}
+	mustWrite("application", app)
+	mustWrite("version", version)
+	mustWrite("team", team)
+	mustWrite("source_message", "release "+version)
+	if bracket != "" {
+		mustWrite("experimentalArgoBracket", bracket)
+	}
+	for env, manifest := range manifests {
+		fw, err := w.CreateFormFile("manifests["+env+"]", "manifests["+env+"]")
+		if err != nil {
+			tb.Fatalf("create form file for %s: %v", env, err)
+		}
+		if _, err := io.WriteString(fw, manifest); err != nil {
+			tb.Fatalf("write manifest for %s: %v", env, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		tb.Fatalf("close multipart writer: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", "http://localhost:"+FrontendPort+"/api/release", &b)
+	if err != nil {
+		tb.Fatalf("build release request for %s v%s: %v", app, version, err)
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		tb.Fatalf("POST /api/release for %s v%s: %v", app, version, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode > 299 {
+		tb.Fatalf("POST /api/release for %s v%s: HTTP %d: %s", app, version, resp.StatusCode, body)
+	}
+}
+
+// StableManifest returns a Deployment + ConfigMap whose pod-template spec is
+// identical across all version numbers so Kubernetes does not roll pods.
+func StableManifest(app, namespace, version string) string {
+	return fmt.Sprintf(`---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s-bracket-cfg
+  namespace: %s
+data:
+  version: "%s"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %s-bracket-dep
+  namespace: %s
+  annotations:
+    kuberpult.freiheit.com/release-version: "%s"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: %s-bracket
+  template:
+    metadata:
+      labels:
+        app: %s-bracket
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: sleep
+        image: busybox:latest
+        command: ["/bin/sh", "-c", "trap 'exit 0' SIGTERM; while true; do sleep 1000; done"]
+        readinessProbe:
+          exec:
+            command: ["ls", "/"]
+          initialDelaySeconds: 3
+          periodSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+`, app, namespace, version, app, namespace, version, app, app)
+}

--- a/tests/kind-brackets/portforward_test.go
+++ b/tests/kind-brackets/portforward_test.go
@@ -35,23 +35,25 @@ type portForwardManager struct {
 	cancel context.CancelFunc
 }
 
-// startPFManager kills any shell-managed port-forward for kuberpult-frontend-service
-// and starts a self-healing manager that owns port 5002 for the test run.
-func startPFManager() *portForwardManager {
+// startPFManager kills any shell-managed port-forward for the given target and
+// starts a self-healing manager for the test run.
+// target is e.g. "deployment/kuberpult-frontend-service".
+// portMapping is e.g. "5002:8081".
+func startPFManager(cfg testConfig, target, portMapping string) *portForwardManager {
 	// Take ownership from any shell background loop; ignore exit code.
-	_ = exec.Command("pkill", "-f", "port-forward.*kuberpult-frontend-service").Run()
+	_ = exec.Command("pkill", "-f", "port-forward.*"+target).Run()
 	ctx, cancel := context.WithCancel(context.Background())
 	m := &portForwardManager{cancel: cancel}
-	go m.loop(ctx)
+	go m.loop(ctx, cfg, target, portMapping)
 	return m
 }
 
-func (m *portForwardManager) loop(ctx context.Context) {
+func (m *portForwardManager) loop(ctx context.Context, cfg testConfig, target, portMapping string) {
 	for ctx.Err() == nil {
 		cmd := exec.CommandContext(ctx, "kubectl", "port-forward",
-			"-n", "default",
-			"deployment/kuberpult-frontend-service",
-			"5002:8081")
+			"-n", cfg.KuberpultNamespace,
+			target,
+			portMapping)
 		m.mu.Lock()
 		m.cmd = cmd
 		m.mu.Unlock()


### PR DESCRIPTION
This changes our kind tests, to also be able to run on our actual test cluster (gke).
This required some changes regarding port-forwarding, the expectation of what is already set up, and how to reset test data.
This also adds a small cmd line tool to run manual tests in main.go.

Ref: SRX-VRKPNL
