### PR TITLE
fix(rollout): gate for bracket deletion 

### DIFF
--- a/charts/kuberpult/install-kuberpult-helm.sh
+++ b/charts/kuberpult/install-kuberpult-helm.sh
@@ -80,6 +80,7 @@ reposerver:
       memory: 200Mi
       cpu: 0.05
 manifestRepoExport:
+  allowBracketMoves: true
   enabled: false
   eslProcessingIdleTimeSeconds: 10
   resources:

--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -11,7 +11,7 @@ trap 'trap - EXIT SIGINT SIGTERM; kill 0' EXIT SIGINT SIGTERM
 
 # This script assumes that the docker images have already been built.
 # To run/debug/develop this locally, you probably want to run like this:
-# rm -rf ./manifests/; make clean; LOCAL_EXECUTION=true ./run-kind.sh
+# rm -rf ./manifests/; make clean; LOCAL_EXECUTION=true GO_TEST_ARGS='' ./run-kind.sh
 
 cd "$(dirname "$0")"
 

--- a/services/rollout-service/Makefile
+++ b/services/rollout-service/Makefile
@@ -14,7 +14,7 @@
 
 # Copyright freiheit.com
 
-MIN_COVERAGE=71.5
+MIN_COVERAGE=74.1
 MAX_DOCKER_SIZE_MB=110
 include ../../infrastructure/make/go/include.mk
 

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -221,7 +221,7 @@ type ArgoAppProcessor struct {
 	ArgoAppsMetricsEnabled  bool
 	ManageArgoAppsFilter    []string
 	DDMetrics               statsd.ClientInterface
-	KnownApps               map[string]map[string]*v1alpha1.Application // first key is the environment name, second key is the argo-app name
+	KnownApps               map[string]map[string]*v1alpha1.Application // first key is the environment name, second key is the kuberpult app name
 	// DBHandler is read by ProcessArgoOverview to look up the current brackets_history
 	// snapshot so its source_transformer_esl_id can be embedded in each bracket Argo CD
 	// app's Spec.Source.Path (see CreateArgoApplication). Nil in unit tests; non-nil in
@@ -428,14 +428,15 @@ func (a *ArgoAppProcessor) extractFullyQualifiedEnvironmentName(commonPrefix, en
 	return commonPrefix + "-" + envName + "-" + argoCDConfig.ConcreteEnvName
 }
 
-func (a *ArgoAppProcessor) isBracketEnv(envName string) bool {
-	return slices.Contains(a.ExperimentalBracketsClusters, envName)
+func (a *ArgoAppProcessor) isBracketEnv(parentEnvName string) bool {
+	return slices.Contains(a.ExperimentalBracketsClusters, parentEnvName)
 }
 
 // isBracketAppReady returns true if the bracket app is part of knownApps and has been synced at least once
 // This is the point where we decide that other apps can be deleted.
 // Parameter bareBracketAppName is the name of the bracket that we want to be ready. It's not the name of the bracket app (that would incl the env name).
 // old name: "knowsBracketApp"
+// envName is the environmentName, NOT the parentEnvironmentName
 func (a *ArgoAppProcessor) isBracketAppReady(envName string, bareBracketAppName string) (bool, string) {
 	knownEnv := a.KnownApps[envName]
 	if knownEnv == nil {
@@ -977,24 +978,25 @@ func (a *ArgoAppProcessor) ProcessAppChange(ctx context.Context, appInfo *AppInf
 	// For non-bracket apps in a bracket env: only delete once the bracket app is established in KnownApps.
 	// This prevents a downtime gap when transitioning an env to bracket mode.
 	knowsBracketApp, reason := a.isBracketAppReady(appInfo.EnvironmentName, currentAppDetails.Application.GetArgoBracket())
+	isBracketEnv := a.isBracketEnv(appInfo.ParentEnvironmentName)
 	// We allow the deletion if either:
 	// * the app itself is a bracket (so it does not depend on another app)
 	// * we are not in bracket mode on this env (in which case nothing is a bracket, no reason to wait)
 	// * or if the corresponding bracket app is known ("parent" bracket was already created and synced once)
 	allowDelete := appInfo.IsBracket ||
-		!a.isBracketEnv(appInfo.EnvironmentName) ||
+		!isBracketEnv ||
 		knowsBracketApp
 	logger.FromContext(ctx).Info("ProcessAppChange",
 		zap.Bool("allow_delete", allowDelete),
 		zap.Bool("isBracket", appInfo.IsBracket),
-		zap.Bool("isBracketEnv", a.isBracketEnv(appInfo.EnvironmentName)),
+		zap.Bool("isBracketEnv", isBracketEnv),
 		zap.Bool("knowsBracket", knowsBracketApp),
 		zap.String("knowsBracketReason", reason),
 		zap.String("app", appInfo.ApplicationName),
 		zap.String("env", appInfo.EnvironmentName))
 	if allowDelete {
 		if ok := a.KnownApps[appInfo.EnvironmentName]; ok != nil { //If argo does not know this application, delete it
-			if !appInfo.IsBracket && a.isBracketEnv(appInfo.EnvironmentName) {
+			if !appInfo.IsBracket && isBracketEnv {
 				// Individual app in a bracket env: delete without cascade so k8s resources
 				// remain under the bracket app's management.
 				if err := a.deleteAppNoCascade(ctx, ok, appInfo.ApplicationName); err != nil {

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -460,7 +460,7 @@ func (a *ArgoAppProcessor) isBracketAppReady(envName string, bareBracketAppName 
 	syncedAtLeastOnce := historyFull || operationStateSynced || statusSynced // either of these is indicating a sync
 
 	if !syncedAtLeastOnce {
-		return false, "or condition"
+		return false, "not synced"
 	}
 	return true, ""
 }

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -186,6 +186,7 @@ type PendingDeletion struct {
 	EnvironmentName       string // key into KnownApps for the DeleteArgoApps call
 	ParentEnvironmentName string // key for isBracketEnv / knowsBracketApp check
 	AppName               string
+	PlainArgoBracketName  string // name of the bracket app that this deletion is waiting for (without env name)
 }
 
 // PendingSpecUpdate tracks a bracket Argo app that lost members to other brackets
@@ -220,7 +221,7 @@ type ArgoAppProcessor struct {
 	ArgoAppsMetricsEnabled  bool
 	ManageArgoAppsFilter    []string
 	DDMetrics               statsd.ClientInterface
-	KnownApps               map[string]map[string]*v1alpha1.Application
+	KnownApps               map[string]map[string]*v1alpha1.Application // first key is the environment name, second key is the argo-app name
 	// DBHandler is read by ProcessArgoOverview to look up the current brackets_history
 	// snapshot so its source_transformer_esl_id can be embedded in each bracket Argo CD
 	// app's Spec.Source.Path (see CreateArgoApplication). Nil in unit tests; non-nil in
@@ -431,13 +432,37 @@ func (a *ArgoAppProcessor) isBracketEnv(envName string) bool {
 	return slices.Contains(a.ExperimentalBracketsClusters, envName)
 }
 
-func (a *ArgoAppProcessor) knowsBracketApp(envName string) bool {
-	for _, appName := range sorting.SortKeys(a.KnownApps[envName]) {
-		if a.KnownApps[envName][appName].Annotations["com.freiheit.kuberpult/is-bracket"] == "true" {
-			return true
-		}
+// isBracketAppReady returns true if the bracket app is part of knownApps and has been synced at least once
+// This is the point where we decide that other apps can be deleted.
+// Parameter bareBracketAppName is the name of the bracket that we want to be ready. It's not the name of the bracket app (that would incl the env name).
+// old name: "knowsBracketApp"
+func (a *ArgoAppProcessor) isBracketAppReady(envName string, bareBracketAppName string) (bool, string) {
+	knownEnv := a.KnownApps[envName]
+	if knownEnv == nil {
+		return false, "not a known environment"
 	}
-	return false
+	knownBracketApp := knownEnv[bareBracketAppName]
+	bracketAppIsKnown := knownBracketApp != nil
+	if !bracketAppIsKnown {
+		return false, fmt.Sprintf("not a known app: %s", bareBracketAppName)
+	}
+	if knownBracketApp.Annotations["com.freiheit.kuberpult/is-bracket"] != "true" {
+		return false, "known, but annotation is-bracket!=true"
+	}
+
+	// calculate the 3 different OR conditions that each alone serve as proof that the app has been synced
+	stat := knownBracketApp.Status
+
+	historyFull := len(stat.History) > 0
+	operationStateSynced := stat.OperationState != nil && stat.OperationState.Phase.Successful() && stat.OperationState.SyncResult != nil
+	statusSynced := stat.Sync.Status == v1alpha1.SyncStatusCodeSynced
+
+	syncedAtLeastOnce := historyFull || operationStateSynced || statusSynced // either of these is indicating a sync
+
+	if syncedAtLeastOnce == false {
+		return false, "or condition"
+	}
+	return true, ""
 }
 
 // ApplicationDeleter is the minimal subset of application.ApplicationServiceClient
@@ -500,7 +525,8 @@ func (a *ArgoAppProcessor) drainPendingDeletions(ctx context.Context, bracketEnv
 	remaining := a.pendingDeletions[:0]
 	for _, pd := range a.pendingDeletions {
 		// if the app belongs to the bracket:
-		if pd.ParentEnvironmentName == bracketEnvName && a.knowsBracketApp(pd.ParentEnvironmentName) {
+		isBracketReady, reason := a.isBracketAppReady(pd.EnvironmentName, pd.PlainArgoBracketName)
+		if pd.EnvironmentName == bracketEnvName && isBracketReady {
 			l.Info("bracket.drain.pending",
 				zap.String("app", pd.AppName),
 				zap.String("env", pd.EnvironmentName))
@@ -538,6 +564,12 @@ func (a *ArgoAppProcessor) drainPendingDeletions(ctx context.Context, bracketEnv
 				continue
 			}
 		} else {
+			l.Info("bracket.drain.not-ready",
+				zap.String("app", pd.AppName),
+				zap.String("env", pd.EnvironmentName),
+				zap.String("bracket", pd.PlainArgoBracketName),
+				zap.String("reason", reason),
+			)
 			remaining = append(remaining, pd)
 		}
 	}
@@ -944,19 +976,25 @@ func (a *ArgoAppProcessor) ProcessAppChange(ctx context.Context, appInfo *AppInf
 	}
 	// For non-bracket apps in a bracket env: only delete once the bracket app is established in KnownApps.
 	// This prevents a downtime gap when transitioning an env to bracket mode.
+	knowsBracketApp, reason := a.isBracketAppReady(appInfo.EnvironmentName, currentAppDetails.Application.GetArgoBracket())
+	// We allow the deletion if either:
+	// * the app itself is a bracket (so it does not depend on another app)
+	// * we are not in bracket mode on this env (in which case nothing is a bracket, no reason to wait)
+	// * or if the corresponding bracket app is known ("parent" bracket was already created and synced once)
 	allowDelete := appInfo.IsBracket ||
-		!a.isBracketEnv(appInfo.ParentEnvironmentName) ||
-		a.knowsBracketApp(appInfo.ParentEnvironmentName)
+		!a.isBracketEnv(appInfo.EnvironmentName) ||
+		knowsBracketApp
 	logger.FromContext(ctx).Info("ProcessAppChange",
 		zap.Bool("allow_delete", allowDelete),
 		zap.Bool("isBracket", appInfo.IsBracket),
-		zap.Bool("isBracketEnv", a.isBracketEnv(appInfo.ParentEnvironmentName)),
-		zap.Bool("knowsBracket", a.knowsBracketApp(appInfo.ParentEnvironmentName)),
+		zap.Bool("isBracketEnv", a.isBracketEnv(appInfo.EnvironmentName)),
+		zap.Bool("knowsBracket", knowsBracketApp),
+		zap.String("knowsBracketReason", reason),
 		zap.String("app", appInfo.ApplicationName),
 		zap.String("env", appInfo.EnvironmentName))
 	if allowDelete {
 		if ok := a.KnownApps[appInfo.EnvironmentName]; ok != nil { //If argo does not know this application, delete it
-			if !appInfo.IsBracket && a.isBracketEnv(appInfo.ParentEnvironmentName) {
+			if !appInfo.IsBracket && a.isBracketEnv(appInfo.EnvironmentName) {
 				// Individual app in a bracket env: delete without cascade so k8s resources
 				// remain under the bracket app's management.
 				if err := a.deleteAppNoCascade(ctx, ok, appInfo.ApplicationName); err != nil {
@@ -1006,7 +1044,7 @@ func (a *ArgoAppProcessor) ProcessAppChange(ctx context.Context, appInfo *AppInf
 		// Guard against duplicates so a second overview before drain doesn't double-queue.
 		alreadyPending := false
 		for _, existing := range a.pendingDeletions {
-			if existing.AppName == appInfo.ApplicationName && existing.ParentEnvironmentName == appInfo.ParentEnvironmentName {
+			if existing.AppName == appInfo.ApplicationName && existing.EnvironmentName == appInfo.EnvironmentName {
 				alreadyPending = true
 				break
 			}
@@ -1019,6 +1057,7 @@ func (a *ArgoAppProcessor) ProcessAppChange(ctx context.Context, appInfo *AppInf
 				EnvironmentName:       appInfo.EnvironmentName,
 				ParentEnvironmentName: appInfo.ParentEnvironmentName,
 				AppName:               appInfo.ApplicationName,
+				PlainArgoBracketName:  currentAppDetails.Application.ArgoBracket,
 			})
 		}
 	}
@@ -1101,8 +1140,8 @@ func (a *ArgoAppProcessor) ProcessArgoWatchEvent(ctx context.Context, l *zap.Log
 type AppInfo struct {
 	ApplicationName              string
 	TeamName                     string
-	EnvironmentName              string
-	ParentEnvironmentName        string
+	EnvironmentName              string // non-aa: "staging"; aa: <prefix-envName-suffix>
+	ParentEnvironmentName        string // "staging" with or without aa
 	ArgoEnvironmentConfiguration *api.ArgoCDEnvironmentConfiguration
 	IsBracket                    bool
 	// BracketSnapshotEslId is the brackets_history.source_transformer_esl_id that

--- a/services/rollout-service/pkg/argo/argo.go
+++ b/services/rollout-service/pkg/argo/argo.go
@@ -183,10 +183,9 @@ type Processor interface {
 }
 
 type PendingDeletion struct {
-	EnvironmentName       string // key into KnownApps for the DeleteArgoApps call
-	ParentEnvironmentName string // key for isBracketEnv / knowsBracketApp check
-	AppName               string
-	PlainArgoBracketName  string // name of the bracket app that this deletion is waiting for (without env name)
+	EnvironmentName      string // key into KnownApps for the DeleteArgoApps call
+	AppName              string
+	PlainArgoBracketName string // name of the bracket app that this deletion is waiting for (without env name)
 }
 
 // PendingSpecUpdate tracks a bracket Argo app that lost members to other brackets
@@ -460,7 +459,7 @@ func (a *ArgoAppProcessor) isBracketAppReady(envName string, bareBracketAppName 
 
 	syncedAtLeastOnce := historyFull || operationStateSynced || statusSynced // either of these is indicating a sync
 
-	if syncedAtLeastOnce == false {
+	if !syncedAtLeastOnce {
 		return false, "or condition"
 	}
 	return true, ""
@@ -1056,10 +1055,9 @@ func (a *ArgoAppProcessor) ProcessAppChange(ctx context.Context, appInfo *AppInf
 				zap.String("app", appInfo.ApplicationName),
 				zap.String("env", appInfo.EnvironmentName))
 			a.pendingDeletions = append(a.pendingDeletions, PendingDeletion{
-				EnvironmentName:       appInfo.EnvironmentName,
-				ParentEnvironmentName: appInfo.ParentEnvironmentName,
-				AppName:               appInfo.ApplicationName,
-				PlainArgoBracketName:  currentAppDetails.Application.ArgoBracket,
+				EnvironmentName:      appInfo.EnvironmentName,
+				AppName:              appInfo.ApplicationName,
+				PlainArgoBracketName: currentAppDetails.Application.ArgoBracket,
 			})
 		}
 	}

--- a/services/rollout-service/pkg/argo/argo_test.go
+++ b/services/rollout-service/pkg/argo/argo_test.go
@@ -2132,7 +2132,6 @@ func TestDrainPendingDeletionsRetryOnError(t *testing.T) {
 			appName := "my-app"
 			argoAppName := "staging-1-my-app"
 			envName := "staging-1"
-			parentEnvName := "staging"
 
 			mockClient := &mockApplicationServiceClient{
 				deleteErr: tc.DeleteErr,
@@ -2161,10 +2160,9 @@ func TestDrainPendingDeletionsRetryOnError(t *testing.T) {
 				},
 				pendingDeletions: []PendingDeletion{
 					{
-						EnvironmentName:       envName,
-						ParentEnvironmentName: parentEnvName,
-						AppName:               appName,
-						PlainArgoBracketName:  "bracket-app",
+						EnvironmentName:      envName,
+						AppName:              appName,
+						PlainArgoBracketName: "bracket-app",
 					},
 				},
 
@@ -3137,7 +3135,7 @@ func TestDrainPendingDeletionsByName(t *testing.T) {
 					},
 				},
 				pendingDeletions: []PendingDeletion{
-					{EnvironmentName: envName, ParentEnvironmentName: parentEnvName, AppName: appName, PlainArgoBracketName: "bracket"},
+					{EnvironmentName: envName, AppName: appName, PlainArgoBracketName: "bracket"},
 				},
 
 				maxProcessedTransformerEslId: &atomic.Int64{},

--- a/services/rollout-service/pkg/argo/argo_test.go
+++ b/services/rollout-service/pkg/argo/argo_test.go
@@ -29,12 +29,8 @@ import (
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	argorepo "github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/argoproj/gitops-engine/pkg/health"
+	"github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/cenkalti/backoff/v4"
-	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
-	"github.com/freiheit-com/kuberpult/pkg/db"
-	"github.com/freiheit-com/kuberpult/pkg/logger"
-	"github.com/freiheit-com/kuberpult/pkg/setup"
-	"github.com/freiheit-com/kuberpult/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc"
@@ -43,6 +39,12 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	api "github.com/freiheit-com/kuberpult/pkg/api/v1"
+	"github.com/freiheit-com/kuberpult/pkg/db"
+	"github.com/freiheit-com/kuberpult/pkg/logger"
+	"github.com/freiheit-com/kuberpult/pkg/setup"
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
 )
 
 // Used to compare two error message strings, needed because errors.Is(fmt.Errorf(text),fmt.Errorf(text)) == false
@@ -2138,18 +2140,19 @@ func TestDrainPendingDeletionsRetryOnError(t *testing.T) {
 			argoProcessor := &ArgoAppProcessor{
 				ApplicationClient: mockClient,
 				KnownApps: map[string]map[string]*v1alpha1.Application{
-					parentEnvName: {
+					envName: {
 						"bracket-app": {
-							//exhaustruct:ignore
 							ObjectMeta: metav1.ObjectMeta{
 								Name:        "staging-bracket",
 								Annotations: map[string]string{"com.freiheit.kuberpult/is-bracket": "true"},
 							},
+							Status: v1alpha1.ApplicationStatus{
+								Sync: v1alpha1.SyncStatus{
+									Status: v1alpha1.SyncStatusCodeSynced,
+								},
+							},
 						},
-					},
-					envName: {
 						appName: {
-							//exhaustruct:ignore
 							ObjectMeta: metav1.ObjectMeta{
 								Name: argoAppName,
 							},
@@ -2161,13 +2164,14 @@ func TestDrainPendingDeletionsRetryOnError(t *testing.T) {
 						EnvironmentName:       envName,
 						ParentEnvironmentName: parentEnvName,
 						AppName:               appName,
+						PlainArgoBracketName:  "bracket-app",
 					},
 				},
 
 				maxProcessedTransformerEslId: &atomic.Int64{},
 			}
 
-			argoProcessor.drainPendingDeletions(ctx, parentEnvName)
+			argoProcessor.drainPendingDeletions(ctx, envName)
 
 			if got := len(argoProcessor.pendingDeletions); got != tc.ExpectedRemaining {
 				t.Errorf("pendingDeletions length: want %d, got %d", tc.ExpectedRemaining, got)
@@ -3116,26 +3120,30 @@ func TestDrainPendingDeletionsByName(t *testing.T) {
 			argoProcessor := &ArgoAppProcessor{
 				ApplicationClient: mockClient,
 				KnownApps: map[string]map[string]*v1alpha1.Application{
-					parentEnvName: {
+					envName: {
 						"bracket": {
-							//exhaustruct:ignore
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "staging-bracket",
 								Annotations: map[string]string{
 									"com.freiheit.kuberpult/is-bracket": "true",
 								},
 							},
+							Status: v1alpha1.ApplicationStatus{
+								Sync: v1alpha1.SyncStatus{
+									Status: v1alpha1.SyncStatusCodeSynced,
+								},
+							},
 						},
 					},
 				},
 				pendingDeletions: []PendingDeletion{
-					{EnvironmentName: envName, ParentEnvironmentName: parentEnvName, AppName: appName},
+					{EnvironmentName: envName, ParentEnvironmentName: parentEnvName, AppName: appName, PlainArgoBracketName: "bracket"},
 				},
 
 				maxProcessedTransformerEslId: &atomic.Int64{},
 			}
 
-			argoProcessor.drainPendingDeletions(ctx, parentEnvName)
+			argoProcessor.drainPendingDeletions(ctx, envName)
 
 			if got := len(argoProcessor.pendingDeletions); got != 0 {
 				t.Errorf("pendingDeletions after drain: want 0, got %d", got)
@@ -3153,6 +3161,219 @@ func TestDrainPendingDeletionsByName(t *testing.T) {
 			if diff := testutil.CmpDiff(true, deleted.NoCascade); diff != "" {
 				t.Errorf("NoCascade mismatch (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func TestKnowsBracketApp(t *testing.T) {
+	tcs := []struct {
+		Name             string
+		InputEnvName     string
+		InputBracketName string
+		GivenKnownApps   map[string]map[string]*v1alpha1.Application
+		ExpectedResult   bool
+		ExpectedStatus   string
+	}{
+		{
+			Name:             "there are zero known apps",
+			InputEnvName:     "dev",
+			InputBracketName: "b1",
+			GivenKnownApps:   nil,
+			ExpectedResult:   false,
+			ExpectedStatus:   "not a known environment",
+		},
+		{
+			Name:             "there is an app but on the wrong env",
+			InputEnvName:     "dev",
+			InputBracketName: "b1",
+			GivenKnownApps: map[string]map[string]*v1alpha1.Application{
+				"dev2": {
+					"b1": {},
+				},
+			},
+			ExpectedResult: false,
+			ExpectedStatus: "not a known environment",
+		},
+		{
+			Name:             "there is an app but on the wrong env",
+			InputEnvName:     "dev",
+			InputBracketName: "b1",
+			GivenKnownApps: map[string]map[string]*v1alpha1.Application{
+				"dev": {
+					"b2": {},
+				},
+			},
+			ExpectedResult: false,
+			ExpectedStatus: "not a known app: b1",
+		},
+		{
+			Name:             "there is an app but it is not a bracket",
+			InputEnvName:     "dev",
+			InputBracketName: "b1",
+			GivenKnownApps: map[string]map[string]*v1alpha1.Application{
+				"dev": {
+					"b1": {
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"com.freiheit.kuberpult/application": "b1",
+								"com.freiheit.kuberpult/is-bracket":  "false",
+							},
+						},
+					},
+				},
+			},
+			ExpectedResult: false,
+			ExpectedStatus: "known, but annotation is-bracket!=true",
+		},
+		{
+			Name:             "there is an app and none of the 3 status conditions are met",
+			InputEnvName:     "dev",
+			InputBracketName: "b1",
+			GivenKnownApps: map[string]map[string]*v1alpha1.Application{
+				"dev": {
+					"b1": {
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"com.freiheit.kuberpult/application": "b1",
+								"com.freiheit.kuberpult/is-bracket":  "true",
+							},
+						},
+					},
+				},
+			},
+			ExpectedResult: false,
+			ExpectedStatus: "or condition",
+		},
+		{
+			Name:             "there is an app and one condition is met: history",
+			InputEnvName:     "dev",
+			InputBracketName: "b1",
+			GivenKnownApps: map[string]map[string]*v1alpha1.Application{
+				"dev": {
+					"b1": {
+						Status: v1alpha1.ApplicationStatus{
+							History: []v1alpha1.RevisionHistory{
+								{
+									ID: 666, // condition 1: we just need a non-empty slice
+								},
+							},
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"com.freiheit.kuberpult/application": "b1",
+								"com.freiheit.kuberpult/is-bracket":  "true",
+							},
+						},
+					},
+				},
+			},
+			ExpectedResult: true,
+			ExpectedStatus: "",
+		},
+		// TODO SU: add further detailed tests
+		{
+			Name:             "there is an app and one conditions is met: operation state synced",
+			InputEnvName:     "dev",
+			InputBracketName: "b1",
+			GivenKnownApps: map[string]map[string]*v1alpha1.Application{
+				"dev": {
+					"b1": {
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"com.freiheit.kuberpult/application": "b1",
+								"com.freiheit.kuberpult/is-bracket":  "true",
+							},
+						},
+						Status: v1alpha1.ApplicationStatus{
+							OperationState: &v1alpha1.OperationState{
+								Phase:      common.OperationSucceeded,
+								SyncResult: &v1alpha1.SyncOperationResult{}, // anything but "nil"
+							},
+						},
+					},
+				},
+			},
+			ExpectedResult: true,
+			ExpectedStatus: "",
+		},
+		{
+			Name:             "there is an app and one conditions is met: status synced",
+			InputEnvName:     "dev",
+			InputBracketName: "b1",
+			GivenKnownApps: map[string]map[string]*v1alpha1.Application{
+				"dev": {
+					"b1": {
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"com.freiheit.kuberpult/application": "b1",
+								"com.freiheit.kuberpult/is-bracket":  "true",
+							},
+						},
+						Status: v1alpha1.ApplicationStatus{
+							Sync: v1alpha1.SyncStatus{
+								Status: v1alpha1.SyncStatusCodeSynced,
+							},
+						},
+					},
+				},
+			},
+			ExpectedResult: true,
+			ExpectedStatus: "",
+		},
+		{
+			Name:             "there is an app and none of the conditions are met but have data",
+			InputEnvName:     "dev",
+			InputBracketName: "b1",
+			GivenKnownApps: map[string]map[string]*v1alpha1.Application{
+				"dev": {
+					"b1": {
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"com.freiheit.kuberpult/application": "b1",
+								"com.freiheit.kuberpult/is-bracket":  "true",
+							},
+						},
+						Status: v1alpha1.ApplicationStatus{
+							Sync: v1alpha1.SyncStatus{
+								Status: v1alpha1.SyncStatusCodeUnknown,
+							},
+							OperationState: &v1alpha1.OperationState{
+								Phase:      common.OperationSucceeded,
+								SyncResult: nil,
+							},
+						},
+					},
+				},
+			},
+			ExpectedResult: false,
+			ExpectedStatus: "or condition",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			testutil.WrapTestRoutine(t, context.Background(), "INFO", func(ctx context.Context) {
+				mockClient := &mockApplicationServiceClient{
+					t:      t,
+					cancel: func() {},
+				}
+				argoProcessor := &ArgoAppProcessor{
+					ApplicationClient:     mockClient,
+					ManageArgoAppsEnabled: true,
+					ManageArgoAppsFilter:  []string{"*"},
+					KnownApps:             tc.GivenKnownApps,
+
+					maxProcessedTransformerEslId: &atomic.Int64{},
+				}
+
+				actualBool, actualStatus := argoProcessor.isBracketAppReady(tc.InputEnvName, tc.InputBracketName)
+
+				if diff := testutil.CmpDiff(tc.ExpectedResult, actualBool); diff != "" {
+					t.Errorf("mismatch (-want, +got):\n%s", diff)
+				}
+				if diff := testutil.CmpDiff(tc.ExpectedStatus, actualStatus); diff != "" {
+					t.Errorf("mismatch (-want, +got):\n%s", diff)
+				}
+			})
 		})
 	}
 }

--- a/services/rollout-service/pkg/argo/argo_test.go
+++ b/services/rollout-service/pkg/argo/argo_test.go
@@ -3215,8 +3215,7 @@ func TestKnowsBracketApp(t *testing.T) {
 					"b1": {
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
-								"com.freiheit.kuberpult/application": "b1",
-								"com.freiheit.kuberpult/is-bracket":  "false",
+								"com.freiheit.kuberpult/is-bracket": "false",
 							},
 						},
 					},
@@ -3234,8 +3233,7 @@ func TestKnowsBracketApp(t *testing.T) {
 					"b1": {
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
-								"com.freiheit.kuberpult/application": "b1",
-								"com.freiheit.kuberpult/is-bracket":  "true",
+								"com.freiheit.kuberpult/is-bracket": "true",
 							},
 						},
 					},
@@ -3260,8 +3258,7 @@ func TestKnowsBracketApp(t *testing.T) {
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
-								"com.freiheit.kuberpult/application": "b1",
-								"com.freiheit.kuberpult/is-bracket":  "true",
+								"com.freiheit.kuberpult/is-bracket": "true",
 							},
 						},
 					},
@@ -3280,8 +3277,7 @@ func TestKnowsBracketApp(t *testing.T) {
 					"b1": {
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
-								"com.freiheit.kuberpult/application": "b1",
-								"com.freiheit.kuberpult/is-bracket":  "true",
+								"com.freiheit.kuberpult/is-bracket": "true",
 							},
 						},
 						Status: v1alpha1.ApplicationStatus{
@@ -3305,8 +3301,7 @@ func TestKnowsBracketApp(t *testing.T) {
 					"b1": {
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
-								"com.freiheit.kuberpult/application": "b1",
-								"com.freiheit.kuberpult/is-bracket":  "true",
+								"com.freiheit.kuberpult/is-bracket": "true",
 							},
 						},
 						Status: v1alpha1.ApplicationStatus{
@@ -3329,8 +3324,7 @@ func TestKnowsBracketApp(t *testing.T) {
 					"b1": {
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
-								"com.freiheit.kuberpult/application": "b1",
-								"com.freiheit.kuberpult/is-bracket":  "true",
+								"com.freiheit.kuberpult/is-bracket": "true",
 							},
 						},
 						Status: v1alpha1.ApplicationStatus{

--- a/services/rollout-service/pkg/argo/argo_test.go
+++ b/services/rollout-service/pkg/argo/argo_test.go
@@ -3238,7 +3238,7 @@ func TestKnowsBracketApp(t *testing.T) {
 				},
 			},
 			ExpectedResult: false,
-			ExpectedStatus: "or condition",
+			ExpectedStatus: "not synced",
 		},
 		{
 			Name:             "there is an app and one condition is met: history",
@@ -3265,7 +3265,6 @@ func TestKnowsBracketApp(t *testing.T) {
 			ExpectedResult: true,
 			ExpectedStatus: "",
 		},
-		// TODO SU: add further detailed tests
 		{
 			Name:             "there is an app and one conditions is met: operation state synced",
 			InputEnvName:     "dev",
@@ -3338,7 +3337,7 @@ func TestKnowsBracketApp(t *testing.T) {
 				},
 			},
 			ExpectedResult: false,
-			ExpectedStatus: "or condition",
+			ExpectedStatus: "not synced",
 		},
 	}
 	for _, tc := range tcs {

--- a/tests/kind-brackets/bracket_stability_test.go
+++ b/tests/kind-brackets/bracket_stability_test.go
@@ -102,7 +102,7 @@ func dumpKuberpultLogs(t *testing.T) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "kubectl get pods: %v\n", err)
 	}
-	for _, dep := range []string{"kuberpult-frontend-service", "kuberpult-cd-service"} {
+	for _, dep := range []string{"kuberpult-frontend-service", "kuberpult-cd-service", "kuberpult-rollout-service", "kuberpult-reposerver-service"} {
 		for _, line := range strings.Fields(string(podsOut)) {
 			podName := strings.TrimPrefix(line, "pod/")
 			if !strings.HasPrefix(podName, dep+"-") {


### PR DESCRIPTION
This fixes the gate that decides when kuberpult may delete a bracket.
We now also check that the bracket app was actually synced at least once.

And this fixes some misuses of "parentEnvironment" vs "environment".

Ref: SRX-9N50YX