### PR TITLE
fix: publish Docker images with versioned builds on main branch

### DIFF
--- a/infrastructure/make/go/include.mk
+++ b/infrastructure/make/go/include.mk
@@ -60,7 +60,7 @@ docker: # no dependencies here!
 release:
 	test -n "$(MAIN_PATH)" || exit 0; docker push $(IMAGE_NAME)
 
-release-main:
+release-main: release
 	@echo "Tagging the PR image as main image"
 ifndef SKIP_UNVERSIONED_BUILDS
 	test -n "$(MAIN_PATH)" || exit 0; docker tag $(IMAGE_NAME) $(MAIN_IMAGE_NAME); docker push $(MAIN_IMAGE_NAME)


### PR DESCRIPTION
Ref: SRX-VX9IKZ

The Docker images with versioned builds on main branch (e.g., `main-v13.52.15-1-g4f9dee00`) should be also published to the registry for performing vulnerability scanning and integration tests. Check the errors at: https://github.com/freiheit-com/kuberpult/actions/runs/27544064238/job/81416021425 