### PR TITLE
fix(ci): commitlint with markdown and improved check

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Lint commit message
+      - name: Lint git commit message
         run: |
           make commitlint
         env:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -14,3 +14,14 @@ jobs:
           make commitlint
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Lint the commit message that squash-merge will create
+        run: |
+          # Squash merge is the only enabled merge method on this repo, and it builds
+          # the commit from the PR title and body - so that is what has to be linted.
+          # Pre-creating commitlint.msg makes the make target skip its `git log -1` recipe.
+          printf '%s (#%s)\n\n%s\n' "$PR_TITLE" "$PR_NUMBER" "$PR_BODY" > commitlint.msg
+          make commitlint
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,7 +5,7 @@ module.exports = {
       "header-min-length": [2, "always", 10],
       "subject-empty": [2, "never"],
       "subject-min-length": [2, "always", 10],
-      "type-enum": [2, "always", ['fix', 'feat', 'chore', 'revert']],
+      "type-enum": [2, "always", ['fix', 'feat']],
       "type-empty": [2, "never"],
   
       "body-max-line-length": [1, "never", 80],

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -41,12 +41,12 @@ module.exports = {
       rules: {
         'check-story-reference': ({body}) => {
           if (body === null) {
-            return [false, 'Commit message must contain a valid reference to a story'];
+            return [false, 'Commit message and PR description must contain a valid reference to a story'];
           }
           const REF_PATTERN = /Ref:\s*\[?SRX-[A-Z0-9]{6}/;
           return [
             REF_PATTERN.test(body),
-            'Commit message must contain a valid reference to a story, e.g. "Ref: SRX-ABCDEF"',
+            'Commit message and PR description must contain a valid reference to a story, e.g. "Ref: SRX-ABCDEF"',
           ];
         },
       },

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -43,11 +43,11 @@ module.exports = {
           if (body === null) {
             return [false, 'Commit message must contain a valid reference to a story'];
           }
-          const REF_PATTERN = /Ref: SRX-[A-Z0-9]{6}/;
-  	return [
-  	  REF_PATTERN.test(body),
-  	  'Commit message must contain a valid reference to a story',
-  	];
+          const REF_PATTERN = /Ref:\s*\[?SRX-[A-Z0-9]{6}/;
+          return [
+            REF_PATTERN.test(body),
+            'Commit message must contain a valid reference to a story, e.g. "Ref: SRX-ABCDEF"',
+          ];
         },
       },
     },

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,7 +5,7 @@ module.exports = {
       "header-min-length": [2, "always", 10],
       "subject-empty": [2, "never"],
       "subject-min-length": [2, "always", 10],
-      "type-enum": [2, "always", ['fix', 'feat']],
+      "type-enum": [2, "always", ['fix', 'feat', 'chore', 'revert']],
       "type-empty": [2, "never"],
   
       "body-max-line-length": [1, "never", 80],


### PR DESCRIPTION
The commitlint PR job now checks both the commit and the PR description. Previously it only checked the commit.

And we now allow the plain format (Ref: SRX...) as well as markdown format (Ref: [SRX...).

Ref: [SRX-7EX4MK](https://revolution.dev/app/-JqFGExX46gs9mH7vxR5/-M37cZx7XYoOvQ5Mmcir/STORY/-P-OmcNXokQ0FQ3BHkm6/)