### PR TITLE
fix: team name rendering in manifest-export

### DIFF
--- a/pkg/valid/validations.go
+++ b/pkg/valid/validations.go
@@ -42,6 +42,9 @@ const (
 	ArgoBracketNameRegExp    = AppNameRegExp
 	MaxArgoBracketNameLength = 63
 	MinArgoBracketNameLength = 1
+
+	MaxKubernetesLabelValueLength = 63
+	KubernetesLabelValueRegExp    = `\A[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?\z`
 )
 
 var (
@@ -52,6 +55,8 @@ var (
 	ArgoBracketNameRx = regexp.MustCompile(ArgoBracketNameRegExp)
 	commitIDPrefixRx  = regexp.MustCompile(commitIDPrefixRegExp)
 	MaxAppNameLen     = setupMaxAppNameLen()
+
+	kubernetesLabelValueRx = regexp.MustCompile(KubernetesLabelValueRegExp)
 )
 
 func setupMaxAppNameLen() int {
@@ -79,7 +84,6 @@ func ArgoBracketName(name types.ArgoBracketName) bool {
 }
 
 func TeamName(name string) bool {
-	// we use the team name in render.go as label and annotations which both have a limit of 63 characters:
 	return len(name) < 63 && teamNameRx.MatchString(name)
 }
 
@@ -245,4 +249,14 @@ func ReadEnvVarJsonMap(envName string) (StringMap, error) {
 		return nil, fmt.Errorf("failed to read env var '%s', not a valid string-map", envName)
 	}
 	return resultJson, nil
+}
+
+// KubernetesLabelValue reports whether value may be used as a kubernetes label value.
+// The empty string is valid; a value with a leading or trailing "_" is not.
+// See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+func KubernetesLabelValue(value string) bool {
+	if value == "" {
+		return true
+	}
+	return len(value) <= MaxKubernetesLabelValueLength && kubernetesLabelValueRx.MatchString(value)
 }

--- a/pkg/valid/validations_test.go
+++ b/pkg/valid/validations_test.go
@@ -1,0 +1,73 @@
+/*This file is part of kuberpult.
+
+Kuberpult is free software: you can redistribute it and/or modify
+it under the terms of the Expat(MIT) License as published by
+the Free Software Foundation.
+
+Kuberpult is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MIT License for more details.
+
+You should have received a copy of the MIT License
+along with kuberpult. If not, see <https://directory.fsf.org/wiki/License:Expat>.
+
+Copyright freiheit.com*/
+
+package valid
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidLabel(t *testing.T) {
+	tcs := []struct {
+		Name           string
+		InputLabel     string
+		ExpectedResult bool
+	}{
+		{
+			Name:           "empty",
+			InputLabel:     "",
+			ExpectedResult: true,
+		},
+		{
+			Name:           "start with underscore",
+			InputLabel:     "_foo",
+			ExpectedResult: false,
+		},
+		{
+			Name:           "end with underscore",
+			InputLabel:     "foo_",
+			ExpectedResult: false,
+		},
+		{
+			Name:           "underscore in the middle",
+			InputLabel:     "foo_bar",
+			ExpectedResult: true,
+		},
+		{
+			Name:           "exactly full",
+			InputLabel:     strings.Repeat("x", 63),
+			ExpectedResult: true,
+		},
+		{
+			Name:           "too much",
+			InputLabel:     strings.Repeat("x", 64),
+			ExpectedResult: false,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := KubernetesLabelValue(tc.InputLabel)
+
+			if actual != tc.ExpectedResult {
+				t.Errorf("Expected %v, got %v for input %s", tc.ExpectedResult, actual, tc.InputLabel)
+			}
+
+		})
+	}
+}

--- a/services/manifest-repo-export-service/pkg/argocd/render.go
+++ b/services/manifest-repo-export-service/pkg/argocd/render.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/freiheit-com/kuberpult/pkg/config"
 	"github.com/freiheit-com/kuberpult/pkg/types"
+	"github.com/freiheit-com/kuberpult/pkg/valid"
 	"github.com/freiheit-com/kuberpult/services/manifest-repo-export-service/pkg/argocd/v1alpha1"
 )
 
