### PR TITLE
fix: optimize DBSelectAppsWithDeploymentInEnvAtTimestamp

### DIFF
--- a/database/migrations/postgres/1788425410155963_deployments_history_index.up.sql
+++ b/database/migrations/postgres/1788425410155963_deployments_history_index.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_deployments_history_app_env_created_version
+    ON deployments_history (appname, envname, created DESC, version DESC)
+    INCLUDE (releaseversion, revision);

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -24,6 +24,9 @@ import (
 	"strings"
 )
 
+type ReleaseVersion = *uint64
+type Revision = uint64
+
 type GitTag string
 
 // EnvName is a type that helps us avoid mixing up envNames from other strings.
@@ -67,7 +70,7 @@ type ManifestLockID int64
 
 type ArgoProjectName string
 
-func EnvNamesToStrings(a []EnvName) []string {
+func NamesToStrings[T ~string](a []T) []string {
 	var result = make([]string, len(a))
 	for i := range a {
 		result[i] = string(a[i])
@@ -75,18 +78,26 @@ func EnvNamesToStrings(a []EnvName) []string {
 	return result
 }
 
-func StringsToEnvNames(a []string) []EnvName {
-	var result = make([]EnvName, len(a))
+func StringsToNames[T ~string](a []string) []T {
+	var result = make([]T, len(a))
 	for i := range a {
-		result[i] = EnvName(a[i])
+		result[i] = T(a[i])
 	}
 	return result
 }
 
-func Sort(a []EnvName) []EnvName {
-	s := EnvNamesToStrings(a)
+func EnvNamesToStrings(a []EnvName) []string {
+	return NamesToStrings(a)
+}
+
+func StringsToEnvNames(a []string) []EnvName {
+	return StringsToNames[EnvName](a)
+}
+
+func Sort[T ~string](a []T) []T {
+	s := NamesToStrings(a)
 	sort.Strings(s)
-	return StringsToEnvNames(s)
+	return StringsToNames[T](s)
 }
 
 func StringPtr(a EnvName) *string {

--- a/services/cd-service/pkg/repository/releasetrain.go
+++ b/services/cd-service/pkg/repository/releasetrain.go
@@ -202,7 +202,7 @@ func (c *ReleaseTrain) Prognosis(
 	for env := range envGroupConfigs {
 		envGroups = append(envGroups, env)
 	}
-	types.Sort(envGroups)
+	envGroups = types.Sort(envGroups)
 
 	envPrognoses := make(map[types.EnvName]ReleaseTrainEnvironmentPrognosis)
 	for _, envName := range envGroups {
@@ -274,7 +274,7 @@ func (c *ReleaseTrain) Transform(
 	for env := range envGroupConfigs {
 		envNames = append(envNames, env)
 	}
-	types.Sort(envNames)
+	envNames = types.Sort(envNames)
 	span.SetTag("environments", len(envNames))
 
 	ts, err := state.GetCommitHashTimestamp(ctx, transaction, c.CommitHash)

--- a/services/manifest-repo-export-service/pkg/db_history/db_history.go
+++ b/services/manifest-repo-export-service/pkg/db_history/db_history.go
@@ -19,101 +19,97 @@ package db_history
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
-	"go.uber.org/zap"
+	"github.com/lib/pq"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
-	"github.com/freiheit-com/kuberpult/pkg/db"
-	"github.com/freiheit-com/kuberpult/pkg/logging"
 	"github.com/freiheit-com/kuberpult/pkg/types"
 )
 
-type DeploymentMap map[types.AppName]db.Deployment
+type DeploymentShort struct {
+	ReleaseVersion types.ReleaseVersion
+	Revision       types.Revision
+}
+type DeploymentMap map[types.AppName]DeploymentShort
 
 // DBSelectAppsWithDeploymentInEnvAtTimestamp returns all apps that had a deployment in the given env at the given timestamp:
-func DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx context.Context, h *db.DBHandler, tx *sql.Tx, envSelector types.EnvName, ts time.Time) (DeploymentMap, error) {
-	selectQuery := h.AdaptQuery(`
-		SELECT
-			created,
-			appName,
-			releaseVersion,
-			envName,
-			metadata,
-			transformereslVersion,
-			revision
-		FROM (
-			SELECT
-				*,
-				ROW_NUMBER() OVER(PARTITION BY appName, envName ORDER BY created DESC) as row_number
-			FROM
-				deployments_history
-			WHERE	
-				created <= ?
-			AND
-				envName = ?
-		) AS subquery
-		WHERE
-			row_number = 1
-		ORDER BY
-			appName ASC, envName ASC
- 	`)
+func DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx context.Context, tx *sql.Tx, envSelector types.EnvName, ts time.Time, appNames []types.AppName) (_ DeploymentMap, err error) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "DBSelectAppsWithDeploymentInEnvAtTimestamp")
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
+	span.SetTag("kuberpultEnvironment", envSelector)
+	span.SetTag("numApps", len(appNames))
+	selectQuery := `
+		 SELECT
+			  a.appname,
+			  d.releaseversion,
+			  d.revision
+		  FROM unnest($1::text[]) AS a(appname)  -- "unnest" simply converts our slice into a row
+		--  For manually using this query in psql, replace this line with:
+		--  FROM unnest((SELECT array_agg(appname::text) FROM apps)) AS a(appname)
+
+		--- Then we join lateral ("subquery") in order to get the latest deployment.
+	    --- This will skip apps that have now deployment - that's ok, we cannot deploy those anyway!
+		  JOIN LATERAL (
+			  SELECT
+				  releaseversion,
+				  revision
+			  FROM deployments_history
+			  WHERE appname = a.appname
+				  AND envname = $2
+				  AND created <= $3
+			  -- Note that we cannot filter "releaseVersion IS NULL" here, even though we later filter out null deployments,
+			  -- because that would not give us the LATEST deployment.
+			  ORDER BY created DESC, version DESC
+			  LIMIT 1
+		  ) AS d ON TRUE
+		  ORDER BY a.appname;`
 	rows, err := tx.QueryContext(
 		ctx,
 		selectQuery,
-		ts,
+		pq.Array(appNames),
 		envSelector,
+		ts,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not select historic deployment on env %s from DB: %w", envSelector, err)
 	}
-	defer func(rows *sql.Rows) {
-		err := rows.Close()
-		if err != nil {
-			logging.Error(ctx, "deployments: row closing error.", zap.Error(err))
-		}
-	}(rows)
-	return processAllLatestDeploymentsForEnv(ctx, rows)
-}
-
-func processAllLatestDeploymentsForEnv(_ context.Context, rows *sql.Rows) (DeploymentMap, error) {
-	result := make(map[types.AppName]db.Deployment)
+	defer func() {
+		_ = rows.Close()
+	}()
+	result := make(DeploymentMap)
 	for rows.Next() {
-		var curr = db.Deployment{
-			Created: time.Time{},
-			Env:     "",
-			App:     "",
-			ReleaseNumbers: types.ReleaseNumbers{
-				Revision: 0,
-				Version:  nil,
-			},
-			Metadata: db.DeploymentMetadata{
-				DeployedByName:  "",
-				DeployedByEmail: "",
-				CiLink:          "",
-			},
-			TransformerID: 0,
-		}
-		var releaseVersion sql.NullInt64
-		var jsonMetadata string
-		err := rows.Scan(&curr.Created, &curr.App, &releaseVersion, &curr.Env, &jsonMetadata, &curr.TransformerID, &curr.ReleaseNumbers.Revision)
+		appName, deployment, err := processOneDeploymentsForEnv(rows)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("error scanning deployments row from DB. Error: %w", err)
+			return nil, err
 		}
-		err = json.Unmarshal(([]byte)(jsonMetadata), &curr.Metadata)
-		if err != nil {
-			return nil, fmt.Errorf("error during json unmarshal in deployments. Error: %w. Data: %s", err, jsonMetadata)
-		}
-		if releaseVersion.Valid {
-			conv := uint64(releaseVersion.Int64)
-			curr.ReleaseNumbers.Version = &conv
-		}
-		result[curr.App] = curr
+		result[appName] = deployment
+	}
+	span.SetTag("resultLen", len(result))
+	err = rows.Err()
+	if err != nil {
+		return nil, fmt.Errorf("could not select historic deployment on env %s from DB: %w", envSelector, err)
 	}
 	return result, nil
+}
+
+func processOneDeploymentsForEnv(rows *sql.Rows) (types.AppName, DeploymentShort, error) {
+	var c = DeploymentShort{
+		ReleaseVersion: nil,
+		Revision:       0,
+	}
+	var sqlReleaseVersion sql.NullInt64
+	var app types.AppName
+	err := rows.Scan(&app, &sqlReleaseVersion, &c.Revision)
+	if err != nil {
+		return app, c, fmt.Errorf("error scanning deployments row from DB. Error: %w", err)
+	}
+	if sqlReleaseVersion.Valid {
+		conv := uint64(sqlReleaseVersion.Int64)
+		c.ReleaseVersion = &conv
+	}
+	return app, c, nil
 }

--- a/services/manifest-repo-export-service/pkg/db_history/db_history_test.go
+++ b/services/manifest-repo-export-service/pkg/db_history/db_history_test.go
@@ -19,14 +19,15 @@ package db_history
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/freiheit-com/kuberpult/pkg/config"
 	"github.com/freiheit-com/kuberpult/pkg/db"
+	"github.com/freiheit-com/kuberpult/pkg/testutil"
 	"github.com/freiheit-com/kuberpult/pkg/testutilauth"
 	"github.com/freiheit-com/kuberpult/pkg/types"
 )
@@ -34,8 +35,12 @@ import (
 func TestDBSelectAppsWithDeploymentInEnvAtTimestamp(t *testing.T) {
 	const appFoo = types.AppName("foo")
 	const appPow = types.AppName("pow")
+	allApps := []types.AppName{appFoo, appPow}
+	allAppsDuplicated := []types.AppName{appFoo, appPow, appFoo, appPow}
+
 	const dev = types.EnvName("dev")
 	const stg = types.EnvName("staging")
+	allEnvs := []types.EnvName{dev, stg}
 
 	Environments := []db.DBEnvironment{
 		{
@@ -84,10 +89,12 @@ func TestDBSelectAppsWithDeploymentInEnvAtTimestamp(t *testing.T) {
 	tcs := []struct {
 		Name                string
 		InputDeployments    []AppEnv
+		InputAllApps        []types.AppName
 		ExpectedDeployments map[types.EnvName]DeploymentMap
 	}{
 		{
-			Name: "one simple deployment works",
+			Name:         "one simple deployment works and appPow is skipped",
+			InputAllApps: allApps,
 			InputDeployments: []AppEnv{
 				{
 					App:            appFoo,
@@ -98,45 +105,31 @@ func TestDBSelectAppsWithDeploymentInEnvAtTimestamp(t *testing.T) {
 			ExpectedDeployments: map[types.EnvName]DeploymentMap{
 				dev: {
 					appFoo: {
-						Created:        time.Time{},
-						App:            appFoo,
-						Env:            dev,
-						ReleaseNumbers: types.MakeReleaseNumbers(1, 0),
-						Metadata:       db.DeploymentMetadata{},
-						TransformerID:  0,
+						ReleaseVersion: types.Ptr(uint64(1)),
+						Revision:       0,
 					},
 				},
+				stg: {},
 			},
 		},
 		{
-			Name: "un-deploying works",
+			Name:         "huge list of apps works",
+			InputAllApps: createHugeListOfApps(70_000), // a "where-in" would be limited to 65k
 			InputDeployments: []AppEnv{
 				{
 					App:            appFoo,
 					Env:            dev,
 					ReleaseNumbers: types.MakeReleaseNumbers(1, 0),
 				},
-				{
-					App:            appFoo,
-					Env:            dev,
-					ReleaseNumbers: types.MakeReleaseNumbers(0, 0),
-				},
 			},
 			ExpectedDeployments: map[types.EnvName]DeploymentMap{
-				dev: {
-					appFoo: {
-						Created:        time.Time{},
-						App:            appFoo,
-						Env:            dev,
-						ReleaseNumbers: types.MakeReleaseNumbers(0, 0),
-						Metadata:       db.DeploymentMetadata{},
-						TransformerID:  0,
-					},
-				},
+				dev: {},
+				stg: {},
 			},
 		},
 		{
-			Name: "re-deploying works",
+			Name:         "un-deploying works",
+			InputAllApps: allApps,
 			InputDeployments: []AppEnv{
 				{
 					App:            appFoo,
@@ -148,6 +141,31 @@ func TestDBSelectAppsWithDeploymentInEnvAtTimestamp(t *testing.T) {
 					Env:            dev,
 					ReleaseNumbers: types.MakeReleaseNumbers(0, 0),
 				},
+			},
+			ExpectedDeployments: map[types.EnvName]DeploymentMap{
+				dev: {
+					appFoo: {
+						ReleaseVersion: types.Ptr(uint64(0)),
+						Revision:       0,
+					},
+				},
+				stg: {},
+			},
+		},
+		{
+			Name:         "re-deploying works",
+			InputAllApps: allApps,
+			InputDeployments: []AppEnv{
+				{
+					App:            appFoo,
+					Env:            dev,
+					ReleaseNumbers: types.MakeReleaseNumbers(1, 0),
+				},
+				{
+					App:            appFoo,
+					Env:            dev,
+					ReleaseNumbers: types.MakeReleaseNumbers(0, 0),
+				},
 				{
 					App:            appFoo,
 					Env:            dev,
@@ -157,18 +175,16 @@ func TestDBSelectAppsWithDeploymentInEnvAtTimestamp(t *testing.T) {
 			ExpectedDeployments: map[types.EnvName]DeploymentMap{
 				dev: {
 					appFoo: {
-						Created:        time.Time{},
-						App:            appFoo,
-						Env:            dev,
-						ReleaseNumbers: types.MakeReleaseNumbers(1, 0),
-						Metadata:       db.DeploymentMetadata{},
-						TransformerID:  0,
+						ReleaseVersion: types.Ptr(uint64(1)),
+						Revision:       0,
 					},
 				},
+				stg: {},
 			},
 		},
 		{
-			Name: "two simple deployments works",
+			Name:         "two simple deployments works",
+			InputAllApps: allApps,
 			InputDeployments: []AppEnv{
 				{
 					App:            appFoo,
@@ -184,22 +200,64 @@ func TestDBSelectAppsWithDeploymentInEnvAtTimestamp(t *testing.T) {
 			ExpectedDeployments: map[types.EnvName]DeploymentMap{
 				dev: {
 					appFoo: {
-						Created:        time.Time{},
-						App:            appFoo,
-						Env:            dev,
-						ReleaseNumbers: types.MakeReleaseNumbers(1, 0),
-						Metadata:       db.DeploymentMetadata{},
-						TransformerID:  0,
+						ReleaseVersion: types.Ptr(uint64(1)),
+						Revision:       0,
 					},
 				},
 				stg: {
 					appPow: {
-						Created:        time.Time{},
-						App:            appPow,
-						Env:            stg,
-						ReleaseNumbers: types.MakeReleaseNumbers(1, 0),
-						Metadata:       db.DeploymentMetadata{},
-						TransformerID:  0,
+						ReleaseVersion: types.Ptr(uint64(1)),
+						Revision:       0,
+					},
+				},
+			},
+		},
+		{
+			Name:         "empty apps return nothing",
+			InputAllApps: []types.AppName{},
+			InputDeployments: []AppEnv{
+				{
+					App:            appFoo,
+					Env:            dev,
+					ReleaseNumbers: types.MakeReleaseNumbers(1, 0),
+				},
+				{
+					App:            appPow,
+					Env:            stg,
+					ReleaseNumbers: types.MakeReleaseNumbers(1, 0),
+				},
+			},
+			ExpectedDeployments: map[types.EnvName]DeploymentMap{
+				dev: {},
+				stg: {},
+			},
+		},
+		{
+			Name:         "duplicate input apps yield same result as unique list of apps",
+			InputAllApps: allAppsDuplicated,
+			InputDeployments: []AppEnv{
+				{
+					App:            appFoo,
+					Env:            dev,
+					ReleaseNumbers: types.MakeReleaseNumbers(1, 0),
+				},
+				{
+					App:            appPow,
+					Env:            stg,
+					ReleaseNumbers: types.MakeReleaseNumbers(1, 0),
+				},
+			},
+			ExpectedDeployments: map[types.EnvName]DeploymentMap{
+				dev: {
+					appFoo: {
+						ReleaseVersion: types.Ptr(uint64(1)),
+						Revision:       0,
+					},
+				},
+				stg: {
+					appPow: {
+						ReleaseVersion: types.Ptr(uint64(1)),
+						Revision:       0,
 					},
 				},
 			},
@@ -210,6 +268,12 @@ func TestDBSelectAppsWithDeploymentInEnvAtTimestamp(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutilauth.MakeTestContext()
+			for _, env := range allEnvs {
+				if tc.ExpectedDeployments[env] == nil {
+					t.Fatalf("test setup broken: no deployment found for env %v: %s", env,
+						"you need to specify all envs in 'ExpectedDeployments'")
+				}
+			}
 			dbHandler := setupDB(t)
 			var err error
 			err = dbHandler.WithTransaction(ctx, false, func(ctx context.Context, transaction *sql.Tx) error {
@@ -259,12 +323,12 @@ func TestDBSelectAppsWithDeploymentInEnvAtTimestamp(t *testing.T) {
 					t.Fatalf("error getting time: %v", err)
 				}
 				for envName, expectedDeploymentMap := range tc.ExpectedDeployments {
-					actualResult, err := DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx, dbHandler, transaction, envName, *timestamp)
+					actualResult, err := DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx, transaction, envName, *timestamp, tc.InputAllApps)
 					if err != nil {
 						t.Fatalf("error selecting deployments: %v", err)
 					}
 					// THEN:
-					if diff := cmp.Diff(expectedDeploymentMap, actualResult, cmpopts.IgnoreFields(db.Deployment{}, "Created")); diff != "" {
+					if diff := testutil.CmpDiff(expectedDeploymentMap, actualResult, cmpopts.IgnoreFields(db.Deployment{}, "Created")); diff != "" {
 						t.Fatalf("deployment mismatch on env %s (-want, +got):\n%s", envName, diff)
 					}
 				}
@@ -277,6 +341,14 @@ func TestDBSelectAppsWithDeploymentInEnvAtTimestamp(t *testing.T) {
 	}
 }
 
+func createHugeListOfApps(numApps uint) []types.AppName {
+	var results []types.AppName
+	for i := range numApps {
+		results = append(results, types.AppName(fmt.Sprintf("TmpApp-%d", i)))
+	}
+	return results
+}
+
 // TestDBDeleteDeploymentWithHistoryReflectsInTimestampQuery ensures that deleting a deployment via
 // the history-aware wrapper makes the timestamped history query stop reporting the app as deployed.
 // A plain DBDeleteDeployment (current table only) would leave the history showing the old version,
@@ -284,6 +356,7 @@ func TestDBSelectAppsWithDeploymentInEnvAtTimestamp(t *testing.T) {
 func TestDBDeleteDeploymentWithHistoryReflectsInTimestampQuery(t *testing.T) {
 	const app = types.AppName("foo")
 	const dev = types.EnvName("dev")
+	allApps := []types.AppName{app}
 	tcs := []struct {
 		Name          string
 		DeployVersion uint64
@@ -330,11 +403,11 @@ func TestDBDeleteDeploymentWithHistoryReflectsInTimestampQuery(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				res, err := DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx, dbHandler, transaction, dev, *ts)
+				res, err := DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx, transaction, dev, *ts, allApps)
 				if err != nil {
 					return err
 				}
-				if dep, ok := res[app]; !ok || dep.ReleaseNumbers.Version == nil {
+				if dep, ok := res[app]; !ok || dep.ReleaseVersion == nil {
 					t.Fatalf("expected app %q to be deployed before deletion, got: %v", app, res)
 				}
 				return nil
@@ -357,12 +430,12 @@ func TestDBDeleteDeploymentWithHistoryReflectsInTimestampQuery(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				res, err := DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx, dbHandler, transaction, dev, *ts)
+				res, err := DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx, transaction, dev, *ts, allApps)
 				if err != nil {
 					return err
 				}
-				if dep, ok := res[app]; ok && dep.ReleaseNumbers.Version != nil {
-					t.Errorf("expected app %q to be un-deployed after deletion, but it still has version %d", app, *dep.ReleaseNumbers.Version)
+				if dep, ok := res[app]; ok && dep.ReleaseVersion != nil {
+					t.Errorf("expected app %q to be un-deployed after deletion, but it still has version %d", app, *dep.ReleaseVersion)
 				}
 				return nil
 			})

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -1122,7 +1122,17 @@ func collectArgoAppDataForEnv(
 	if err != nil {
 		return nil, fmt.Errorf("could not select environment applications at timestamp: %w", err)
 	}
-	deploymentsPerApp, err := db_history.DBSelectAppsWithDeploymentInEnvAtTimestamp(ctx, dbHandler, transaction, parentEnvName, timestamp)
+	var appNames []types.AppName
+	for _, appTeam := range appTeams {
+		appNames = append(appNames, appTeam.AppName)
+	}
+	deploymentsPerApp, err := db_history.DBSelectAppsWithDeploymentInEnvAtTimestamp(
+		ctx,
+		transaction,
+		parentEnvName,
+		timestamp,
+		appNames,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("could not select apps with deployment in env at timestamp: %w", err)
 	}
@@ -1188,7 +1198,7 @@ func CalculateAppDataWithBrackets(_ context.Context, allBrackets *db.BracketRow,
 
 	appToTeamMap := appTeamsToMap(appTeams)
 	for bracketName, appNames := range bracketMap {
-		bracketsTeamNames := []string{}
+		var bracketsTeamNames []string
 		hasDeployedApp := false
 		for _, appName := range appNames {
 			appsTeamName, ok := appToTeamMap[appName]
@@ -1201,7 +1211,7 @@ func CalculateAppDataWithBrackets(_ context.Context, allBrackets *db.BracketRow,
 				// nothing was deployed here at that time, skip:
 				continue
 			}
-			if deployment.ReleaseNumbers.Version == nil || *deployment.ReleaseNumbers.Version == 0 {
+			if deployment.ReleaseVersion == nil || *deployment.ReleaseVersion == 0 {
 				// There was a deployment here previously, but at the timestamp, nothing is deployed, skip:
 				continue
 			}

--- a/services/manifest-repo-export-service/pkg/repository/repository.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository.go
@@ -1407,7 +1407,7 @@ func (s *State) GetEnvironmentConfigsSortedFromManifest() (map[types.EnvName]con
 	for envName := range configs {
 		envNames = append(envNames, envName)
 	}
-	types.Sort(envNames)
+	envNames = types.Sort(envNames)
 	return configs, envNames, nil
 }
 
@@ -2456,7 +2456,7 @@ func (s *State) GetEnvironmentConfigsForGroup(ctx context.Context, transaction *
 	if len(groupEnvNames) == 0 {
 		return nil, fmt.Errorf("no environment found with given group '%s'", envGroup)
 	}
-	types.Sort(groupEnvNames)
+	groupEnvNames = types.Sort(groupEnvNames)
 	return groupEnvNames, nil
 }
 

--- a/services/manifest-repo-export-service/pkg/repository/repository_test.go
+++ b/services/manifest-repo-export-service/pkg/repository/repository_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/cenkalti/backoff/v4"
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	git "github.com/libgit2/git2go/v34"
 
@@ -58,13 +57,9 @@ func TestCalculateAppDatWithBrackets(t *testing.T) {
 		result := db_history.DeploymentMap{}
 		for _, appName := range appNames {
 			v := uint64(1)
-			result[appName] = db.Deployment{
-				App: appName,
-				Env: "dontcare",
-				ReleaseNumbers: types.ReleaseNumbers{
-					Version:  &v,
-					Revision: 1,
-				},
+			result[appName] = db_history.DeploymentShort{
+				ReleaseVersion: &v,
+				Revision:       1,
 			}
 		}
 		return result
@@ -484,11 +479,11 @@ func TestDeleteDirIfEmpty(t *testing.T) {
 			}
 
 			successReason, err := state.DeleteDirIfEmpty(tc.DeleteThisDir)
-			if diff := cmp.Diff(tc.ExpectedError, err, cmpopts.EquateErrors()); diff != "" {
+			if diff := testutil.CmpDiff(tc.ExpectedError, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("error mismatch (-want, +got):\n%s", diff)
 			}
 			if successReason != tc.ExpectedReason {
-				t.Fatal("Output mismatch (-want +got):\n", cmp.Diff(tc.ExpectedReason, successReason))
+				t.Fatal("Output mismatch (-want +got):\n", testutil.CmpDiff(tc.ExpectedReason, successReason))
 			}
 		})
 	}
@@ -3209,7 +3204,7 @@ func TestMeasureGitSyncStatus(t *testing.T) {
 					return true
 				}
 			}
-			if diff := cmp.Diff(tc.ExpectedGauges, mockClient.gauges, cmpopts.SortSlices(cmpGauge)); diff != "" {
+			if diff := testutil.CmpDiff(tc.ExpectedGauges, mockClient.gauges, cmpopts.SortSlices(cmpGauge)); diff != "" {
 				t.Errorf("gauges mismatch (-want, +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
This query plays an important role in determining "what apps will be deployed".
Now we only query the absolutely required columns, so the json parsing is also gone.

This change optimizes the query and adds an appropriate index on top for the table deployments_history.

Ref: SRX-LJHTO5