### PR TITLE
fix(test): align golangcilint with Makefile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,3 +57,5 @@ formatters:
         - prefix(github.com/freiheit-com/kuberpult) # Your local packages.
       section-separators:
         - newLine # Ensures a newline between the sections above.
+run:
+  tests: false


### PR DESCRIPTION
The makefiles already skip the tests in the linter, so we remove this setting from golangci-lint to be consistent

Ref: SRX-9N50YX