### PR TITLE
fix: kubernetes.io/ingress.class is required for GKE

### DIFF
--- a/charts/kuberpult/templates/ingress.yaml
+++ b/charts/kuberpult/templates/ingress.yaml
@@ -29,6 +29,9 @@ metadata:
   annotations:
     cert-manager.io/acme-challenge-type: dns01
     cert-manager.io/cluster-issuer: {{ required ".ingress.clusterIssuer is required" .Values.ingress.clusterIssuer | quote }}
+{{- if eq .Values.kubernetesEngine "GKE" }}
+    kubernetes.io/ingress.class: {{ .Values.ingress.ingressClassName | quote }}
+{{- end }}
 {{- if .Values.ingress.annotations }}
 {{ .Values.ingress.annotations | toYaml | indent 4}}
 {{- end }}

--- a/charts/kuberpult/tests/charts_test.go
+++ b/charts/kuberpult/tests/charts_test.go
@@ -2016,6 +2016,7 @@ ingress:
 				"cert-manager.io/acme-challenge-type":            "dns01",
 				"cert-manager.io/cluster-issuer":                 "letsencrypt",
 				"kubernetes.io/ingress.allow-http":               "false",
+				"kubernetes.io/ingress.class":                    "",
 				"nginx.ingress.kubernetes.io/proxy-read-timeout": "300",
 			}
 			for key, value := range tc.ExpectedExtraAnnotations {


### PR DESCRIPTION
Ref: SRX-IWC3Y6

`kubernetes.io/ingress.class` is deprecated in K8S docs, but GKE still relies exclusively on this annotation.

https://docs.cloud.google.com/kubernetes-engine/docs/concepts/ingress#deprecated_annotation