### PR TITLE
fix: do not squash deployment commits

### DIFF
--- a/pkg/db/db_deployments.go
+++ b/pkg/db/db_deployments.go
@@ -440,9 +440,16 @@ func (h *DBHandler) DBSelectDeploymentsByTransformerID(ctx context.Context, tx *
 		span.Finish(tracer.WithError(err))
 	}()
 
+	// We use deploymentsHistoryTable instead of deploymentsTable.
+	// Either would technically work.
+	// The issue with the deploymentsTable is that
+	// the manifest-export would generate fewer commits.
+	// E.g. if we have 2 events "deploy v1", and "deploy v1"
+	// The manifest-export would collapse them into one commit.
+	// This would make the commit history hard to read.
 	selectQuery := h.AdaptQuery(`
 		SELECT created, releaseVersion, appName, envName, metadata, transformereslVersion, revision
-		FROM ` + deploymentsTable + `
+		FROM ` + deploymentsHistoryTable + `
 		WHERE transformereslVersion=?;
 	`)
 

--- a/pkg/db/db_sync_status.go
+++ b/pkg/db/db_sync_status.go
@@ -297,6 +297,11 @@ func (h *DBHandler) DBBulkUpdateAllDeployments(ctx context.Context, tx *sql.Tx, 
 	if err != nil {
 		return fmt.Errorf("could not update deployments from %q to %q. Error: %w", oldId, newId, err)
 	}
+	query = h.AdaptQuery("UPDATE deployments_history SET transformereslversion = ? WHERE transformereslversion= ?;")
+	_, err = tx.ExecContext(ctx, query, newId, oldId)
+	if err != nil {
+		return fmt.Errorf("could not update deployments from %q to %q. Error: %w", oldId, newId, err)
+	}
 	return nil
 }
 

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -6292,7 +6292,6 @@ func TestDbUpdateAllDeployments(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutilauth.MakeTestContext()
@@ -6324,7 +6323,7 @@ func TestDbUpdateAllDeployments(t *testing.T) {
 						return err
 					}
 
-					err = dbHandler.upsertDeploymentRow(ctx, transaction, deployment)
+					err = dbHandler.DBUpdateOrCreateDeployment(ctx, transaction, deployment)
 					if err != nil {
 						return fmt.Errorf("error while writing deployment, error: %w", err)
 					}


### PR DESCRIPTION
This switches 1 query to use the historic deployment table, instead of the current deployment table.

We generally prefer the historic tables for everything in the manifest-export. In this specific case, using the current table would "collapse" multiple deployment commits into 1.

Not a technical problem, but it makes the git history unnecessarily hard to read.

Ref: SRX-V9XENP