### PR TITLE
fix: remove the max batch limit

### DIFF
--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -267,8 +267,7 @@ manifestRepoExport:
   # its single push must finish comfortably within `networkTimeoutSeconds` above (NOT
   # `git.networkTimeout`, which governs the cd-service). An oversized batch that trips the timeout
   # forces the whole batch to reprocess, which is strictly worse than not
-  # batching. Must be between 1 and 100 (inclusive); the service rejects values
-  # above 100. This is a hard guard against having a excessive configuration.
+  # batching. Must be at least 1; there is no upper bound enforced by the service.
   # For details, view `docs/operators/timeouts.md`.
   maxExportBatchSize: 1
 

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -52,9 +52,6 @@ const (
 	maxReleaseVersionsLimit = 30
 
 	maxEslProcessingTimeSeconds int64 = 600 // see eslProcessingIdleTimeSeconds in values.yaml
-
-	// maxExportBatchSizeLimit is a hard upper bound on KUBERPULT_MAX_EXPORT_BATCH_SIZE.
-	maxExportBatchSizeLimit = 100
 )
 
 func RunServer() {
@@ -188,9 +185,6 @@ func Run(ctx context.Context) error {
 	}
 	if maxExportBatchSize == 0 {
 		return fmt.Errorf("error KUBERPULT_MAX_EXPORT_BATCH_SIZE must be >=1 but was: %v", maxExportBatchSize)
-	}
-	if maxExportBatchSize > maxExportBatchSizeLimit {
-		return fmt.Errorf("error KUBERPULT_MAX_EXPORT_BATCH_SIZE must be <=%v but was: %v", maxExportBatchSizeLimit, maxExportBatchSize)
 	}
 	logging.Info(ctx, "maxExportBatchSize", zap.Uint("maxExportBatchSize", maxExportBatchSize))
 


### PR DESCRIPTION
After some practical experience with using the batch feature, it became clear that the overhead of batching is smaller than I expected. With no measurable increase of latency even for big values.