### PR TITLE
fix: re-render env docs and tooltips

### DIFF
--- a/docs/operators/_DO_NOT_RENAME.md
+++ b/docs/operators/_DO_NOT_RENAME.md
@@ -1,0 +1,3 @@
+Do not rename files here without a good reason!
+The files here are referenced for example in
+kuberpult's UI. It links to this documentation as a reference.

--- a/docs/users/61_rerender_with_locks.md
+++ b/docs/users/61_rerender_with_locks.md
@@ -1,0 +1,15 @@
+# Re-render with Locks
+
+## Concept
+The button "Re-render environment <env>" triggers the manifest-export-service to write all relevant files for Argo CD
+into the manifest-repo again.
+This is useful if the repo lost files, or if someone manually changed files, due to an emergency.
+
+
+## Written files
+
+"Re-render" touches three file locations:
+1) `argocd/v1alpha/<env>.yaml`: This is always re-rendered.
+2) `environments/<env>/applications/<app>/manifests/manifests.yaml`: Skipped if a manifest-lock exists on `<app>/<env>`.
+3) `environments/<env>/brackets/<bracket>/<app>.yaml`: Skipped if a manifest-lock exists on **any** app in `<bracket>`.
+

--- a/docs/users/_DO_NOT_RENAME.md
+++ b/docs/users/_DO_NOT_RENAME.md
@@ -1,0 +1,3 @@
+Do not rename files here without a good reason!
+The files here are referenced for example in
+kuberpult's UI. It links to this documentation as a reference.

--- a/infrastructure/scripts/create-testdata/manifest-setup.sh
+++ b/infrastructure/scripts/create-testdata/manifest-setup.sh
@@ -25,7 +25,7 @@ TEAM="sre"
 for v in $(seq 1 "$NUM_VERSIONS"); do
     echo "$v"
     REVISION=$v RELEASE_VERSION=$((START_VERSION + v)) \
-        "${SCRIPT_DIR}/create-release.sh" "${APP_NAME}" "${TEAM}" "" "${ARGO_BRACKET}"
+        "${SCRIPT_DIR}/create-release-allparams.sh" "${APP_NAME}" "${TEAM}" "${ARGO_BRACKET}"
     NEXT_VERSION=$((START_VERSION + v + 1))
 done
 
@@ -33,4 +33,4 @@ done
 
 # One extra release so not all apps are in the same state
 REVISION=6 RELEASE_VERSION=$NEXT_VERSION \
-    "${SCRIPT_DIR}/create-release.sh" "${APP_NAME}" "${TEAM}" "" "${ARGO_BRACKET}"
+    "${SCRIPT_DIR}/create-release-allparams.sh" "${APP_NAME}" "${TEAM}" "${ARGO_BRACKET}"

--- a/services/frontend-service/src/ui/components/EnvironmentCard/EnvironmentCard.scss
+++ b/services/frontend-service/src/ui/components/EnvironmentCard/EnvironmentCard.scss
@@ -120,4 +120,26 @@ Copyright freiheit.com*/
     a:active {
         color: var(--mdc-theme-anchor-on-surface);
     }
+
+    .re-render-group {
+        display: inline-flex;
+        align-items: stretch;
+        margin: $environment-buttons-column-margin;
+
+        .re-render-button {
+            margin: 0;
+            //border-right: none;
+            border-radius: $environment-add-lock-button-border-radius 0 0 $environment-add-lock-button-border-radius;
+        }
+        .re-render-info-link {
+            display: flex;
+            align-items: center;
+            padding: 0 8px;
+            border: $environment-add-lock-button-border;
+            border-left: none;
+            border-radius: 0 $environment-add-lock-button-border-radius $environment-add-lock-button-border-radius 0;
+            border-color: var(--mdc-theme-on-surface-light);
+            text-decoration: none;
+        }
+    }
 }

--- a/services/frontend-service/src/ui/components/EnvironmentCard/EnvironmentCard.tsx
+++ b/services/frontend-service/src/ui/components/EnvironmentCard/EnvironmentCard.tsx
@@ -13,7 +13,13 @@ You should have received a copy of the MIT License
 along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
 
 Copyright freiheit.com*/
-import { addAction, getPriorityClassName, useFilteredEnvironmentLockIDs, useTeamNames } from '../../utils/store';
+import {
+    addAction,
+    getPriorityClassName,
+    useFilteredEnvironmentLockIDs,
+    useKuberpultVersion,
+    useTeamNames,
+} from '../../utils/store';
 import { Button } from '../button';
 import { Locks } from '../../../images';
 import * as React from 'react';
