### PR TITLE
fix: mark apps as synced in git_sync_status after successful update

### DIFF
--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -714,7 +714,7 @@ func ProcessOneEvent(
 			// the same reason as the SYNC_FAILED path above.
 			err = dbHandler.WithTransactionR(ctx, 2, false, func(ctx context.Context, transaction *sql.Tx) error {
 				for _, b := range batch {
-					if e := dbHandler.DBBulkUpdateUnsyncedApps(ctx, transaction, db.TransformerID(b.Esl.EslVersion), db.SYNCED); e != nil {
+					if e := dbHandler.DBBulkUpdateAllApps(ctx, transaction, db.TransformerID(b.Esl.EslVersion), db.TransformerID(b.Esl.EslVersion), db.SYNCED); e != nil {
 						return e
 					}
 				}

--- a/services/manifest-repo-export-service/pkg/cmd/server_test.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server_test.go
@@ -383,6 +383,7 @@ func TestProcessOneEvent(t *testing.T) {
 		Name                  string
 		withCutoff            *CutoffData
 		expectedError         error
+		initialSyncStatus     db.SyncStatus
 		expectedTransformer   repository.Transformer
 		expectedSleepDuration time.Duration
 		expectedSyncStatus    []GitSyncStatusRow
@@ -407,6 +408,31 @@ func TestProcessOneEvent(t *testing.T) {
 					AuthorEmail: "email two",
 				},
 			},
+			initialSyncStatus:     db.UNSYNCED,
+			expectedError:         nil,
+			expectedTransformer:   nil,
+			expectedSleepDuration: 0,
+			expectedSyncStatus: []GitSyncStatusRow{
+				{
+					TransformerId: 1,
+					EnvName:       env,
+					AppName:       app,
+					Status:        db.SYNCED,
+				},
+			},
+			expectNotification: true,
+		},
+		{
+			Name: "process one transformer from sync failed",
+			withCutoff: &CutoffData{
+				eventType: db.EvtCreateApplicationVersion,
+				data:      nil,
+				metadata: db.ESLMetadata{
+					AuthorName:  "author one",
+					AuthorEmail: "email two",
+				},
+			},
+			initialSyncStatus:     db.SYNC_FAILED,
 			expectedError:         nil,
 			expectedTransformer:   nil,
 			expectedSleepDuration: 0,
@@ -430,6 +456,7 @@ func TestProcessOneEvent(t *testing.T) {
 					AuthorEmail: "email two",
 				},
 			},
+			initialSyncStatus:     db.UNSYNCED,
 			expectedError:         nil,
 			expectedTransformer:   nil,
 			expectedSleepDuration: 0,
@@ -467,7 +494,9 @@ func TestProcessOneEvent(t *testing.T) {
 							t.Fatalf("DBReadEslEventInternal Error: %v", err)
 						}
 						transformerId = db.TransformerID(event.EslVersion)
-						err = dbHandler.DBWriteNewSyncEvent(ctx, transaction, initialSyncData)
+						syncData := *initialSyncData
+						syncData.SyncStatus = tc.initialSyncStatus
+						err = dbHandler.DBWriteNewSyncEvent(ctx, transaction, &syncData)
 						if err != nil {
 							t.Fatalf("DBReadEslEventInternal Error: %v", err)
 						}


### PR DESCRIPTION
The system marks app/env rows as SYNC_FAILED when processing or push fails. Later, when processing succeeds, those rows are expected to stop appearing as failed. In practice, stale SYNC_FAILED rows can remain and continue to be reported.