### PR TITLE
fix(db): do not insert duplicates in app teams

### DIFF
--- a/pkg/db/db_apps.go
+++ b/pkg/db/db_apps.go
@@ -22,8 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
-	"strings"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -77,7 +75,7 @@ by reading the latest row created_at <= a given timestamp.
 */
 const appsTeamsHistoryTable = "apps_teams_history"
 
-type AppTeamMap = map[string][]types.AppName
+type TeamToAppsMap = map[string][]types.AppName
 
 // SELECTS
 
@@ -211,23 +209,15 @@ func (h *DBHandler) DBInsertAppsTeamsHistory(ctx context.Context, tx *sql.Tx, ap
 	defer func() {
 		span.Finish(tracer.WithError(err))
 	}()
-	latestAppsWithTeams, toInsertMap, err := h.DBSelectLatestAppsTeamsHistory(ctx, tx)
+	_, toInsertMap, err := h.DBSelectLatestAppsTeamsHistory(ctx, tx)
 	if err != nil {
 		return err
 	}
 
 	if stateChange == AppStateChangeDelete {
-		toInsertMap = RemoveAppFromTeams(toInsertMap, appName)
+		toInsertMap = removeAppFromTeams(toInsertMap, appName)
 	} else {
-		toInsertMap = UpsertAppTeam(toInsertMap, teamName, appName)
-	}
-
-	for _, appWithTeam := range latestAppsWithTeams {
-		if appWithTeam.AppName != appName {
-			toInsertMap = UpsertAppTeam(toInsertMap, appWithTeam.TeamName, appWithTeam.AppName)
-		} else if stateChange == AppStateChangeUpdate {
-			toInsertMap = UpsertAppTeam(toInsertMap, teamName, appName)
-		}
+		toInsertMap = upsertAppTeam(toInsertMap, teamName, appName)
 	}
 
 	if ts == nil {
@@ -300,24 +290,13 @@ func (h *DBHandler) DBMigrateAppsHistoryToAppsTeamsHistory(ctx context.Context, 
 	return nil
 }
 
-func (h *DBHandler) insertAppsTeamsHistoryRow(ctx context.Context, transaction *sql.Tx, appTeamMap AppTeamMap, ts *time.Time) (err error) {
+func (h *DBHandler) insertAppsTeamsHistoryRow(ctx context.Context, transaction *sql.Tx, appTeamMap TeamToAppsMap, ts *time.Time) (err error) {
 	insertQuery := h.AdaptQuery(`
 		INSERT INTO ` + appsTeamsHistoryTable + ` (created_at, apps_teams)
 		VALUES (?, ?);
 	`)
 
-	appsWithTeams := make([]AppWithTeam, 0)
-	for team, v := range appTeamMap {
-		for _, appName := range v {
-			appsWithTeams = append(appsWithTeams, AppWithTeam{
-				AppName:  appName,
-				TeamName: team,
-			})
-		}
-	}
-	slices.SortFunc(appsWithTeams, func(a, b AppWithTeam) int {
-		return strings.Compare(string(a.AppName), string(b.AppName))
-	})
+	appsWithTeams := appsTeamsFromMap(appTeamMap)
 
 	jsonToInsert, err := json.Marshal(appsWithTeams)
 	if err != nil {
@@ -377,7 +356,7 @@ func (h *DBHandler) DBSelectAppsWithReleasesAtTimestamp(ctx context.Context, tra
 	return apps, nil
 }
 
-func (h *DBHandler) DBSelectLatestAppsTeamsHistory(ctx context.Context, transaction *sql.Tx) (_ []AppWithTeam, _ AppTeamMap, err error) {
+func (h *DBHandler) DBSelectLatestAppsTeamsHistory(ctx context.Context, transaction *sql.Tx) (_ []AppWithTeam, _ TeamToAppsMap, err error) {
 	query := h.AdaptQuery(`
 		SELECT apps_teams
 		FROM ` + appsTeamsHistoryTable + `
@@ -388,7 +367,7 @@ func (h *DBHandler) DBSelectLatestAppsTeamsHistory(ctx context.Context, transact
 	return h.processAppsTeamsRow(rows, err)
 }
 
-func (h *DBHandler) DBSelectAppsTeamsHistoryAtTimestamp(ctx context.Context, transaction *sql.Tx, ts time.Time) (_ []AppWithTeam, _ AppTeamMap, err error) {
+func (h *DBHandler) DBSelectAppsTeamsHistoryAtTimestamp(ctx context.Context, transaction *sql.Tx, ts time.Time) (_ []AppWithTeam, _ TeamToAppsMap, err error) {
 	query := h.AdaptQuery(`
 		SELECT apps_teams
 		FROM ` + appsTeamsHistoryTable + `
@@ -400,7 +379,7 @@ func (h *DBHandler) DBSelectAppsTeamsHistoryAtTimestamp(ctx context.Context, tra
 	return h.processAppsTeamsRow(rows, err)
 }
 
-func (h *DBHandler) processAppsTeamsRow(rows *sql.Rows, err error) ([]AppWithTeam, AppTeamMap, error) {
+func (h *DBHandler) processAppsTeamsRow(rows *sql.Rows, err error) ([]AppWithTeam, TeamToAppsMap, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not query apps_teams_history table. Error: %w", err)
 	}

--- a/pkg/db/db_apps.go
+++ b/pkg/db/db_apps.go
@@ -367,7 +367,7 @@ func (h *DBHandler) DBSelectLatestAppsTeamsHistory(ctx context.Context, transact
 	return h.processAppsTeamsRow(rows, err)
 }
 
-func (h *DBHandler) DBSelectAppsTeamsHistoryAtTimestamp(ctx context.Context, transaction *sql.Tx, ts time.Time) (_ []AppWithTeam, _ TeamToAppsMap, err error) {
+func (h *DBHandler) DBSelectAppsTeamsHistoryAtTimestamp(ctx context.Context, transaction *sql.Tx, ts time.Time) (_ []AppWithTeam, err error) {
 	query := h.AdaptQuery(`
 		SELECT apps_teams
 		FROM ` + appsTeamsHistoryTable + `
@@ -376,7 +376,8 @@ func (h *DBHandler) DBSelectAppsTeamsHistoryAtTimestamp(ctx context.Context, tra
 		LIMIT 1;
 	`)
 	rows, err := transaction.QueryContext(ctx, query, ts)
-	return h.processAppsTeamsRow(rows, err)
+	result, _, err := h.processAppsTeamsRow(rows, err)
+	return result, err
 }
 
 func (h *DBHandler) processAppsTeamsRow(rows *sql.Rows, err error) ([]AppWithTeam, TeamToAppsMap, error) {

--- a/pkg/db/db_apps.go
+++ b/pkg/db/db_apps.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -74,6 +76,8 @@ Callers reconstruct the full team snapshot by reading the latest row, or a histo
 by reading the latest row created_at <= a given timestamp.
 */
 const appsTeamsHistoryTable = "apps_teams_history"
+
+type AppTeamMap = map[string][]types.AppName
 
 // SELECTS
 
@@ -207,37 +211,22 @@ func (h *DBHandler) DBInsertAppsTeamsHistory(ctx context.Context, tx *sql.Tx, ap
 	defer func() {
 		span.Finish(tracer.WithError(err))
 	}()
-	latestAppsWithTeams, err := h.DBSelectLatestAppsTeamsHistory(ctx, tx)
+	latestAppsWithTeams, toInsertMap, err := h.DBSelectLatestAppsTeamsHistory(ctx, tx)
 	if err != nil {
 		return err
 	}
 
-	var toInsert []AppWithTeam
-	var latestApp *AppWithTeam
+	if stateChange == AppStateChangeDelete {
+		toInsertMap = RemoveAppFromTeams(toInsertMap, appName)
+	} else {
+		toInsertMap = UpsertAppTeam(toInsertMap, teamName, appName)
+	}
+
 	for _, appWithTeam := range latestAppsWithTeams {
-		if appWithTeam.AppName == appName {
-			latestApp = &appWithTeam
-			break
-		}
-	}
-
-	if stateChange == AppStateChangeCreate || stateChange == AppStateChangeMigrate || (stateChange == AppStateChangeUpdate && latestApp == nil) {
-		toInsert = append(latestAppsWithTeams, AppWithTeam{
-			AppName:  appName,
-			TeamName: teamName,
-		})
-	}
-
-	if latestApp != nil {
-		for _, appWithTeam := range latestAppsWithTeams {
-			if appWithTeam.AppName != appName {
-				toInsert = append(toInsert, appWithTeam)
-			} else if stateChange == AppStateChangeUpdate {
-				toInsert = append(toInsert, AppWithTeam{
-					AppName:  appName,
-					TeamName: teamName,
-				})
-			}
+		if appWithTeam.AppName != appName {
+			toInsertMap = UpsertAppTeam(toInsertMap, appWithTeam.TeamName, appWithTeam.AppName)
+		} else if stateChange == AppStateChangeUpdate {
+			toInsertMap = UpsertAppTeam(toInsertMap, teamName, appName)
 		}
 	}
 
@@ -249,7 +238,7 @@ func (h *DBHandler) DBInsertAppsTeamsHistory(ctx context.Context, tx *sql.Tx, ap
 		}
 	}
 
-	err = h.insertAppsTeamsHistoryRow(ctx, tx, toInsert, ts)
+	err = h.insertAppsTeamsHistoryRow(ctx, tx, toInsertMap, ts)
 	if err != nil {
 		return err
 	}
@@ -311,11 +300,24 @@ func (h *DBHandler) DBMigrateAppsHistoryToAppsTeamsHistory(ctx context.Context, 
 	return nil
 }
 
-func (h *DBHandler) insertAppsTeamsHistoryRow(ctx context.Context, transaction *sql.Tx, appsWithTeams []AppWithTeam, ts *time.Time) (err error) {
+func (h *DBHandler) insertAppsTeamsHistoryRow(ctx context.Context, transaction *sql.Tx, appTeamMap AppTeamMap, ts *time.Time) (err error) {
 	insertQuery := h.AdaptQuery(`
 		INSERT INTO ` + appsTeamsHistoryTable + ` (created_at, apps_teams)
 		VALUES (?, ?);
 	`)
+
+	appsWithTeams := make([]AppWithTeam, 0)
+	for team, v := range appTeamMap {
+		for _, appName := range v {
+			appsWithTeams = append(appsWithTeams, AppWithTeam{
+				AppName:  appName,
+				TeamName: team,
+			})
+		}
+	}
+	slices.SortFunc(appsWithTeams, func(a, b AppWithTeam) int {
+		return strings.Compare(string(a.AppName), string(b.AppName))
+	})
 
 	jsonToInsert, err := json.Marshal(appsWithTeams)
 	if err != nil {
@@ -375,7 +377,7 @@ func (h *DBHandler) DBSelectAppsWithReleasesAtTimestamp(ctx context.Context, tra
 	return apps, nil
 }
 
-func (h *DBHandler) DBSelectLatestAppsTeamsHistory(ctx context.Context, transaction *sql.Tx) (_ []AppWithTeam, err error) {
+func (h *DBHandler) DBSelectLatestAppsTeamsHistory(ctx context.Context, transaction *sql.Tx) (_ []AppWithTeam, _ AppTeamMap, err error) {
 	query := h.AdaptQuery(`
 		SELECT apps_teams
 		FROM ` + appsTeamsHistoryTable + `
@@ -386,7 +388,7 @@ func (h *DBHandler) DBSelectLatestAppsTeamsHistory(ctx context.Context, transact
 	return h.processAppsTeamsRow(rows, err)
 }
 
-func (h *DBHandler) DBSelectAppsTeamsHistoryAtTimestamp(ctx context.Context, transaction *sql.Tx, ts time.Time) (_ []AppWithTeam, err error) {
+func (h *DBHandler) DBSelectAppsTeamsHistoryAtTimestamp(ctx context.Context, transaction *sql.Tx, ts time.Time) (_ []AppWithTeam, _ AppTeamMap, err error) {
 	query := h.AdaptQuery(`
 		SELECT apps_teams
 		FROM ` + appsTeamsHistoryTable + `
@@ -398,26 +400,27 @@ func (h *DBHandler) DBSelectAppsTeamsHistoryAtTimestamp(ctx context.Context, tra
 	return h.processAppsTeamsRow(rows, err)
 }
 
-func (h *DBHandler) processAppsTeamsRow(rows *sql.Rows, err error) ([]AppWithTeam, error) {
+func (h *DBHandler) processAppsTeamsRow(rows *sql.Rows, err error) ([]AppWithTeam, AppTeamMap, error) {
 	if err != nil {
-		return nil, fmt.Errorf("could not query apps_teams_history table. Error: %w", err)
+		return nil, nil, fmt.Errorf("could not query apps_teams_history table. Error: %w", err)
 	}
 
 	appsWithTeam := make([]AppWithTeam, 0)
 	for rows.Next() {
 		var appsTeamsJson string
 		if err := rows.Scan(&appsTeamsJson); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if err := json.Unmarshal([]byte(appsTeamsJson), &appsWithTeam); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 	err = closeRows(rows)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return appsWithTeam, nil
+	asMap := appsTeamsToMap(appsWithTeam)
+	return appsTeamsFromMap(asMap), asMap, nil
 }
 
 // actual changes in tables

--- a/pkg/db/db_environments.go
+++ b/pkg/db/db_environments.go
@@ -324,7 +324,7 @@ func (h *DBHandler) DBSelectEnvironmentApplicationsAtTimestamp(ctx context.Conte
 		span.Finish(tracer.WithError(err))
 	}()
 
-	appsWithTeam, err := h.DBSelectAppsTeamsHistoryAtTimestamp(ctx, tx, ts)
+	_, teamAppMap, err := h.DBSelectAppsTeamsHistoryAtTimestamp(ctx, tx, ts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not select apps teams history: %w", err)
 	}
@@ -340,10 +340,12 @@ func (h *DBHandler) DBSelectEnvironmentApplicationsAtTimestamp(ctx context.Conte
 
 	var appNames = []types.AppName{}
 	var appNamesWithTeam = []AppWithTeam{}
-	for _, appWithTeam := range appsWithTeam {
-		if _, ok := appsWithReleaseMap[appWithTeam.AppName]; ok {
-			appNames = append(appNames, appWithTeam.AppName)
-			appNamesWithTeam = append(appNamesWithTeam, appWithTeam)
+	for team, apps := range teamAppMap {
+		for _, app := range apps {
+			if _, ok := appsWithReleaseMap[app]; ok {
+				appNames = append(appNames, app)
+				appNamesWithTeam = append(appNamesWithTeam, AppWithTeam{TeamName: team, AppName: app})
+			}
 		}
 	}
 

--- a/pkg/db/db_environments.go
+++ b/pkg/db/db_environments.go
@@ -324,7 +324,7 @@ func (h *DBHandler) DBSelectEnvironmentApplicationsAtTimestamp(ctx context.Conte
 		span.Finish(tracer.WithError(err))
 	}()
 
-	teamAppSlice, _, err := h.DBSelectAppsTeamsHistoryAtTimestamp(ctx, tx, ts)
+	teamAppSlice, err := h.DBSelectAppsTeamsHistoryAtTimestamp(ctx, tx, ts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not select apps teams history: %w", err)
 	}

--- a/pkg/db/db_environments.go
+++ b/pkg/db/db_environments.go
@@ -324,7 +324,7 @@ func (h *DBHandler) DBSelectEnvironmentApplicationsAtTimestamp(ctx context.Conte
 		span.Finish(tracer.WithError(err))
 	}()
 
-	_, teamAppMap, err := h.DBSelectAppsTeamsHistoryAtTimestamp(ctx, tx, ts)
+	teamAppSlice, _, err := h.DBSelectAppsTeamsHistoryAtTimestamp(ctx, tx, ts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not select apps teams history: %w", err)
 	}
@@ -338,18 +338,17 @@ func (h *DBHandler) DBSelectEnvironmentApplicationsAtTimestamp(ctx context.Conte
 		appsWithReleaseMap[app] = struct{}{}
 	}
 
-	var appNames = []types.AppName{}
+	// filter out apps without release:
+	var appNamesWithRelease = []types.AppName{}
 	var appNamesWithTeam = []AppWithTeam{}
-	for team, apps := range teamAppMap {
-		for _, app := range apps {
-			if _, ok := appsWithReleaseMap[app]; ok {
-				appNames = append(appNames, app)
-				appNamesWithTeam = append(appNamesWithTeam, AppWithTeam{TeamName: team, AppName: app})
-			}
+	for _, appWithTeam := range teamAppSlice {
+		if _, ok := appsWithReleaseMap[appWithTeam.AppName]; ok {
+			appNamesWithRelease = append(appNamesWithRelease, appWithTeam.AppName)
+			appNamesWithTeam = append(appNamesWithTeam, appWithTeam)
 		}
 	}
 
-	return appNames, appNamesWithTeam, nil
+	return appNamesWithRelease, appNamesWithTeam, nil
 }
 
 // INSERT, UPDATE, DELETE

--- a/pkg/db/db_team_apps.go
+++ b/pkg/db/db_team_apps.go
@@ -23,7 +23,8 @@ import (
 	"github.com/freiheit-com/kuberpult/pkg/types"
 )
 
-func RemoveAppFromTeams(appTeams AppTeamMap, appName types.AppName) AppTeamMap {
+// removeAppFromTeams removes the given app, and returns the modified map
+func removeAppFromTeams(appTeams TeamToAppsMap, appName types.AppName) TeamToAppsMap {
 	for team, apps := range appTeams {
 		idx := slices.Index(apps, appName)
 		if idx < 0 {
@@ -39,20 +40,21 @@ func RemoveAppFromTeams(appTeams AppTeamMap, appName types.AppName) AppTeamMap {
 	return appTeams
 }
 
-func UpsertAppTeam(appTeams AppTeamMap, teamName string, appName types.AppName) AppTeamMap {
+// upsertAppTeam adds the given app, if it's not already in, and returns the modified map
+func upsertAppTeam(appTeams TeamToAppsMap, teamName string, appName types.AppName) TeamToAppsMap {
 	if appTeams == nil {
-		appTeams = make(AppTeamMap)
+		appTeams = make(TeamToAppsMap)
 	}
 	if slices.Contains(appTeams[teamName], appName) {
 		return appTeams
 	}
-	appTeams = RemoveAppFromTeams(appTeams, appName)
+	appTeams = removeAppFromTeams(appTeams, appName)
 	appTeams[teamName] = append(appTeams[teamName], appName)
 	return appTeams
 }
 
 // appsTeamsFromMap is the inverse of appsTeamsToMap: one entry per app, sorted by app name.
-func appsTeamsFromMap(appTeams AppTeamMap) []AppWithTeam {
+func appsTeamsFromMap(appTeams TeamToAppsMap) []AppWithTeam {
 	result := make([]AppWithTeam, 0, len(appTeams))
 	for team, apps := range appTeams {
 		for _, appName := range apps {
@@ -65,12 +67,12 @@ func appsTeamsFromMap(appTeams AppTeamMap) []AppWithTeam {
 	return result
 }
 
-func appsTeamsToMap(appsWithTeam []AppWithTeam) AppTeamMap {
+func appsTeamsToMap(appsWithTeam []AppWithTeam) TeamToAppsMap {
 	teamByApp := make(map[types.AppName]string, len(appsWithTeam))
 	for _, v := range appsWithTeam {
 		teamByApp[v.AppName] = v.TeamName // last occurrence wins
 	}
-	result := make(AppTeamMap)
+	result := make(TeamToAppsMap)
 	for app, team := range teamByApp {
 		result[team] = append(result[team], app)
 	}

--- a/pkg/db/db_team_apps.go
+++ b/pkg/db/db_team_apps.go
@@ -1,0 +1,81 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package db
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/freiheit-com/kuberpult/pkg/types"
+)
+
+func RemoveAppFromTeams(appTeams AppTeamMap, appName types.AppName) AppTeamMap {
+	for team, apps := range appTeams {
+		idx := slices.Index(apps, appName)
+		if idx < 0 {
+			continue
+		}
+		apps = slices.Delete(apps, idx, idx+1)
+		if len(apps) == 0 {
+			delete(appTeams, team)
+		} else {
+			appTeams[team] = apps
+		}
+	}
+	return appTeams
+}
+
+func UpsertAppTeam(appTeams AppTeamMap, teamName string, appName types.AppName) AppTeamMap {
+	if appTeams == nil {
+		appTeams = make(AppTeamMap)
+	}
+	if slices.Contains(appTeams[teamName], appName) {
+		return appTeams
+	}
+	appTeams = RemoveAppFromTeams(appTeams, appName)
+	appTeams[teamName] = append(appTeams[teamName], appName)
+	return appTeams
+}
+
+// appsTeamsFromMap is the inverse of appsTeamsToMap: one entry per app, sorted by app name.
+func appsTeamsFromMap(appTeams AppTeamMap) []AppWithTeam {
+	result := make([]AppWithTeam, 0, len(appTeams))
+	for team, apps := range appTeams {
+		for _, appName := range apps {
+			result = append(result, AppWithTeam{AppName: appName, TeamName: team})
+		}
+	}
+	slices.SortFunc(result, func(a, b AppWithTeam) int {
+		return strings.Compare(string(a.AppName), string(b.AppName))
+	})
+	return result
+}
+
+func appsTeamsToMap(appsWithTeam []AppWithTeam) AppTeamMap {
+	teamByApp := make(map[types.AppName]string, len(appsWithTeam))
+	for _, v := range appsWithTeam {
+		teamByApp[v.AppName] = v.TeamName // last occurrence wins
+	}
+	result := make(AppTeamMap)
+	for app, team := range teamByApp {
+		result[team] = append(result[team], app)
+	}
+	for team := range result {
+		slices.Sort(result[team])
+	}
+	return result
+}

--- a/pkg/db/db_team_apps_test.go
+++ b/pkg/db/db_team_apps_test.go
@@ -27,51 +27,51 @@ import (
 func TestUpsertAppTeam(t *testing.T) {
 	tcs := []struct {
 		Name     string
-		Initial  AppTeamMap
+		Initial  TeamToAppsMap
 		TeamName string
 		AppName  types.AppName
-		Expected AppTeamMap
+		Expected TeamToAppsMap
 	}{
 		{
 			Name:     "add to nil map",
 			Initial:  nil,
 			TeamName: "team1",
 			AppName:  "app1",
-			Expected: AppTeamMap{"team1": {"app1"}},
+			Expected: TeamToAppsMap{"team1": {"app1"}},
 		},
 		{
 			Name:     "app already in the right team is a no-op",
-			Initial:  AppTeamMap{"team1": {"app1", "app2"}},
+			Initial:  TeamToAppsMap{"team1": {"app1", "app2"}},
 			TeamName: "team1",
 			AppName:  "app1",
-			Expected: AppTeamMap{"team1": {"app1", "app2"}},
+			Expected: TeamToAppsMap{"team1": {"app1", "app2"}},
 		},
 		{
 			Name:     "moving an app keeps the other apps of the old team",
-			Initial:  AppTeamMap{"team1": {"app1", "app2"}},
+			Initial:  TeamToAppsMap{"team1": {"app1", "app2"}},
 			TeamName: "team2",
 			AppName:  "app1",
-			Expected: AppTeamMap{"team1": {"app2"}, "team2": {"app1"}},
+			Expected: TeamToAppsMap{"team1": {"app2"}, "team2": {"app1"}},
 		},
 		{
 			Name:     "emptied team is removed",
-			Initial:  AppTeamMap{"team1": {"app1"}},
+			Initial:  TeamToAppsMap{"team1": {"app1"}},
 			TeamName: "team2",
 			AppName:  "app1",
-			Expected: AppTeamMap{"team2": {"app1"}},
+			Expected: TeamToAppsMap{"team2": {"app1"}},
 		},
 		{
 			Name:     "app listed under several teams ends up in exactly one",
-			Initial:  AppTeamMap{"team1": {"app1"}, "team2": {"app1"}, "team3": {"app1", "app2"}},
+			Initial:  TeamToAppsMap{"team1": {"app1"}, "team2": {"app1"}, "team3": {"app1", "app2"}},
 			TeamName: "team4",
 			AppName:  "app1",
-			Expected: AppTeamMap{"team3": {"app2"}, "team4": {"app1"}},
+			Expected: TeamToAppsMap{"team3": {"app2"}, "team4": {"app1"}},
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			actual := UpsertAppTeam(tc.Initial, tc.TeamName, tc.AppName)
+			actual := upsertAppTeam(tc.Initial, tc.TeamName, tc.AppName)
 			if diff := cmp.Diff(tc.Expected, actual); diff != "" {
 				t.Errorf("app team map mismatch (-want, +got):\n%s", diff)
 			}
@@ -82,39 +82,39 @@ func TestUpsertAppTeam(t *testing.T) {
 func TestRemoveAppFromTeams(t *testing.T) {
 	tcs := []struct {
 		Name     string
-		Initial  AppTeamMap
+		Initial  TeamToAppsMap
 		AppName  types.AppName
-		Expected AppTeamMap
+		Expected TeamToAppsMap
 	}{
 		{
 			Name:     "removing keeps the other apps of the team",
-			Initial:  AppTeamMap{"team1": {"app1", "app2"}},
+			Initial:  TeamToAppsMap{"team1": {"app1", "app2"}},
 			AppName:  "app1",
-			Expected: AppTeamMap{"team1": {"app2"}},
+			Expected: TeamToAppsMap{"team1": {"app2"}},
 		},
 		{
 			Name:     "emptied team is removed",
-			Initial:  AppTeamMap{"team1": {"app1"}, "team2": {"app2"}},
+			Initial:  TeamToAppsMap{"team1": {"app1"}, "team2": {"app2"}},
 			AppName:  "app1",
-			Expected: AppTeamMap{"team2": {"app2"}},
+			Expected: TeamToAppsMap{"team2": {"app2"}},
 		},
 		{
 			Name:     "unknown app is a no-op",
-			Initial:  AppTeamMap{"team1": {"app1"}},
+			Initial:  TeamToAppsMap{"team1": {"app1"}},
 			AppName:  "app-does-not-exist",
-			Expected: AppTeamMap{"team1": {"app1"}},
+			Expected: TeamToAppsMap{"team1": {"app1"}},
 		},
 		{
 			Name:     "app listed under several teams is removed everywhere",
-			Initial:  AppTeamMap{"team1": {"app1"}, "team2": {"app1", "app2"}},
+			Initial:  TeamToAppsMap{"team1": {"app1"}, "team2": {"app1", "app2"}},
 			AppName:  "app1",
-			Expected: AppTeamMap{"team2": {"app2"}},
+			Expected: TeamToAppsMap{"team2": {"app2"}},
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			actual := RemoveAppFromTeams(tc.Initial, tc.AppName)
+			actual := removeAppFromTeams(tc.Initial, tc.AppName)
 			if diff := cmp.Diff(tc.Expected, actual); diff != "" {
 				t.Errorf("app team map mismatch (-want, +got):\n%s", diff)
 			}

--- a/pkg/db/db_team_apps_test.go
+++ b/pkg/db/db_team_apps_test.go
@@ -1,0 +1,123 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package db
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/freiheit-com/kuberpult/pkg/types"
+)
+
+func TestUpsertAppTeam(t *testing.T) {
+	tcs := []struct {
+		Name     string
+		Initial  AppTeamMap
+		TeamName string
+		AppName  types.AppName
+		Expected AppTeamMap
+	}{
+		{
+			Name:     "add to nil map",
+			Initial:  nil,
+			TeamName: "team1",
+			AppName:  "app1",
+			Expected: AppTeamMap{"team1": {"app1"}},
+		},
+		{
+			Name:     "app already in the right team is a no-op",
+			Initial:  AppTeamMap{"team1": {"app1", "app2"}},
+			TeamName: "team1",
+			AppName:  "app1",
+			Expected: AppTeamMap{"team1": {"app1", "app2"}},
+		},
+		{
+			Name:     "moving an app keeps the other apps of the old team",
+			Initial:  AppTeamMap{"team1": {"app1", "app2"}},
+			TeamName: "team2",
+			AppName:  "app1",
+			Expected: AppTeamMap{"team1": {"app2"}, "team2": {"app1"}},
+		},
+		{
+			Name:     "emptied team is removed",
+			Initial:  AppTeamMap{"team1": {"app1"}},
+			TeamName: "team2",
+			AppName:  "app1",
+			Expected: AppTeamMap{"team2": {"app1"}},
+		},
+		{
+			Name:     "app listed under several teams ends up in exactly one",
+			Initial:  AppTeamMap{"team1": {"app1"}, "team2": {"app1"}, "team3": {"app1", "app2"}},
+			TeamName: "team4",
+			AppName:  "app1",
+			Expected: AppTeamMap{"team3": {"app2"}, "team4": {"app1"}},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			actual := UpsertAppTeam(tc.Initial, tc.TeamName, tc.AppName)
+			if diff := cmp.Diff(tc.Expected, actual); diff != "" {
+				t.Errorf("app team map mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRemoveAppFromTeams(t *testing.T) {
+	tcs := []struct {
+		Name     string
+		Initial  AppTeamMap
+		AppName  types.AppName
+		Expected AppTeamMap
+	}{
+		{
+			Name:     "removing keeps the other apps of the team",
+			Initial:  AppTeamMap{"team1": {"app1", "app2"}},
+			AppName:  "app1",
+			Expected: AppTeamMap{"team1": {"app2"}},
+		},
+		{
+			Name:     "emptied team is removed",
+			Initial:  AppTeamMap{"team1": {"app1"}, "team2": {"app2"}},
+			AppName:  "app1",
+			Expected: AppTeamMap{"team2": {"app2"}},
+		},
+		{
+			Name:     "unknown app is a no-op",
+			Initial:  AppTeamMap{"team1": {"app1"}},
+			AppName:  "app-does-not-exist",
+			Expected: AppTeamMap{"team1": {"app1"}},
+		},
+		{
+			Name:     "app listed under several teams is removed everywhere",
+			Initial:  AppTeamMap{"team1": {"app1"}, "team2": {"app1", "app2"}},
+			AppName:  "app1",
+			Expected: AppTeamMap{"team2": {"app2"}},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			actual := RemoveAppFromTeams(tc.Initial, tc.AppName)
+			if diff := cmp.Diff(tc.Expected, actual); diff != "" {
+				t.Errorf("app team map mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -6698,6 +6698,34 @@ func TestDBSelectLatestAppsTeamsHistory(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "should update and fetch apps_teams_history table correctly",
+			Actions: []Action{
+				{
+					AppStateChange: AppStateChangeCreate,
+					AppWithTeam:    map[types.AppName]string{"app1": "team1"},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1": {"app1"},
+					},
+				},
+				{
+					AppStateChange: AppStateChangeCreate,
+					AppWithTeam:    map[types.AppName]string{"app2": "team2"},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1": {"app1"},
+						"team2": {"app2"},
+					},
+				},
+				{
+					AppStateChange: AppStateChangeDelete,
+					AppWithTeam:    map[types.AppName]string{"app3": "team1"}, // unknown app
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1": {"app1"},
+						"team2": {"app2"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tcs {

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -6570,12 +6570,13 @@ func TestDBSelectEnvironmentApplications(t *testing.T) {
 				for envName, expectedApps := range tc.ExpectedEnvironmentApplications {
 					apps, err := dbHandler.DBSelectEnvironmentApplications(ctx, transaction, envName)
 					if err != nil {
-						return fmt.Errorf("Couldn't retrieve environment %s applications, error: %w", envName, err)
+						t.Fatalf("couldn't retrieve environment %s applications, error: %v", envName, err)
 					}
 					if diff := cmp.Diff(expectedApps, apps); diff != "" {
-						return fmt.Errorf("environment applications mismatch (-want, +got):\n%s", diff)
+						t.Fatalf("environment applications mismatch (-want, +got):\n%s", diff)
 					}
 				}
+
 				return nil
 			})
 			if err != nil {
@@ -6589,105 +6590,110 @@ func TestDBSelectLatestAppsTeamsHistory(t *testing.T) {
 	type Action struct {
 		AppStateChange         AppStateChange
 		AppWithTeam            map[types.AppName]string
-		ExpectedAppTeamHistory []AppWithTeam
+		ExpectedAppTeamHistory map[string][]types.AppName
 	}
 	tcs := []struct {
 		Name    string
 		Actions []Action
 	}{
 		{
+			Name: "re-creating an existing app must not duplicate entries",
+			Actions: []Action{
+				{
+					AppStateChange: AppStateChangeCreate,
+					AppWithTeam:    map[types.AppName]string{"app1": "team1"},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1": {"app1"},
+					},
+				},
+				{
+					AppStateChange: AppStateChangeCreate,
+					AppWithTeam:    map[types.AppName]string{"app2": "team2"},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1": {"app1"},
+						"team2": {"app2"},
+					},
+				},
+				{
+					// app1 already exists: the list must stay at 2 entries, not double to 4
+					AppStateChange: AppStateChangeCreate,
+					AppWithTeam:    map[types.AppName]string{"app1": "team1"},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1": {"app1"},
+						"team2": {"app2"},
+					},
+				},
+				{
+					// creating an existing app again with a new team: last write wins, position kept
+					AppStateChange: AppStateChangeCreate,
+					AppWithTeam:    map[types.AppName]string{"app1": "team1-recreated"},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1-recreated": {"app1"},
+						"team2":           {"app2"},
+					},
+				},
+				{
+					// Migrate takes the same code path as Create
+					AppStateChange: AppStateChangeMigrate,
+					AppWithTeam:    map[types.AppName]string{"app2": "team2-migrated"},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1-recreated": {"app1"},
+						"team2-migrated":  {"app2"},
+					},
+				},
+			},
+		},
+		{
 			Name: "should update and fetch apps_teams_history table correctly",
 			Actions: []Action{
 				{
 					AppStateChange: AppStateChangeCreate,
 					AppWithTeam:    map[types.AppName]string{"app1": "team1"},
-					ExpectedAppTeamHistory: []AppWithTeam{
-						{
-							AppName:  "app1",
-							TeamName: "team1",
-						},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1": {"app1"},
 					},
 				},
 				{
 					AppStateChange: AppStateChangeCreate,
 					AppWithTeam:    map[types.AppName]string{"app2": "team2"},
-					ExpectedAppTeamHistory: []AppWithTeam{
-						{
-							AppName:  "app1",
-							TeamName: "team1",
-						},
-						{
-							AppName:  "app2",
-							TeamName: "team2",
-						},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1": {"app1"},
+						"team2": {"app2"},
 					},
 				},
 				{
 					AppStateChange: AppStateChangeCreate,
 					AppWithTeam:    map[types.AppName]string{"app3": "team3"},
-					ExpectedAppTeamHistory: []AppWithTeam{
-						{
-							AppName:  "app1",
-							TeamName: "team1",
-						},
-						{
-							AppName:  "app2",
-							TeamName: "team2",
-						},
-						{
-							AppName:  "app3",
-							TeamName: "team3",
-						},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1": {"app1"},
+						"team2": {"app2"},
+						"team3": {"app3"},
 					},
 				},
 				{
 					AppStateChange: AppStateChangeUpdate,
 					AppWithTeam:    map[types.AppName]string{"app1": "team1-updated"},
-					ExpectedAppTeamHistory: []AppWithTeam{
-						{
-							AppName:  "app1",
-							TeamName: "team1-updated",
-						},
-						{
-							AppName:  "app2",
-							TeamName: "team2",
-						},
-						{
-							AppName:  "app3",
-							TeamName: "team3",
-						},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1-updated": {"app1"},
+						"team2":         {"app2"},
+						"team3":         {"app3"},
 					},
 				},
 				{
 					AppStateChange: AppStateChangeDelete,
 					AppWithTeam:    map[types.AppName]string{"app2": "team2"},
-					ExpectedAppTeamHistory: []AppWithTeam{
-						{
-							AppName:  "app1",
-							TeamName: "team1-updated",
-						},
-						{
-							AppName:  "app3",
-							TeamName: "team3",
-						},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1-updated": {"app1"},
+						"team3":         {"app3"},
 					},
 				},
 				{
 					AppStateChange: AppStateChangeCreate,
 					AppWithTeam:    map[types.AppName]string{"app4": "team4"},
-					ExpectedAppTeamHistory: []AppWithTeam{
-						{
-							AppName:  "app1",
-							TeamName: "team1-updated",
-						},
-						{
-							AppName:  "app3",
-							TeamName: "team3",
-						},
-						{
-							AppName:  "app4",
-							TeamName: "team4",
-						},
+					ExpectedAppTeamHistory: map[string][]types.AppName{
+						"team1-updated": {"app1"},
+						"team3":         {"app3"},
+						"team4":         {"app4"},
 					},
 				},
 			},
@@ -6701,7 +6707,7 @@ func TestDBSelectLatestAppsTeamsHistory(t *testing.T) {
 			dbHandler := setupDB(t)
 
 			err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-				for _, action := range tc.Actions {
+				for index, action := range tc.Actions {
 					for appName, teamName := range action.AppWithTeam {
 						err := dbHandler.DBInsertOrUpdateApplication(ctx, transaction, appName, action.AppStateChange, DBAppMetaData{
 							Team: teamName,
@@ -6711,13 +6717,13 @@ func TestDBSelectLatestAppsTeamsHistory(t *testing.T) {
 						}
 					}
 
-					appsWithTeam, err := dbHandler.DBSelectLatestAppsTeamsHistory(ctx, transaction)
+					_, teamAppMap, err := dbHandler.DBSelectLatestAppsTeamsHistory(ctx, transaction)
 					if err != nil {
-						return fmt.Errorf("error while selecting apps teams history: %w", err)
+						return fmt.Errorf("error at action [%d] while selecting apps teams history: %w", index, err)
 					}
 
-					if diff := cmp.Diff(action.ExpectedAppTeamHistory, appsWithTeam); diff != "" {
-						return fmt.Errorf("apps teams history mismatch (-want, +got):\n%s", diff)
+					if diff := cmp.Diff(action.ExpectedAppTeamHistory, teamAppMap); diff != "" {
+						return fmt.Errorf("apps teams history mismatch at action [%d] (-want, +got):\n%s", index, diff)
 					}
 				}
 				return nil

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -6624,7 +6624,7 @@ func TestDBSelectLatestAppsTeamsHistory(t *testing.T) {
 					},
 				},
 				{
-					// creating an existing app again with a new team: last write wins, position kept
+					// creating an existing app again with a new team: last write wins
 					AppStateChange: AppStateChangeCreate,
 					AppWithTeam:    map[types.AppName]string{"app1": "team1-recreated"},
 					ExpectedAppTeamHistory: map[string][]types.AppName{
@@ -6699,7 +6699,7 @@ func TestDBSelectLatestAppsTeamsHistory(t *testing.T) {
 			},
 		},
 		{
-			Name: "should update and fetch apps_teams_history table correctly",
+			Name: "should ignore an unknown app in deletion",
 			Actions: []Action{
 				{
 					AppStateChange: AppStateChangeCreate,


### PR DESCRIPTION
The apps_teams_history table was used inefficiently. On every team change, it stored team changes additionally, instead of removing old entries, leading to a significant size increase over time.

Now duplicates are removed in the two functions that read from and write to that table.

Ref: SRX-HMADWG