### PR TITLE
chore: add minor modification to trigger ci-run

### DIFF
--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -1133,6 +1133,7 @@ func collectArgoAppDataForEnv(
 	return appData, nil
 }
 
+// renderRootAppForCluster renders the argocd root app for one specific cluster in an environment.
 func (r *repository) renderRootAppForCluster(
 	ctx context.Context,
 	info *argocd.EnvironmentInfo,


### PR DESCRIPTION
Rev: [SRX-27YE0T](https://revolution.dev/app/-JqFGExX46gs9mH7vxR5/-M37cZx7XYoOvQ5Mmcir/STORY/-P-TtPQjgRdtAnqkjT3G/)

Previously the CD failed following merge and there seem to be issues with re-running the CD at the moment. So we trigger a completely new run with a small change as a temporary workaround.