@@ -100,6 +106,8 @@ export const EnvironmentCard: React.FC<{ environment: Environment; group: Enviro
             multiselect={true}></TeamSelectionDialog>
     );
 
+    const kuberpultVersion: string = useKuberpultVersion();
+
     return (
         <div className="environment-lane">
             {dialog}
@@ -136,16 +144,25 @@ export const EnvironmentCard: React.FC<{ environment: Environment; group: Enviro
                         onClick={popupSelectTeams}
                         highlightEffect={false}
                     />
-                    <span
-                        title={
-                            'Kuberpult generally renders all necessary files automatically.\nRe-rendering is useful if you did manual changes in the manifest repository, and you want to restore the content.\nNote that "re-render" ignores all locks except manifest-locks.'
-                        }>
+                    <span className={'re-render-group'}>
                         <Button
-                            className="environment-action"
+                            className="environment-action re-render-button"
                             label={'Re-render environment ' + environment.name}
                             onClick={renderEnvironment}
                             highlightEffect={false}
                         />
+                        <a
+                            className={'re-render-info-link'}
+                            href={
+                                'https://github.com/freiheit-com/kuberpult/blob/' +
+                                kuberpultVersion +
+                                '/docs/users/61_rerender_with_locks.md'
+                            }
+                            target="_blank"
+                            rel="noreferrer"
+                            aria-label="Re-render documentation">
+                            ⓘ
+                        </a>
                     </span>
                     <Button
                         className="environment-action service-action--show-config"

--- a/services/frontend-service/src/ui/components/EnvironmentCard/EnvironmentCard.tsx
+++ b/services/frontend-service/src/ui/components/EnvironmentCard/EnvironmentCard.tsx
@@ -138,7 +138,7 @@ export const EnvironmentCard: React.FC<{ environment: Environment; group: Enviro
                     />
                     <span
                         title={
-                            'Kuberpult generally renders all necessary files automatically.\nRe-rendering is useful if you did manual changes in the manifest repository.'
+                            'Kuberpult generally renders all necessary files automatically.\nRe-rendering is useful if you did manual changes in the manifest repository, and you want to restore the content.\nNote that "re-render" ignores all locks except manifest-locks.'
                         }>
                         <Button
                             className="environment-action"

--- a/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
+++ b/services/frontend-service/src/ui/components/chip/EnvironmentGroupChip.tsx
@@ -43,7 +43,7 @@ export const AppLockSummary: React.FC<{
     const cssClass: string = isManifestLock ? 'app-lock-summary-manifest-lock' : '';
     const message: string = isManifestLock ? 'M-Locked' : 'Locked';
     const title: string = isManifestLock
-        ? 'Go to the locks page on /ui/locks to see details.'
+        ? 'Go to the locks page on /ui/locks to see details. Note that for Manifest-Locks in brackets, the entire bracket is locked!'
         : 'Click on a tile to see details.';
     return (
         <div

--- a/services/manifest-repo-export-service/pkg/repository/transformer.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer.go
@@ -104,15 +104,16 @@ func writeManifests(fs billy.Filesystem, completeFilePath string, envManifest st
 	return nil
 }
 
-func writeManifestsIfNoManifestLock(ctx context.Context, dbHandler *db.DBHandler, transaction *sql.Tx, fs billy.Filesystem, completePath string, envManifest string, app types.AppName, env types.EnvName) error {
+// writeManifestsIfNoManifestLock returns true if we have confirmed there is a manifest-lock
+func writeManifestsIfNoManifestLock(ctx context.Context, dbHandler *db.DBHandler, transaction *sql.Tx, fs billy.Filesystem, completePath string, envManifest string, app types.AppName, env types.EnvName) (bool, error) {
 	hasLock, err := dbHandler.DBHasActiveManifestLock(ctx, transaction, app, env)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if hasLock {
-		return nil
+		return true, nil
 	}
-	return writeManifests(fs, completePath, envManifest)
+	return false, writeManifests(fs, completePath, envManifest)
 }
 
 // releasesDirectoryWithVersion returns applications/<app>/releases/<version>
@@ -409,7 +410,7 @@ func (c *DeployApplicationVersion) Transform(
 	}
 
 	if state.ArgoRenderOptions.RenderApps {
-		if err := writeManifestsIfNoManifestLock(ctx, state.DBHandler, transaction, fsys, fsys.Join(manifestsDir, "manifests.yaml"), manifestContent, types.AppName(c.Application), c.Environment); err != nil {
+		if _, err := writeManifestsIfNoManifestLock(ctx, state.DBHandler, transaction, fsys, fsys.Join(manifestsDir, "manifests.yaml"), manifestContent, types.AppName(c.Application), c.Environment); err != nil {
 			return "", err
 		}
 	}
@@ -485,7 +486,7 @@ func (c *DeployApplicationVersion) writeBracketFiles(ctx context.Context, state 
 	if err := fsys.MkdirAll(dir.BracketDirectory, 0777); err != nil {
 		return fmt.Errorf("could not create directory %s: %v", dir.BracketDirectory, err)
 	}
-	err = writeManifestsIfNoManifestLock(ctx, state.DBHandler, transaction, fsys, dir.BracketPath, string(manifestContent), types.AppName(c.Application), c.Environment)
+	_, err = writeManifestsIfNoManifestLock(ctx, state.DBHandler, transaction, fsys, dir.BracketPath, string(manifestContent), types.AppName(c.Application), c.Environment)
 	if err != nil {
 		return fmt.Errorf("could not write bracket for deployment of app %s on env %s: %v", c.Application, envName, err)
 	}
@@ -1029,6 +1030,7 @@ func (c *RenderEnvironment) Transform(
 
 	fs := state.Filesystem
 	appToManifestMap := make(map[types.AppName]string)
+	appsWithManifestLock := []types.AppName{}
 	for appName, releaseNumbers := range deployments {
 		release, err := state.DBHandler.DBSelectReleaseByVersionAtTimestamp(ctx, tx, appName, releaseNumbers, false, c.CreationTimestamp)
 		if err != nil {
@@ -1063,15 +1065,18 @@ func (c *RenderEnvironment) Transform(
 			if err := fs.MkdirAll(manifestsDir, 0777); err != nil {
 				return "", fmt.Errorf("could not create directory %s: %v", manifestsDir, err)
 			}
-
-			if err := writeManifests(fs, fs.Join(manifestsDir, "manifests.yaml"), envManifest); err != nil {
-				return "", fmt.Errorf("could not write manifests for app '%s' on env '%s': %v", appName, c.Environment, err)
+			lockExists, err := writeManifestsIfNoManifestLock(ctx, state.DBHandler, tx, fs, fs.Join(manifestsDir, "manifests.yaml"), envManifest, appName, c.Environment)
+			if err != nil {
+				return "", err
 			}
-
+			if lockExists {
+				appsWithManifestLock = append(appsWithManifestLock, appName)
+			}
 			tCtx.AddAppEnv(string(appName), c.Environment)
 		}
 	}
 
+	extraMessages := []string{}
 	// re-render brackets for all the apps in the environment (if brackets are enabled)
 	if state.ArgoRenderOptions.RenderBrackets {
 		bracketRow, err := db.DBSelectBracketHistoryLatest(ctx, state.DBHandler, tx)
@@ -1081,6 +1086,11 @@ func (c *RenderEnvironment) Transform(
 		if bracketRow != nil {
 			for bracketName, appNames := range bracketRow.AllBracketsJsonBlob.BracketMap {
 				for _, appName := range appNames {
+					if slices.Contains(appsWithManifestLock, appName) {
+						extraMessages = append(extraMessages, fmt.Sprintf("bracket %s skipped due to app %s's manifest-lock", bracketName, appName))
+						break // on to the next bracket
+					}
+
 					// as an app can be moved to a different bracket,
 					// we have to clean up all old brackes for this app on this env before rendering new brackets
 					if err := cleanupBracketFile(ctx, state, tx, fs, c.Environment, appName, c.TransformerEslVersion); err != nil {
@@ -1109,7 +1119,8 @@ func (c *RenderEnvironment) Transform(
 		}
 	}
 
-	return "re-render all deployed apps for environment " + string(c.Environment), nil
+	extra := "\n" + strings.Join(extraMessages, "\n")
+	return "re-render all deployed apps for environment " + string(c.Environment) + extra, nil
 }
 
 type CreateEnvironment struct {

--- a/services/manifest-repo-export-service/pkg/repository/transformer_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/transformer_test.go
@@ -1217,6 +1217,212 @@ spec:
 	}
 }
 
+// TestRerenderEnvironmentFailures is very similar to TestRerenderEnvironment, but it handles the case when
+// writing the file was interrupted (by a manifest lock).
+// And it tests the before and after states of the files, which in this test are different.
+func TestRerenderEnvironmentFailures(t *testing.T) {
+	const appName = "myapp"
+	const authorName = "testAuthorName"
+	const authorEmail = "testAuthorEmail@example.com"
+	const brokenManifest = "this file is broken now"
+	tcs := []struct {
+		Name                 string
+		SetupTransformers    []Transformer
+		RenderEnvTransformer Transformer
+		ExpectedFilesBefore  []*FilenameAndData
+		ExpectedFilesAfter   []*FilenameAndData
+		ArgoRenderOptions    func(*argocd.RenderOptions)
+	}{
+		{
+			Name: "should not re-render application and bracket manifests due to manifest-lock",
+			ArgoRenderOptions: func(opts *argocd.RenderOptions) {
+				opts.RenderApps = true
+				opts.RenderBrackets = true
+				opts.PointToBrackets = true
+			},
+			SetupTransformers: []Transformer{
+				&CreateEnvironment{
+					Environment: "development",
+					Config: config.EnvironmentConfig{
+						Upstream: &config.EnvironmentConfigUpstream{
+							Latest: true,
+						},
+						ArgoCd: &config.EnvironmentConfigArgoCd{
+							Destination: config.ArgoCdDestination{
+								Server: "development",
+							},
+						},
+					},
+					TransformerEslVersion: 1,
+					TransformerMetadata: TransformerMetadata{
+						AuthorName:  authorName,
+						AuthorEmail: authorEmail,
+					},
+				},
+				&CreateApplicationVersion{
+					Application:    appName,
+					SourceCommitId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Manifests: map[types.EnvName]string{
+						"development": "normal manifest",
+					},
+					WriteCommitData:       false,
+					Version:               1,
+					Revision:              0,
+					TransformerEslVersion: 2,
+					Team:                  "myteam",
+					TransformerMetadata: TransformerMetadata{
+						AuthorName:  authorName,
+						AuthorEmail: authorEmail,
+					},
+				},
+				&DeployApplicationVersion{
+					Authentication:        Authentication{},
+					Environment:           "development",
+					Application:           appName,
+					Version:               1,
+					Revision:              0,
+					LockBehaviour:         1,
+					WriteCommitData:       false,
+					SourceTrain:           nil,
+					Author:                "",
+					TransformerEslVersion: 3,
+					TransformerMetadata: TransformerMetadata{
+						AuthorName:  authorName,
+						AuthorEmail: authorEmail,
+					},
+				},
+			},
+			RenderEnvTransformer: &RenderEnvironment{
+				Environment:           "development",
+				TransformerEslVersion: 4,
+				TransformerMetadata: TransformerMetadata{
+					AuthorName:  authorName,
+					AuthorEmail: authorEmail,
+				},
+			},
+			ExpectedFilesBefore: []*FilenameAndData{
+				{
+					path:     "environments/development/brackets/myapp/myapp.yaml",
+					fileData: []byte("normal manifest"),
+				},
+				{
+					path:     "environments/development/applications/myapp/manifests/manifests.yaml",
+					fileData: []byte("normal manifest"),
+				},
+			},
+			ExpectedFilesAfter: []*FilenameAndData{
+				{
+					path:     "environments/development/brackets/myapp/myapp.yaml",
+					fileData: []byte("this file is broken now"),
+				},
+				{
+					path:     "environments/development/applications/myapp/manifests/manifests.yaml",
+					fileData: []byte("this file is broken now"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			repo, _ := setupRepositoryTestWithPath(t, tc.ArgoRenderOptions)
+
+			ctx := AddGeneratorToContext(testutilauth.MakeTestContext(), testutil.NewIncrementalUUIDGenerator())
+			dbHandler := repo.State().DBHandler
+			err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				err := dbHandler.DBWriteMigrationsTransformer(ctx, transaction)
+				if err != nil {
+					return fmt.Errorf("migration error: %w", err)
+				}
+				for index, tr := range tc.SetupTransformers {
+					err := dbHandler.DBWriteEslEventInternal(ctx, tr.GetDBEventType(), transaction, t, db.ESLMetadata{AuthorName: tr.GetMetadata().AuthorName, AuthorEmail: tr.GetMetadata().AuthorEmail})
+					if err != nil {
+						return fmt.Errorf("setup transformer[%d] failed: %w", index, err)
+					}
+					prepareDatabaseLikeCdService(ctx, transaction, tr, dbHandler, t, authorEmail, authorName)
+				}
+
+				for index, t := range tc.SetupTransformers {
+					err := repo.Apply(ctx, transaction, t)
+					if err != nil {
+						return fmt.Errorf("apply[%d] failed: %w", index, err)
+					}
+					// just for testing, we push each transformer change separately.
+					// if you need to debug this test, you can git clone the repo
+					// and we will only see anything if we push.
+					err = repo.PushRepo(ctx)
+					if err != nil {
+						return fmt.Errorf("push[%d] failed: %w", index, err)
+					}
+				}
+				return nil
+			})
+			if err != nil {
+				t.Errorf("error: %v", err)
+			}
+			updatedState := repo.State()
+			if err := verifyContent(updatedState.Filesystem, tc.ExpectedFilesBefore); err != nil {
+				t.Fatalf("error while verifying content: %v.\nFilesystem content:\n%s", err, strings.Join(listFiles(updatedState.Filesystem), "\n"))
+			}
+
+			// Manually modify the manifests.yml in Git
+			if tc.ExpectedFilesBefore != nil {
+				for i := range tc.ExpectedFilesBefore {
+					expectedFile := tc.ExpectedFilesBefore[i]
+					updatedState := repo.State()
+					fullPath := updatedState.Filesystem.Join(updatedState.Filesystem.Root(), expectedFile.path)
+
+					if err := util.WriteFile(updatedState.Filesystem, fullPath, []byte(brokenManifest), 0666); err != nil {
+						t.Fatalf("failed to write file: %v path=%s", err, fullPath)
+					}
+
+					_, _, applyError := repo.createCommit(ctx, updatedState, tc.SetupTransformers[i], []string{"broken content"})
+					if applyError != nil {
+						t.Fatalf("failed to create commit: %v", applyError)
+					}
+
+					actualFileData, err := util.ReadFile(updatedState.Filesystem, fullPath)
+					if err != nil {
+						t.Fatalf("failed to read file: %v path=%s", err, fullPath)
+					}
+
+					if !cmp.Equal(string(actualFileData), brokenManifest) {
+						t.Fatalf("expected '%v', got '%v'", brokenManifest, string(actualFileData))
+					}
+				}
+			}
+
+			// RenderEnvironment transformer should re-render the state of manifests.yml in Git (data fetched from database)
+			err = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				err = dbHandler.DBWriteManifestLock(ctx, transaction, appName, "development", db.LockMetadata{})
+				if err != nil {
+					return fmt.Errorf("failed to write manifest lock: %w", err)
+				}
+				err := dbHandler.DBWriteEslEventInternal(ctx, tc.RenderEnvTransformer.GetDBEventType(), transaction, t, db.ESLMetadata{AuthorName: tc.RenderEnvTransformer.GetMetadata().AuthorName, AuthorEmail: tc.RenderEnvTransformer.GetMetadata().AuthorEmail})
+				if err != nil {
+					return err
+				}
+				prepareDatabaseLikeCdService(ctx, transaction, tc.RenderEnvTransformer, dbHandler, t, authorEmail, authorName)
+
+				err = repo.Apply(ctx, transaction, tc.RenderEnvTransformer)
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("failed to execute transaction: %v", err)
+			}
+
+			updatedState = repo.State()
+			if err := verifyContent(updatedState.Filesystem, tc.ExpectedFilesAfter); err != nil {
+				t.Fatalf("error while verifying content: %v.\nFilesystem content:\n%s", err, strings.Join(listFiles(updatedState.Filesystem), "\n"))
+			}
+		})
+	}
+}
+
 func TestReleasesAndDeployments(t *testing.T) {
 	const appName = "myapp"
 	const authorName = "testAuthorName"


### PR DESCRIPTION
The re-render button now got an info link:
<img width="1040" height="222" alt="image" src="https://github.com/user-attachments/assets/e18ebc8d-37cc-4255-9095-65dea199b6a5" />


This link leads to the new documentation file docs/users/61_rerender_with_locks.md.

Other changes include better tooltips and unit tests and fixing manifest-setup.sh which now works with brackets.

<img width="1097" height="387" alt="image" src="https://github.com/user-attachments/assets/55692e89-380c-4724-bca3-8e74ee0890a9" />



Ref: SRX-MPWOLJ