### PR TITLE
fix(rollout): movement between brackets

### DIFF
--- a/pkg/api/v1/api.proto
+++ b/pkg/api/v1/api.proto
@@ -487,6 +487,11 @@ message BracketDeployment {
 message GetBracketDetailsResponse {
   string bracket_name = 1;
   map<string, BracketDeployment> deployments = 2;
+  // Names of brackets that gained members this bracket lost in this change.
+  // The rollout-service must not refresh this bracket's Argo app spec (which
+  // would prune the moved apps' resources) until each named bracket has
+  // adopted them (reported Synced by Argo CD).
+  repeated string lost_members_to = 3;
 }
 
 message GetAllAppLocksRequest {}

--- a/pkg/db/db_brackets_history.go
+++ b/pkg/db/db_brackets_history.go
@@ -213,7 +213,8 @@ func executeSelectQuery(ctx context.Context, tx *sql.Tx, selectQuery string, arg
 // DBSelectBracketHistoryPrevious returns the bracket snapshot immediately before
 // the latest one (the second-newest row). It is used to detect which bracket an
 // app just left: comparing the previous snapshot with the latest reveals brackets
-// that became empty, so the rollout-service can delete their now-orphaned Argo app.
+// the app moved out of, so the rollout-service can delete their now-orphaned Argo
+// app (bracket emptied) or refresh its spec (bracket still has other members).
 func DBSelectBracketHistoryPrevious(ctx context.Context, h *DBHandler, tx *sql.Tx) (result *BracketRow, err error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "DBSelectBracketHistoryPrevious")
 	defer func() {

--- a/services/cd-service/pkg/notify/notify.go
+++ b/services/cd-service/pkg/notify/notify.go
@@ -17,6 +17,7 @@ Copyright freiheit.com*/
 package notify
 
 import (
+	"slices"
 	"sync"
 
 	"github.com/freiheit-com/kuberpult/pkg/types"
@@ -79,6 +80,26 @@ func (n *Notify) SubscribeChangesApps() (<-chan ChangedAppNames, Unsubscribe) {
 	}
 }
 
+// mergeChangedAppNames unions a still-pending notification with the next one.
+// An empty list is the "all apps" sentinel (see SubscribeChangesApps), which
+// already covers any concrete list. The result is deduped and sorted.
+func mergeChangedAppNames(pending, next ChangedAppNames) ChangedAppNames {
+	if len(pending) == 0 {
+		return pending // sentinel: all apps
+	}
+	if len(next) == 0 {
+		return next // sentinel: all apps
+	}
+	merged := slices.Clone(pending)
+	for _, app := range next {
+		if !slices.Contains(merged, app) {
+			merged = append(merged, app)
+		}
+	}
+	slices.Sort(merged)
+	return merged
+}
+
 func (n *Notify) NotifyChangedApps(changedApps ChangedAppNames) {
 	n.mx.Lock()
 	defer n.mx.Unlock()
@@ -86,6 +107,28 @@ func (n *Notify) NotifyChangedApps(changedApps ChangedAppNames) {
 		select {
 		case ch <- changedApps:
 		default:
+			// The subscriber has not consumed the previous notification yet.
+			// Dropping the new one would lose those app names for good — the
+			// fast path sends each change exactly once — so merge the two
+			// notifications instead.
+			var pending ChangedAppNames
+			hadPending := false
+			select {
+			case pending = <-ch:
+				hadPending = true
+			default:
+				// The subscriber consumed it just now; the buffer is free again.
+			}
+			merged := changedApps
+			if hadPending {
+				merged = mergeChangedAppNames(pending, changedApps)
+			}
+			select {
+			case ch <- merged:
+			default:
+				// Cannot happen: all senders hold n.mx and the only buffer slot
+				// was just drained.
+			}
 		}
 	}
 }

--- a/services/cd-service/pkg/notify/notify_test.go
+++ b/services/cd-service/pkg/notify/notify_test.go
@@ -1,0 +1,81 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package notify
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestNotifyChangedAppsMergesWhenSubscriberIsSlow verifies that change
+// notifications are never lost: when the subscriber has not consumed the
+// previous notification yet, the next one is merged into it instead of being
+// dropped. The fast path sends each change exactly once, so a dropped
+// notification would leave e.g. a bracket Argo app pinned to a stale snapshot
+// until an unrelated later change happens to touch it again.
+func TestNotifyChangedAppsMergesWhenSubscriberIsSlow(t *testing.T) {
+	tcs := []struct {
+		Name string
+		// ConsumeSeed drains the initial "all apps" sentinel before notifying.
+		ConsumeSeed   bool
+		Notifications []ChangedAppNames
+		WantReceived  ChangedAppNames
+	}{
+		{
+			Name:          "single notification is delivered as-is",
+			ConsumeSeed:   true,
+			Notifications: []ChangedAppNames{{"app1"}},
+			WantReceived:  ChangedAppNames{"app1"},
+		},
+		{
+			Name:          "second notification merges instead of dropping",
+			ConsumeSeed:   true,
+			Notifications: []ChangedAppNames{{"app1"}, {"app2"}},
+			WantReceived:  ChangedAppNames{"app1", "app2"},
+		},
+		{
+			Name:          "merging dedupes and sorts",
+			ConsumeSeed:   true,
+			Notifications: []ChangedAppNames{{"b-app"}, {"a-app"}, {"b-app"}},
+			WantReceived:  ChangedAppNames{"a-app", "b-app"},
+		},
+		{
+			Name:          "pending all-apps sentinel absorbs concrete notifications",
+			ConsumeSeed:   false,
+			Notifications: []ChangedAppNames{{"app1"}},
+			WantReceived:  ChangedAppNames{},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			var n Notify
+			ch, unsubscribe := n.SubscribeChangesApps()
+			defer unsubscribe()
+			if tc.ConsumeSeed {
+				<-ch
+			}
+			for _, notification := range tc.Notifications {
+				n.NotifyChangedApps(notification)
+			}
+			got := <-ch
+			if diff := cmp.Diff(tc.WantReceived, got); diff != "" {
+				t.Errorf("received changed apps mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/services/cd-service/pkg/service/overview.go
+++ b/services/cd-service/pkg/service/overview.go
@@ -792,7 +792,7 @@ func combineBracketDeployments(appDetails []*api.GetAppDetailsResponse, bracketE
 	return result
 }
 
-func (o *OverviewServiceServer) getBracketDetails(ctx context.Context, bracketName types.ArgoBracketName, appNames db.AppNames) (*api.GetBracketDetailsResponse, error) {
+func (o *OverviewServiceServer) getBracketDetails(ctx context.Context, bracketName types.ArgoBracketName, appNames db.AppNames, lostMembersTo []string) (*api.GetBracketDetailsResponse, error) {
 	appDetails := make([]*api.GetAppDetailsResponse, 0, len(appNames))
 	for _, appName := range appNames {
 		detail, err := o.GetAppDetails(ctx, &api.GetAppDetailsRequest{AppName: string(appName)})
@@ -806,8 +806,9 @@ func (o *OverviewServiceServer) getBracketDetails(ctx context.Context, bracketNa
 		appDetails = append(appDetails, detail)
 	}
 	return &api.GetBracketDetailsResponse{
-		BracketName: string(bracketName),
-		Deployments: combineBracketDeployments(appDetails, o.ExperimentalBracketsClusters),
+		BracketName:   string(bracketName),
+		Deployments:   combineBracketDeployments(appDetails, o.ExperimentalBracketsClusters),
+		LostMembersTo: lostMembersTo,
 	}, nil
 }
 
@@ -858,6 +859,9 @@ func (o *OverviewServiceServer) getChangedBrackets(ctx context.Context, changedA
 
 	// Determine which brackets to update.
 	var affectedBrackets []types.ArgoBracketName
+	// lostMembersTo maps a bracket to the brackets that gained members it lost in
+	// this change (see GetBracketDetailsResponse.lost_members_to).
+	lostMembersTo := make(map[types.ArgoBracketName][]string)
 	if len(changedApps) == 0 {
 		// Initial load: include all brackets.
 		for bracketName := range bracketMap {
@@ -888,10 +892,14 @@ func (o *OverviewServiceServer) getChangedBrackets(ctx context.Context, changedA
 				}
 			}
 		}
-		// Include the bracket a still-existing app just *left* if that bracket became
-		// empty (a bracket move). Without this the now-orphaned old bracket Argo app is
-		// never deleted, and its auto-sync prunes the workload the app moved to the new
-		// bracket. A real undeploy (app deleted) is intentionally skipped here — its
+		// Include the bracket a still-existing app just *left* (a bracket move).
+		// If the old bracket became empty, it is emitted with the delete sentinel so
+		// its now-orphaned Argo app is torn down. If the old bracket still has other
+		// members, it must be re-emitted anyway: its Argo app spec pins the
+		// brackets_history snapshot it was last updated against, and without a spec
+		// refresh the reposerver keeps rendering the moved app's manifests in the old
+		// bracket — both brackets then own the app and Argo CD fights over its
+		// resources. A real undeploy (app deleted) is intentionally skipped here — its
 		// resource cleanup goes through the rollout_should_undeploy_cascade path.
 		if lookup.prevBracketRow != nil {
 			prevMap := lookup.prevBracketRow.AllBracketsJsonBlob.BracketMap
@@ -900,8 +908,18 @@ func (o *OverviewServiceServer) getChangedBrackets(ctx context.Context, changedA
 					continue
 				}
 				for prevBracket, apps := range prevMap {
-					if _, stillExists := bracketMap[prevBracket]; stillExists {
-						continue // old bracket still has apps; not emptied
+					if slices.Contains(bracketMap[prevBracket], appName) {
+						continue // app is still a member of this bracket; it did not leave it
+					}
+					if slices.Contains(apps, appName) {
+						// Record which bracket gained the app, so the rollout-service can
+						// defer this bracket's Argo app spec refresh until the gainer has
+						// adopted the app's resources (Argo would otherwise prune them).
+						for gainer, gainerApps := range bracketMap {
+							if slices.Contains(gainerApps, appName) && !slices.Contains(lostMembersTo[prevBracket], string(gainer)) {
+								lostMembersTo[prevBracket] = append(lostMembersTo[prevBracket], string(gainer))
+							}
+						}
 					}
 					if slices.Contains(apps, appName) && !seen[prevBracket] {
 						seen[prevBracket] = true
@@ -915,7 +933,9 @@ func (o *OverviewServiceServer) getChangedBrackets(ctx context.Context, changedA
 
 	result := make([]*api.GetBracketDetailsResponse, 0, len(affectedBrackets))
 	for _, bracketName := range affectedBrackets {
-		detail, err := o.getBracketDetails(ctx, bracketName, bracketMap[bracketName])
+		lost := lostMembersTo[bracketName]
+		sort.Strings(lost) // deterministic order (gainers were collected in map order)
+		detail, err := o.getBracketDetails(ctx, bracketName, bracketMap[bracketName], lost)
 		if err != nil {
 			return nil, err
 		}

--- a/services/cd-service/pkg/service/overview_test.go
+++ b/services/cd-service/pkg/service/overview_test.go
@@ -3498,6 +3498,10 @@ func TestGetChangedBracketsEmitsEmptiedBracketOnMove(t *testing.T) {
 		WantDeletedBrackets []string
 		// WantLiveBrackets must appear with a non-delete, non-empty version.
 		WantLiveBrackets []string
+		// WantLostMembersTo maps each emitted bracket to the brackets that gained
+		// members it lost (the LostMembersTo field). Brackets without an entry must
+		// have an empty LostMembersTo.
+		WantLostMembersTo map[string][]string
 	}{
 		{
 			Name: "move empties the old bracket",
@@ -3508,6 +3512,7 @@ func TestGetChangedBracketsEmitsEmptiedBracketOnMove(t *testing.T) {
 			ChangedApps:         []types.AppName{"app-a"},
 			WantDeletedBrackets: []string{"bracket-one"},
 			WantLiveBrackets:    []string{"bracket-two"},
+			WantLostMembersTo:   map[string][]string{"bracket-one": {"bracket-two"}},
 		},
 		{
 			Name: "no move keeps the bracket alive",
@@ -3518,9 +3523,10 @@ func TestGetChangedBracketsEmitsEmptiedBracketOnMove(t *testing.T) {
 			ChangedApps:         []types.AppName{"app-a"},
 			WantDeletedBrackets: nil,
 			WantLiveBrackets:    []string{"bracket-one"},
+			WantLostMembersTo:   map[string][]string{},
 		},
 		{
-			Name: "move out of a shared bracket does not delete it",
+			Name: "move out of a shared bracket does not delete it but re-emits it",
 			Releases: []release{
 				{App: "app-a", Bracket: "bracket-one", Version: 1},
 				{App: "app-b", Bracket: "bracket-one", Version: 1},
@@ -3528,7 +3534,11 @@ func TestGetChangedBracketsEmitsEmptiedBracketOnMove(t *testing.T) {
 			},
 			ChangedApps:         []types.AppName{"app-a"},
 			WantDeletedBrackets: nil,
-			WantLiveBrackets:    []string{"bracket-two"},
+			// bracket-one must be re-emitted (live, with only app-b remaining) so the
+			// rollout-service refreshes its Argo app spec — otherwise the old bracket
+			// keeps rendering app-a's manifests from its stale pinned snapshot.
+			WantLiveBrackets:  []string{"bracket-one", "bracket-two"},
+			WantLostMembersTo: map[string][]string{"bracket-one": {"bracket-two"}},
 		},
 	}
 	for _, tc := range tcs {
@@ -3610,6 +3620,15 @@ func TestGetChangedBracketsEmitsEmptiedBracketOnMove(t *testing.T) {
 			wantCount := len(tc.WantDeletedBrackets) + len(tc.WantLiveBrackets)
 			if len(gotVersions) != wantCount {
 				t.Errorf("got %d brackets %v, want %d", len(gotVersions), gotVersions, wantCount)
+			}
+			gotLostMembersTo := make(map[string][]string)
+			for _, b := range brackets {
+				if len(b.LostMembersTo) > 0 {
+					gotLostMembersTo[b.BracketName] = b.LostMembersTo
+				}
+			}
+			if diff := cmp.Diff(tc.WantLostMembersTo, gotLostMembersTo, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("LostMembersTo mismatch (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -78,6 +78,28 @@ The only reasons to delete a k8s deployment is when
 * combineBracketDeployments (cd-service/pkg/service/overview.go) emits the BracketVersionDelete
   sentinel for env E when no member has a deployment in E, so the rollout-service tears down the
   per-env bracket Argo app instead of recreating it.
+* The pause protocol (prune-vs-adopt protection on bracket moves): while a bracket that lost a
+  member still pins its old snapshot, BOTH the losing and the gaining bracket render the moved
+  app's manifests — each apply steals Argo's resource tracking, the other side goes OutOfSync
+  and re-steals after sync backoff, and a spec refresh of the loser during such a flap prunes
+  the moved app's workload. The cd-service names the gainers in
+  GetBracketDetailsResponse.lost_members_to; for such a loser, ProcessAppChange replaces the
+  normal spec refresh with a three-step handover (pendingSpecUpdates, advanced on watch events):
+  1. PAUSE in place — auto-sync disabled, manifest path unchanged. An Argo sync operation
+     executes against the spec path read at execution time (with the prune flag from its
+     initiation), so the path must not move while an operation can be running.
+  2. RETARGET — once the app is provably quiet (controller reconciled the paused spec: the
+     refresh annotation requested by the pause is gone, and no operation is requested or
+     running), the path moves to the new snapshot, still paused.
+  3. RESUME — auto-sync is restored only once the loser's own sync status (compared against the
+     new path) reports no resource as requiring pruning — derived from the same cluster cache
+     that computes prune tasks, so the resume is provably prune-free.
+  The paused-for-move marker annotation records the phase, driving recovery after a
+  rollout-service restart via the watch ADDED replay (a loser recovered in the paused phase
+  stays paused until the next overview tick rebuilds the retarget payload). Known limitation:
+  an unrelated member resource legitimately requiring pruning during the move window blocks
+  the resume ("bracket.resume.blocked" log) until a later change resolves it; the workload is
+  unaffected.
 
 */
 
@@ -109,6 +131,30 @@ import (
 	"github.com/freiheit-com/kuberpult/pkg/setup"
 	"github.com/freiheit-com/kuberpult/pkg/sorting"
 )
+
+// BracketPausedForMoveAnnotation marks a bracket Argo app whose auto-sync has been
+// temporarily disabled while another bracket adopts members it lost (bracket move).
+// Its value is the protocol phase (BracketMovePhase*), which makes the paused state
+// recoverable after a rollout-service restart via the watch ADDED replay.
+const BracketPausedForMoveAnnotation = "com.freiheit.kuberpult/paused-for-move"
+
+// The pause-protocol phases stored as BracketPausedForMoveAnnotation values.
+const (
+	// BracketMovePhasePaused: auto-sync disabled, manifest path still the old
+	// snapshot. An in-flight sync operation executes against the spec path at
+	// execution time, so the path may only move once the app is provably quiet.
+	BracketMovePhasePaused = "paused"
+	// BracketMovePhaseRetargeted: still paused, manifest path moved to the new
+	// snapshot; waiting for the disown before auto-sync is restored.
+	BracketMovePhaseRetargeted = "retargeted"
+)
+
+// argocdRefreshAnnotation requests an app reconcile from the Argo CD application
+// controller, which removes the annotation when it processes the request. The
+// pause update sets it so the quiet check can prove the controller has reconciled
+// the paused spec (per-app reconciles are serialised, so once it is removed no
+// reconcile of the pre-pause spec can still initiate a sync operation).
+const argocdRefreshAnnotation = "argocd.argoproj.io/refresh"
 
 // this is a simpler version of ApplicationServiceClient from the application package
 type SimplifiedApplicationServiceClient interface {
@@ -142,6 +188,25 @@ type PendingDeletion struct {
 	AppName               string
 }
 
+// PendingSpecUpdate tracks a bracket Argo app that lost members to other brackets
+// (a bracket move) and is going through the pause protocol (see the package
+// comment): paused in place, retargeted to the new snapshot once quiet, and
+// resumed once its own sync status — compared against ExpectedPath — no longer
+// attributes any resource as requiring pruning, i.e. the gainers have adopted the
+// moved resources and the controller's cluster cache has registered it.
+type PendingSpecUpdate struct {
+	EnvironmentName string
+	ApplicationName string
+	// ExpectedPath is the manifest path the app is (or will be) retargeted to.
+	ExpectedPath string
+	// Phase is BracketMovePhasePaused (waiting for quiet, then send Retarget) or
+	// BracketMovePhaseRetargeted (waiting for the disown, then resume).
+	Phase string
+	// Retarget is the prepared paused application at the new path. Nil after a
+	// restart recovery in the paused phase — rebuilt by the next overview tick.
+	Retarget *v1alpha1.Application
+}
+
 type ArgoAppProcessor struct {
 	trigger chan argoTrigger
 
@@ -166,6 +231,9 @@ type ArgoAppProcessor struct {
 	// The apps that will be recreated as brackets.
 	// We store them, so we can delete them only once the bracket is there.
 	pendingDeletions []PendingDeletion
+	// Brackets paused for a member move, waiting to have auto-sync restored
+	// once they no longer own the moved resources (see PendingSpecUpdate).
+	pendingSpecUpdates []*PendingSpecUpdate
 }
 
 func New(appClient application.ApplicationServiceClient, manageArgoApplicationEnabled, kuberpultMetricsEnabled, argoAppsMetricsEnabled bool, manageArgoApplicationFilter []string, triggerChannelSize, argoAppsChannelSize int, ddMetrics statsd.ClientInterface, experimentalBracketsClusters []string, dbHandler *db.DBHandler) ArgoAppProcessor {
@@ -184,6 +252,7 @@ func New(appClient application.ApplicationServiceClient, manageArgoApplicationEn
 		//
 		ExperimentalBracketsClusters: experimentalBracketsClusters,
 		pendingDeletions:             []PendingDeletion{},
+		pendingSpecUpdates:           []*PendingSpecUpdate{},
 	}
 }
 
@@ -266,6 +335,10 @@ func (a *ArgoAppProcessor) Consume(ctx context.Context, hlth *setup.HealthReport
 type ArgoOverview struct {
 	AppDetails map[string]*api.GetAppDetailsResponse //Map from appName to app Details. Gets filled with information based on what apps have changed.
 	Overview   *api.GetOverviewResponse              //Standard overview. Only information regarding environments should be retrieved from this overview.
+	// LostMembersTo maps a bracket name to the brackets that gained members it
+	// lost in this change (GetBracketDetailsResponse.lost_members_to). The
+	// loser's Argo app spec refresh is deferred until those gainers are Synced.
+	LostMembersTo map[string][]string
 }
 
 func (a *ArgoAppProcessor) ProcessArgoOverview(ctx context.Context, l *zap.Logger, argoOv *ArgoOverview) {
@@ -295,6 +368,7 @@ func (a *ArgoAppProcessor) ProcessArgoOverview(ctx context.Context, l *zap.Logge
 							ArgoEnvironmentConfiguration: cfg,
 							IsBracket:                    isBracket,
 							BracketSnapshotEslId:         bracketSnapshotEslId,
+							LostMembersTo:                argoOv.LostMembersTo[currentApp],
 						}
 						a.ProcessAppChange(ctx, appInfo, currentAppDetails, overview, argoOv.AppDetails)
 					}
@@ -307,6 +381,7 @@ func (a *ArgoAppProcessor) ProcessArgoOverview(ctx context.Context, l *zap.Logge
 						ArgoEnvironmentConfiguration: parentEnvironment.Config.Argocd,
 						IsBracket:                    isBracket,
 						BracketSnapshotEslId:         bracketSnapshotEslId,
+						LostMembersTo:                argoOv.LostMembersTo[currentApp],
 					}
 					a.ProcessAppChange(ctx, appInfo, currentAppDetails, overview, argoOv.AppDetails)
 				}
@@ -460,6 +535,338 @@ func (a *ArgoAppProcessor) drainPendingDeletions(ctx context.Context, bracketEnv
 	a.pendingDeletions = remaining
 }
 
+// bracketDisowned reports whether the paused bracket app's sync status —
+// computed against expectedPath — no longer attributes any resource as
+// requiring pruning. RequiresPruning is derived from the same cluster cache the
+// application controller computes prune tasks from, so once it is clear,
+// re-enabling auto-sync cannot prune the moved resources. The path check guards
+// against reading a stale status from before the retarget (whose desired
+// manifests still contained the moved apps — "nothing to prune" for the wrong
+// reason).
+func bracketDisowned(app *v1alpha1.Application, expectedPath string) bool {
+	if app.Status.Sync.ComparedTo.Source.Path != expectedPath {
+		return false
+	}
+	for _, res := range app.Status.Resources {
+		if res.RequiresPruning {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *ArgoAppProcessor) findPendingSpecUpdate(envName, appName string) *PendingSpecUpdate {
+	for _, pu := range a.pendingSpecUpdates {
+		if pu.EnvironmentName == envName && pu.ApplicationName == appName {
+			return pu
+		}
+	}
+	return nil
+}
+
+func (a *ArgoAppProcessor) removePendingSpecUpdate(envName, appName string) {
+	remaining := a.pendingSpecUpdates[:0]
+	for _, pu := range a.pendingSpecUpdates {
+		if pu.EnvironmentName != envName || pu.ApplicationName != appName {
+			remaining = append(remaining, pu)
+		}
+	}
+	a.pendingSpecUpdates = remaining
+}
+
+// bracketPausedAndQuiet reports whether the watched app provably can no longer
+// start a sync operation: the spec is paused (no automated sync policy), the
+// controller has reconciled the paused spec — it removed the refresh annotation
+// the pause update requested, and per-app reconciles are serialised, so no
+// reconcile of the pre-pause spec can still initiate an operation — and no
+// requested or running operation remains. Only then is it safe to move the
+// manifest path: an in-flight sync operation executes against the spec path at
+// execution time, with the prune flag it was initiated with.
+func bracketPausedAndQuiet(app *v1alpha1.Application) bool {
+	if app.Spec.SyncPolicy != nil && app.Spec.SyncPolicy.Automated != nil {
+		return false
+	}
+	if _, refreshPending := app.Annotations[argocdRefreshAnnotation]; refreshPending {
+		return false
+	}
+	if app.Operation != nil {
+		return false
+	}
+	if state := app.Status.OperationState; state != nil {
+		if state.Phase == "Running" || state.Phase == "Terminating" {
+			return false
+		}
+	}
+	return true
+}
+
+// recoverPendingSpecUpdate re-enters the pause protocol for an app carrying the
+// paused-for-move marker when no pending entry exists for it (e.g. after a
+// rollout-service restart). In the retargeted phase the disown-wait condition is
+// fully derivable from the app's status; in the paused phase the retarget
+// payload is gone and only the next overview tick can rebuild it — until then
+// the app stays safely paused. Returns true when the app is in the protocol.
+func (a *ArgoAppProcessor) recoverPendingSpecUpdate(ctx context.Context, envName, appName string, app *v1alpha1.Application) bool {
+	marker := app.Annotations[BracketPausedForMoveAnnotation]
+	if marker == "" {
+		return false
+	}
+	if a.findPendingSpecUpdate(envName, appName) != nil {
+		return true
+	}
+	expectedPath := ""
+	phase := BracketMovePhaseRetargeted
+	if marker == BracketMovePhasePaused {
+		phase = BracketMovePhasePaused
+	} else if app.Spec.Source != nil {
+		expectedPath = app.Spec.Source.Path
+	}
+	logger.FromContext(ctx).Info("bracket.move.pause.recovered",
+		zap.String("app", appName),
+		zap.String("env", envName),
+		zap.String("phase", phase),
+		zap.String("expected-path", expectedPath))
+	a.pendingSpecUpdates = append(a.pendingSpecUpdates, &PendingSpecUpdate{
+		EnvironmentName: envName,
+		ApplicationName: appName,
+		ExpectedPath:    expectedPath,
+		Phase:           phase,
+		Retarget:        nil,
+	})
+	return true
+}
+
+// upsertExistingArgoApp resolves a create conflict: the app already exists in
+// Argo CD but its watch event has not arrived yet, so it is missing from
+// KnownApps and ProcessAppChange took the create path. Dropping the change
+// would pin the app to its old spec forever — the fast path sends each change
+// exactly once — so the desired spec is applied as an update instead. An app
+// paused for a bracket move is handed back to the pause protocol.
+func (a *ArgoAppProcessor) upsertExistingArgoApp(ctx context.Context, appInfo *AppInfo, desired *v1alpha1.Application) {
+	//exhaustruct:ignore
+	existing, err := a.ApplicationClient.Get(ctx, &application.ApplicationQuery{Name: conversion.FromString(desired.Name)})
+	if err != nil {
+		logger.FromContext(ctx).Error("argo.create.conflict.get.failed",
+			zap.String("argo.app", desired.Name), zap.Error(err))
+		return
+	}
+	if a.recoverPendingSpecUpdate(ctx, appInfo.EnvironmentName, appInfo.ApplicationName, existing) {
+		return
+	}
+	_ = a.updateApplication(ctx, desired, "argo.create.conflict.update")
+}
+
+// isGoneErr reports whether an application RPC failed because the app does not
+// exist. Argo CD reports operations on unknown apps as PermissionDenied (it
+// hides existence from unauthorised callers), so both codes mean "gone" here.
+func isGoneErr(err error) bool {
+	code := status.Code(err)
+	return code == codes.NotFound || code == codes.PermissionDenied
+}
+
+// createPausedApplication creates (upsert) an application in its paused
+// pause-protocol state, e.g. when the loser's app object is unknown or has
+// vanished underneath the protocol. A fresh app with the same name re-owns any
+// still-labelled k8s resources, so it must not sync before the disown either.
+func (a *ArgoAppProcessor) createPausedApplication(ctx context.Context, paused *v1alpha1.Application) {
+	upsert := true
+	validate := false
+	appCreateRequest := &application.ApplicationCreateRequest{
+		XXX_NoUnkeyedLiteral: struct{}{},
+		XXX_unrecognized:     nil, //nolint:misspell
+		XXX_sizecache:        0,
+		Application:          paused,
+		Upsert:               &upsert,
+		Validate:             &validate,
+	}
+	logger.FromContext(ctx).Info("bracket.move.pause.create",
+		zap.String("argo.app", paused.Name))
+	if _, err := a.ApplicationClient.Create(ctx, appCreateRequest); err != nil {
+		logger.FromContext(ctx).Error("bracket.move.pause.create.failed",
+			zap.String("argo.app", paused.Name), zap.Error(err))
+	}
+}
+
+// updateApplication sends an application update for the pause protocol and logs it.
+func (a *ArgoAppProcessor) updateApplication(ctx context.Context, app *v1alpha1.Application, logMsg string) error {
+	path := ""
+	if app.Spec.Source != nil {
+		path = app.Spec.Source.Path
+	}
+	logger.FromContext(ctx).Info(logMsg,
+		zap.String("argo.app", app.Name),
+		zap.String("path", path))
+	appUpdateRequest := &application.ApplicationUpdateRequest{
+		XXX_NoUnkeyedLiteral: struct{}{},
+		XXX_unrecognized:     nil, //nolint:misspell
+		XXX_sizecache:        0,
+		Validate:             conversion.Bool(false),
+		Application:          app,
+		Project:              conversion.FromString(app.Spec.Project),
+	}
+	_, err := a.ApplicationClient.Update(ctx, appUpdateRequest)
+	if err != nil {
+		logger.FromContext(ctx).Error(logMsg+".failed", zap.String("argo.app", app.Name), zap.Error(err))
+	}
+	return err
+}
+
+// deferSpecUpdateIfWaiting implements the PAUSE step of the pause protocol for a
+// bracket that lost members to other brackets (a bracket move). Instead of the
+// normal spec refresh — whose auto-sync would prune the moved apps' resources
+// while Argo's tracking ownership is still in flux — the bracket's auto-sync is
+// disabled in place (path unchanged) and the prepared retarget to the new
+// snapshot is stored on the pending entry; drainPendingSpecUpdates applies it
+// once the app is provably quiet. Returns true when the normal create/update
+// must be skipped. A bracket with a pending entry always stays in the protocol,
+// even when a later tick carries no member loss, so sequential moves cannot
+// bypass an unfinished handover.
+func (a *ArgoAppProcessor) deferSpecUpdateIfWaiting(ctx context.Context, appInfo *AppInfo, overview *api.GetOverviewResponse) bool {
+	existing := a.findPendingSpecUpdate(appInfo.EnvironmentName, appInfo.ApplicationName)
+	if existing == nil && len(appInfo.LostMembersTo) == 0 {
+		return false
+	}
+	retarget := CreateArgoApplication(overview, appInfo)
+	retarget.Spec.SyncPolicy.Automated = nil
+	retarget.Annotations[BracketPausedForMoveAnnotation] = BracketMovePhaseRetargeted
+	path := retarget.Spec.Source.Path
+	if existing != nil {
+		// Merge: the newest payload wins. If the target moved on after the
+		// retarget was already applied, re-send it so the disown check matches
+		// the spec on the cluster.
+		resend := existing.Phase == BracketMovePhaseRetargeted && existing.ExpectedPath != path
+		existing.Retarget = retarget
+		existing.ExpectedPath = path
+		if resend {
+			if err := a.updateApplication(ctx, retarget, "bracket.move.retarget"); err != nil && isGoneErr(err) {
+				// The app vanished underneath the protocol (e.g. it was emptied
+				// and deleted while its DELETED watch event is still queued
+				// behind this burst of overview ticks). Recreate it paused at
+				// the target path; the drain resumes it once its own status
+				// shows nothing to prune.
+				a.createPausedApplication(ctx, retarget)
+			}
+		}
+		return true
+	}
+	logger.FromContext(ctx).Info("bracket.move.pause",
+		zap.String("app", appInfo.ApplicationName),
+		zap.String("env", appInfo.EnvironmentName),
+		zap.String("target-path", path),
+		zap.Strings("lost-members-to", appInfo.LostMembersTo))
+	argoApp := a.isKnownArgoApp(appInfo.ApplicationName, appInfo.EnvironmentName, a.KnownApps[appInfo.EnvironmentName])
+	if argoApp == nil {
+		// The loser's Argo app object is unknown (e.g. lost watch state after a
+		// restart). Create it directly in the retargeted paused state: a fresh
+		// app has no in-flight sync operations.
+		a.createPausedApplication(ctx, retarget)
+		a.pendingSpecUpdates = append(a.pendingSpecUpdates, &PendingSpecUpdate{
+			EnvironmentName: appInfo.EnvironmentName,
+			ApplicationName: appInfo.ApplicationName,
+			ExpectedPath:    path,
+			Phase:           BracketMovePhaseRetargeted,
+			Retarget:        retarget,
+		})
+		return true
+	}
+	// PAUSE in place: disable auto-sync without touching the path — an in-flight
+	// sync operation executes against the spec path at execution time, so the
+	// path may only move once the app is provably quiet (bracketPausedAndQuiet).
+	pausedApp := argoApp.DeepCopy()
+	if pausedApp.Spec.SyncPolicy != nil {
+		pausedApp.Spec.SyncPolicy.Automated = nil
+	}
+	if pausedApp.Annotations == nil {
+		pausedApp.Annotations = map[string]string{}
+	}
+	pausedApp.Annotations[BracketPausedForMoveAnnotation] = BracketMovePhasePaused
+	pausedApp.Annotations[argocdRefreshAnnotation] = "normal"
+	phase := BracketMovePhasePaused
+	if err := a.updateApplication(ctx, pausedApp, "bracket.move.pause.update"); err != nil && isGoneErr(err) {
+		// The app vanished underneath us (stale KnownApps): skip the in-place
+		// pause and create it paused at the target path directly — a fresh app
+		// has no in-flight sync operations.
+		a.createPausedApplication(ctx, retarget)
+		phase = BracketMovePhaseRetargeted
+	}
+	a.pendingSpecUpdates = append(a.pendingSpecUpdates, &PendingSpecUpdate{
+		EnvironmentName: appInfo.EnvironmentName,
+		ApplicationName: appInfo.ApplicationName,
+		ExpectedPath:    path,
+		Phase:           phase,
+		Retarget:        retarget,
+	})
+	return true
+}
+
+// resumeBracketAutoSync re-enables auto-sync on a paused bracket app and removes
+// the paused-for-move marker (the RESUME step of the pause protocol).
+func (a *ArgoAppProcessor) resumeBracketAutoSync(ctx context.Context, app *v1alpha1.Application) error {
+	resumed := app.DeepCopy()
+	if resumed.Spec.SyncPolicy == nil {
+		//exhaustruct:ignore
+		resumed.Spec.SyncPolicy = &v1alpha1.SyncPolicy{}
+	}
+	resumed.Spec.SyncPolicy.Automated = &v1alpha1.SyncPolicyAutomated{
+		Prune:    true,
+		SelfHeal: true,
+		// AllowEmpty=false is the bracket default, see CreateArgoApplication.
+		AllowEmpty: false,
+	}
+	delete(resumed.Annotations, BracketPausedForMoveAnnotation)
+	return a.updateApplication(ctx, resumed, "bracket.move.resume")
+}
+
+// drainPendingSpecUpdates advances the pause protocol on watch events: paused
+// brackets are retargeted to the new snapshot once provably quiet, and
+// retargeted brackets get auto-sync restored once their own sync status proves
+// the moved resources are no longer attributed to them.
+func (a *ArgoAppProcessor) drainPendingSpecUpdates(ctx context.Context) {
+	l := logger.FromContext(ctx)
+	remaining := a.pendingSpecUpdates[:0]
+	for _, pu := range a.pendingSpecUpdates {
+		var app *v1alpha1.Application
+		if knownApps := a.KnownApps[pu.EnvironmentName]; knownApps != nil {
+			app = knownApps[pu.ApplicationName]
+		}
+		if app == nil {
+			remaining = append(remaining, pu)
+			continue
+		}
+		switch pu.Phase {
+		case BracketMovePhasePaused:
+			if !bracketPausedAndQuiet(app) || pu.Retarget == nil {
+				l.Info("bracket.retarget.blocked",
+					zap.String("app", pu.ApplicationName),
+					zap.String("env", pu.EnvironmentName),
+					zap.Bool("retarget-known", pu.Retarget != nil))
+				remaining = append(remaining, pu)
+				continue
+			}
+			if err := a.updateApplication(ctx, pu.Retarget, "bracket.move.retarget"); err != nil {
+				remaining = append(remaining, pu)
+				continue
+			}
+			pu.Phase = BracketMovePhaseRetargeted
+			remaining = append(remaining, pu)
+		default: // BracketMovePhaseRetargeted
+			if !bracketDisowned(app, pu.ExpectedPath) {
+				l.Info("bracket.resume.blocked",
+					zap.String("app", pu.ApplicationName),
+					zap.String("env", pu.EnvironmentName),
+					zap.String("expected-path", pu.ExpectedPath))
+				remaining = append(remaining, pu)
+				continue
+			}
+			if err := a.resumeBracketAutoSync(ctx, app); err != nil {
+				remaining = append(remaining, pu)
+				continue
+			}
+		}
+	}
+	a.pendingSpecUpdates = remaining
+}
+
 func (a *ArgoAppProcessor) ProcessAppChange(ctx context.Context, appInfo *AppInfo, currentAppDetails *api.GetAppDetailsResponse, overview *api.GetOverviewResponse, allAppDetails map[string]*api.GetAppDetailsResponse) {
 	logger.FromContext(ctx).Sugar().Debugf("Processing app %q on environment %q", appInfo.ApplicationName, appInfo.EnvironmentName)
 	// Bracket-to-individual transition guard (rollback: staging switched from true→false).
@@ -510,20 +917,21 @@ func (a *ArgoAppProcessor) ProcessAppChange(ctx context.Context, appInfo *AppInf
 			} else {
 				// Bracket move detection: if another bracket has a deployment for the same env,
 				// delete without cascade so the new bracket takes over k8s resource ownership.
-				noCascade := false
-				if appInfo.IsBracket {
+				deleteWithNoCascade := false
+				// only consider deletion, if the current app is not deployed anymore:
+				if appInfo.IsBracket && currentAppDetails.Deployments[appInfo.ParentEnvironmentName] == nil {
 					for _, otherApp := range sorting.SortKeys(allAppDetails) {
 						otherDetails := allAppDetails[otherApp]
 						if otherApp != appInfo.ApplicationName &&
 							otherDetails.Application != nil &&
 							otherDetails.Application.ArgoBracket == otherApp &&
 							otherDetails.Deployments[appInfo.ParentEnvironmentName] != nil {
-							noCascade = true
+							deleteWithNoCascade = true
 							break
 						}
 					}
 				}
-				if noCascade {
+				if deleteWithNoCascade {
 					if err := a.deleteAppNoCascade(ctx, ok, appInfo.ApplicationName); err != nil {
 						logger.FromContext(ctx).Error("bracket.move.delete.failed",
 							zap.String("app", appInfo.ApplicationName), zap.Error(err))
@@ -564,6 +972,12 @@ func (a *ArgoAppProcessor) ProcessAppChange(ctx context.Context, appInfo *AppInf
 	}
 
 	if currentAppDetails.Deployments[appInfo.ParentEnvironmentName] != nil { //If there is a deployment for this app on this environment
+		// Pause protocol (prune-vs-adopt protection on bracket moves): a bracket
+		// that lost members is retargeted with auto-sync disabled instead of the
+		// normal refresh — see the package comment and deferSpecUpdateIfWaiting.
+		if appInfo.IsBracket && a.deferSpecUpdateIfWaiting(ctx, appInfo, overview) {
+			return
+		}
 		argoApp := a.isKnownArgoApp(appInfo.ApplicationName, appInfo.EnvironmentName, a.KnownApps[appInfo.EnvironmentName])
 		if argoApp == nil {
 			a.CreateArgoApp(ctx, overview, appInfo)
@@ -616,11 +1030,19 @@ func (a *ArgoAppProcessor) ProcessArgoWatchEvent(ctx context.Context, l *zap.Log
 				zap.String("sync", string(ev.Application.Status.Sync.Status)),
 				zap.String("health", string(ev.Application.Status.Health.Status)),
 				zap.Int("pending.deletions", len(a.pendingDeletions)))
+			// Restart recovery for the pause protocol: a bracket paused for a move
+			// whose pending entry was lost (rollout-service restart) re-enters the
+			// protocol at the phase recorded in the marker annotation.
+			a.recoverPendingSpecUpdate(ctx, envName, appName, &ev.Application)
 			a.drainPendingDeletions(ctx, envName)
+			a.drainPendingSpecUpdates(ctx)
 		}
 	case "DELETED":
 		l.Info("deleted:kuberpult.application:" + ev.Application.Name + ",kuberpult.environment:" + envName)
 		delete(a.KnownApps[envName], appName)
+		// Drop any pause-protocol entry for the deleted app — e.g. the bracket
+		// was emptied mid-move and the delete-sentinel path removed its object.
+		a.removePendingSpecUpdate(envName, appName)
 	}
 }
 
@@ -636,6 +1058,9 @@ type AppInfo struct {
 	// Zero means "emit the legacy path with no suffix" (e.g. for non-bracket apps
 	// or when the rollout-service runs without DB access in tests).
 	BracketSnapshotEslId db.TransformerID
+	// LostMembersTo names the brackets that gained members this bracket lost in
+	// the current change (only set for bracket apps; see ArgoOverview.LostMembersTo).
+	LostMembersTo []string
 }
 
 func (a *ArgoAppProcessor) isKnownArgoApp(appName, envName string, appsKnownToArgo map[string]*v1alpha1.Application) *v1alpha1.Application {
@@ -672,10 +1097,12 @@ func (a *ArgoAppProcessor) CreateArgoApp(ctx context.Context, overview *api.GetO
 		}
 		_, err := a.ApplicationClient.Create(ctx, appCreateRequest)
 		if err != nil {
-			// We check if the application was created in the meantime
 			if status.Code(err) != codes.InvalidArgument {
-
 				logger.FromContext(ctx).Sugar().Errorf("creating %s, env %s: %v", appToCreate.Name, appInfo.EnvironmentName, err)
+			} else {
+				// The app exists with a different spec — its watch event has not
+				// arrived yet (KnownApps lag), so the update path was missed.
+				a.upsertExistingArgoApp(ctx, appInfo, appToCreate)
 			}
 		}
 		createSpan.Finish()
@@ -712,6 +1139,14 @@ func (a *ArgoAppProcessor) UpdateArgoApp(ctx context.Context, overview *api.GetO
 		_, err := a.ApplicationClient.Update(ctx, appUpdateRequest)
 		if err != nil {
 			logger.FromContext(ctx).Error("updating application: "+appToUpdate.Name+",env "+appInfo.EnvironmentName, zap.Error(err))
+			if isGoneErr(err) {
+				// The app vanished underneath us (stale KnownApps; e.g. its
+				// DELETED watch event is still queued behind a burst of overview
+				// ticks). Recreate it with the desired spec — the change would
+				// otherwise be lost for good (the fast path sends each change
+				// exactly once).
+				a.CreateArgoApp(ctx, overview, appInfo)
+			}
 		}
 		updateSpan.Finish()
 	}

--- a/services/rollout-service/pkg/argo/argo_test.go
+++ b/services/rollout-service/pkg/argo/argo_test.go
@@ -84,7 +84,13 @@ type mockApplicationServiceClient struct {
 	t                 *testing.T
 	cancel            context.CancelFunc
 	lastUpdateRequest *application.ApplicationUpdateRequest
+	updateRequests    []*application.ApplicationUpdateRequest
 	deleteErr         error
+	// updateErr makes Update fail with this error (the request is still recorded).
+	updateErr error
+	// createConflictOnExisting makes Create fail with InvalidArgument for apps
+	// that already exist, like the real Argo CD server does when the specs differ.
+	createConflictOnExisting bool
 	grpc.ClientStream
 }
 
@@ -99,6 +105,16 @@ func (m *mockApplicationServiceClient) ListResourceEvents(ctx context.Context, i
 }
 
 func (m *mockApplicationServiceClient) Get(ctx context.Context, in *application.ApplicationQuery, opts ...grpc.CallOption) (*v1alpha1.Application, error) {
+	if in.Name != nil {
+		for i := len(m.Apps) - 1; i >= 0; i-- {
+			if m.Apps[i].App.Name == *in.Name {
+				if m.Apps[i].LastEvent == "DELETED" {
+					break
+				}
+				return m.Apps[i].App, nil
+			}
+		}
+	}
 	return nil, status.Error(codes.NotFound, "app not found")
 }
 
@@ -251,6 +267,10 @@ func (m *mockApplicationServiceClient) Delete(ctx context.Context, req *applicat
 
 func (m *mockApplicationServiceClient) Update(ctx context.Context, req *application.ApplicationUpdateRequest, opts ...grpc.CallOption) (*v1alpha1.Application, error) {
 	m.lastUpdateRequest = req
+	m.updateRequests = append(m.updateRequests, req)
+	if m.updateErr != nil {
+		return nil, m.updateErr
+	}
 	for _, a := range m.Apps {
 		if a.App.Name == req.Application.Name {
 			updateApp := &ArgoApp{App: a.App, LastEvent: "MODIFIED"}
@@ -276,6 +296,9 @@ func (m *mockApplicationServiceClient) Create(ctx context.Context, req *applicat
 		}
 	}
 	if lastEvent == "ADDED" || lastEvent == "MODIFIED" {
+		if m.createConflictOnExisting {
+			return nil, status.Error(codes.InvalidArgument, "existing application spec is different, use upsert flag to force update")
+		}
 		return nil, nil
 	}
 	m.Apps = append(m.Apps, newApp)
@@ -2281,6 +2304,631 @@ func TestBracketMoveNoCascadeDelete(t *testing.T) {
 				}
 			} else if bracket1Delete != nil {
 				t.Fatalf("bracket1 was deleted by ProcessArgoOverview but the cascade table should be the sole authority (NoCascade=%v)", bracket1Delete.NoCascade)
+			}
+		})
+	}
+}
+
+// TestBracketMoveDefersLoserSpecUpdate verifies the prune-vs-adopt protection on a
+// bracket move (the "pause protocol"): a bracket that lost members to another
+// bracket (LostMembersTo) is first PAUSED in place (auto-sync disabled, path
+// unchanged — an in-flight sync operation executes against the spec path at
+// execution time, so the path must not move while one can be running), then
+// RETARGETED to the new snapshot once it is provably quiet (controller reconciled
+// the paused spec — refresh annotation cleared — and no operation is running),
+// and auto-sync is RESUMED only once its own sync status proves the moved
+// resources are no longer attributed to it (compared against the new path, no
+// entry requires pruning).
+func TestBracketMoveDefersLoserSpecUpdate(t *testing.T) {
+	// The old pinned path of the live bracket1 app, and the path
+	// CreateArgoApplication emits with no DB handler (snapshot id 0 = legacy format).
+	oldPath := "environments/staging/brackets/bracket1@1"
+	newPath := "environments/staging/brackets/bracket1"
+	type watchEvent struct {
+		RefreshPending  bool // the argocd refresh annotation is still on the app
+		OpRunning       bool
+		ComparedToPath  string
+		RequiresPruning bool
+		// WantUpdates is the total number of update requests expected after this
+		// event was processed (1 = only the pause, 2 = +retarget, 3 = +resume).
+		WantUpdates int
+	}
+	tcs := []struct {
+		Name   string
+		Events []watchEvent
+	}{
+		{
+			Name: "retarget only once quiet, resume only after disown",
+			Events: []watchEvent{
+				// Controller has not reconciled the paused spec yet: no retarget.
+				{RefreshPending: true, OpRunning: false, ComparedToPath: oldPath, RequiresPruning: false, WantUpdates: 1},
+				// Pre-pause sync operation still running: no retarget.
+				{RefreshPending: false, OpRunning: true, ComparedToPath: oldPath, RequiresPruning: false, WantUpdates: 1},
+				// Quiet: retarget fires.
+				{RefreshPending: false, OpRunning: false, ComparedToPath: oldPath, RequiresPruning: false, WantUpdates: 2},
+				// Still attributed the moved resources: no resume.
+				{RefreshPending: false, OpRunning: false, ComparedToPath: newPath, RequiresPruning: true, WantUpdates: 2},
+				// Disowned: resume fires.
+				{RefreshPending: false, OpRunning: false, ComparedToPath: newPath, RequiresPruning: false, WantUpdates: 3},
+			},
+		},
+		{
+			Name: "stale comparison against the old pinned path never resumes",
+			Events: []watchEvent{
+				{RefreshPending: false, OpRunning: false, ComparedToPath: oldPath, RequiresPruning: false, WantUpdates: 2},
+				{RefreshPending: false, OpRunning: false, ComparedToPath: oldPath, RequiresPruning: false, WantUpdates: 2},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := context.Background()
+
+			mockClient := &mockApplicationServiceClient{
+				deleteErr: nil,
+			}
+
+			argoProcessor := &ArgoAppProcessor{
+				ApplicationClient:            mockClient,
+				ManageArgoAppsEnabled:        true,
+				ManageArgoAppsFilter:         []string{"*"},
+				KnownApps:                    map[string]map[string]*v1alpha1.Application{},
+				ExperimentalBracketsClusters: []string{"staging"},
+				trigger:                      make(chan argoTrigger, 10),
+				ArgoApps:                     make(chan *v1alpha1.ApplicationWatchEvent, 10),
+				pendingDeletions:             []PendingDeletion{},
+
+				maxProcessedTransformerEslId: &atomic.Int64{},
+			}
+
+			// Seed KnownApps and mockClient.Apps with the pre-existing bracket1 app.
+			argoProcessor.PopulateAppsToKnownApps([]ArgoAppMetadata{
+				{
+					Name: "bracket1", Environment: "staging", ParentEnvironment: "staging",
+					Event: "ADDED", ManifestPath: "/environments/staging/brackets/bracket1",
+					IsBracket: true,
+				},
+			})
+			mockClient.PopulateApps([]ArgoAppMetadata{
+				{
+					Name: "bracket1", Environment: "staging", ParentEnvironment: "staging",
+					Event: "ADDED", ManifestPath: "/environments/staging/brackets/bracket1",
+				},
+			})
+			// The live bracket1 app pins the old snapshot path.
+			//exhaustruct:ignore
+			argoProcessor.KnownApps["staging"]["bracket1"].Spec.Source = &v1alpha1.ApplicationSource{Path: oldPath}
+
+			// Both brackets are live: app moved from bracket1 to bracket2, but bracket1
+			// still has another member deployed.
+			appDetails := map[string]*api.GetAppDetailsResponse{
+				"bracket1": {
+					//exhaustruct:ignore
+					Application: &api.Application{Name: "bracket1", ArgoBracket: "bracket1"},
+					Deployments: map[string]*api.Deployment{"staging": {}}, //exhaustruct:ignore
+				},
+				"bracket2": {
+					//exhaustruct:ignore
+					Application: &api.Application{Name: "bracket2", ArgoBracket: "bracket2"},
+					Deployments: map[string]*api.Deployment{"staging": {}}, //exhaustruct:ignore
+				},
+			}
+
+			argoOv := &ArgoOverview{
+				AppDetails:    appDetails,
+				LostMembersTo: map[string][]string{"bracket1": {"bracket2"}},
+				Overview: &api.GetOverviewResponse{
+					EnvironmentGroups: []*api.EnvironmentGroup{
+						{
+							EnvironmentGroupName: "staging-group",
+							Environments: []*api.Environment{
+								{
+									Name:     "staging",
+									Priority: api.Priority_UPSTREAM,
+									Config: &api.EnvironmentConfig{
+										Argocd: &api.ArgoCDEnvironmentConfiguration{
+											Destination: &api.ArgoCDEnvironmentConfiguration_Destination{
+												Name:   "staging",
+												Server: "test-server",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					GitRevision: "1234",
+				},
+			}
+
+			l := logger.FromContext(ctx)
+			argoProcessor.ProcessArgoOverview(ctx, l, argoOv)
+
+			// PAUSE: exactly one update — bracket1 with auto-sync disabled, path
+			// UNCHANGED (an in-flight sync op executes against the live spec path),
+			// the paused marker, and a refresh request so the quiet check can prove
+			// the controller reconciled the paused spec.
+			if got := len(mockClient.updateRequests); got != 1 {
+				t.Fatalf("got %d update requests in the move tick, want exactly 1 (pause)", got)
+			}
+			paused := mockClient.updateRequests[0].Application
+			if paused.Name != "staging-bracket1" {
+				t.Fatalf("pause update targeted %q, want %q", paused.Name, "staging-bracket1")
+			}
+			if got := paused.Spec.Source.Path; got != oldPath {
+				t.Errorf("pause update path = %q, want unchanged old path %q", got, oldPath)
+			}
+			if paused.Spec.SyncPolicy != nil && paused.Spec.SyncPolicy.Automated != nil {
+				t.Errorf("pause update must disable auto-sync (Automated=nil), got %+v", paused.Spec.SyncPolicy)
+			}
+			if got := paused.Annotations[BracketPausedForMoveAnnotation]; got != BracketMovePhasePaused {
+				t.Errorf("pause update annotation %q = %q, want %q", BracketPausedForMoveAnnotation, got, BracketMovePhasePaused)
+			}
+			if got := paused.Annotations[argocdRefreshAnnotation]; got == "" {
+				t.Errorf("pause update must request a refresh via the %q annotation", argocdRefreshAnnotation)
+			}
+
+			for i, ev := range tc.Events {
+				marker := BracketMovePhasePaused
+				if len(mockClient.updateRequests) >= 2 {
+					marker = BracketMovePhaseRetargeted
+				}
+				annotations := map[string]string{
+					"com.freiheit.kuberpult/application": "bracket1",
+					"com.freiheit.kuberpult/environment": "staging",
+					"com.freiheit.kuberpult/is-bracket":  "true",
+					BracketPausedForMoveAnnotation:       marker,
+				}
+				if ev.RefreshPending {
+					annotations[argocdRefreshAnnotation] = "normal"
+				}
+				var opState *v1alpha1.OperationState
+				if ev.OpRunning {
+					//exhaustruct:ignore
+					opState = &v1alpha1.OperationState{Phase: "Running"}
+				}
+				argoProcessor.ProcessArgoWatchEvent(ctx, l, &v1alpha1.ApplicationWatchEvent{
+					Type: "MODIFIED",
+					//exhaustruct:ignore
+					Application: v1alpha1.Application{
+						//exhaustruct:ignore
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "staging-bracket1",
+							Annotations: annotations,
+						},
+						//exhaustruct:ignore
+						Spec: v1alpha1.ApplicationSpec{
+							//exhaustruct:ignore
+							Source: &v1alpha1.ApplicationSource{Path: oldPath},
+						},
+						//exhaustruct:ignore
+						Status: v1alpha1.ApplicationStatus{
+							OperationState: opState,
+							//exhaustruct:ignore
+							Sync: v1alpha1.SyncStatus{
+								Status: v1alpha1.SyncStatusCodeSynced,
+								//exhaustruct:ignore
+								ComparedTo: v1alpha1.ComparedTo{
+									//exhaustruct:ignore
+									Source: v1alpha1.ApplicationSource{Path: ev.ComparedToPath},
+								},
+							},
+							Resources: []v1alpha1.ResourceStatus{
+								//exhaustruct:ignore
+								{Kind: "Deployment", Name: "app1-dep", RequiresPruning: ev.RequiresPruning},
+							},
+						},
+					},
+				})
+				if got := len(mockClient.updateRequests); got != ev.WantUpdates {
+					t.Fatalf("after event %d: got %d update requests, want %d", i+1, got, ev.WantUpdates)
+				}
+			}
+
+			if len(mockClient.updateRequests) >= 2 {
+				// RETARGET: new path, still paused, marker advanced.
+				retargeted := mockClient.updateRequests[1].Application
+				if got := retargeted.Spec.Source.Path; got != newPath {
+					t.Errorf("retarget update path = %q, want %q", got, newPath)
+				}
+				if retargeted.Spec.SyncPolicy == nil || retargeted.Spec.SyncPolicy.Automated != nil {
+					t.Errorf("retarget update must keep auto-sync disabled, got %+v", retargeted.Spec.SyncPolicy)
+				}
+				if got := retargeted.Annotations[BracketPausedForMoveAnnotation]; got != BracketMovePhaseRetargeted {
+					t.Errorf("retarget update annotation = %q, want %q", got, BracketMovePhaseRetargeted)
+				}
+			}
+			if len(mockClient.updateRequests) >= 3 {
+				// RESUME: policy restored, marker removed.
+				resumed := mockClient.updateRequests[2].Application
+				if resumed.Spec.SyncPolicy == nil {
+					t.Fatal("resume update has no SyncPolicy")
+				}
+				wantPolicy := &v1alpha1.SyncPolicyAutomated{Prune: true, SelfHeal: true, AllowEmpty: false}
+				if diff := cmp.Diff(wantPolicy, resumed.Spec.SyncPolicy.Automated); diff != "" {
+					t.Errorf("resume Automated policy mismatch (-want, +got):\n%s", diff)
+				}
+				if _, ok := resumed.Annotations[BracketPausedForMoveAnnotation]; ok {
+					t.Errorf("resume update must remove the %q annotation", BracketPausedForMoveAnnotation)
+				}
+			}
+		})
+	}
+}
+
+// TestBracketMovePauseRecoveryAfterRestart verifies that a rollout-service restart
+// does not strand a paused bracket: the watch ADDED replay re-enters the disown
+// wait for any bracket app carrying the paused-for-move annotation.
+func TestBracketMovePauseRecoveryAfterRestart(t *testing.T) {
+	pausedPath := "environments/staging/brackets/bracket1"
+	tcs := []struct {
+		Name            string
+		Marker          string
+		RequiresPruning bool
+		WantResume      bool
+	}{
+		{
+			Name:            "retargeted, still attributed the moved resources: stays paused",
+			Marker:          BracketMovePhaseRetargeted,
+			RequiresPruning: true,
+			WantResume:      false,
+		},
+		{
+			Name:            "retargeted and already disowned: resumes immediately",
+			Marker:          BracketMovePhaseRetargeted,
+			RequiresPruning: false,
+			WantResume:      true,
+		},
+		{
+			Name: "paused but not yet retargeted: stays paused until the next tick",
+			// The retarget payload was lost with the restart; only a new overview
+			// tick can rebuild it, so recovery must not resume here.
+			Marker:          BracketMovePhasePaused,
+			RequiresPruning: false,
+			WantResume:      false,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := context.Background()
+
+			mockClient := &mockApplicationServiceClient{
+				deleteErr: nil,
+			}
+
+			argoProcessor := &ArgoAppProcessor{
+				ApplicationClient:            mockClient,
+				ManageArgoAppsEnabled:        true,
+				ManageArgoAppsFilter:         []string{"*"},
+				KnownApps:                    map[string]map[string]*v1alpha1.Application{},
+				ExperimentalBracketsClusters: []string{"staging"},
+				trigger:                      make(chan argoTrigger, 10),
+				ArgoApps:                     make(chan *v1alpha1.ApplicationWatchEvent, 10),
+				pendingDeletions:             []PendingDeletion{},
+
+				maxProcessedTransformerEslId: &atomic.Int64{},
+			}
+
+			l := logger.FromContext(ctx)
+			argoProcessor.ProcessArgoWatchEvent(ctx, l, &v1alpha1.ApplicationWatchEvent{
+				Type: "ADDED",
+				//exhaustruct:ignore
+				Application: v1alpha1.Application{
+					//exhaustruct:ignore
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "staging-bracket1",
+						Annotations: map[string]string{
+							"com.freiheit.kuberpult/application": "bracket1",
+							"com.freiheit.kuberpult/environment": "staging",
+							"com.freiheit.kuberpult/is-bracket":  "true",
+							BracketPausedForMoveAnnotation:       tc.Marker,
+						},
+					},
+					//exhaustruct:ignore
+					Spec: v1alpha1.ApplicationSpec{
+						//exhaustruct:ignore
+						Source: &v1alpha1.ApplicationSource{Path: pausedPath},
+					},
+					//exhaustruct:ignore
+					Status: v1alpha1.ApplicationStatus{
+						//exhaustruct:ignore
+						Sync: v1alpha1.SyncStatus{
+							Status: v1alpha1.SyncStatusCodeSynced,
+							//exhaustruct:ignore
+							ComparedTo: v1alpha1.ComparedTo{
+								//exhaustruct:ignore
+								Source: v1alpha1.ApplicationSource{Path: pausedPath},
+							},
+						},
+						Resources: []v1alpha1.ResourceStatus{
+							//exhaustruct:ignore
+							{Kind: "Deployment", Name: "app1-dep", RequiresPruning: tc.RequiresPruning},
+						},
+					},
+				},
+			})
+
+			wantUpdates := 0
+			if tc.WantResume {
+				wantUpdates = 1
+			}
+			if got := len(mockClient.updateRequests); got != wantUpdates {
+				t.Fatalf("got %d update requests after recovery event, want %d", got, wantUpdates)
+			}
+			if tc.WantResume {
+				resumed := mockClient.updateRequests[0].Application
+				if resumed.Spec.SyncPolicy == nil || resumed.Spec.SyncPolicy.Automated == nil || !resumed.Spec.SyncPolicy.Automated.Prune {
+					t.Errorf("resume update must restore the Automated sync policy, got %+v", resumed.Spec.SyncPolicy)
+				}
+				if _, ok := resumed.Annotations[BracketPausedForMoveAnnotation]; ok {
+					t.Errorf("resume update must remove the %q annotation", BracketPausedForMoveAnnotation)
+				}
+			}
+		})
+	}
+}
+
+// TestCreateConflictFallsBackToUpdate verifies that a spec change is not lost
+// when the Argo app already exists but its watch event has not arrived yet
+// (KnownApps lag): ProcessAppChange then takes the create path and Argo rejects
+// the create with InvalidArgument ("existing application spec is different").
+// The rollout-service must fall back to updating the app with its desired spec —
+// except when the existing app is paused for a bracket move, in which case the
+// pause protocol takes over via a recovered pending entry.
+func TestCreateConflictFallsBackToUpdate(t *testing.T) {
+	tcs := []struct {
+		Name             string
+		ExistingPaused   bool
+		WantUpdate       bool
+		WantPendingEntry bool
+	}{
+		{
+			Name:             "existing app: create conflict falls back to update",
+			ExistingPaused:   false,
+			WantUpdate:       true,
+			WantPendingEntry: false,
+		},
+		{
+			Name:             "existing paused app: pause protocol recovered instead",
+			ExistingPaused:   true,
+			WantUpdate:       false,
+			WantPendingEntry: true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := context.Background()
+
+			mockClient := &mockApplicationServiceClient{
+				deleteErr:                nil,
+				createConflictOnExisting: true,
+			}
+
+			argoProcessor := &ArgoAppProcessor{
+				ApplicationClient:            mockClient,
+				ManageArgoAppsEnabled:        true,
+				ManageArgoAppsFilter:         []string{"*"},
+				KnownApps:                    map[string]map[string]*v1alpha1.Application{},
+				ExperimentalBracketsClusters: []string{"staging"},
+				trigger:                      make(chan argoTrigger, 10),
+				ArgoApps:                     make(chan *v1alpha1.ApplicationWatchEvent, 10),
+				pendingDeletions:             []PendingDeletion{},
+
+				maxProcessedTransformerEslId: &atomic.Int64{},
+			}
+
+			// The app exists in Argo CD, but its watch event has not arrived yet:
+			// it is in mockClient.Apps but NOT in KnownApps.
+			mockClient.PopulateApps([]ArgoAppMetadata{
+				{
+					Name: "bracket1", Environment: "staging", ParentEnvironment: "staging",
+					Event: "ADDED", ManifestPath: "/environments/staging/brackets/bracket1",
+				},
+			})
+			if tc.ExistingPaused {
+				existing := mockClient.Apps[0].App
+				existing.Annotations[BracketPausedForMoveAnnotation] = BracketMovePhaseRetargeted
+				//exhaustruct:ignore
+				existing.Spec.Source = &v1alpha1.ApplicationSource{Path: "environments/staging/brackets/bracket1"}
+			}
+
+			appDetails := map[string]*api.GetAppDetailsResponse{
+				"bracket1": {
+					//exhaustruct:ignore
+					Application: &api.Application{Name: "bracket1", ArgoBracket: "bracket1"},
+					Deployments: map[string]*api.Deployment{"staging": {}}, //exhaustruct:ignore
+				},
+			}
+
+			argoOv := &ArgoOverview{
+				AppDetails:    appDetails,
+				LostMembersTo: nil,
+				Overview: &api.GetOverviewResponse{
+					EnvironmentGroups: []*api.EnvironmentGroup{
+						{
+							EnvironmentGroupName: "staging-group",
+							Environments: []*api.Environment{
+								{
+									Name:     "staging",
+									Priority: api.Priority_UPSTREAM,
+									Config: &api.EnvironmentConfig{
+										Argocd: &api.ArgoCDEnvironmentConfiguration{
+											Destination: &api.ArgoCDEnvironmentConfiguration_Destination{
+												Name:   "staging",
+												Server: "test-server",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					GitRevision: "1234",
+				},
+			}
+
+			l := logger.FromContext(ctx)
+			argoProcessor.ProcessArgoOverview(ctx, l, argoOv)
+
+			wantUpdates := 0
+			if tc.WantUpdate {
+				wantUpdates = 1
+			}
+			if got := len(mockClient.updateRequests); got != wantUpdates {
+				t.Fatalf("got %d update requests, want %d", got, wantUpdates)
+			}
+			if tc.WantUpdate {
+				if got := mockClient.updateRequests[0].Application.Name; got != "staging-bracket1" {
+					t.Errorf("conflict fallback updated %q, want %q", got, "staging-bracket1")
+				}
+			}
+			wantPending := 0
+			if tc.WantPendingEntry {
+				wantPending = 1
+			}
+			if got := len(argoProcessor.pendingSpecUpdates); got != wantPending {
+				t.Errorf("got %d pending spec updates, want %d", got, wantPending)
+			}
+		})
+	}
+}
+
+// TestVanishedAppFallsBackToCreate verifies that a spec change is not lost when
+// the Argo app was deleted but its DELETED watch event has not been processed
+// yet (stale KnownApps; e.g. the event is queued behind a burst of overview
+// ticks). The update then fails with NotFound/PermissionDenied and the app must
+// be recreated: in the paused-retargeted state when it is going through the
+// pause protocol, with the normal spec otherwise.
+func TestVanishedAppFallsBackToCreate(t *testing.T) {
+	newPath := "environments/staging/brackets/bracket1"
+	tcs := []struct {
+		Name             string
+		WithPendingEntry bool
+		WantPausedCreate bool
+	}{
+		{
+			Name:             "stale pause-protocol entry: recreated paused at the target path",
+			WithPendingEntry: true,
+			WantPausedCreate: true,
+		},
+		{
+			Name:             "no pending entry: recreated with the normal spec",
+			WithPendingEntry: false,
+			WantPausedCreate: false,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := context.Background()
+
+			mockClient := &mockApplicationServiceClient{
+				deleteErr: nil,
+				updateErr: status.Error(codes.PermissionDenied, "permission denied"),
+			}
+
+			argoProcessor := &ArgoAppProcessor{
+				ApplicationClient:            mockClient,
+				ManageArgoAppsEnabled:        true,
+				ManageArgoAppsFilter:         []string{"*"},
+				KnownApps:                    map[string]map[string]*v1alpha1.Application{},
+				ExperimentalBracketsClusters: []string{"staging"},
+				trigger:                      make(chan argoTrigger, 10),
+				ArgoApps:                     make(chan *v1alpha1.ApplicationWatchEvent, 10),
+				pendingDeletions:             []PendingDeletion{},
+
+				maxProcessedTransformerEslId: &atomic.Int64{},
+			}
+
+			// KnownApps still contains bracket1, but the app is gone from Argo CD
+			// (mockClient.Apps is empty): the DELETED watch event is still queued.
+			argoProcessor.PopulateAppsToKnownApps([]ArgoAppMetadata{
+				{
+					Name: "bracket1", Environment: "staging", ParentEnvironment: "staging",
+					Event: "ADDED", ManifestPath: "/environments/staging/brackets/bracket1",
+					IsBracket: true,
+				},
+			})
+			if tc.WithPendingEntry {
+				argoProcessor.pendingSpecUpdates = []*PendingSpecUpdate{
+					{
+						EnvironmentName: "staging",
+						ApplicationName: "bracket1",
+						ExpectedPath:    "environments/staging/brackets/bracket1@1",
+						Phase:           BracketMovePhaseRetargeted,
+						Retarget:        nil,
+					},
+				}
+			}
+
+			appDetails := map[string]*api.GetAppDetailsResponse{
+				"bracket1": {
+					//exhaustruct:ignore
+					Application: &api.Application{Name: "bracket1", ArgoBracket: "bracket1"},
+					Deployments: map[string]*api.Deployment{"staging": {}}, //exhaustruct:ignore
+				},
+			}
+
+			argoOv := &ArgoOverview{
+				AppDetails:    appDetails,
+				LostMembersTo: nil,
+				Overview: &api.GetOverviewResponse{
+					EnvironmentGroups: []*api.EnvironmentGroup{
+						{
+							EnvironmentGroupName: "staging-group",
+							Environments: []*api.Environment{
+								{
+									Name:     "staging",
+									Priority: api.Priority_UPSTREAM,
+									Config: &api.EnvironmentConfig{
+										Argocd: &api.ArgoCDEnvironmentConfiguration{
+											Destination: &api.ArgoCDEnvironmentConfiguration_Destination{
+												Name:   "staging",
+												Server: "test-server",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					GitRevision: "1234",
+				},
+			}
+
+			l := logger.FromContext(ctx)
+			argoProcessor.ProcessArgoOverview(ctx, l, argoOv)
+
+			if got := len(mockClient.Apps); got != 1 {
+				t.Fatalf("got %d apps in Argo after the tick, want 1 (recreated)", got)
+			}
+			created := mockClient.Apps[0]
+			if created.LastEvent != "ADDED" {
+				t.Fatalf("app event = %q, want ADDED", created.LastEvent)
+			}
+			if created.App.Name != "staging-bracket1" {
+				t.Fatalf("created app %q, want %q", created.App.Name, "staging-bracket1")
+			}
+			if got := created.App.Spec.Source.Path; got != newPath {
+				t.Errorf("created app path = %q, want %q", got, newPath)
+			}
+			marker := created.App.Annotations[BracketPausedForMoveAnnotation]
+			if tc.WantPausedCreate {
+				if marker != BracketMovePhaseRetargeted {
+					t.Errorf("created app marker = %q, want %q", marker, BracketMovePhaseRetargeted)
+				}
+				if created.App.Spec.SyncPolicy == nil || created.App.Spec.SyncPolicy.Automated != nil {
+					t.Errorf("created app must be paused (Automated=nil), got %+v", created.App.Spec.SyncPolicy)
+				}
+				if got := len(argoProcessor.pendingSpecUpdates); got != 1 {
+					t.Errorf("got %d pending spec updates, want 1", got)
+				}
+			} else {
+				if marker != "" {
+					t.Errorf("created app must not carry the paused marker, got %q", marker)
+				}
+				if created.App.Spec.SyncPolicy == nil || created.App.Spec.SyncPolicy.Automated == nil || !created.App.Spec.SyncPolicy.Automated.Prune {
+					t.Errorf("created app must have the normal Automated policy, got %+v", created.App.Spec.SyncPolicy)
+				}
 			}
 		})
 	}

--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -269,8 +269,9 @@ func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEven
 			)
 
 			overview := argo.ArgoOverview{
-				Overview:   ov,
-				AppDetails: nil,
+				Overview:      ov,
+				AppDetails:    nil,
+				LostMembersTo: nil,
 			}
 
 			for _, appDetailsResponse := range changedApps.ChangedApps {
@@ -366,6 +367,12 @@ func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEven
 
 			for _, bracketDetails := range changedApps.ChangedBrackets {
 				bracketName := bracketDetails.BracketName
+				if len(bracketDetails.LostMembersTo) > 0 {
+					if overview.LostMembersTo == nil {
+						overview.LostMembersTo = make(map[string][]string)
+					}
+					overview.LostMembersTo[bracketName] = bracketDetails.LostMembersTo
+				}
 				logging.Info(ctx, "changed bracket loop", zap.String("bracketName", bracketName), zap.Any("bracketDetails", bracketDetails.Deployments))
 				for envName, bracketDeployment := range bracketDetails.Deployments {
 					if !slices.Contains(v.experimentalBracketsClusters, envName) {


### PR DESCRIPTION
The cd-service now also sends lost bracket members to the rollout.

The rollout-service uses that to
1) add new bracket members first
2) wait until argo reports they are applied
3) then remove old bracket members

This way there is no downtime in between.

Ref: SRX-PQRQ5V