### PR TITLE
fix(rollout): fix active/active env name in versions

### DIFF
--- a/charts/kuberpult/values.yaml
+++ b/charts/kuberpult/values.yaml
@@ -408,7 +408,7 @@ rollout:
     # clusters:
     #   <env1>: true
     #   <env2>: true
-    # For active/active environments, you can enable them 1 by 1. The naming scheme is "<commonEnvPrefix>-<envName>-<concreteEnvName>"
+    # For active/active environments, use the plain "<envName>", all a/a clusters within it will be enabled at the same time.
     # When switching this option to true for an environment, the rollout-service will:
     # 1) keep the normal argo apps for now
     # 2) create bracket apps for argo - for a moment the apps will "fight" against each other, but not find any meaningful difference.

--- a/services/rollout-service/pkg/versions/versions.go
+++ b/services/rollout-service/pkg/versions/versions.go
@@ -401,29 +401,33 @@ func (v *versionClient) ConsumeEvents(ctx context.Context, processor VersionEven
 
 					isProduction := false
 					envGroup := ""
+					clusters := []string{envName}
 					for _, eg := range ov.EnvironmentGroups {
 						for _, env := range eg.Environments {
 							if env.Name == envName {
 								isProduction = eg.Priority == api.Priority_PROD || eg.Priority == api.Priority_CANARY
 								envGroup = eg.EnvironmentGroupName
+								clusters = childEnvironments(env)
 							}
 						}
 					}
 
 					l.Info("event.new", zap.String("source", "cd-service"), zap.String("type", "bracket"), zap.String("app", bracketName), zap.String("env", envName), zap.String("version", bracketDeployment.Version))
-					processor.ProcessKuberpultEvent(ctx, KuberpultEvent{
-						Application:       bracketName,
-						Environment:       envName,
-						ParentEnvironment: envName,
-						EnvironmentGroup:  envGroup,
-						IsProduction:      isProduction,
-						Team:              "",
-						Version: &VersionInfo{
-							Version:        bracketVersion,
-							SourceCommitId: bracketDeployment.SourceCommitId,
-							DeployedAt:     deployedAt,
-						},
-					})
+					for _, cluster := range clusters {
+						processor.ProcessKuberpultEvent(ctx, KuberpultEvent{
+							Application:       bracketName,
+							Environment:       cluster,
+							ParentEnvironment: envName,
+							EnvironmentGroup:  envGroup,
+							IsProduction:      isProduction,
+							Team:              "",
+							Version: &VersionInfo{
+								Version:        bracketVersion,
+								SourceCommitId: bracketDeployment.SourceCommitId,
+								DeployedAt:     deployedAt,
+							},
+						})
+					}
 					switch bracketVersion {
 					case types.BracketVersionDelete:
 						// Empty bracket: register with no deployment so ProcessAppChange


### PR DESCRIPTION
This fixes a mixup between envname/parentEnvname in active/active environments.

Ref: SRX-LJ7U87