### PR TITLE
fix: add metrics for queue input/output and fix 1-off

### DIFF
--- a/pkg/db/cutoff_test.go
+++ b/pkg/db/cutoff_test.go
@@ -21,10 +21,13 @@ import (
 	"database/sql"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
 	"github.com/freiheit-com/kuberpult/pkg/testutilauth"
+	"github.com/freiheit-com/kuberpult/pkg/types"
 )
 
 // For testing purposes only
@@ -49,7 +52,6 @@ func TestTransformerWritesEslDataRoundTrip(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutilauth.MakeTestContext()
@@ -89,6 +91,96 @@ func TestTransformerWritesEslDataRoundTrip(t *testing.T) {
 				}
 
 				if diff := cmp.Diff(tc.ExpectedEslVersion, *actual); diff != "" {
+					t.Fatalf("error mismatch (-want, +got):\n%s", diff)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("transaction error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGetCurrentDelays(t *testing.T) {
+	tcs := []struct {
+		Name                 string
+		NumEvents            int
+		Cutoff               *EslVersion // nil = no cutoff written yet
+		ExpectedDelayEvents  uint64
+		ExpectedDelaySeconds float64
+	}{
+		{
+			Name:                 "empty table",
+			NumEvents:            0,
+			Cutoff:               nil,
+			ExpectedDelayEvents:  0,
+			ExpectedDelaySeconds: 0,
+		},
+		{
+			Name:                 "single event, no cutoff",
+			NumEvents:            1,
+			Cutoff:               nil,
+			ExpectedDelayEvents:  1,
+			ExpectedDelaySeconds: 90,
+		},
+		{
+			Name:                 "no cutoff yet counts everything",
+			NumEvents:            3,
+			Cutoff:               nil,
+			ExpectedDelayEvents:  3,
+			ExpectedDelaySeconds: 90,
+		},
+		{
+			Name:                 "exactly one event left",
+			NumEvents:            3,
+			Cutoff:               types.Ptr(EslVersion(2)),
+			ExpectedDelayEvents:  1,
+			ExpectedDelaySeconds: 90,
+		},
+		{
+			Name:                 "fully caught up",
+			NumEvents:            3,
+			Cutoff:               types.Ptr(EslVersion(3)),
+			ExpectedDelayEvents:  0,
+			ExpectedDelaySeconds: 0,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutilauth.MakeTestContext()
+
+			dbHandler := setupDB(t)
+
+			err := dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
+				tf := EmptyTransformer{} // we don't care which transformer it is
+				for i := 0; i < tc.NumEvents; i++ {
+					err := dbHandler.DBWriteEslEventInternal(ctx, "empty", transaction, tf, ESLMetadata{})
+					if err != nil {
+						return err
+					}
+				}
+				if tc.Cutoff != nil {
+					err := DBWriteCutoff(dbHandler, ctx, transaction, *tc.Cutoff)
+					if err != nil {
+						return err
+					}
+				}
+
+				// all writes in this transaction share one timestamp, so the age is exact
+				created, err := dbHandler.DBReadTransactionTimestamp(ctx, transaction)
+				if err != nil {
+					return err
+				}
+				delaySeconds, delayEvents, err := dbHandler.GetCurrentDelays(ctx, transaction, created.Add(90*time.Second))
+				if err != nil {
+					return err
+				}
+				if diff := testutil.CmpDiff(tc.ExpectedDelayEvents, delayEvents); diff != "" {
+					t.Fatalf("error mismatch (-want, +got):\n%s", diff)
+				}
+				if diff := testutil.CmpDiff(tc.ExpectedDelaySeconds, delaySeconds); diff != "" {
 					t.Fatalf("error mismatch (-want, +got):\n%s", diff)
 				}
 				return nil

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -399,6 +399,11 @@ func convertObjectToMap(obj interface{}) (map[string]interface{}, error) {
 	return result, nil
 }
 
+type EslEventRowBare struct {
+	EslVersion EslVersion
+	Created    time.Time
+}
+
 type EslEventRow struct {
 	EslVersion EslVersion
 	Created    time.Time
@@ -415,6 +420,36 @@ type EslFailedEventRow struct {
 	EventJson             string
 	Reason                string
 	TransformerEslVersion EslVersion
+}
+
+func DBReadMaxEslVersion(h *DBHandler, ctx context.Context, tx *sql.Tx) (EslVersion, error) {
+	selectQuery := h.AdaptQuery(`
+		SELECT COALESCE(MAX(eslVersion), 0) -- maximum, or 0 if no entries found
+		FROM ` + eslTable + ";",
+	)
+	rows, err := tx.QueryContext(
+		ctx,
+		selectQuery,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("readmax: could not query esl table from DB. Error: %w", err)
+	}
+	defer closeRowsAndLog(rows, ctx, "DBReadMaxEslVersion")
+
+	var eslVersion EslVersion = 0
+	if !rows.Next() {
+		return 0, fmt.Errorf("readmax: query did not return any row")
+	}
+	err = rows.Scan(&eslVersion)
+	if err != nil {
+		// sql.ErrNoRows cannot happen, the query itself guarantees one row
+		return 0, fmt.Errorf("readmax: Error scanning row from DB. Error: %w", err)
+	}
+	err = rows.Err()
+	if err != nil {
+		return 0, fmt.Errorf("readmax: row has error: %v", err)
+	}
+	return eslVersion, nil
 }
 
 // DBReadEslEventInternal returns either the first or the last row of the esl table
@@ -464,10 +499,10 @@ func (h *DBHandler) DBReadEslEventInternal(ctx context.Context, tx *sql.Tx, firs
 }
 
 // DBReadEslEventLaterThan returns the first row of the esl table that has an eslVersion > the given eslVersion
-func (h *DBHandler) DBReadEslEventLaterThan(ctx context.Context, tx *sql.Tx, eslVersion EslVersion) (_ *EslEventRow, err error) {
+func (h *DBHandler) DBReadEslEventLaterThan(ctx context.Context, tx *sql.Tx, eslVersion EslVersion) (_ *EslEventRowBare, err error) {
 	sort := "ASC"
 	selectQuery := h.AdaptQuery(fmt.Sprintf(`
-		SELECT eslVersion, created, event_type, json, trace_id, span_id
+		SELECT eslVersion, created
 		FROM `+eslTable+`
 		WHERE eslVersion > (?)
 		ORDER BY eslVersion %s
@@ -482,20 +517,14 @@ func (h *DBHandler) DBReadEslEventLaterThan(ctx context.Context, tx *sql.Tx, esl
 		return nil, fmt.Errorf("could not query event_sourcing_light table from DB. Error: %w", err)
 	}
 	defer closeRowsAndLog(rows, ctx, "DBReadEslEventLaterThan")
-	zeroTrace := uint64(0)
-	zeroSpan := uint64(0)
-	var row = &EslEventRow{
+	var row = &EslEventRowBare{
 		EslVersion: 0,
 		Created:    time.Unix(0, 0),
-		EventType:  "",
-		EventJson:  "",
-		TraceId:    &zeroTrace,
-		SpanId:     &zeroSpan,
 	}
 	if !rows.Next() {
 		row = nil
 	} else {
-		err := rows.Scan(&row.EslVersion, &row.Created, &row.EventType, &row.EventJson, &row.TraceId, &row.SpanId)
+		err := rows.Scan(&row.EslVersion, &row.Created)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return nil, nil
@@ -564,7 +593,7 @@ func (h *DBHandler) DBReadEslEventBatch(ctx context.Context, tx *sql.Tx, cutoff 
 	return result, nil
 }
 
-func (h *DBHandler) DBReadEslEvent(ctx context.Context, transaction *sql.Tx, eslVersion *EslVersion) (*EslEventRow, error) {
+func (h *DBHandler) DBReadEslEventBare(ctx context.Context, transaction *sql.Tx, eslVersion *EslVersion) (*EslEventRowBare, error) {
 	if eslVersion == nil {
 		logging.Info(ctx, "no cutoff found, starting at the beginning of time.")
 		// no read cutoff yet, we have to start from the beginning
@@ -575,7 +604,10 @@ func (h *DBHandler) DBReadEslEvent(ctx context.Context, transaction *sql.Tx, esl
 		if esl == nil {
 			return nil, nil
 		}
-		return esl, nil
+		return &EslEventRowBare{
+			EslVersion: esl.EslVersion,
+			Created:    esl.Created,
+		}, nil
 	} else {
 		esl, err := h.DBReadEslEventLaterThan(ctx, transaction, *eslVersion)
 		if err != nil {
@@ -584,12 +616,12 @@ func (h *DBHandler) DBReadEslEvent(ctx context.Context, transaction *sql.Tx, esl
 		return esl, nil
 	}
 }
-func (h *DBHandler) DBCountEslEventsNewer(ctx context.Context, tx *sql.Tx, eslVersion EslVersion) (_ uint64, err error) {
+func (h *DBHandler) DBCountEslEventsFrom(ctx context.Context, tx *sql.Tx, eslVersion EslVersion) (_ uint64, err error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "DBCountEslEventsNewer")
 	defer func() {
 		span.Finish(tracer.WithError(err))
 	}()
-	countQuery := h.AdaptQuery("SELECT COUNT(*) FROM " + eslTable + " WHERE eslVersion > ?;")
+	countQuery := h.AdaptQuery("SELECT COUNT(*) FROM " + eslTable + " WHERE eslVersion >= ?;")
 	rows, err := tx.QueryContext(
 		ctx,
 		countQuery,
@@ -2080,12 +2112,12 @@ func (h *DBHandler) DBReadCommitHashTransactionTimestamp(ctx context.Context, tx
 	return timestamp, nil
 }
 
-func (h *DBHandler) GetCurrentDelays(ctx context.Context, transaction *sql.Tx) (float64, uint64, error) {
+func (h *DBHandler) GetCurrentDelays(ctx context.Context, transaction *sql.Tx, now time.Time) (float64, uint64, error) {
 	eslVersion, err := DBReadCutoff(h, ctx, transaction)
 	if err != nil {
 		return math.MaxFloat64, math.MaxUint64, err
 	}
-	esl, err := h.DBReadEslEvent(ctx, transaction, eslVersion)
+	esl, err := h.DBReadEslEventBare(ctx, transaction, eslVersion)
 	if err != nil {
 		return math.MaxFloat64, math.MaxUint64, err
 	}
@@ -2096,11 +2128,10 @@ func (h *DBHandler) GetCurrentDelays(ctx context.Context, transaction *sql.Tx) (
 	if esl.Created.IsZero() {
 		return 0, 0, nil
 	}
-	count, err := h.DBCountEslEventsNewer(ctx, transaction, esl.EslVersion)
+	count, err := h.DBCountEslEventsFrom(ctx, transaction, esl.EslVersion)
 	if err != nil {
 		return math.MaxFloat64, math.MaxUint64, err
 	}
-	now := time.Now().UTC()
 	diff := now.Sub(esl.Created).Seconds()
 	return diff, count, nil
 }

--- a/services/manifest-repo-export-service/pkg/cmd/server.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server.go
@@ -57,6 +57,11 @@ const (
 	maxExportBatchSizeLimit = 100
 )
 
+const (
+	metricNameArrivedEvents  = "manifest_export_events_arrived"
+	metricNameDepartedEvents = "manifest_export_events_departed"
+)
+
 func RunServer() {
 	logging.Wrap(context.Background(), func(ctx context.Context) error {
 		defer logging.HandlePanic(true)
@@ -491,6 +496,15 @@ func Run(ctx context.Context) error {
 					return processEsls(ctx, repo, dbHandler, cfg.DDMetrics, eslProcessingIdleTimeSeconds, failOnErrorWithGitPushTags, int(maxExportBatchSize))
 				},
 			},
+			{
+				Shutdown: nil,
+				Name:     "queueMetrics",
+				Run: func(ctx context.Context, reporter *setup.HealthReporter) error {
+					reporter.ReportReady("Handling Queue Metrics")
+					const metricsInterval = time.Second * 20
+					return reportEslQueueMetrics(ctx, dbHandler, cfg.DDMetrics, metricsInterval)
+				},
+			},
 		},
 		Shutdown: func(ctx context.Context) error {
 			close(shutdownCh)
@@ -498,6 +512,100 @@ func Run(ctx context.Context) error {
 		},
 	})
 	return nil
+}
+
+func reportEslQueueMetrics(ctx context.Context, dbHandler *db.DBHandler, ddMetrics statsd.ClientInterface, interval time.Duration) error {
+	if ddMetrics == nil {
+		<-ctx.Done()
+		return nil
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	lastMaxEsl := db.EslVersion(0)
+	lastCutoff := db.EslVersion(0)
+	firstRun := true
+	for {
+		select {
+		case <-ctx.Done():
+			// context is done, nothing we can or should do about that
+			return nil
+		case <-ticker.C:
+			currentMetrics, err := getEslMetrics(ctx, dbHandler)
+			if err != nil {
+				logging.Warn(ctx, "failed to report esl queue metrics, skipping this loop", zap.Error(err))
+				continue
+			}
+
+			if !firstRun {
+				// we only have data from the second run onwards
+				arrivedEvents := currentMetrics.MaxEslVersion - lastMaxEsl
+				departedEvents := currentMetrics.Cutoff - lastCutoff
+
+				err = ddMetrics.Count(metricNameArrivedEvents, int64(arrivedEvents), []string{}, 1)
+				if err != nil {
+					logging.Warn(ctx, "failed to report esl queue metric", zap.Error(err), zap.String("metric", metricNameArrivedEvents))
+				}
+
+				// note that both successfully and failing processing of an event counts as "departed" - as long as it leaves the queue
+				err = ddMetrics.Count(metricNameDepartedEvents, int64(departedEvents), []string{}, 1)
+				if err != nil {
+					logging.Warn(ctx, "failed to report esl queue metric", zap.Error(err), zap.String("metric", metricNameDepartedEvents))
+				}
+			}
+			lastMaxEsl = currentMetrics.MaxEslVersion
+			lastCutoff = currentMetrics.Cutoff
+			firstRun = false
+
+			measureDelays(ctx, ddMetrics, currentMetrics.ProcessDelaySeconds, currentMetrics.ProcessDelayEvents)
+		}
+	}
+}
+
+type eslMetrics struct {
+	MaxEslVersion db.EslVersion
+	Cutoff        db.EslVersion
+
+	ProcessDelayEvents  uint64
+	ProcessDelaySeconds float64
+}
+
+func getEslMetrics(ctx context.Context, dbHandler *db.DBHandler) (*eslMetrics, error) {
+	var maxEsl db.EslVersion = 0
+	var cutoff db.EslVersion = 0
+	var delayEvents uint64 = 0
+	var delaySeconds float64 = 0
+	err := dbHandler.WithTransaction(ctx, true, func(ctx context.Context, transaction *sql.Tx) error {
+		var e2 error
+		delaySeconds, delayEvents, e2 = dbHandler.GetCurrentDelays(ctx, transaction, time.Now().UTC())
+		if e2 != nil {
+			return fmt.Errorf("error in GetCurrentDelays: %v", e2)
+		}
+		maxEsl, e2 = db.DBReadMaxEslVersion(dbHandler, ctx, transaction)
+		if e2 != nil {
+			return e2
+		}
+		tmpCutoff, e2 := db.DBReadCutoff(dbHandler, ctx, transaction)
+		if e2 != nil {
+			return e2
+		}
+		if tmpCutoff == nil {
+			cutoff = 0
+		} else {
+			cutoff = *tmpCutoff
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &eslMetrics{
+		MaxEslVersion:       maxEsl,
+		Cutoff:              cutoff,
+		ProcessDelayEvents:  delayEvents,
+		ProcessDelaySeconds: delaySeconds,
+	}, nil
 }
 
 func ParseEnvironmentOverrides(ctx context.Context, configuredArgoNamesPerEnv valid.StringMap, existingEnvsInDb []types.EnvName) *argocd.ArgoProjectNamesPerEnv {
@@ -547,7 +655,6 @@ func processEsls(
 			return err
 		}
 		if wantedSleepTime > 0 {
-			measureDelays(ctx, ddMetrics, 0, 0)
 			time.Sleep(wantedSleepTime)
 		}
 	}
@@ -588,7 +695,7 @@ func ProcessOneEvent(
 			return resetErr
 		}
 		var err2 error
-		batch, err2 = HandleBatchEvents(ctx, transaction, dbHandler, ddMetrics, repo, maxBatchSize)
+		batch, err2 = HandleBatchEvents(ctx, transaction, dbHandler, repo, maxBatchSize)
 		return err2
 	})
 	if err != nil {
@@ -827,14 +934,7 @@ type batchedEvent struct {
 // HandleBatchEvents additionally returns, aligned one-to-one with the returned esl rows, the
 // hash of the commit each event produced ("" for a NoOp event that produced none), so the caller can
 // write one commit-transaction-timestamp per commit.
-func HandleBatchEvents(ctx context.Context, transaction *sql.Tx, dbHandler *db.DBHandler, ddMetrics statsd.ClientInterface, repo repository.Repository, maxBatchSize int) ([]batchedEvent, error) {
-	if ddMetrics != nil {
-		delaySeconds, delayEvents, err := dbHandler.GetCurrentDelays(ctx, transaction)
-		if err != nil {
-			return nil, fmt.Errorf("error in GetCurrentDelays: %v", err)
-		}
-		measureDelays(ctx, ddMetrics, delaySeconds, delayEvents)
-	}
+func HandleBatchEvents(ctx context.Context, transaction *sql.Tx, dbHandler *db.DBHandler, repo repository.Repository, maxBatchSize int) ([]batchedEvent, error) {
 	eslVersion, err := db.DBReadCutoff(dbHandler, ctx, transaction)
 	if err != nil {
 		return nil, fmt.Errorf("error in DBReadCutoff: %v", err)

--- a/services/manifest-repo-export-service/pkg/cmd/server_test.go
+++ b/services/manifest-repo-export-service/pkg/cmd/server_test.go
@@ -264,7 +264,7 @@ func TestHandleBatchEvents(t *testing.T) {
 				return nil
 			})
 			_ = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
-				actualBatch, actualError := HandleBatchEvents(ctx, transaction, dbHandler, nil, repo, 1)
+				actualBatch, actualError := HandleBatchEvents(ctx, transaction, dbHandler, repo, 1)
 				if diff := cmp.Diff(tc.expectedError, actualError, cmpopts.EquateErrors()); diff != "" {
 					t.Fatalf("error mismatch (-want, +got):\n%s", diff)
 				}

--- a/services/manifest-repo-export-service/pkg/service/git.go
+++ b/services/manifest-repo-export-service/pkg/service/git.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"time"
 
 	billy "github.com/go-git/go-billy/v5"
 	"github.com/onokonem/sillyQueueServer/timeuuid"
@@ -181,7 +182,7 @@ func (s *GitServer) GetGitSyncStatus(ctx context.Context, _ *api.GetGitSyncStatu
 		AppStatuses: make(map[string]*api.EnvSyncStatus),
 	}
 	err = dbHandler.WithTransactionR(ctx, 2, true, func(ctx context.Context, transaction *sql.Tx) error {
-		delaySecs, delayEvents, err := dbHandler.GetCurrentDelays(ctx, transaction)
+		delaySecs, delayEvents, err := dbHandler.GetCurrentDelays(ctx, transaction, time.Now().UTC())
 		if err != nil {
 			return fmt.Errorf("GetCurrentDelays: %v", err)
 		}


### PR DESCRIPTION
This introduces new metrics which allow operators to see the throughput of the manifest-export:
* manifest_export_events_arrived how many events where added to the queue since the last measurement
* manifest_export_events_departed how many events were remove from the queue (successful and failing count)

Diff := departed - arrived

Independent of that, it also fixes two things with the existing metrics:
* it always loaded the entire esl event, which is a pointless json blob for just the metric.
* it had a 1 off error, counting 1 too much, unless the number was 0.

The existing metrics where also moved into a separate go routine, so that all the metrics happen at the same point.

Ref: SRX-UG5WLO