### PR TITLE
chore: avoid mult-fetching environment data for aa-environments during argo config rendering

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,7 +82,6 @@ type ArgoCdIgnoreDifference struct {
 // IsAAEnv
 // Note that there is also a function isAAEnv in argo.go for a similar type.
 // Keep them in sync.
-// TODO(ccreinatz): Validate that it is intended behaviour that we can return `isAAEnv=true`  when `ArgoCDConfigs=nil`.
 func IsAAEnv(config *EnvironmentConfig) bool {
 	if config.IsActiveActive != nil {
 		return *config.IsActiveActive

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,7 @@ type ArgoCdIgnoreDifference struct {
 // IsAAEnv
 // Note that there is also a function isAAEnv in argo.go for a similar type.
 // Keep them in sync.
+// TODO(ccreinatz): Validate that it is intended behaviour that we can return `isAAEnv=true`  when `ArgoCDConfigs=nil`.
 func IsAAEnv(config *EnvironmentConfig) bool {
 	if config.IsActiveActive != nil {
 		return *config.IsActiveActive

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -1032,7 +1032,7 @@ func calculateRenderTargets(
 	} else if cfg.ArgoCd != nil {
 		// This covers the legacy configuration of the envs via the ArgoCd field.
 		argoCDConfigs = []*config.EnvironmentConfigArgoCd{cfg.ArgoCd}
-	} else if cfg.ArgoCd == nil && len(cfg.ArgoCdConfigs.ArgoCdConfigurations) > 0 {
+	} else if cfg.ArgoCdConfigs != nil && len(cfg.ArgoCdConfigs.ArgoCdConfigurations) > 0 {
 		// This covers the 'new' way to define regular non-active-active environments.
 		// In non-AA environments, each environment should contain only a single cluster and thus
 		// a single argocd configuration.
@@ -1042,12 +1042,11 @@ func calculateRenderTargets(
 	rootAppFilteringActive := opts != nil && opts.RootAppFiltering.Enabled
 	for _, argoCDConfig := range argoCDConfigs {
 		envInfo := &argocd.EnvironmentInfo{
-			ArgoCDConfig:          argoCDConfig,
-			CommonPrefix:          commonEnvPrefix,
-			ParentEnvironmentName: env,
-			IsAAEnv:               isAAEnv,
-			// ArgoProjectNameOverride is filled in by renderApp, which owns the overrides:
-			ArgoProjectNameOverride: "",
+			ArgoCDConfig:            argoCDConfig,
+			CommonPrefix:            commonEnvPrefix,
+			ParentEnvironmentName:   env,
+			IsAAEnv:                 isAAEnv,
+			ArgoProjectNameOverride: "", // may be overridden below
 		}
 		envFQDN := envInfo.GetFullyQualifiedName()
 		if projectNames != nil && projectNames.ActiveActiveEnvironments != nil && projectNames.Environments != nil {
@@ -1066,7 +1065,7 @@ func calculateRenderTargets(
 		}
 		renderTargets = append(renderTargets, envInfo)
 	}
-	return nil
+	return renderTargets
 }
 
 func (r *repository) updateArgoCdApps(ctx context.Context, transaction *sql.Tx, state *State, env types.EnvName, cfg config.EnvironmentConfig, ts time.Time, eslVersion db.TransformerID, fsMutex *sync.Mutex) (err error) {
@@ -1115,7 +1114,9 @@ func collectArgoAppDataForEnv(
 	eslVersion db.TransformerID,
 ) (appData []argocd.AppData, err error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "collectArgoAppDataForEnv")
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	_, appTeams, err := dbHandler.DBSelectEnvironmentApplicationsAtTimestamp(ctx, transaction, parentEnvName, timestamp)
 	if err != nil {
 		return nil, fmt.Errorf("could not select environment applications at timestamp: %w", err)

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -1016,6 +1016,11 @@ func (r *repository) updateArgoCdApps(ctx context.Context, transaction *sql.Tx, 
 		return nil
 	}
 
+	if cfg.ArgoCd == nil && (cfg.ArgoCdConfigs == nil || len(cfg.ArgoCdConfigs.ArgoCdConfigurations) == 0) {
+		logging.Error(ctx, "No argo cd configuration found for environment.", zap.String("env", string(env)))
+		return nil
+	}
+
 	opts := r.config.ArgoRenderOptions
 	if config.IsAAEnv(&cfg) {
 		for _, currentArgoCdConfiguration := range cfg.ArgoCdConfigs.ArgoCdConfigurations {
@@ -1036,12 +1041,7 @@ func (r *repository) updateArgoCdApps(ctx context.Context, transaction *sql.Tx, 
 			logging.Info(ctx, "rootAppFiltering enabled for normal env", zap.String("env", string(env)))
 			return nil
 		}
-		if cfg.ArgoCd == nil && (cfg.ArgoCdConfigs == nil || len(cfg.ArgoCdConfigs.ArgoCdConfigurations) == 0) {
-			logging.Error(ctx, "No argo cd configuration found for environment.", zap.String("env", string(env)))
-			return nil
-		}
 		var conf *config.EnvironmentConfigArgoCd
-
 		if cfg.ArgoCd == nil {
 			conf = cfg.ArgoCdConfigs.ArgoCdConfigurations[0]
 		} else {

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -1006,6 +1006,69 @@ func (r *repository) afterTransform(ctx context.Context, transaction *sql.Tx, st
 	return errorGroup.Wait()
 }
 
+func calculateRenderTargets(
+	ctx context.Context,
+	env types.EnvName,
+	cfg config.EnvironmentConfig,
+	opts *argocd.RenderOptions,
+	projectNames *argocd.AllArgoProjectNameOverrides,
+) (renderTargets []*argocd.EnvironmentInfo) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "calculateRenderTargets")
+	defer func() {
+		span.Finish()
+	}()
+	var argoCDConfigs []*config.EnvironmentConfigArgoCd
+	isAAEnv := config.IsAAEnv(&cfg)
+
+	commonEnvPrefix := ""
+	// Unified types between the legacy `cfg.ArgoCd` and new `cfg.ArgoCdConfigs` types.
+	if isAAEnv {
+		if cfg.ArgoCdConfigs != nil {
+			argoCDConfigs = cfg.ArgoCdConfigs.ArgoCdConfigurations
+			if cfg.ArgoCdConfigs.CommonEnvPrefix != nil {
+				commonEnvPrefix = *cfg.ArgoCdConfigs.CommonEnvPrefix
+			}
+		}
+	} else if cfg.ArgoCd != nil {
+		// This covers the legacy configuration of the envs via the ArgoCd field.
+		argoCDConfigs = []*config.EnvironmentConfigArgoCd{cfg.ArgoCd}
+	} else if cfg.ArgoCd == nil && len(cfg.ArgoCdConfigs.ArgoCdConfigurations) > 0 {
+		// This covers the 'new' way to define regular non-active-active environments.
+		// In non-AA environments, each environment should contain only a single cluster and thus
+		// a single argocd configuration.
+		argoCDConfigs = []*config.EnvironmentConfigArgoCd{cfg.ArgoCdConfigs.ArgoCdConfigurations[0]}
+	}
+
+	rootAppFilteringActive := opts != nil && opts.RootAppFiltering.Enabled
+	for _, argoCDConfig := range argoCDConfigs {
+		envInfo := &argocd.EnvironmentInfo{
+			ArgoCDConfig:          argoCDConfig,
+			CommonPrefix:          commonEnvPrefix,
+			ParentEnvironmentName: env,
+			IsAAEnv:               isAAEnv,
+			// ArgoProjectNameOverride is filled in by renderApp, which owns the overrides:
+			ArgoProjectNameOverride: "",
+		}
+		envFQDN := envInfo.GetFullyQualifiedName()
+		if projectNames != nil && projectNames.ActiveActiveEnvironments != nil && projectNames.Environments != nil {
+			names := projectNames.Environments
+			if isAAEnv {
+				names = projectNames.ActiveActiveEnvironments
+			}
+			envInfo.ArgoProjectNameOverride = (*names)[types.EnvName(envFQDN)]
+		}
+		if rootAppFilteringActive {
+			isEnabledEnv := slices.Contains(opts.RootAppFiltering.EnabledEnvironments, types.EnvName(envFQDN))
+			if !isEnabledEnv {
+				logging.Info(ctx, "rootAppFiltering excludes environment", zap.String("env", envFQDN))
+				continue
+			}
+		}
+		renderTargets = append(renderTargets, envInfo)
+	}
+	return nil
+}
+
 func (r *repository) updateArgoCdApps(ctx context.Context, transaction *sql.Tx, state *State, env types.EnvName, cfg config.EnvironmentConfig, ts time.Time, eslVersion db.TransformerID, fsMutex *sync.Mutex) (err error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "updateArgoCdApps")
 	defer func() {
@@ -1015,86 +1078,24 @@ func (r *repository) updateArgoCdApps(ctx context.Context, transaction *sql.Tx, 
 	if !r.config.ArgoCdGenerateFiles {
 		return nil
 	}
-
 	if cfg.ArgoCd == nil && (cfg.ArgoCdConfigs == nil || len(cfg.ArgoCdConfigs.ArgoCdConfigurations) == 0) {
-		logging.Error(ctx, "No argo cd configuration found for environment.", zap.String("env", string(env)))
+		logging.Info(ctx, "No argo cd configuration found for environment.", zap.String("env", string(env)))
 		return nil
 	}
-
-	opts := r.config.ArgoRenderOptions
-	if config.IsAAEnv(&cfg) {
-		for _, currentArgoCdConfiguration := range cfg.ArgoCdConfigs.ArgoCdConfigurations {
-			if opts != nil && opts.RootAppFiltering.Enabled {
-				aaEnvName := types.EnvName(*cfg.ArgoCdConfigs.CommonEnvPrefix + "-" + string(env) + "-" + currentArgoCdConfiguration.ConcreteEnvName)
-				if !slices.Contains(opts.RootAppFiltering.EnabledEnvironments, aaEnvName) {
-					logging.Info(ctx, "rootAppFiltering enabled for active/active env", zap.String("env", string(aaEnvName)))
-					continue
-				}
-			}
-			err := r.processApp(ctx, transaction, state, env, cfg.ArgoCdConfigs.CommonEnvPrefix, currentArgoCdConfiguration, true, ts, eslVersion, fsMutex)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		if opts != nil && opts.RootAppFiltering.Enabled && !slices.Contains(opts.RootAppFiltering.EnabledEnvironments, env) {
-			logging.Info(ctx, "rootAppFiltering enabled for normal env", zap.String("env", string(env)))
-			return nil
-		}
-		var conf *config.EnvironmentConfigArgoCd
-		if cfg.ArgoCd == nil {
-			conf = cfg.ArgoCdConfigs.ArgoCdConfigurations[0]
-		} else {
-			conf = cfg.ArgoCd
-		}
-
-		err := r.processApp(ctx, transaction, state, env, nil, conf, false, ts, eslVersion, fsMutex)
-
-		if err != nil {
-			return err
+	renderTargets := calculateRenderTargets(ctx, env, cfg, r.config.ArgoRenderOptions, r.ArgoProjectNames)
+	if len(renderTargets) == 0 {
+		return nil
+	}
+	appData, err := collectArgoAppDataForEnv(ctx, transaction, state.DBHandler, env, ts, eslVersion)
+	if err != nil {
+		return fmt.Errorf("could not collect app data for env '%s': %w", env, err)
+	}
+	for _, target := range renderTargets {
+		if err = r.renderRootAppForCluster(ctx, target, appData, state.Filesystem, fsMutex); err != nil {
+			return fmt.Errorf("cannot render root app for cluster '%s': %w", target.GetFullyQualifiedName(), err)
 		}
 	}
 	return nil
-}
-
-func (r *repository) processApp(
-	ctx context.Context,
-	transaction *sql.Tx,
-	state *State,
-	env types.EnvName,
-	commonEnvPrefix *string,
-	currentArgoCdConfiguration *config.EnvironmentConfigArgoCd,
-	isAAEnv bool,
-	ts time.Time,
-	eslVersion db.TransformerID,
-	fsMutex *sync.Mutex,
-) error {
-	prefix := ""
-	if commonEnvPrefix != nil {
-		prefix = *commonEnvPrefix
-	}
-	environmentInfo := &argocd.EnvironmentInfo{
-		ArgoCDConfig:          currentArgoCdConfiguration,
-		CommonPrefix:          prefix,
-		ParentEnvironmentName: env,
-		IsAAEnv:               isAAEnv,
-	}
-	projectNameOverride := types.ArgoProjectName("")
-	if r.ArgoProjectNames != nil && r.ArgoProjectNames.ActiveActiveEnvironments != nil && r.ArgoProjectNames.Environments != nil {
-		ok := false
-		if isAAEnv {
-			projectNameOverride, ok = (*r.ArgoProjectNames.ActiveActiveEnvironments)[types.EnvName(environmentInfo.GetFullyQualifiedName())]
-		} else {
-			projectNameOverride, ok = (*r.ArgoProjectNames.Environments)[types.EnvName(environmentInfo.GetFullyQualifiedName())]
-		}
-		if ok {
-			environmentInfo.ArgoProjectNameOverride = projectNameOverride
-		} else {
-			environmentInfo.ArgoProjectNameOverride = ""
-		}
-	}
-	err := r.processArgoAppForEnv(ctx, transaction, state, environmentInfo, ts, eslVersion, fsMutex)
-	return err
 }
 
 func appTeamsToMap(appTeams []db.AppWithTeam) map[types.AppName]string {
@@ -1105,35 +1106,49 @@ func appTeamsToMap(appTeams []db.AppWithTeam) map[types.AppName]string {
 	return result
 }
 
-func (r *repository) processArgoAppForEnv(ctx context.Context, transaction *sql.Tx, state *State, info *argocd.EnvironmentInfo, timestamp time.Time, eslVersion db.TransformerID, fsMutex *sync.Mutex) error {
-	_, appTeams, err := state.DBHandler.DBSelectEnvironmentApplicationsAtTimestamp(ctx, transaction, info.ParentEnvironmentName, timestamp)
+func collectArgoAppDataForEnv(
+	ctx context.Context,
+	transaction *sql.Tx,
+	dbHandler *db.DBHandler,
+	parentEnvName types.EnvName,
+	timestamp time.Time,
+	eslVersion db.TransformerID,
+) (appData []argocd.AppData, err error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "collectArgoAppDataForEnv")
+	defer span.Finish(tracer.WithError(err))
+	_, appTeams, err := dbHandler.DBSelectEnvironmentApplicationsAtTimestamp(ctx, transaction, parentEnvName, timestamp)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("could not select environment applications at timestamp: %w", err)
 	}
-	spanCollectData, ctx := tracer.StartSpanFromContext(ctx, "collectData")
-	defer spanCollectData.Finish()
-	deploymentsPerApp, err := db_history.DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx, state.DBHandler, transaction, info.ParentEnvironmentName, timestamp)
+	deploymentsPerApp, err := db_history.DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx, dbHandler, transaction, parentEnvName, timestamp)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("could not select apps with deployment in env at timestamp: %w", err)
 	}
-	allBrackets, err := db.DBSelectBracketHistoryById(ctx, state.DBHandler, transaction, eslVersion)
+	allBrackets, err := db.DBSelectBracketHistoryById(ctx, dbHandler, transaction, eslVersion)
 	if err != nil {
-		return fmt.Errorf("could not find bracket at %v: %w", eslVersion, err)
+		return nil, fmt.Errorf("could not find bracket at %v: %w", eslVersion, err)
 	}
-	appData := CalculateAppDataWithBrackets(ctx, allBrackets, appTeams, deploymentsPerApp)
-	spanCollectData.Finish()
+	appData = CalculateAppDataWithBrackets(ctx, allBrackets, appTeams, deploymentsPerApp)
+	return appData, nil
+}
 
-	spanRenderAndWrite, ctx := tracer.StartSpanFromContext(ctx, "RenderAndWrite")
-	defer spanRenderAndWrite.Finish()
+func (r *repository) renderRootAppForCluster(
+	ctx context.Context,
+	info *argocd.EnvironmentInfo,
+	appData []argocd.AppData,
+	fileSystem billy.Filesystem,
+	fsMutex *sync.Mutex,
+) (err error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "renderRootAppForCluster")
+	span.SetTag("argoEnvFQDN", info.GetFullyQualifiedName())
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	manifests, err := argocd.Render(ctx, r.config.URL, r.config.Branch, info, appData, r.config.ArgoRenderOptions)
 	if err != nil {
 		return err
 	}
-	err = writeArgoCdRootEnvManifestsSynced(ctx, state.Filesystem, info, manifests, fsMutex)
-	if err != nil {
-		return err
-	}
-	return nil
+	return writeArgoCdRootEnvManifestsSynced(ctx, fileSystem, info, manifests, fsMutex)
 }
 
 // CalculateAppDataWithBrackets returns the list of AppData that needs to be rendered in render.go

--- a/services/manifest-repo-export-service/pkg/repository/repository_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository_test.go
@@ -1246,6 +1246,232 @@ func TestArgoCDRootAppFilterAAEnv(t *testing.T) {
 	}
 }
 
+func TestArgoCDRootAppContent(t *testing.T) {
+	const envName = types.EnvName("staging")
+	const appOne = "app-one"
+	const appTwo = "app-two"
+	const teamOne = "team-one"
+	const teamTwo = "team-two"
+	aaPrefix := "aa"
+	meta := TransformerMetadata{AuthorName: "test", AuthorEmail: "test@test.com"}
+
+	// appProject renders the AppProject document, which is the first document of every root app file.
+	appProject := func(fullyQualifiedName, destinationName, destinationServer string) string {
+		return fmt.Sprintf(`apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: %s
+spec:
+  description: %s
+  destinations:
+  - name: %s
+    server: %s
+  sourceRepos:
+  - '*'
+`, fullyQualifiedName, fullyQualifiedName, destinationName, destinationServer)
+	}
+	// application renders one Application document of a root app file.
+	application := func(fullyQualifiedName, argoProjectName, appName, teamName, destinationName, destinationServer string) string {
+		return fmt.Sprintf(`apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/%s/applications/%s/manifests;
+    com.freiheit.kuberpult/aa-parent-environment: %s
+    com.freiheit.kuberpult/application: %s
+    com.freiheit.kuberpult/environment: %s
+    com.freiheit.kuberpult/teams: %s
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  labels:
+    com.freiheit.kuberpult/teams: %s
+  name: %s-%s
+spec:
+  destination:
+    name: %s
+    server: %s
+  project: %s
+  sources:
+  - path: environments/%s/applications/%s/manifests
+    repoURL: test
+    targetRevision: master
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+`, envName, appName, envName, appName, fullyQualifiedName, teamName, teamName, fullyQualifiedName, appName,
+			destinationName, destinationServer, argoProjectName, envName, appName)
+	}
+	// rootApp joins the documents of one root app file the same way argocd.Render does.
+	rootApp := func(documents ...string) []byte {
+		return []byte(strings.Join(documents, "---\n"))
+	}
+
+	tcs := []struct {
+		Name          string
+		EnvConfig     config.EnvironmentConfig
+		ProjectNames  *argocd.AllArgoProjectNameOverrides
+		ExpectedFiles []*FilenameAndData
+	}{
+		{
+			Name: "every cluster of an active/active environment renders the same applications",
+			EnvConfig: config.EnvironmentConfig{
+				Upstream: &config.EnvironmentConfigUpstream{Latest: true},
+				ArgoCdConfigs: &config.ArgoCDConfigs{
+					CommonEnvPrefix: &aaPrefix,
+					ArgoCdConfigurations: []*config.EnvironmentConfigArgoCd{
+						testutil.MakeArgoCdConfigDestination("c1", "destination-1", "server-1"),
+						testutil.MakeArgoCdConfigDestination("c2", "destination-2", "server-2"),
+					},
+				},
+			},
+			ExpectedFiles: []*FilenameAndData{
+				{
+					path: "argocd/v1alpha1/aa-staging-c1.yaml",
+					fileData: rootApp(
+						appProject("aa-staging-c1", "destination-1", "server-1"),
+						application("aa-staging-c1", "aa-staging-c1", appOne, teamOne, "destination-1", "server-1"),
+						application("aa-staging-c1", "aa-staging-c1", appTwo, teamTwo, "destination-1", "server-1"),
+					),
+				},
+				{
+					path: "argocd/v1alpha1/aa-staging-c2.yaml",
+					fileData: rootApp(
+						appProject("aa-staging-c2", "destination-2", "server-2"),
+						application("aa-staging-c2", "aa-staging-c2", appOne, teamOne, "destination-2", "server-2"),
+						application("aa-staging-c2", "aa-staging-c2", appTwo, teamTwo, "destination-2", "server-2"),
+					),
+				},
+			},
+		},
+		{
+			Name: "the argo project name override applies to the configured cluster only",
+			EnvConfig: config.EnvironmentConfig{
+				Upstream: &config.EnvironmentConfigUpstream{Latest: true},
+				ArgoCdConfigs: &config.ArgoCDConfigs{
+					CommonEnvPrefix: &aaPrefix,
+					ArgoCdConfigurations: []*config.EnvironmentConfigArgoCd{
+						testutil.MakeArgoCdConfigDestination("c1", "destination-1", "server-1"),
+						testutil.MakeArgoCdConfigDestination("c2", "destination-2", "server-2"),
+					},
+				},
+			},
+			ProjectNames: &argocd.AllArgoProjectNameOverrides{
+				ActiveActiveEnvironments: &argocd.ArgoProjectNamesPerEnv{"aa-staging-c1": "custom-project"},
+				Environments:             &argocd.ArgoProjectNamesPerEnv{},
+			},
+			ExpectedFiles: []*FilenameAndData{
+				{
+					// The AppProject is always created with the default name, only the
+					// applications point to the overridden project.
+					path: "argocd/v1alpha1/aa-staging-c1.yaml",
+					fileData: rootApp(
+						appProject("aa-staging-c1", "destination-1", "server-1"),
+						application("aa-staging-c1", "custom-project", appOne, teamOne, "destination-1", "server-1"),
+						application("aa-staging-c1", "custom-project", appTwo, teamTwo, "destination-1", "server-1"),
+					),
+				},
+				{
+					path: "argocd/v1alpha1/aa-staging-c2.yaml",
+					fileData: rootApp(
+						appProject("aa-staging-c2", "destination-2", "server-2"),
+						application("aa-staging-c2", "aa-staging-c2", appOne, teamOne, "destination-2", "server-2"),
+						application("aa-staging-c2", "aa-staging-c2", appTwo, teamTwo, "destination-2", "server-2"),
+					),
+				},
+			},
+		},
+		{
+			Name: "a non active/active environment renders the first argocd configuration",
+			EnvConfig: config.EnvironmentConfig{
+				Upstream: &config.EnvironmentConfigUpstream{Latest: true},
+				ArgoCdConfigs: &config.ArgoCDConfigs{
+					ArgoCdConfigurations: []*config.EnvironmentConfigArgoCd{
+						testutil.MakeArgoCdConfigDestination("c1", "destination-1", "server-1"),
+						testutil.MakeArgoCdConfigDestination("c2", "destination-2", "server-2"),
+					},
+				},
+			},
+			ExpectedFiles: []*FilenameAndData{
+				{
+					path: "argocd/v1alpha1/staging.yaml",
+					fileData: rootApp(
+						appProject("staging", "destination-1", "server-1"),
+						application("staging", "staging", appOne, teamOne, "destination-1", "server-1"),
+						application("staging", "staging", appTwo, teamTwo, "destination-1", "server-1"),
+					),
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			r, dbHandler, _ := SetupRepositoryTestWithDB(t)
+			repo := r.(*repository)
+			// The rendered files contain the git url, which otherwise depends on the temporary directory of the test:
+			repo.config.URL = "test"
+			repo.ArgoProjectNames = tc.ProjectNames
+			ctx := testutilauth.MakeTestContext()
+
+			transformers := []Transformer{
+				&CreateEnvironment{
+					Environment:         envName,
+					Config:              tc.EnvConfig,
+					TransformerMetadata: meta,
+				},
+				&CreateApplicationVersion{
+					Application:         appOne,
+					Team:                teamOne,
+					Manifests:           map[types.EnvName]string{envName: "manifest-one"},
+					Version:             1,
+					TransformerMetadata: meta,
+				},
+				&DeployApplicationVersion{
+					Application:         appOne,
+					Environment:         envName,
+					Version:             1,
+					TransformerMetadata: meta,
+				},
+				&CreateApplicationVersion{
+					Application:         appTwo,
+					Team:                teamTwo,
+					Manifests:           map[types.EnvName]string{envName: "manifest-two"},
+					Version:             1,
+					TransformerMetadata: meta,
+				},
+				&DeployApplicationVersion{
+					Application:         appTwo,
+					Environment:         envName,
+					Version:             1,
+					TransformerMetadata: meta,
+				},
+			}
+
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				for _, tr := range transformers {
+					prepareDatabaseLikeCdService(ctx, transaction, tr, dbHandler, t, "test", "test@test.com")
+				}
+				return nil
+			})
+			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				for i, tr := range transformers {
+					_, applyErr := repo.ApplyTransformer(ctx, transaction, tr)
+					if applyErr != nil {
+						t.Fatalf("Unexpected error applying transformer[%d]: %v", i, applyErr)
+					}
+				}
+				return nil
+			})
+
+			state := repo.State()
+			if err := verifyContent(state.Filesystem, tc.ExpectedFiles); err != nil {
+				t.Errorf("root app content mismatch: %v\nFiles:\n%s", err, strings.Join(listFiles(state.Filesystem), "\n"))
+			}
+		})
+	}
+}
+
 func TestArgoCDFileGenerationAcrossTimestamps(t *testing.T) {
 	const authorName = "testAuthorName"
 	const authorEmail = "testAuthorEmail@example.com"

--- a/services/manifest-repo-export-service/pkg/repository/repository_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository_test.go
@@ -834,6 +834,174 @@ func TestArgoCDFileGeneration(t *testing.T) {
 	}
 }
 
+func TestCalculateRenderTargets(t *testing.T) {
+	const envName = types.EnvName("staging")
+	aaPrefix := "aa"
+	isActiveActive := true
+	// legacyConfig is the old way to configure a single cluster via config.EnvironmentConfig.ArgoCd:
+	legacyConfig := testutil.MakeArgoCdConfigDestination("", "legacy-destination", "legacy-server")
+	// clusterConfig1 and clusterConfig2 are the two clusters of an active/active environment:
+	clusterConfig1 := testutil.MakeArgoCdConfigDestination("c1", "destination-1", "server-1")
+	clusterConfig2 := testutil.MakeArgoCdConfigDestination("c2", "destination-2", "server-2")
+
+	tcs := []struct {
+		Name            string
+		Config          config.EnvironmentConfig
+		RenderOptions   *argocd.RenderOptions
+		ProjectNames    *argocd.AllArgoProjectNameOverrides
+		ExpectedTargets []*argocd.EnvironmentInfo
+	}{
+		{
+			Name:   "legacy argoCd configuration results in one render target",
+			Config: config.EnvironmentConfig{ArgoCd: legacyConfig},
+			ExpectedTargets: []*argocd.EnvironmentInfo{
+				{ArgoCDConfig: legacyConfig, CommonPrefix: "", ParentEnvironmentName: envName, IsAAEnv: false, ArgoProjectNameOverride: ""},
+			},
+		},
+		{
+			Name: "non active/active environment uses only the first argoCd configuration",
+			Config: config.EnvironmentConfig{
+				ArgoCdConfigs: &config.ArgoCDConfigs{
+					ArgoCdConfigurations: []*config.EnvironmentConfigArgoCd{clusterConfig1, clusterConfig2},
+				},
+			},
+			ExpectedTargets: []*argocd.EnvironmentInfo{
+				{ArgoCDConfig: clusterConfig1, CommonPrefix: "", ParentEnvironmentName: envName, IsAAEnv: false, ArgoProjectNameOverride: ""},
+			},
+		},
+		{
+			Name: "active/active environment results in one render target per cluster",
+			Config: config.EnvironmentConfig{
+				ArgoCdConfigs: &config.ArgoCDConfigs{
+					CommonEnvPrefix:      &aaPrefix,
+					ArgoCdConfigurations: []*config.EnvironmentConfigArgoCd{clusterConfig1, clusterConfig2},
+				},
+			},
+			ExpectedTargets: []*argocd.EnvironmentInfo{
+				{ArgoCDConfig: clusterConfig1, CommonPrefix: "aa", ParentEnvironmentName: envName, IsAAEnv: true, ArgoProjectNameOverride: ""},
+				{ArgoCDConfig: clusterConfig2, CommonPrefix: "aa", ParentEnvironmentName: envName, IsAAEnv: true, ArgoProjectNameOverride: ""},
+			},
+		},
+		{
+			Name: "root app filter renders only the listed cluster of an active/active environment",
+			Config: config.EnvironmentConfig{
+				ArgoCdConfigs: &config.ArgoCDConfigs{
+					CommonEnvPrefix:      &aaPrefix,
+					ArgoCdConfigurations: []*config.EnvironmentConfigArgoCd{clusterConfig1, clusterConfig2},
+				},
+			},
+			RenderOptions: &argocd.RenderOptions{
+				RootAppFiltering: argocd.RootAppFiltering{Enabled: true, EnabledEnvironments: []types.EnvName{"aa-staging-c2"}},
+			},
+			ExpectedTargets: []*argocd.EnvironmentInfo{
+				{ArgoCDConfig: clusterConfig2, CommonPrefix: "aa", ParentEnvironmentName: envName, IsAAEnv: true, ArgoProjectNameOverride: ""},
+			},
+		},
+		{
+			Name: "root app filter on the parent environment name renders no cluster",
+			Config: config.EnvironmentConfig{
+				ArgoCdConfigs: &config.ArgoCDConfigs{
+					CommonEnvPrefix:      &aaPrefix,
+					ArgoCdConfigurations: []*config.EnvironmentConfigArgoCd{clusterConfig1, clusterConfig2},
+				},
+			},
+			RenderOptions: &argocd.RenderOptions{
+				RootAppFiltering: argocd.RootAppFiltering{Enabled: true, EnabledEnvironments: []types.EnvName{envName}},
+			},
+			ExpectedTargets: nil,
+		},
+		{
+			Name:   "root app filter with an empty list renders nothing",
+			Config: config.EnvironmentConfig{ArgoCd: legacyConfig},
+			RenderOptions: &argocd.RenderOptions{
+				RootAppFiltering: argocd.RootAppFiltering{Enabled: true, EnabledEnvironments: []types.EnvName{}},
+			},
+			ExpectedTargets: nil,
+		},
+		{
+			Name:   "disabled root app filter ignores the list of environments",
+			Config: config.EnvironmentConfig{ArgoCd: legacyConfig},
+			RenderOptions: &argocd.RenderOptions{
+				RootAppFiltering: argocd.RootAppFiltering{Enabled: false, EnabledEnvironments: []types.EnvName{"some-other-env"}},
+			},
+			ExpectedTargets: []*argocd.EnvironmentInfo{
+				{ArgoCDConfig: legacyConfig, CommonPrefix: "", ParentEnvironmentName: envName, IsAAEnv: false, ArgoProjectNameOverride: ""},
+			},
+		},
+		{
+			Name: "argo project name override is applied to the matching cluster only",
+			Config: config.EnvironmentConfig{
+				ArgoCdConfigs: &config.ArgoCDConfigs{
+					CommonEnvPrefix:      &aaPrefix,
+					ArgoCdConfigurations: []*config.EnvironmentConfigArgoCd{clusterConfig1, clusterConfig2},
+				},
+			},
+			ProjectNames: &argocd.AllArgoProjectNameOverrides{
+				ActiveActiveEnvironments: &argocd.ArgoProjectNamesPerEnv{"aa-staging-c1": "custom-project"},
+				Environments:             &argocd.ArgoProjectNamesPerEnv{},
+			},
+			ExpectedTargets: []*argocd.EnvironmentInfo{
+				{ArgoCDConfig: clusterConfig1, CommonPrefix: "aa", ParentEnvironmentName: envName, IsAAEnv: true, ArgoProjectNameOverride: "custom-project"},
+				{ArgoCDConfig: clusterConfig2, CommonPrefix: "aa", ParentEnvironmentName: envName, IsAAEnv: true, ArgoProjectNameOverride: ""},
+			},
+		},
+		{
+			Name: "overrides for normal environments are not applied to active/active environments",
+			Config: config.EnvironmentConfig{
+				ArgoCdConfigs: &config.ArgoCDConfigs{
+					CommonEnvPrefix:      &aaPrefix,
+					ArgoCdConfigurations: []*config.EnvironmentConfigArgoCd{clusterConfig1},
+				},
+			},
+			ProjectNames: &argocd.AllArgoProjectNameOverrides{
+				ActiveActiveEnvironments: &argocd.ArgoProjectNamesPerEnv{},
+				Environments:             &argocd.ArgoProjectNamesPerEnv{"aa-staging-c1": "wrong-project"},
+			},
+			ExpectedTargets: []*argocd.EnvironmentInfo{
+				{ArgoCDConfig: clusterConfig1, CommonPrefix: "aa", ParentEnvironmentName: envName, IsAAEnv: true, ArgoProjectNameOverride: ""},
+			},
+		},
+		{
+			Name:   "override of a normal environment is applied",
+			Config: config.EnvironmentConfig{ArgoCd: legacyConfig},
+			ProjectNames: &argocd.AllArgoProjectNameOverrides{
+				ActiveActiveEnvironments: &argocd.ArgoProjectNamesPerEnv{},
+				Environments:             &argocd.ArgoProjectNamesPerEnv{envName: "custom-project"},
+			},
+			ExpectedTargets: []*argocd.EnvironmentInfo{
+				{ArgoCDConfig: legacyConfig, CommonPrefix: "", ParentEnvironmentName: envName, IsAAEnv: false, ArgoProjectNameOverride: "custom-project"},
+			},
+		},
+		{
+			Name: "active/active environment without any cluster renders nothing",
+			Config: config.EnvironmentConfig{
+				ArgoCdConfigs: &config.ArgoCDConfigs{
+					CommonEnvPrefix:      &aaPrefix,
+					ArgoCdConfigurations: nil,
+				},
+			},
+			ExpectedTargets: nil,
+		},
+		{
+			Name:            "active/active environment without argoCdConfigs renders nothing",
+			Config:          config.EnvironmentConfig{IsActiveActive: &isActiveActive, ArgoCd: legacyConfig},
+			ExpectedTargets: nil,
+		},
+		{
+			Name:            "environment without any argoCd configuration renders nothing",
+			Config:          config.EnvironmentConfig{},
+			ExpectedTargets: nil,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			actualTargets := calculateRenderTargets(context.Background(), envName, tc.Config, tc.RenderOptions, tc.ProjectNames)
+			testutil.DiffOrFail(t, "render targets", tc.ExpectedTargets, actualTargets)
+		})
+	}
+}
+
 func TestArgoCDRootAppFilter(t *testing.T) {
 	tcs := []struct {
 		Name             string


### PR DESCRIPTION
Rev: [SRX-27YE0T](https://revolution.dev/app/-JqFGExX46gs9mH7vxR5/-M37cZx7XYoOvQ5Mmcir/STORY/-P-TtPQjgRdtAnqkjT3G/)