@@ -47,6 +48,8 @@ type RootAppFiltering struct {
 type ApiVersion string
 
 const V1Alpha1 ApiVersion = "v1alpha1"
+
+const LabelKeyTeam = "com.freiheit.kuberpult/team"
 
 type AppData struct {
 	ArgoAppName        string   // name of the bracket if bracket mode is on
@@ -220,11 +223,9 @@ func RenderAppEnv(
 			manifestPathsArgoFormat = manifestPathsArgoFormat + manifestPathToArgoFormat(manifestPath)
 		}
 	}
-	teamsAnnotation := generateTeamNameAnnotationValue(teamNames)
 	for k, v := range applicationAnnotations {
 		annotations[k] = v
 	}
-	annotations["com.freiheit.kuberpult/teams"] = teamsAnnotation
 	annotations["com.freiheit.kuberpult/application"] = name
 	annotations["com.freiheit.kuberpult/environment"] = info.GetFullyQualifiedName()
 	annotations["com.freiheit.kuberpult/aa-parent-environment"] = string(info.ParentEnvironmentName)
@@ -232,7 +233,12 @@ func RenderAppEnv(
 	// It has to start with a "/" to be absolute to the git repo.
 	// See https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#webhook-and-manifest-paths-annotation
 	annotations["argocd.argoproj.io/manifest-generate-paths"] = manifestPathsArgoFormat
-	labels["com.freiheit.kuberpult/teams"] = teamsAnnotation
+	teamsLabel := generateTeamNameLabelValue(teamNames)
+	if valid.KubernetesLabelValue(teamsLabel) {
+		labels[LabelKeyTeam] = teamsLabel
+	} else {
+		labels[LabelKeyTeam] = ""
+	}
 	app := v1alpha1.Application{
 		TypeMeta: v1alpha1.ApplicationTypeMeta,
 		ObjectMeta: v1alpha1.ObjectMeta{
@@ -272,9 +278,16 @@ func manifestPathToArgoFormat(path string) string {
 	return "/" + path + ";"
 }
 
-func generateTeamNameAnnotationValue(teamNames []string) string {
+// generateTeamNameLabelValue joins the teams of all apps in this argo app into one
+// label value. Apps without a team contribute an empty string, which we drop here,
+// because otherwise the joined value starts with "_", which is not a valid
+// kubernetes label value.
+func generateTeamNameLabelValue(teamNames []string) string {
 	slices.Sort(teamNames)                // sort both for convenience and to allow Compact to work
-	teamNames = slices.Compact(teamNames) // like "uniq" remove duplicates that are next to each other
+	teamNames = slices.Compact(teamNames) // remove duplicates that are next to each other
+	teamNames = slices.DeleteFunc(teamNames, func(teamName string) bool {
+		return teamName == ""
+	})
 	return strings.Join(teamNames, "_")
 }
 

--- a/services/manifest-repo-export-service/pkg/argocd/render.go
+++ b/services/manifest-repo-export-service/pkg/argocd/render.go
@@ -49,7 +49,7 @@ type ApiVersion string
 
 const V1Alpha1 ApiVersion = "v1alpha1"
 
-const LabelKeyTeam = "com.freiheit.kuberpult/team"
+const LabelAnnotationKeyTeam = "com.freiheit.kuberpult/teams"
 
 type AppData struct {
 	ArgoAppName        string   // name of the bracket if bracket mode is on
@@ -223,9 +223,11 @@ func RenderAppEnv(
 			manifestPathsArgoFormat = manifestPathsArgoFormat + manifestPathToArgoFormat(manifestPath)
 		}
 	}
+	teamsAnnotation := generateTeamNameAnnotationValue(teamNames)
 	for k, v := range applicationAnnotations {
 		annotations[k] = v
 	}
+	annotations[LabelAnnotationKeyTeam] = teamsAnnotation
 	annotations["com.freiheit.kuberpult/application"] = name
 	annotations["com.freiheit.kuberpult/environment"] = info.GetFullyQualifiedName()
 	annotations["com.freiheit.kuberpult/aa-parent-environment"] = string(info.ParentEnvironmentName)
@@ -235,9 +237,9 @@ func RenderAppEnv(
 	annotations["argocd.argoproj.io/manifest-generate-paths"] = manifestPathsArgoFormat
 	teamsLabel := generateTeamNameLabelValue(teamNames)
 	if valid.KubernetesLabelValue(teamsLabel) {
-		labels[LabelKeyTeam] = teamsLabel
+		labels[LabelAnnotationKeyTeam] = teamsLabel
 	} else {
-		labels[LabelKeyTeam] = ""
+		labels[LabelAnnotationKeyTeam] = ""
 	}
 	app := v1alpha1.Application{
 		TypeMeta: v1alpha1.ApplicationTypeMeta,
@@ -278,17 +280,27 @@ func manifestPathToArgoFormat(path string) string {
 	return "/" + path + ";"
 }
 
+func generateTeamNameAnnotationValue(teamNames []string) string {
+	teamNames = slices.Clone(teamNames)   // do not mutate the callers slice
+	slices.Sort(teamNames)                // sort both for convenience and to allow Compact to work
+	teamNames = slices.Compact(teamNames) // like "uniq" remove duplicates that are next to each other
+	return strings.Join(teamNames, "_")
+}
+
 // generateTeamNameLabelValue joins the teams of all apps in this argo app into one
 // label value. Apps without a team contribute an empty string, which we drop here,
 // because otherwise the joined value starts with "_", which is not a valid
 // kubernetes label value.
 func generateTeamNameLabelValue(teamNames []string) string {
-	slices.Sort(teamNames)                // sort both for convenience and to allow Compact to work
-	teamNames = slices.Compact(teamNames) // remove duplicates that are next to each other
+	teamNames = slices.Clone(teamNames) // do not mutate the callers slice
 	teamNames = slices.DeleteFunc(teamNames, func(teamName string) bool {
 		return teamName == ""
 	})
-	return strings.Join(teamNames, "_")
+	annotation := generateTeamNameAnnotationValue(teamNames)
+	if !valid.KubernetesLabelValue(annotation) {
+		return ""
+	}
+	return annotation
 }
 
 // generateSources returns either one ApplicationSource for backwards compatibility with old argo setups

--- a/services/manifest-repo-export-service/pkg/argocd/render.go
+++ b/services/manifest-repo-export-service/pkg/argocd/render.go
@@ -49,7 +49,7 @@ type ApiVersion string
 
 const V1Alpha1 ApiVersion = "v1alpha1"
 
-const LabelAnnotationKeyTeam = "com.freiheit.kuberpult/teams"
+const LabelAnnotationKeyTeams = "com.freiheit.kuberpult/teams"
 
 type AppData struct {
 	ArgoAppName        string   // name of the bracket if bracket mode is on
@@ -227,7 +227,7 @@ func RenderAppEnv(
 	for k, v := range applicationAnnotations {
 		annotations[k] = v
 	}
-	annotations[LabelAnnotationKeyTeam] = teamsAnnotation
+	annotations[LabelAnnotationKeyTeams] = teamsAnnotation
 	annotations["com.freiheit.kuberpult/application"] = name
 	annotations["com.freiheit.kuberpult/environment"] = info.GetFullyQualifiedName()
 	annotations["com.freiheit.kuberpult/aa-parent-environment"] = string(info.ParentEnvironmentName)
@@ -235,12 +235,7 @@ func RenderAppEnv(
 	// It has to start with a "/" to be absolute to the git repo.
 	// See https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#webhook-and-manifest-paths-annotation
 	annotations["argocd.argoproj.io/manifest-generate-paths"] = manifestPathsArgoFormat
-	teamsLabel := generateTeamNameLabelValue(teamNames)
-	if valid.KubernetesLabelValue(teamsLabel) {
-		labels[LabelAnnotationKeyTeam] = teamsLabel
-	} else {
-		labels[LabelAnnotationKeyTeam] = ""
-	}
+	labels[LabelAnnotationKeyTeams] = generateTeamNameLabelValue(teamNames)
 	app := v1alpha1.Application{
 		TypeMeta: v1alpha1.ApplicationTypeMeta,
 		ObjectMeta: v1alpha1.ObjectMeta{

--- a/services/manifest-repo-export-service/pkg/argocd/render_test.go
+++ b/services/manifest-repo-export-service/pkg/argocd/render_test.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	godebug "github.com/kylelemons/godebug/diff"
 
 	"github.com/freiheit-com/kuberpult/pkg/config"
 	"github.com/freiheit-com/kuberpult/pkg/conversion"
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
 	"github.com/freiheit-com/kuberpult/services/manifest-repo-export-service/pkg/argocd/v1alpha1"
 )
 
@@ -47,11 +47,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: dev
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: dev
-    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: ""
+    com.freiheit.kuberpult/team: ""
   name: dev-app1
 spec:
   destination: {}
@@ -98,11 +97,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: dev
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: dev
-    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: ""
+    com.freiheit.kuberpult/team: ""
   name: dev-app1
 spec:
   destination: {}
@@ -149,11 +147,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: dev
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: dev
-    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: ""
+    com.freiheit.kuberpult/team: ""
   name: dev-app1
 spec:
   destination:
@@ -201,11 +198,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: dev
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: AA-dev-dev-1
-    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: ""
+    com.freiheit.kuberpult/team: ""
   name: AA-dev-dev-1-app1
 spec:
   destination:
@@ -254,11 +250,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: dev
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: dev
-    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: ""
+    com.freiheit.kuberpult/team: ""
   name: dev-app1
 spec:
   destination: {}
@@ -462,11 +457,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: test-env
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
-    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: ""
+    com.freiheit.kuberpult/team: ""
   name: test-env-app1
 spec:
   destination:
@@ -519,11 +513,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: test-env
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
-    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: ""
+    com.freiheit.kuberpult/team: ""
   name: test-env-app1
 spec:
   destination: {}
@@ -644,11 +637,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: test-env
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
-    com.freiheit.kuberpult/teams: some-team
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: some-team
+    com.freiheit.kuberpult/team: some-team
   name: test-env-app1
 spec:
   destination: {}
@@ -701,11 +693,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: test-env
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: AA-test-env-dev-1
-    com.freiheit.kuberpult/teams: some-team
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: some-team
+    com.freiheit.kuberpult/team: some-team
   name: AA-test-env-dev-1-app1
 spec:
   destination: {}
@@ -758,15 +749,126 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: test-env
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
-    com.freiheit.kuberpult/teams: team1_team2
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: team1_team2
+    com.freiheit.kuberpult/team: team1_team2
   name: test-env-app1
 spec:
   destination:
     namespace: bar2
+  project: test-env
+  sources:
+  - path: environments/test-env/brackets/app1
+    repoURL: https://git.example.com/
+    targetRevision: branch-name
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+`,
+		},
+		{
+			name: "with team name plus empty team will not produce leading underscore",
+			config: config.EnvironmentConfig{
+				ArgoCd: &config.EnvironmentConfigArgoCd{
+					Destination: config.ArgoCdDestination{
+						Namespace:            nil,
+						AppProjectNamespace:  conversion.FromString("bar1"),
+						ApplicationNamespace: nil,
+					},
+				},
+			},
+			appData: []AppData{
+				{
+					ArgoAppName:        "app1",
+					ReferencedAppTeams: []string{"", "some-team"},
+				},
+			},
+			pointToBrackets: true,
+			want: `apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: test-env
+spec:
+  description: test-env
+  destinations:
+  - namespace: bar1
+  sourceRepos:
+  - '*'
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/test-env/brackets/app1;
+    com.freiheit.kuberpult/aa-parent-environment: test-env
+    com.freiheit.kuberpult/application: app1
+    com.freiheit.kuberpult/environment: test-env
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  labels:
+    com.freiheit.kuberpult/team: some-team
+  name: test-env-app1
+spec:
+  destination: {}
+  project: test-env
+  sources:
+  - path: environments/test-env/brackets/app1
+    repoURL: https://git.example.com/
+    targetRevision: branch-name
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+`,
+		},
+		{
+			name: "empty string for teams label if they are too long",
+			config: config.EnvironmentConfig{
+				ArgoCd: &config.EnvironmentConfigArgoCd{
+					Destination: config.ArgoCdDestination{
+						Namespace:            nil,
+						AppProjectNamespace:  conversion.FromString("bar1"),
+						ApplicationNamespace: nil,
+					},
+				},
+			},
+			appData: []AppData{
+				{
+					ArgoAppName:        "app1",
+					ReferencedAppTeams: []string{"t123456789", "u123456789", "v123456789", "w123456789", "x123456789", "z123456789", "z123456789"},
+				},
+			},
+			pointToBrackets: true,
+			want: `apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: test-env
+spec:
+  description: test-env
+  destinations:
+  - namespace: bar1
+  sourceRepos:
+  - '*'
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/manifest-generate-paths: /environments/test-env/brackets/app1;
+    com.freiheit.kuberpult/aa-parent-environment: test-env
+    com.freiheit.kuberpult/application: app1
+    com.freiheit.kuberpult/environment: test-env
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  labels:
+    com.freiheit.kuberpult/team: ""
+  name: test-env-app1
+spec:
+  destination: {}
   project: test-env
   sources:
   - path: environments/test-env/brackets/app1
@@ -799,7 +901,7 @@ spec:
 				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if d := cmp.Diff(tt.want, string(got)); d != "" {
+			if d := testutil.CmpDiff[string](tt.want, string(got)); d != "" {
 				t.Errorf("mismatch: %s", d)
 			}
 		})

--- a/services/manifest-repo-export-service/pkg/argocd/render_test.go
+++ b/services/manifest-repo-export-service/pkg/argocd/render_test.go
@@ -18,6 +18,7 @@ package argocd
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	godebug "github.com/kylelemons/godebug/diff"
@@ -47,10 +48,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: dev
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: dev
+    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: ""
+    com.freiheit.kuberpult/teams: ""
   name: dev-app1
 spec:
   destination: {}
@@ -97,10 +99,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: dev
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: dev
+    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: ""
+    com.freiheit.kuberpult/teams: ""
   name: dev-app1
 spec:
   destination: {}
@@ -147,10 +150,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: dev
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: dev
+    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: ""
+    com.freiheit.kuberpult/teams: ""
   name: dev-app1
 spec:
   destination:
@@ -198,10 +202,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: dev
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: AA-dev-dev-1
+    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: ""
+    com.freiheit.kuberpult/teams: ""
   name: AA-dev-dev-1-app1
 spec:
   destination:
@@ -250,10 +255,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: dev
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: dev
+    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: ""
+    com.freiheit.kuberpult/teams: ""
   name: dev-app1
 spec:
   destination: {}
@@ -457,10 +463,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: test-env
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
+    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: ""
+    com.freiheit.kuberpult/teams: ""
   name: test-env-app1
 spec:
   destination:
@@ -513,10 +520,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: test-env
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
+    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: ""
+    com.freiheit.kuberpult/teams: ""
   name: test-env-app1
 spec:
   destination: {}
@@ -637,10 +645,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: test-env
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
+    com.freiheit.kuberpult/teams: some-team
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: some-team
+    com.freiheit.kuberpult/teams: some-team
   name: test-env-app1
 spec:
   destination: {}
@@ -693,10 +702,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: test-env
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: AA-test-env-dev-1
+    com.freiheit.kuberpult/teams: some-team
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: some-team
+    com.freiheit.kuberpult/teams: some-team
   name: AA-test-env-dev-1-app1
 spec:
   destination: {}
@@ -749,10 +759,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: test-env
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
+    com.freiheit.kuberpult/teams: team1_team2
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: team1_team2
+    com.freiheit.kuberpult/teams: team1_team2
   name: test-env-app1
 spec:
   destination:
@@ -806,10 +817,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: test-env
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
+    com.freiheit.kuberpult/teams: _some-team
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: some-team
+    com.freiheit.kuberpult/teams: some-team
   name: test-env-app1
 spec:
   destination: {}
@@ -826,7 +838,7 @@ spec:
 `,
 		},
 		{
-			name: "empty string for teams label if they are too long",
+			name: "empty string for teams label if they are too long, but annotation keeps full value",
 			config: config.EnvironmentConfig{
 				ArgoCd: &config.EnvironmentConfigArgoCd{
 					Destination: config.ArgoCdDestination{
@@ -862,10 +874,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: test-env
     com.freiheit.kuberpult/application: app1
     com.freiheit.kuberpult/environment: test-env
+    com.freiheit.kuberpult/teams: t123456789_u123456789_v123456789_w123456789_x123456789_z123456789
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: ""
+    com.freiheit.kuberpult/teams: ""
   name: test-env-app1
 spec:
   destination: {}
@@ -903,6 +916,45 @@ spec:
 			}
 			if d := testutil.CmpDiff[string](tt.want, string(got)); d != "" {
 				t.Errorf("mismatch: %s", d)
+			}
+		})
+	}
+}
+
+func TestAnnotationAndLabel(t *testing.T) {
+	tests := []struct {
+		name               string
+		InputTeamNames     []string
+		ExpectedLabel      string
+		ExpectedAnnotation string
+	}{
+		{
+			name:               "simple case",
+			InputTeamNames:     []string{"foo"},
+			ExpectedLabel:      "foo",
+			ExpectedAnnotation: "foo",
+		},
+		{
+			name:               "deletion case",
+			InputTeamNames:     []string{"foo", "", "bar"},
+			ExpectedLabel:      "bar_foo",
+			ExpectedAnnotation: "_bar_foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectedTeamNames := slices.Clone(tt.InputTeamNames)
+			actualAnnotation := generateTeamNameAnnotationValue(tt.InputTeamNames)
+			actualLabel := generateTeamNameLabelValue(tt.InputTeamNames)
+
+			if d := testutil.CmpDiff[[]string](expectedTeamNames, tt.InputTeamNames); d != "" {
+				t.Errorf("function changed its slice parameter: %s", d)
+			}
+			if d := testutil.CmpDiff[string](tt.ExpectedLabel, actualLabel); d != "" {
+				t.Errorf("label mismatch: %s", d)
+			}
+			if d := testutil.CmpDiff[string](tt.ExpectedAnnotation, actualAnnotation); d != "" {
+				t.Errorf("annotation mismatch: %s", d)
 			}
 		})
 	}

--- a/services/manifest-repo-export-service/pkg/repository/repository_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository_test.go
@@ -1856,10 +1856,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: production
     com.freiheit.kuberpult/application: test
     com.freiheit.kuberpult/environment: production
+    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: ""
+    com.freiheit.kuberpult/teams: ""
   name: production-test
 spec:
   destination:
@@ -1998,10 +1999,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: production
     com.freiheit.kuberpult/application: test
     com.freiheit.kuberpult/environment: production
+    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: ""
+    com.freiheit.kuberpult/teams: ""
   name: production-test
 spec:
   destination:

--- a/services/manifest-repo-export-service/pkg/repository/repository_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository_test.go
@@ -1308,11 +1308,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: %s
     com.freiheit.kuberpult/application: %s
     com.freiheit.kuberpult/environment: %s
-    com.freiheit.kuberpult/teams: %s
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: %s
+    com.freiheit.kuberpult/team: %s
   name: %s-%s
 spec:
   destination:
@@ -1328,7 +1327,7 @@ spec:
       allowEmpty: true
       prune: true
       selfHeal: true
-`, envName, appName, envName, appName, fullyQualifiedName, teamName, teamName, fullyQualifiedName, appName,
+`, envName, appName, envName, appName, fullyQualifiedName, teamName, fullyQualifiedName, appName,
 			destinationName, destinationServer, argoProjectName, envName, appName)
 	}
 	// rootApp joins the documents of one root app file the same way argocd.Render does.
@@ -1545,11 +1544,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: %s
     com.freiheit.kuberpult/application: %s
     com.freiheit.kuberpult/environment: %s
-    com.freiheit.kuberpult/teams: %s
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: %s
+    com.freiheit.kuberpult/team: %s
   name: %s-%s
 spec:
   destination:
@@ -1565,7 +1563,7 @@ spec:
       allowEmpty: true
       prune: true
       selfHeal: true
-`, envName, bracket, envName, bracket, envName, teamNames, teamNames, envName, bracket,
+`, envName, bracket, envName, bracket, envName, teamNames, envName, bracket,
 			destinationName, destinationServer, envName, envName, bracket)
 	}
 	// application renders one Application document that points at a single app's manifests directory,
@@ -1579,11 +1577,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: %s
     com.freiheit.kuberpult/application: %s
     com.freiheit.kuberpult/environment: %s
-    com.freiheit.kuberpult/teams: %s
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: %s
+    com.freiheit.kuberpult/team: %s
   name: %s-%s
 spec:
   destination:
@@ -1599,7 +1596,7 @@ spec:
       allowEmpty: true
       prune: true
       selfHeal: true
-`, envName, appName, envName, appName, envName, teamName, teamName, envName, appName,
+`, envName, appName, envName, appName, envName, teamName, envName, appName,
 			destinationName, destinationServer, envName, envName, appName)
 	}
 	// rootApp joins the documents of one root app file the same way argocd.Render does.
@@ -1859,11 +1856,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: production
     com.freiheit.kuberpult/application: test
     com.freiheit.kuberpult/environment: production
-    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: ""
+    com.freiheit.kuberpult/team: ""
   name: production-test
 spec:
   destination:
@@ -2002,11 +1998,10 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: production
     com.freiheit.kuberpult/application: test
     com.freiheit.kuberpult/environment: production
-    com.freiheit.kuberpult/teams: ""
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/teams: ""
+    com.freiheit.kuberpult/team: ""
   name: production-test
 spec:
   destination:

--- a/services/manifest-repo-export-service/pkg/repository/repository_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository_test.go
@@ -1308,10 +1308,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: %s
     com.freiheit.kuberpult/application: %s
     com.freiheit.kuberpult/environment: %s
+    com.freiheit.kuberpult/teams: %s
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: %s
+    com.freiheit.kuberpult/teams: %s
   name: %s-%s
 spec:
   destination:
@@ -1327,7 +1328,7 @@ spec:
       allowEmpty: true
       prune: true
       selfHeal: true
-`, envName, appName, envName, appName, fullyQualifiedName, teamName, fullyQualifiedName, appName,
+`, envName, appName, envName, appName, fullyQualifiedName, teamName, teamName, fullyQualifiedName, appName,
 			destinationName, destinationServer, argoProjectName, envName, appName)
 	}
 	// rootApp joins the documents of one root app file the same way argocd.Render does.

--- a/services/manifest-repo-export-service/pkg/repository/repository_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository_test.go
@@ -1544,10 +1544,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: %s
     com.freiheit.kuberpult/application: %s
     com.freiheit.kuberpult/environment: %s
+    com.freiheit.kuberpult/teams: %s
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: %s
+    com.freiheit.kuberpult/teams: %s
   name: %s-%s
 spec:
   destination:
@@ -1563,7 +1564,7 @@ spec:
       allowEmpty: true
       prune: true
       selfHeal: true
-`, envName, bracket, envName, bracket, envName, teamNames, envName, bracket,
+`, envName, bracket, envName, bracket, envName, teamNames, teamNames, envName, bracket,
 			destinationName, destinationServer, envName, envName, bracket)
 	}
 	// application renders one Application document that points at a single app's manifests directory,
@@ -1577,10 +1578,11 @@ metadata:
     com.freiheit.kuberpult/aa-parent-environment: %s
     com.freiheit.kuberpult/application: %s
     com.freiheit.kuberpult/environment: %s
+    com.freiheit.kuberpult/teams: %s
   finalizers:
   - resources-finalizer.argocd.argoproj.io
   labels:
-    com.freiheit.kuberpult/team: %s
+    com.freiheit.kuberpult/teams: %s
   name: %s-%s
 spec:
   destination:
@@ -1596,7 +1598,7 @@ spec:
       allowEmpty: true
       prune: true
       selfHeal: true
-`, envName, appName, envName, appName, envName, teamName, envName, appName,
+`, envName, appName, envName, appName, envName, teamName, teamName, envName, appName,
 			destinationName, destinationServer, envName, envName, appName)
 	}
 	// rootApp joins the documents of one root app file the same way argocd.Render does.


### PR DESCRIPTION
This fixes an issue where the manifest-export rendered a label that has a value starting with "_" which is invalid according to kubernetes.

Ref: SRX-UG5WLO