### PR TITLE
fix(run-kind): set kubernetes context

### DIFF
--- a/charts/kuberpult/run-kind.sh
+++ b/charts/kuberpult/run-kind.sh
@@ -124,6 +124,8 @@ EOF
     )
 fi
 
+kind export kubeconfig
+
 export IMAGE_REGISTRY=europe-west3-docker.pkg.dev/fdc-public-docker-registry/kuberpult
 print version...
 VERSION=$(make --no-print-directory -C ../../ version)


### PR DESCRIPTION
This ensures that the right k8s context is used when running the script multiple times, so "kind cluster create" would not set the context.

Ref: SRX-SQKMSM