### PR TITLE
fix(ci): speed up benchmarks

### DIFF
--- a/infrastructure/make/go/include.mk
+++ b/infrastructure/make/go/include.mk
@@ -38,7 +38,7 @@ unit-test::
 .PHONY: bench-test
 bench-test:
 	docker compose -f $(ROOT_DIR)/docker-compose-unittest.yml up -d
-	docker run --rm -w $(SERVICE_DIR) --network kuberpult-test-net -v ".:$(SERVICE_DIR)" -v $(MIGRATION_VOLUME) $(PKG_VOLUME) $(BUILDER_IMAGE) sh -c "go test $(GO_TEST_ARGS) -bench=. ./..."
+	docker run --rm -w $(SERVICE_DIR) --network kuberpult-test-net -v ".:$(SERVICE_DIR)" -v $(MIGRATION_VOLUME) $(PKG_VOLUME) $(BUILDER_IMAGE) sh -c "go test $(GO_TEST_ARGS) -run=NONE -bench=. ./..." # run benchmarks only, no tests
 	docker compose -f $(ROOT_DIR)/docker-compose-unittest.yml down
 
 .PHONY: lint


### PR DESCRIPTION
Now the benchmarks won't run the tests again. We are already running all tests twice to detect flakyness.

In one quick experiment this saved 3 minutes in the cd-service build (12.5min => 9.5min).

Ref: SRX-2960J8