### PR TITLE
fix: make kuberpult-datadog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ kuberpult-datadog: prepare-compose prepare-git prepare-pgp compose-down
 ifndef DD_ENV
 	$(error "DD_ENV should be set to execute this target. E.g., DD_ENV=example-local-nov7-a make kuberpult-datadog")
 else
-	DD_ENV=$(DD_ENV) docker compose -f docker-compose.datadog.yml -f docker-compose.yml -f docker-compose.persist.yml up
+	DD_ENV=$(DD_ENV) docker compose --env-file .env.local -f docker-compose.datadog.yml -f docker-compose.yml -f docker-compose.persist.yml up
 endif
 
 kuberpult: prepare-compose prepare-git prepare-pgp compose-down

--- a/docker-compose.datadog.yml
+++ b/docker-compose.datadog.yml
@@ -25,7 +25,7 @@ services:
       - ./datadog-api-key.txt:/etc/datadog/api-key
     environment:
       - KUBERPULT_DATADOG_API_KEY_LOCATION=/etc/datadog/api-key
-      - KUBERPULT_ENABLE_PROFILING=true
+      - KUBERPULT_ENABLE_PROFILING=false
       - KUBERPULT_ENABLE_METRICS=true
       - KUBERPULT_ENABLE_TRACING=true
       - DD_AGENT_HOST=datadog-agent


### PR DESCRIPTION
This fixes the target kuberpult-datadog,
it was previously not reading the .env.local, so it used different ports than the test scripts expect.

This also disables profiling locally, because the setup is not mounting correctly, and otherwise make kuberpult-datadog is crashing on startup.

Ref: SRX-UG5WLO